### PR TITLE
Add minimal buildscript and test programs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.17)
+project(Adept
+  VERSION 0.1.0
+  DESCRIPTION "Accelerated demonstrator of electromagnetic Particle Transport"
+  LANGUAGES C CXX CUDA)
+
+# - Include needed custom/core modules
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+include(CMakeSettings)
+
+# - Core/C++/CUDA build and dependency settings
+# For single-mode generators, default to Optimized with Debug if nothing is specified
+if(NOT CMAKE_CONFIGURATION_TYPES)
+  set(__DEFAULT_CMAKE_BUILD_TYPE RelWithDebInfo)
+  if(CMAKE_BUILD_TYPE)
+    set(__DEFAULT_CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}")
+  endif()
+  set(CMAKE_BUILD_TYPE "${__DEFAULT_CMAKE_BUILD_TYPE}"
+    CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo MinSizeRel."
+    FORCE)
+endif()
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CUDA_STANDARD ${CMAKE_CXX_STANDARD})
+set(CMAKE_CUDA_STANDARD_REQUIRED ${CMAKE_CXX_STANDARD_REQUIRED})
+set(CMAKE_CUDA_EXTENSIONS OFF)
+
+# With CUDA language enabled above, this should find the toolkit alongside the compiler
+find_package(CUDAToolkit REQUIRED)
+
+# Builds...
+add_subdirectory(test)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # AdePT
 Accelerated demonstrator of electromagnetic Particle Transport
+
+## Build Requirements
+The following packages are a required to build and run:
+
+- CMake >= 3.17
+- C/C++ Compiler with C++14 support
+- CUDA Toolkit (tested 10.1, min version TBD)
+
+To build, simply run:
+
+```console
+$ cmake -S. -B./adept-build <otherargs>
+...
+$ cmake --build ./adept-build
+```

--- a/cmake/CMakeSettings.cmake
+++ b/cmake/CMakeSettings.cmake
@@ -1,0 +1,48 @@
+
+# - Project wide CMake settings
+# - Though we check for some absolute paths, ensure there are no others
+set(CMAKE_ERROR_ON_ABSOLUTE_INSTALL_DESTINATION ON)
+
+# - Never export to or search in user/system package registry
+set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY ON)
+set(CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY ON)
+set(CMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY ON)
+
+# - Force project directories to appear first in any list of includes
+set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
+
+# - Only relink shared libs when interface changes
+set(CMAKE_LINK_DEPENDS_NO_SHARED ON)
+
+# - Only report newly installed files
+set(CMAKE_INSTALL_MESSAGE LAZY)
+
+#-------------------------------------------------------------------------------
+# Output Directories for Build products
+#-------------------------------------------------------------------------------
+# In all cases, build products are stored in a directory tree rooted
+# in a directory named ``BuildProducts`` under the ``PROJECT_BINARY_DIRECTORY``.
+set(BASE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/BuildProducts")
+
+# - Base subdirectories on GNU style, which also provides a common
+include(GNUInstallDirs)
+
+# - Single mode case
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${BASE_OUTPUT_DIRECTORY}/${CMAKE_INSTALL_BINDIR}")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${BASE_OUTPUT_DIRECTORY}/${CMAKE_INSTALL_LIBDIR}")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${BASE_OUTPUT_DIRECTORY}/${CMAKE_INSTALL_LIBDIR}")
+
+# - Multimode case
+foreach(_conftype ${CMAKE_CONFIGURATION_TYPES})
+  string(TOUPPER ${_conftype} _conftype_uppercase)
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${_conftype_uppercase}
+    "${BASE_OUTPUT_DIRECTORY}/${_conftype}/${CMAKE_INSTALL_BINDIR}"
+    )
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${_conftype_uppercase}
+    "${BASE_OUTPUT_DIRECTORY}/${_conftype}/${CMAKE_INSTALL_LIBDIR}"
+    )
+  set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${_conftype_uppercase}
+    "${BASE_OUTPUT_DIRECTORY}/${_conftype}/${CMAKE_INSTALL_LIBDIR}"
+    )
+endforeach()
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,8 @@
+# - Minimal test of cuda compilation
+add_executable(example_add example_add.cu)
+
+# Noddy example of particle processing on CPU
+add_executable(fisher_price fisher_price.cpp)
+# Noddy example of particle processing with GPU
+add_executable(cufisher_price cufisher_price.cu)
+target_link_libraries(cufisher_price PRIVATE CUDA::curand)

