### PR TITLE
Add draft contribution and CoC guides

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2020 CERN
+# SPDX-License-Identifier: Apache-2.0
+
+# Minimal flake8 tweak to be compatible with black's line length
+# of 88 characters 
+# https://black.readthedocs.io/en/stable/the_black_code_style.html#line-length
+
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,110 @@
+<!--
+SPDX-FileCopyrightText: 2010-2020 CERN
+SPDX-License-Identifier: CC-BY-ND-4.0
+-->
+
+# Code Of Conduct
+
+The AdePT project observes [CERN's Code of Conduct](https://cern.ch/codeofconduct). 
+Below is a plain text summary of the [official PDF](https://cds.cern.ch/record/2240689/files/BrochureCodeofConductEN.pdf?)
+as of 1. April 2020. Please consult the [PDF](https://cds.cern.ch/record/2240689/files/BrochureCodeofConductEN.pdf?)
+for up-to-date information.
+
+## USING THE CODE OF CONDUCT
+
+We encourage a culture of openness where all contributors feel free to engage in a discussion about the Code of Conduct.
+
+If you are unsure about any aspect of the Code of Conduct, there are a number of resources you may wish to access, including your hierarchy, the Human Resources Department, the Ombud Oﬃce or the Internal Audit.
+
+In addition, to increase understanding of how the Code of Conduct applies to practical situations, you are encouraged to consult the Code of Conduct online FAQ’s, accessible at cern.ch/codeofconduct. This website will be updated on a regular basis.
+
+## INTRODUCTION BY THE DIRECTOR-GENERAL
+
+What we do in our working lives is important, and the way we do it is equally so. This is particularly true with the diverse community we have at CERN. People from all over the world come here, bringing with them different cultures and different ways of working. This diversity is part of our strength, and it’s something that we need to nurture constantly. That’s why CERN has developed a Code of Conduct that is built on a set of core CERN values, defined following broad consultation by the HR Department across the Organization in order to determine the values that underline the spirit of CERN.
+
+Those values are integrity, commitment, professionalism, creativity and diversity. Taken together, they provide the basis for respect: respect for others, respect for the Organization and respect for its mission.
+
+The Code of Conduct is the blueprint for how we work together. It was launched in 2010, accompanied by an Ombud Oﬃce to provide an informal route to the resolution of potential conflicts, and to serve as an interpreter of the Code of Conduct if and when necessary. I think it is fair to say that since then CERN’s values have become a natural and inherent part of the Organisation’s working landscape.
+
+There have been occasions where people have had to be reminded of the Code’s stipulations, but these have been rare. Rather than a tool for the Organization to use as a stick, the Code is a tool for all of us to use as a guide.
+
+Our Code of Conduct sets out in black and white the basic standards and rules of behaviour that we can expect to find in the workplace, and it provides guidance on how our actions may influence and support the good reputation of CERN. It is there to ensure that we pursue our mission of research, innovation, training and collaboration while respecting the highest ethical standards of behaviour.
+
+It is not an exhaustive list of dos and don’ts. Rather, it is a practical guide, assisting us in understanding the consequences of how we treat others, how can we expect to be treated in the workplace, and how we should behave as ambassadors for CERN and for particle physics. It serves to help us maintain and develop a workplace marked by mutual respect.
+
+Nurturing respect generates self-respect, and a respectful workplace is one where everyone can give their best in a supportive, collaborative, and pleasant environment.
+
+**Fabiola Gianotti**, Director-General
+
+## INTEGRITY
+BEHAVING ETHICALLY, WITH INTELLECTUAL HONESTY AND BEING ACCOUNTABLE FOR ONE’S OWN ACTIONS.
+
+A high standard of integrity in the performance of our work and in our relationships with others promotes a culture of trust and responsibility.
+
+### AS CERN CONTRIBUTORS, WE:
+
+- Exercise our authority responsibly. In particular, we abstain from using our authority or position to obtain personal benefits or favours.
+- Demonstrate fairness and impartiality.
+- Ensure that we credit others for their contribution.
+- Avoid conflict of interest or situations that could be perceived as such.
+- Refrain from any act or omission designed to deceive others, or to achieve a gain resulting in a loss of funds or reputation for CERN.
+- Safeguard confidential information, documents or data, and ensure that such material in our possession is properly protected.
+- Respect the privacy of others and protect personal information given to us in confidence.
+
+## COMMITMENT
+DEMONSTRATING A HIGH LEVEL OF MOTIVATION AND DEDICATION TO THE ORGANIZATION
+
+Our collective commitment to CERN is essential both to the achievement of its mission and the protection of its reputation.
+
+### AS CERN CONTRIBUTORS, WE:
+- Promote the CERN mission and act in accordance with CERN values.
+- Appreciate that our behaviour, both on site and outside CERN, may reflect upon CERN.
+- Protect the reputation of CERN and our colleagues in communications with internal and external parties.
+- Familiarize ourselves with all applicable rules and regulations.
+- Promote and maintain a safe and healthy environment, following relevant safety rules.
+- Educate ourselves on the responsibilities which accompany the privileges and immunities which may be granted to us for the benefit of CERN.
+- Demonstrate flexibility and adapt to CERN’s evolving needs.
+
+## PROFESSIONALISM
+PRODUCING A HIGH LEVEL OF RESULTS WITHIN RESOURCE AND TIME CONSTRAINTS AND FOSTERING MUTUAL UNDERSTANDING
+
+Our ability to deliver and to create a positive work environment permits us to achieve high professional standards, individually and collectively.
+
+### AS CERN CONTRIBUTORS, WE:
+
+- Define clear and realistic objectives and deliverables for our activities, and communicate them to our colleagues.
+- Ensure that the human, material and financial resources entrusted to us are used optimally for the benefit of CERN.
+- Invest in CERN’s future by taking long-term effectiveness into account when managing short and medium-term activities.
+- Maintain a professional environment characterized by good working relations and an atmosphere of tolerance and mutual respect.
+- Provide advice and guidance to colleagues, where appropriate, and exercise adequate supervision and control over tasks that we delegate.
+- Address conflict proactively and impartially.
+- Abstain from and actively discourage all forms of harassment as well as verbal, non-verbal, written or physical abuse.
+
+## CREATIVITY
+BEING AT THE FOREFRONT OF ONE’S PROFESSIONAL FIELD, FURTHERING INNOVATION AND ORGANIZATIONAL DEVELOPMENT
+
+CERN encourages continuous learning and development and values innovation as well as a proactive approach to acquiring and sharing information.
+
+### AS CERN CONTRIBUTORS, WE:
+- Follow developments within our domain.
+- Use our professional experience in a constructive manner.
+- Contribute to the evolution of CERN by committing to sharing our knowledge.
+- Share with internal parties any information that could benefit them in their work.
+- Are open to new ideas and approaches.
+- Adopt alternative outlooks in order to generate new thoughts and concepts.
+- Conduct our work in a structured way to enhance knowledge transfer and continuity.
+
+## DIVERSITY
+APPRECIATING DIFFERENCES, FOSTERING EQUALITY, AND PROMOTING COLLABORATION
+
+CERN’s excellence derives from an environment in which the knowledge and perspectives of a diverse workforce are valued and dialogue is encouraged at all levels.
+
+### AS CERN CONTRIBUTORS, WE:
+- Respect and value differences.
+- Promote inclusiveness in the workplace in terms of both personal characteristics and professional abilities.
+- Demonstrate team spirit and invest in team building.
+- Treat others with tact, courtesy and respect.
+- Abstain from and actively discourage discrimination in all forms.
+- Avoid offending others by exercising restraint, and are aware that statements or actions not intended to be offensive to another person may be perceived as such.
+- Refrain from unpleasant or disparaging remarks or actions, in particular on the basis of sex, age, religion, beliefs, nationality, culture, ethnicity, race, sexual orientation, status at CERN, disability, or family situation.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,167 @@
+<!--
+SPDX-FileCopyrightText: 2010-2020 CERN
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# Contributing to AdePT
+
+Contributions to the AdePT project are very welcome and feedback on the documentation is greatly appreciated.
+
+Please also see our [code of conduct](CODE_OF_CONDUCT.md).
+
+## Mailing lists
+
+**FIXME: We need to set these up**
+
+## Bug reports and feature requests
+
+To report an issue and before starting work, please create an issue in the [Github issue tracker](https://github.com/apt-sim/AdePT/issues). A comprehensive explanation will help the development team to respond in a timely manner. Verbalizing the issue before starting work allows the other contributors to chime in and avoids disagreements how to progress.
+
+- The title should summarize the issue
+- Describe the issue in as much detail as possible in the comment
+
+Github does not allow editing labels, assignees or setting milestone to non-members of a project with at least "Triage" permission. These will have to be set by members with Triage permission after an issue/PR is created.
+Guidelines regarding labels, assignees and milestone therefore only concern members of apt-sim with the necessary rights and can be ignored by others.
+
+- Assign to yourself or leave empty
+- Choose labels as appropriate
+  - type of issue
+  - which component is affected
+  - urgency
+  - fix versions
+- bug reports
+  - mention affected version(s)
+  - issue type: "Bug"
+  - a detailed description of the bug including a recipe on how to reproduce it and any hints which may help diagnosing the problem
+- feature requests
+  - issue type: "Improvement" or "New Feature"
+  - a detailed description of the feature request including possible use cases and benefits for other users
+
+## Make a contribution
+
+Anyone is welcome to contribute to AdePT. Below is a short description how to contribute. If you have any questions, feel free to ask us **FIXME add mailing list** for help or guidance.
+
+Please always fork the AdePT repository and create branches only in your own fork. Once you want to share your work, create a Pull Request (PR) (for gitlab users: equivalent to merge request) to the master branch of the upstream AdePT repository. If it is not yet ready to be merged in, please create a draft pull request (by clicking on the small arrow on the green "create pull request" button) to mark it *work in progress*. Once you want your branch to be merged in, request a review. Once a draft merge request is reviewed, it can be merged in.
+
+To get started with git, please refer to the [short introduction](http://git-scm.com/docs/gittutorial) as well as the [full git documentation](https://git-scm.com/doc). Tutorials as well as explanations of concepts and workflows with git can also be found on [Atlassian](http://www.atlassian.com/git/).
+
+### Checklist for pull requests
+
+- Your branch has been rebased on the target branch and can be integrated through a fast-forward merge.
+- A detailed description of the pull request is provided.
+- The issue the PR closes is linked.
+- All CI jobs pass.
+- All newly introduced functions and classes have been documented properly with doxygen.
+- Unit tests are provided for new functionalities.
+- For bugfixes: a test case has been added to avoid the re-appearance of this bug in the future.
+- All added cmake options were added to 'cmake/PrintOptions.cmake'.
+
+### Workflow recommendations
+
+In the following a few recommendations are outlined which should help you to get familiar with development process in the AdePT project.
+
+1. **Each development in its own branch of your private fork!**
+Write access for developers has been disabled for developers on AdePT-project. Therefore, always start by creating your own fork and creating branches there. You should start a new branch for every development and all work which is logically/conceptually linked should happen in one branch. Try to keep your branches short. This helps immensely to understand the git history if you need to look at it in the future and helps reviewers of your code.
+If projects are complex (e.g. large code refactoring or complex new features), you may want to use _sub_-branches from the main development branch.
+
+1. **Never, ever directly work on any "official" branch!**
+Though not strictly necessary and in the end it is up to you, it is strongly recommended that you never commit directly on a branch which tracks an "official" branch. As all branches are equal in git, the definition of "official" branch is quite subjective. In the AdePT project you should not work directly on branches which are **protected** in the repository. Usually, these are the _master_ and _release/X.Y.Z_ branches. The benefit of this strategy is that you will never have problems to update your fork. Any git merge in your local repository on such an "official" branch will always be a fast-forward merge.
+
+1. **Use atomic commits!**
+Similarly to the concept of branches, each commit should reflect a self-contained change. Try to avoid overly large commits (bad examples are for instance mixing logical change with code cleanup and typo fixes).
+
+1. **Write good commit messages!**
+Well-written commit messages are key to understand your changes. There are many guidelines available on how to write proper commit logs (e.g. [here](http://alistapart.com/article/the-art-of-the-commit), [here](http://chris.beams.io/posts/git-commit/), or [here](https://wiki.openstack.org/wiki/GitCommitMessages#Information_in_commit_messages)). As a short summary:
+    - Structure your commit messages into short title (max 50 characters) and longer description (max width 72 characters)!
+      This is best achieved by avoiding the `commit -m` option. Instead write the commit message in an editor/git tool/IDE...
+    - Describe why you did the change (git diff already tells you what has changed)!
+    - Mention any side effects/implications/consequences!
+
+1. **Prefer git pull --rebase!**
+If you work with a colleague on a new development, you may want to include his latest changes. This is usually done by calling `git pull` which will synchronise your local working copy with the remote repository (which may have been updated by your colleague). By default, this action creates a merge commit if you have local commits which were not yet published to the remote repository. These merge commits are considered to contribute little information to the development process of the feature and they clutter the history (read more e.g.  [here](https://developer.atlassian.com/blog/2016/04/stop-foxtrots-now/) or [here](http://victorlin.me/posts/2013/09/30/keep-a-readable-git-history)). This problem can be avoided by using `git pull --rebase` which replays your local (un-pushed) commits on the tip of the remote branch. You can make this the default behaviour by running `git config pull.rebase true`. More about merging vs rebasing can be found [here](https://www.atlassian.com/git/tutorials/merging-vs-rebasing/).
+
+1. **Update the documentation!**
+Make sure that the documentation is still valid after your changes. Perform updates where needed and ensure integrity between the code and its documentation.
+
+### Coding style and guidelines
+
+#### C++
+
+The AdePT project uses [clang-format](http://clang.llvm.org/docs/ClangFormat.html) for formatting its C++ source code. A `.clang-format` configuration file comes with the project **FIXME** and should be used to automatically format the code. Developers can use the provided Docker image to format their project or install clang-format locally. Developers should be aware that clang-format will behave differently for different versions, so installing the same clang version as used in the CI **FIXME** is recommended. There are several instructions available on how to integrate clang-format with your favourite IDE (e.g. [eclipse](https://marketplace.eclipse.org/content/cppstyle), [Xcode](https://github.com/travisjeffery/ClangFormat-Xcode), [emacs](http://clang.llvm.org/docs/ClangFormat.html#emacs-integration)). The AdePT CI system will automatically apply code reformatting using the provided clang-format configuration once pull requests are opened. However, developers are encouraged to use this code formatter also locally to reduce conflicts due to formatting issues.
+
+In addition, some conventions are used in AdePT code, details can be found [here](https://AdePT.readthedocs.io/en/latest/codeguide.html). For Doxygen documentation, please follow these recommendations:
+
+- Put all documentation in the header files.
+- Use `///` as block comment (instead of `/* ... */`).
+- Doxygen documentation goes in front of the documented entity (class, function, (member) variable).
+- Use the `@<cmd>` notation.
+- Document all (template) parameters using \@(t)param and explain the return value for non-void functions. Mention important conditions which may affect the return value.
+- Use `@remark` to specify pre-conditions.
+- Use `@note` to provide additional information.
+- Link other related entities (e.g. functions) using `@sa`.
+
+#### Python
+
+Any Python code should be formatted with `black` and should be clean when run through the `flake8` Python linter. There is a `.flake8` file in the repository that will set the configuration to be compatible with `black`.
+
+#### Markdown
+
+This is **TBD**!
+
+Markdown files should conform to the `markdownlint` specifications from [David Anson](https://github.com/DavidAnson/markdownlint).
+
+### Example: Make a bugfix while working on a feature
+  
+During the development of a new feature you discover a bug which needs to be fixed. In order to not mix bugfix and feature development, the bugfix should happen in a different branch. The recommended procedure for handling this situation is the following:
+
+1. Get into a clean state of your working directory on your feature branch (either by committing open changes or by stashing them).
+1. Checkout the branch the bugfix should be merged into (either _master_ or _release/X.Y.Z_) and get the most recent version.
+1. Create a new branch for the bugfix.
+1. Fix the bug, write a test, update documentation etc.
+1. Open a pull request for the bug fix.
+1. Switch back to your feature branch.
+1. Merge your local bugfix branch into the feature branch. Continue your feature development.
+1. Eventually, the bugfix will be merged into _master_. Then, you can rebase your feature branch on master which will remove all duplicate commits related to the bugfix.
+
+### Example: Backporting a feature or bugfix
+
+Suppose you have a bugfix or feature branch that is eventually going to be merged in `master`. You might want to have the feature/bugfix available in a patch (say `0.25.1`) tag. To to that, find the corresponding release branch, for this example that would be `release/v0.25.X`. You must create a dedicated branch that **only** contains the commits that relate to your feature/bugfix, otherwise the PR will contain all other commits that were merged into master since the release was branched off. With that branch, open a PR to that branch, and make it clear that it is a backport, also linking to a potential equivalent PR that targets `master`.
+
+### Tips for users migrating from Gitlab
+
+- The most obvious difference first: What is called Merge Request (MR) in GitLab is called Pull Request (PR) in Github.
+- Once your PR is ready to be merged, request a review by the users in the [reviewers team](https://github.com/orgs/AdePT-project/teams/reviewers)
+- As AdePT started enforcing using your own fork with the switch to Github, developers no longer have write access to the upstream repository.
+- The CI will fail if a PR does not yet have the required approvals.
+
+## Review other contributions
+
+AdePT requires that every pull request receives at least one review by a member of the reviewers team before being merged but anyone is welcome to contribute by commenting on code changes. You can help reviewing proposed contributions by going to [the "pull requests" section of the AdePT (core) Github repository](https://github.com/apt-sim/AdePT/pulls).
+
+As some of the guidelines recommended here require rights granted to the reviewers team, this guide specifically addresses the people in this team. The present contribution guide should serve as a good indication of what we expect from code submissions.
+
+### Configuring your own PRs and PRs by people with read rights
+
+- Check if the "request review" label is set, if it is a draft PR or if the title starts with WIP. The latter two are equivalent.
+- Check if the "triage" label is set and configure labels, assignees and milestone for those PR
+  - Needs at least label "Bug", "Improvement", "Infrastructure" or "New Feature"
+
+### Approving a pull request
+
+- Does its title and description reflect its contents?
+- Do the automated continuous integration tests pass without problems?
+- Have all the comments raised by previous reviewers been addressed?
+
+If you are confident that a pull request is ready for integration, please make it known by clicking the "Approve pull request" button of the GitLab interface. This notifies other members of the AdePT team of your decision, and marks the pull request as ready to be merged.
+
+### Merging a pull request
+
+If you have been granted write access on the AdePT repository, you can merge a pull request into the AdePT master branch after it has been approved.
+
+Github may warn you that a "Fast-forward merge is not possible". This warning means that the pull request has fallen behind the current AdePT master branch, and should be updated through a rebase. Please notify the pull request author in order to make sure that the latest master changes do not affect the pull request, and to have it updated as appropriate.
+
+For a PR that is behind master, a button "Update branch" may appear. This should NOT be used as it merges instead of rebasing, which is not our workflow.
+
+## Acknowledgement
+
+This contribution guide was inspired by the guide from the [Acts project](https://github.com/acts-project/acts). Thanks to those authors!

--- a/LICENSES/CC-BY-ND-4.0.txt
+++ b/LICENSES/CC-BY-ND-4.0.txt
@@ -1,0 +1,321 @@
+Creative Commons Attribution-NoDerivatives 4.0 International Creative Commons
+Corporation ("Creative Commons") is not a law firm and does not provide legal
+services or legal advice. Distribution of Creative Commons public licenses
+does not create a lawyer-client or other relationship. Creative Commons makes
+its licenses and related information available on an "as-is" basis. Creative
+Commons gives no warranties regarding its licenses, any material licensed
+under their terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the fullest
+extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and conditions
+that creators and other rights holders may use to share original works of
+authorship and other material subject to copyright and certain other rights
+specified in the public license below. The following considerations are for
+informational purposes only, are not exhaustive, and do not form part of our
+licenses.
+
+Considerations for licensors: Our public licenses are intended for use by
+those authorized to give the public permission to use material in ways otherwise
+restricted by copyright and certain other rights. Our licenses are irrevocable.
+Licensors should read and understand the terms and conditions of the license
+they choose before applying it. Licensors should also secure all rights necessary
+before applying our licenses so that the public can reuse the material as
+expected. Licensors should clearly mark any material not subject to the license.
+This includes other CC-licensed material, or material used under an exception
+or limitation to copyright. More considerations for licensors : wiki.creativecommons.org/Considerations_for_licensors
+
+Considerations for the public: By using one of our public licenses, a licensor
+grants the public permission to use the licensed material under specified
+terms and conditions. If the licensor's permission is not necessary for any
+reason–for example, because of any applicable exception or limitation to copyright–then
+that use is not regulated by the license. Our licenses grant only permissions
+under copyright and certain other rights that a licensor has authority to
+grant. Use of the licensed material may still be restricted for other reasons,
+including because others have copyright or other rights in the material. A
+licensor may make special requests, such as asking that all changes be marked
+or described. Although not required by our licenses, you are encouraged to
+respect those requests where reasonable. More considerations for the public
+: wiki.creativecommons.org/Considerations_for_licensees
+
+Creative Commons Attribution-NoDerivatives 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree to
+be bound by the terms and conditions of this Creative Commons Attribution-NoDerivatives
+4.0 International Public License ("Public License"). To the extent this Public
+License may be interpreted as a contract, You are granted the Licensed Rights
+in consideration of Your acceptance of these terms and conditions, and the
+Licensor grants You such rights in consideration of benefits the Licensor
+receives from making the Licensed Material available under these terms and
+conditions.
+
+Section 1 – Definitions.
+
+a. Adapted Material means material subject to Copyright and Similar Rights
+that is derived from or based upon the Licensed Material and in which the
+Licensed Material is translated, altered, arranged, transformed, or otherwise
+modified in a manner requiring permission under the Copyright and Similar
+Rights held by the Licensor. For purposes of this Public License, where the
+Licensed Material is a musical work, performance, or sound recording, Adapted
+Material is always produced where the Licensed Material is synched in timed
+relation with a moving image.
+
+b. Copyright and Similar Rights means copyright and/or similar rights closely
+related to copyright including, without limitation, performance, broadcast,
+sound recording, and Sui Generis Database Rights, without regard to how the
+rights are labeled or categorized. For purposes of this Public License, the
+rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+c. Effective Technological Measures means those measures that, in the absence
+of proper authority, may not be circumvented under laws fulfilling obligations
+under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996,
+and/or similar international agreements.
+
+d. Exceptions and Limitations means fair use, fair dealing, and/or any other
+exception or limitation to Copyright and Similar Rights that applies to Your
+use of the Licensed Material.
+
+e. Licensed Material means the artistic or literary work, database, or other
+material to which the Licensor applied this Public License.
+
+f. Licensed Rights means the rights granted to You subject to the terms and
+conditions of this Public License, which are limited to all Copyright and
+Similar Rights that apply to Your use of the Licensed Material and that the
+Licensor has authority to license.
+
+g. Licensor means the individual(s) or entity(ies) granting rights under this
+Public License.
+
+h. Share means to provide material to the public by any means or process that
+requires permission under the Licensed Rights, such as reproduction, public
+display, public performance, distribution, dissemination, communication, or
+importation, and to make material available to the public including in ways
+that members of the public may access the material from a place and at a time
+individually chosen by them.
+
+i. Sui Generis Database Rights means rights other than copyright resulting
+from Directive 96/9/EC of the European Parliament and of the Council of 11
+March 1996 on the legal protection of databases, as amended and/or succeeded,
+as well as other essentially equivalent rights anywhere in the world.
+
+j. You means the individual or entity exercising the Licensed Rights under
+this Public License. Your has a corresponding meaning.
+
+Section 2 – Scope.
+
+   a. License grant.
+
+1. Subject to the terms and conditions of this Public License, the Licensor
+hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive,
+irrevocable license to exercise the Licensed Rights in the Licensed Material
+to:
+
+         A. reproduce and Share the Licensed Material, in whole or in part; and
+
+         B. produce and reproduce, but not Share, Adapted Material.
+
+2. Exceptions and Limitations. For the avoidance of doubt, where Exceptions
+and Limitations apply to Your use, this Public License does not apply, and
+You do not need to comply with its terms and conditions.
+
+      3. Term. The term of this Public License is specified in Section 6(a).
+
+4. Media and formats; technical modifications allowed. The Licensor authorizes
+You to exercise the Licensed Rights in all media and formats whether now known
+or hereafter created, and to make technical modifications necessary to do
+so. The Licensor waives and/or agrees not to assert any right or authority
+to forbid You from making technical modifications necessary to exercise the
+Licensed Rights, including technical modifications necessary to circumvent
+Effective Technological Measures. For purposes of this Public License, simply
+making modifications authorized by this Section 2(a)(4) never produces Adapted
+Material.
+
+      5. Downstream recipients.
+
+A. Offer from the Licensor – Licensed Material. Every recipient of the Licensed
+Material automatically receives an offer from the Licensor to exercise the
+Licensed Rights under the terms and conditions of this Public License.
+
+B. No downstream restrictions. You may not offer or impose any additional
+or different terms or conditions on, or apply any Effective Technological
+Measures to, the Licensed Material if doing so restricts exercise of the Licensed
+Rights by any recipient of the Licensed Material.
+
+6. No endorsement. Nothing in this Public License constitutes or may be construed
+as permission to assert or imply that You are, or that Your use of the Licensed
+Material is, connected with, or sponsored, endorsed, or granted official status
+by, the Licensor or others designated to receive attribution as provided in
+Section 3(a)(1)(A)(i).
+
+   b. Other rights.
+
+1. Moral rights, such as the right of integrity, are not licensed under this
+Public License, nor are publicity, privacy, and/or other similar personality
+rights; however, to the extent possible, the Licensor waives and/or agrees
+not to assert any such rights held by the Licensor to the limited extent necessary
+to allow You to exercise the Licensed Rights, but not otherwise.
+
+2. Patent and trademark rights are not licensed under this Public License.
+
+3. To the extent possible, the Licensor waives any right to collect royalties
+from You for the exercise of the Licensed Rights, whether directly or through
+a collecting society under any voluntary or waivable statutory or compulsory
+licensing scheme. In all other cases the Licensor expressly reserves any right
+to collect such royalties.
+
+Section 3 – License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the following
+conditions.
+
+   a. Attribution.
+
+      1. If You Share the Licensed Material, You must:
+
+A. retain the following if it is supplied by the Licensor with the Licensed
+Material:
+
+i. identification of the creator(s) of the Licensed Material and any others
+designated to receive attribution, in any reasonable manner requested by the
+Licensor (including by pseudonym if designated);
+
+            ii. a copyright notice;
+
+            iii. a notice that refers to this Public License;
+
+            iv. a notice that refers to the disclaimer of warranties;
+
+v. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+
+B. indicate if You modified the Licensed Material and retain an indication
+of any previous modifications; and
+
+C. indicate the Licensed Material is licensed under this Public License, and
+include the text of, or the URI or hyperlink to, this Public License.
+
+2. For the avoidance of doubt, You do not have permission under this Public
+License to Share Adapted Material.
+
+3. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner
+based on the medium, means, and context in which You Share the Licensed Material.
+For example, it may be reasonable to satisfy the conditions by providing a
+URI or hyperlink to a resource that includes the required information.
+
+4. If requested by the Licensor, You must remove any of the information required
+by Section 3(a)(1)(A) to the extent reasonably practicable.
+
+Section 4 – Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to
+Your use of the Licensed Material:
+
+a. for the avoidance of doubt, Section 2(a)(1) grants You the right to extract,
+reuse, reproduce, and Share all or a substantial portion of the contents of
+the database, provided You do not Share Adapted Material;
+
+b. if You include all or a substantial portion of the database contents in
+a database in which You have Sui Generis Database Rights, then the database
+in which You have Sui Generis Database Rights (but not its individual contents)
+is Adapted Material; and
+
+c. You must comply with the conditions in Section 3(a) if You Share all or
+a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not replace
+Your obligations under this Public License where the Licensed Rights include
+other Copyright and Similar Rights.
+
+Section 5 – Disclaimer of Warranties and Limitation of Liability.
+
+a. Unless otherwise separately undertaken by the Licensor, to the extent possible,
+the Licensor offers the Licensed Material as-is and as-available, and makes
+no representations or warranties of any kind concerning the Licensed Material,
+whether express, implied, statutory, or other. This includes, without limitation,
+warranties of title, merchantability, fitness for a particular purpose, non-infringement,
+absence of latent or other defects, accuracy, or the presence or absence of
+errors, whether or not known or discoverable. Where disclaimers of warranties
+are not allowed in full or in part, this disclaimer may not apply to You.
+
+b. To the extent possible, in no event will the Licensor be liable to You
+on any legal theory (including, without limitation, negligence) or otherwise
+for any direct, special, indirect, incidental, consequential, punitive, exemplary,
+or other losses, costs, expenses, or damages arising out of this Public License
+or use of the Licensed Material, even if the Licensor has been advised of
+the possibility of such losses, costs, expenses, or damages. Where a limitation
+of liability is not allowed in full or in part, this limitation may not apply
+to You.
+
+c. The disclaimer of warranties and limitation of liability provided above
+shall be interpreted in a manner that, to the extent possible, most closely
+approximates an absolute disclaimer and waiver of all liability.
+
+Section 6 – Term and Termination.
+
+a. This Public License applies for the term of the Copyright and Similar Rights
+licensed here. However, if You fail to comply with this Public License, then
+Your rights under this Public License terminate automatically.
+
+b. Where Your right to use the Licensed Material has terminated under Section
+6(a), it reinstates:
+
+1. automatically as of the date the violation is cured, provided it is cured
+within 30 days of Your discovery of the violation; or
+
+      2. upon express reinstatement by the Licensor.
+
+c. For the avoidance of doubt, this Section 6(b) does not affect any right
+the Licensor may have to seek remedies for Your violations of this Public
+License.
+
+d. For the avoidance of doubt, the Licensor may also offer the Licensed Material
+under separate terms or conditions or stop distributing the Licensed Material
+at any time; however, doing so will not terminate this Public License.
+
+   e. Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+
+Section 7 – Other Terms and Conditions.
+
+a. The Licensor shall not be bound by any additional or different terms or
+conditions communicated by You unless expressly agreed.
+
+b. Any arrangements, understandings, or agreements regarding the Licensed
+Material not stated herein are separate from and independent of the terms
+and conditions of this Public License.
+
+Section 8 – Interpretation.
+
+a. For the avoidance of doubt, this Public License does not, and shall not
+be interpreted to, reduce, limit, restrict, or impose conditions on any use
+of the Licensed Material that could lawfully be made without permission under
+this Public License.
+
+b. To the extent possible, if any provision of this Public License is deemed
+unenforceable, it shall be automatically reformed to the minimum extent necessary
+to make it enforceable. If the provision cannot be reformed, it shall be severed
+from this Public License without affecting the enforceability of the remaining
+terms and conditions.
+
+c. No term or condition of this Public License will be waived and no failure
+to comply consented to unless expressly agreed to by the Licensor.
+
+d. Nothing in this Public License constitutes or may be interpreted as a limitation
+upon, or waiver of, any privileges and immunities that apply to the Licensor
+or You, including from the legal processes of any jurisdiction or authority.
+
+Creative Commons is not a party to its public licenses. Notwithstanding, Creative
+Commons may elect to apply one of its public licenses to material it publishes
+and in those instances will be considered the "Licensor." The text of the
+Creative Commons public licenses is dedicated to the public domain under the
+CC0 Public Domain Dedication. Except for the limited purpose of indicating
+that material is shared under a Creative Commons public license or as otherwise
+permitted by the Creative Commons policies published at creativecommons.org/policies,
+Creative Commons does not authorize the use of the trademark "Creative Commons"
+or any other trademark or logo of Creative Commons without its prior written
+consent including, without limitation, in connection with any unauthorized
+modifications to any of its public licenses or any other arrangements, understandings,
+or agreements concerning use of licensed material. For the avoidance of doubt,
+this paragraph does not form part of the public licenses.
+
+Creative Commons may be contacted at creativecommons.org.


### PR DESCRIPTION
Code of conduct is from CERN, which seems to be perfect for out project - thanks to @paulgessinger for having textified it in Acts.

Contribution guide is also an adapted version from Acts (thanks!), so makes reference to things that we have not yet setup in AdePT (marked by **FIXME**), but does form a good basis for discussion.

Note that as well as C++ I added some draft guidance for Python and Markdown files in the project.

Closes #3 
