### PR TITLE
Bump minimum required CMake to 3.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.18)
 project(Adept
   VERSION 0.1.0
   DESCRIPTION "Accelerated demonstrator of electromagnetic Particle Transport"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Accelerated demonstrator of electromagnetic Particle Transport
 ## Build Requirements
 The following packages are a required to build and run:
 
-- CMake >= 3.17
+- CMake >= 3.18
 - C/C++ Compiler with C++14 support
 - CUDA Toolkit (tested 10.1, min version TBD)
 


### PR DESCRIPTION
CMake 3.18 introduces the new variable `CMAKE_CUDA_ARCHITECTURES` and target property `CUDA_ARCHITECTURE`:

- https://cmake.org/cmake/help/v3.18/variable/CMAKE_CUDA_ARCHITECTURES.html
- https://cmake.org/cmake/help/v3.18/prop_tgt/CUDA_ARCHITECTURES.html

These list the required architectures to generate device code for, and set the required CUDA compiler flags. See e.g. https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#gpu-generations

To better support selection of CUDA architecture flags, require CMake 3.18 as the minimum. `CMAKE_CUDA_ARCHITECTURES` is _not_ set so the defaults for the compiler will be used until the range of supported devices is defined. 

However, it can still be set manually via, e.g. `cmake -DCMAKE_CUDA_ARCHITECTURES="62;71" <args>", and I'd guess it can eventually become a cache variable to allow interactive setting if needed.