--- a/test/cufisher_price.cu
+++ b/test/cufisher_price.cu
@@ -1,0 +1,10 @@
+#include <curand.h>
+
+int main()
+{
+  // What are the ways to transform the CPU `fisher_price` to CUDA/GPU
+  // An obvious branch/divergence (eloss vs pair), but good exercise
+  // As first steps in microkernel workflow.
+
+  return 0;
+}

--- a/test/example_add.cu
+++ b/test/example_add.cu
@@ -1,0 +1,46 @@
+// Very simple CUDA program to exercise build system
+// Taken from: https://devblogs.nvidia.com/even-easier-introduction-cuda/
+
+#include <iostream>
+#include <math.h>
+// Kernel function to add the elements of two arrays
+__global__
+void add(int n, float *x, float *y)
+{
+  for (int i = 0; i < n; i++)
+    y[i] = x[i] + y[i];
+}
+
+int main(void)
+{
+  int N = 1<<20;
+  float *x, *y;
+
+  // Allocate Unified Memory – accessible from CPU or GPU
+  cudaMallocManaged(&x, N*sizeof(float));
+  cudaMallocManaged(&y, N*sizeof(float));
+
+  // initialize x and y arrays on the host
+  for (int i = 0; i < N; i++) {
+    x[i] = 1.0f;
+    y[i] = 2.0f;
+  }
+
+  // Run kernel on 1M elements on the GPU
+  add<<<1, 1>>>(N, x, y);
+
+  // Wait for GPU to finish before accessing on host
+  cudaDeviceSynchronize();
+
+  // Check for errors (all values should be 3.0f)
+  float maxError = 0.0f;
+  for (int i = 0; i < N; i++)
+    maxError = fmax(maxError, fabs(y[i]-3.0f));
+  std::cout << "Max error: " << maxError << std::endl;
+
+  // Free memory
+  cudaFree(x);
+  cudaFree(y);
+
+  return 0;
+}

--- a/test/fisher_price.cpp
+++ b/test/fisher_price.cpp
@@ -1,0 +1,50 @@
+#include <deque>
+#include <iostream>
+#include <random>
+
+struct particle {
+  float energy;
+};
+
+int main()
+{
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<float> rng;
+
+  std::deque<particle> particleStack;
+
+  // Just one particle
+  particleStack.emplace_back(particle{100.0f});
+
+  // "Scoring"
+  size_t numberOfSecondaries = 0;
+  float totalEnergyLoss      = 0;
+
+  while (!particleStack.empty()) {
+    auto &p = particleStack.front();
+    while (p.energy > 0.0f) {
+      // Essentially "process selection"
+      float r = rng(gen);
+
+      if (r < 0.5f) {
+        // do energy loss
+        float eloss = 0.2f * p.energy;
+        totalEnergyLoss += (eloss < 0.001f ? p.energy : eloss);
+        p.energy = (eloss < 0.001f ? 0.0f : (p.energy - eloss));
+      } else {
+        // do "pair production"
+        numberOfSecondaries++;
+        float eloss = 0.5f * p.energy;
+        particleStack.emplace_back(particle{eloss});
+        p.energy -= eloss;
+      }
+    }
+    // "Kill" particle
+    particleStack.pop_front();
+  }
+
+  // "Persist"
+  std::cout << "Number of secondaries: " << numberOfSecondaries << "\n"
+            << "Total energy loss    : " << totalEnergyLoss << "\n";
+}


### PR DESCRIPTION
As a trivial starting point, this copies across the minimal build setup from Excalibur/emcuda but with the CMake min version bumped to 3.17. This [recent version](https://cmake.org/cmake/help/latest/release/3.17.html) is chosen as it provides very simple configure/use of the CUDA toolkit through the [FindCUDAToolkit](https://cmake.org/cmake/help/v3.17/module/FindCUDAToolkit.html#module:FindCUDAToolkit) module. 

The C++/CUDA standard is fixed at C++14 for now, but can be reviewed, along with any min requirements on CUDA version or compute capability.  

To check that this works a, for now arbitrary, `test` directory holds a couple of programs to exercise CPU/CUDA builds. Those can be tried locally, I haven't thought about what, if any, CI we'll use.