### PR TITLE
Added atomic ops type and BlockData concurrent container

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,16 +42,13 @@ set(VecCore_VERSION 0.5.2)
 set(VecCore_BACKEND CUDA)
 find_package(VecCore ${VecCore_VERSION} REQUIRED COMPONENTS ${VecCore_BACKEND})
 message(STATUS "Using VecCore version ${VecCore_VERSION}")
-add_definitions(${VecCore_CUDA_DEFINITIONS})
-set(ADEPT_LIBRARIES_EXTERNAL ${ADEPT_LIBRARIES_EXTERNAL} VecCore::VecCore)
 
 # Find VecGeom geometry headers library
 set(VecGeom_VERSION 1.1.7)
 find_package(VecGeom ${VecGeom_VERSION} REQUIRED)
 message(STATUS "Using VecGeom version ${VecGeom_VERSION}")
-# make sure we import VecGeom architecture flags
+# make sure we import VecGeom architecture flags - is this needed?
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${VECGEOM_CXX_FLAGS}")
-set(ADEPT_LIBRARIES_EXTERNAL ${ADEPT_LIBRARIES_EXTERNAL} ${VECGEOM_LIBRARIES})
 
 # Builds...
 add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ set(VecCore_VERSION 0.5.2)
 set(VecCore_BACKEND CUDA)
 find_package(VecCore ${VecCore_VERSION} REQUIRED COMPONENTS ${VecCore_BACKEND})
 message(STATUS "Using VecCore version ${VecCore_VERSION}")
+add_definitions(${VecCore_CUDA_DEFINITIONS})
 set(ADEPT_LIBRARIES_EXTERNAL ${ADEPT_LIBRARIES_EXTERNAL} VecCore::VecCore)
 
 # Find VecGeom geometry headers library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ project(Adept
 # - Include needed custom/core modules
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 include(CMakeSettings)
+include(CTest)
 
 # - Core/C++/CUDA build and dependency settings
 # For single-mode generators, default to Optimized with Debug if nothing is specified

--- a/base/inc/AdePT/Atomic.h
+++ b/base/inc/AdePT/Atomic.h
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file Utils.h
+ * @brief Portable atomic structure.
+ * @author Andrei Gheata (andrei.gheata@cern.ch)
+ */
+
+#ifndef ADEPT_ATOMIC_H_
+#define ADEPT_ATOMIC_H_
+
+#include <VecCore/CUDA.h>
+#include <AdePT/Utils.h>
+#ifndef VECCORE_CUDA_DEVICE_COMPILATION
+#include <atomic>
+#endif
+
+namespace adept {
+/**
+ * @brief A portable atomic type. Not all base types are supported by CUDA.
+ */
+template <typename Type>
+struct Atomic_t {
+
+  /** @brief Constructor taking an address */
+  Atomic_t(void *addr) { EmplaceDataAt(addr); }
+
+  /** @brief Emplace the data at a given address */
+  char *EmplaceDataAt(void *addr)
+  {
+    if (addr) {
+      fData = (AtomicType_t *)utils::round_up_align((char *)addr, alignof(AtomicType_t));
+      store(0);
+    }
+    return (char *)fData;
+  }
+
+  /** @brief Compute size of the data, including the alignment offset */
+  static size_t SizeOfData() { return (sizeof(AtomicType_t) + alignof(AtomicType_t)); }
+
+#ifndef VECCORE_CUDA_DEVICE_COMPILATION
+  /// Standard library atomic behaviour.
+  using AtomicType_t = std::atomic<Type>;
+
+  /** @brief Atomically assigns the desired value to the atomic variable. */
+  Type operator=(Type desired) { return fData->operator=(desired); }
+
+  /** @brief Atomically replaces the current value with desired. */
+  void store(Type desired) { fData->store(desired); }
+
+  /** @brief Atomically loads and returns the current value of the atomic variable. */
+  Type load() { return fData->load(); }
+
+  /** @brief Atomically replaces the underlying value with desired. */
+  Type exchange(Type desired) { return fData->exchange(desired); }
+
+  /** @brief Atomically replaces the current value with the result of arithmetic addition of the value and arg. */
+  Type fetch_add(Type arg) { return fData->fetch_add(arg); }
+
+  /** @brief Atomically replaces the current value with the result of arithmetic subtraction of the value and arg. */
+  Type fetch_sub(Type arg) { return fData->fetch_sub(arg); }
+
+  /** @brief Atomically replaces the current value with the result of bitwise AND of the value and arg. */
+  Type fetch_and(Type arg) { return fData->fetch_and(arg); }
+
+  /** @brief Atomically replaces the current value with the result of bitwise OR of the value and arg. */
+  Type fetch_or(Type arg) { return fData->fetch_or(arg); }
+
+  /** @brief Atomically replaces the current value with the result of bitwise XOR of the value and arg. */
+  Type fetch_xor(Type arg) { return fData->fetch_xor(arg); }
+
+  /** @brief Atomically compares the stored value with the expected one, and if equal stores desired.
+   * If not loads the old value into expected. Returns true if swap was successful. */
+  bool compare_exchange_strong(Type &expected, Type desired)
+  {
+    return fData->compare_exchange_strong(expected, desired);
+  }
+
+  /** @brief Performs atomic pre-increment. */
+  Type operator++() { return (fetch_add(1) + 1); }
+
+  /** @brief Performs atomic post-increment. */
+  Type operator++(int) { return fetch_add(1); }
+
+  /** @brief Performs atomic pre-decrement. */
+  Type operator--() { return (fetch_sub(1) - 1); }
+
+  /** @brief Performs atomic post-decrement. */
+  Type operator--(int) { return fetch_sub(1); }
+
+#else
+  /// CUDA atomic operations.
+  using AtomicType_t = Type;
+
+  /** @brief Atomically assigns the desired value to the atomic variable. */
+  VECCORE_ATT_DEVICE
+  Type operator=(Type desired)
+  {
+    atomicExch(fData, desired);
+    return desired;
+  }
+
+  /** @brief Atomically replaces the current value with desired. */
+  VECCORE_ATT_DEVICE
+  void store(Type desired) { atomicExch(fData, desired); }
+
+  /** @brief Atomically loads and returns the current value of the atomic variable. */
+  VECCORE_ATT_DEVICE
+  Type load() { return *fData; }
+
+  /** @brief Atomically replaces the underlying value with desired. */
+  VECCORE_ATT_DEVICE
+  Type exchange(Type desired) { return atomicExch(fData, desired); }
+
+  /** @brief Atomically replaces the current value with the result of arithmetic addition of the value and arg. */
+  VECCORE_ATT_DEVICE
+  Type fetch_add(Type arg) { return atomicAdd(fData, arg); }
+
+  /** @brief Atomically replaces the current value with the result of arithmetic subtraction of the value and arg. */
+  VECCORE_ATT_DEVICE
+  Type fetch_sub(Type arg) { return atomicAdd(fData, -arg); }
+
+  /** @brief Atomically replaces the current value with the result of bitwise AND of the value and arg. */
+  VECCORE_ATT_DEVICE
+  Type fetch_and(Type arg) { return atomicAnd(fData, arg); }
+
+  /** @brief Atomically replaces the current value with the result of bitwise OR of the value and arg. */
+  VECCORE_ATT_DEVICE
+  Type fetch_or(Type arg) { return atomicOr(fData, arg); }
+
+  /** @brief Atomically replaces the current value with the result of bitwise XOR of the value and arg. */
+  VECCORE_ATT_DEVICE
+  Type fetch_xor(Type arg) { return atomicXor(fData, arg); }
+
+  /** @brief Atomically compares the stored value with the expected one, and if equal stores desired.
+   * If not loads the old value into expected. Returns true if swap was successful. */
+  VECCORE_ATT_DEVICE
+  bool compare_exchange_strong(Type &expected, Type desired)
+  {
+    Type old    = atomicCAS(fData, expected, desired);
+    bool worked = (old == expected);
+    if (!worked) expected = *fData;
+    return worked;
+  }
+
+  /** @brief Performs atomic pre-increment. */
+  VECCORE_ATT_DEVICE
+  Type operator++() { return (fetch_add(1) + 1); }
+
+  /** @brief Performs atomic post-increment. */
+  VECCORE_ATT_DEVICE
+  Type operator++(int) { return fetch_add(1); }
+
+  /** @brief Performs atomic pre-decrement. */
+  VECCORE_ATT_DEVICE
+  Type operator--() { return (fetch_sub(1) - 1); }
+
+  /** @brief Performs atomic post-decrement. */
+  VECCORE_ATT_DEVICE
+  Type operator--(int) { return fetch_sub(1); }
+#endif
+
+  AtomicType_t *fData{nullptr}; ///< Atomic data
+
+}; // End struct Atomic_t
+
+} // End namespace adept
+#endif // ADEPT_ATOMIC_H_

--- a/base/inc/AdePT/Atomic.h
+++ b/base/inc/AdePT/Atomic.h
@@ -48,7 +48,7 @@ struct Atomic_t {
   void store(Type desired) { fData.store(desired); }
 
   /** @brief Atomically loads and returns the current value of the atomic variable. */
-  Type load() { return fData.load(); }
+  Type load() const { return fData.load(); }
 
   /** @brief Atomically replaces the underlying value with desired. */
   Type exchange(Type desired) { return fData.exchange(desired); }
@@ -105,7 +105,7 @@ struct Atomic_t {
 
   /** @brief Atomically loads and returns the current value of the atomic variable. */
   VECCORE_ATT_DEVICE
-  Type load() { return fData; }
+  Type load() const { return fData; }
 
   /** @brief Atomically replaces the underlying value with desired. */
   VECCORE_ATT_DEVICE

--- a/base/inc/AdePT/Atomic.h
+++ b/base/inc/AdePT/Atomic.h
@@ -10,8 +10,9 @@
 #ifndef ADEPT_ATOMIC_H_
 #define ADEPT_ATOMIC_H_
 
-#include <VecCore/CUDA.h>
-#include <AdePT/Utils.h>
+#include <VecCore/VecCore>
+#include <cassert>
+
 #ifndef VECCORE_CUDA_DEVICE_COMPILATION
 #include <atomic>
 #endif
@@ -22,59 +23,56 @@ namespace adept {
  */
 template <typename Type>
 struct Atomic_t {
-
   /** @brief Constructor taking an address */
-  Atomic_t(void *addr) { EmplaceDataAt(addr); }
+  VECCORE_ATT_HOST_DEVICE
+  Atomic_t() : fData{0} {}
 
   /** @brief Emplace the data at a given address */
-  char *EmplaceDataAt(void *addr)
+  VECCORE_ATT_HOST_DEVICE
+  static Atomic_t *MakeInstanceAt(void *addr)
   {
-    if (addr) {
-      fData = (AtomicType_t *)utils::round_up_align((char *)addr, alignof(AtomicType_t));
-      store(0);
-    }
-    return (char *)fData;
+    assert(addr != nullptr && "cannot allocate at nullptr address");
+    assert((((unsigned long long)addr) % alignof(AtomicType_t)) == 0 && "addr does not satisfy alignment");
+    Atomic_t *obj = new (addr) Atomic_t();
+    return obj;
   }
-
-  /** @brief Compute size of the data, including the alignment offset */
-  static size_t SizeOfData() { return (sizeof(AtomicType_t) + alignof(AtomicType_t)); }
 
 #ifndef VECCORE_CUDA_DEVICE_COMPILATION
   /// Standard library atomic behaviour.
   using AtomicType_t = std::atomic<Type>;
 
   /** @brief Atomically assigns the desired value to the atomic variable. */
-  Type operator=(Type desired) { return fData->operator=(desired); }
+  Type operator=(Type desired) { return fData.operator=(desired); }
 
   /** @brief Atomically replaces the current value with desired. */
-  void store(Type desired) { fData->store(desired); }
+  void store(Type desired) { fData.store(desired); }
 
   /** @brief Atomically loads and returns the current value of the atomic variable. */
-  Type load() { return fData->load(); }
+  Type load() { return fData.load(); }
 
   /** @brief Atomically replaces the underlying value with desired. */
-  Type exchange(Type desired) { return fData->exchange(desired); }
+  Type exchange(Type desired) { return fData.exchange(desired); }
 
   /** @brief Atomically replaces the current value with the result of arithmetic addition of the value and arg. */
-  Type fetch_add(Type arg) { return fData->fetch_add(arg); }
+  Type fetch_add(Type arg) { return fData.fetch_add(arg); }
 
   /** @brief Atomically replaces the current value with the result of arithmetic subtraction of the value and arg. */
-  Type fetch_sub(Type arg) { return fData->fetch_sub(arg); }
+  Type fetch_sub(Type arg) { return fData.fetch_sub(arg); }
 
   /** @brief Atomically replaces the current value with the result of bitwise AND of the value and arg. */
-  Type fetch_and(Type arg) { return fData->fetch_and(arg); }
+  Type fetch_and(Type arg) { return fData.fetch_and(arg); }
 
   /** @brief Atomically replaces the current value with the result of bitwise OR of the value and arg. */
-  Type fetch_or(Type arg) { return fData->fetch_or(arg); }
+  Type fetch_or(Type arg) { return fData.fetch_or(arg); }
 
   /** @brief Atomically replaces the current value with the result of bitwise XOR of the value and arg. */
-  Type fetch_xor(Type arg) { return fData->fetch_xor(arg); }
+  Type fetch_xor(Type arg) { return fData.fetch_xor(arg); }
 
   /** @brief Atomically compares the stored value with the expected one, and if equal stores desired.
    * If not loads the old value into expected. Returns true if swap was successful. */
   bool compare_exchange_strong(Type &expected, Type desired)
   {
-    return fData->compare_exchange_strong(expected, desired);
+    return fData.compare_exchange_strong(expected, desired);
   }
 
   /** @brief Performs atomic pre-increment. */
@@ -97,50 +95,50 @@ struct Atomic_t {
   VECCORE_ATT_DEVICE
   Type operator=(Type desired)
   {
-    atomicExch(fData, desired);
+    atomicExch(&fData, desired);
     return desired;
   }
 
   /** @brief Atomically replaces the current value with desired. */
   VECCORE_ATT_DEVICE
-  void store(Type desired) { atomicExch(fData, desired); }
+  void store(Type desired) { atomicExch(&fData, desired); }
 
   /** @brief Atomically loads and returns the current value of the atomic variable. */
   VECCORE_ATT_DEVICE
-  Type load() { return *fData; }
+  Type load() { return fData; }
 
   /** @brief Atomically replaces the underlying value with desired. */
   VECCORE_ATT_DEVICE
-  Type exchange(Type desired) { return atomicExch(fData, desired); }
+  Type exchange(Type desired) { return atomicExch(&fData, desired); }
 
   /** @brief Atomically replaces the current value with the result of arithmetic addition of the value and arg. */
   VECCORE_ATT_DEVICE
-  Type fetch_add(Type arg) { return atomicAdd(fData, arg); }
+  Type fetch_add(Type arg) { return atomicAdd(&fData, arg); }
 
   /** @brief Atomically replaces the current value with the result of arithmetic subtraction of the value and arg. */
   VECCORE_ATT_DEVICE
-  Type fetch_sub(Type arg) { return atomicAdd(fData, -arg); }
+  Type fetch_sub(Type arg) { return atomicAdd(&fData, -arg); }
 
   /** @brief Atomically replaces the current value with the result of bitwise AND of the value and arg. */
   VECCORE_ATT_DEVICE
-  Type fetch_and(Type arg) { return atomicAnd(fData, arg); }
+  Type fetch_and(Type arg) { return atomicAnd(&fData, arg); }
 
   /** @brief Atomically replaces the current value with the result of bitwise OR of the value and arg. */
   VECCORE_ATT_DEVICE
-  Type fetch_or(Type arg) { return atomicOr(fData, arg); }
+  Type fetch_or(Type arg) { return atomicOr(&fData, arg); }
 
   /** @brief Atomically replaces the current value with the result of bitwise XOR of the value and arg. */
   VECCORE_ATT_DEVICE
-  Type fetch_xor(Type arg) { return atomicXor(fData, arg); }
+  Type fetch_xor(Type arg) { return atomicXor(&fData, arg); }
 
   /** @brief Atomically compares the stored value with the expected one, and if equal stores desired.
    * If not loads the old value into expected. Returns true if swap was successful. */
   VECCORE_ATT_DEVICE
   bool compare_exchange_strong(Type &expected, Type desired)
   {
-    Type old    = atomicCAS(fData, expected, desired);
+    Type old    = atomicCAS(&fData, expected, desired);
     bool worked = (old == expected);
-    if (!worked) expected = *fData;
+    if (!worked) expected = fData;
     return worked;
   }
 
@@ -161,7 +159,7 @@ struct Atomic_t {
   Type operator--(int) { return fetch_sub(1); }
 #endif
 
-  AtomicType_t *fData{nullptr}; ///< Atomic data
+  AtomicType_t fData{0}; ///< Atomic data
 
 }; // End struct Atomic_t
 

--- a/base/inc/AdePT/BlockData.h
+++ b/base/inc/AdePT/BlockData.h
@@ -118,7 +118,10 @@ public:
   {
     // Try to get a hole index if any
     int index = -1;
-    if (fHoles->dequeue(index)) return &fData[index];
+    if (fHoles->dequeue(index)) {
+      fNused--;
+      return &fData[index];
+    }
     index = fNbooked.fetch_add(1);
     if (index >= fCapacity) return nullptr;
     fNused++;

--- a/base/inc/AdePT/BlockData.h
+++ b/base/inc/AdePT/BlockData.h
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file BlockData.h
+ * @brief Templated data structure storing a contiguous block of data.
+ * @author Andrei Gheata (andrei.gheata@cern.ch)
+ */
+
+#ifndef ADEPT_BLOCKDATA_H_
+#define ADEPT_BLOCKDATA_H_
+
+#include <AdePT/Atomic.h>
+#include <VecGeom/base/VariableSizeObj.h>
+
+namespace adept {
+
+/** @brief A container of data that adopts memory. It is caller responsibility to allocate
+  at least SizeOfInstance bytes for a single object, and SizeOfAlignAware for multiple objects.
+  Write access to data elements in the block is given atomically, up to the capacity.
+ */
+template <typename Type>
+class BlockData : protected vecgeom::VariableSizeObjectInterface<BlockData<Type>, Type> {
+
+public:
+  using AtomicInt_t = adept::Atomic_t<int>;
+  using Value_t     = Type;
+  using Base_t      = vecgeom::VariableSizeObjectInterface<BlockData<Value_t>, Value_t>;
+  using ArrayData_t = vecgeom::VariableSizeObj<Value_t>;
+
+private:
+  int fCapacity{0};     ///< Maximum number of elements
+  AtomicInt_t fNbooked; ///< Number of booked elements
+  AtomicInt_t fNused; ///< Number of used elements
+  ArrayData_t fData;    ///< Data follows, has to be last
+
+private:
+  friend Base_t;
+
+  /** @brief Functions required by VariableSizeObjectInterface */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  ArrayData_t &GetVariableData() { return fData; }
+
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  const ArrayData_t &GetVariableData() const { return fData; }
+
+  // constructors and assignment operators are private
+  // states have to be constructed using MakeInstance() function
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  BlockData(size_t nvalues) : fCapacity(nvalues), fData(nvalues) {}
+
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  BlockData(size_t /*new_size*/, BlockData & /*other*/) {}
+
+public:
+  ///< Enumerate the part of the private interface, we want to expose.
+  using Base_t::MakeCopy;
+  using Base_t::MakeCopyAt;
+  using Base_t::MakeInstance;
+  using Base_t::MakeInstanceAt;
+  using Base_t::ReleaseInstance;
+  using Base_t::SizeOf;
+  using Base_t::SizeOfAlignAware;
+
+  /** @brief Returns the size in bytes of a BlockData object with given capacity */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  static size_t SizeOfInstance(int capacity) { return Base_t::SizeOf(capacity); }
+
+  /** @brief Size of container in bytes */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  int SizeOf() const { return BlockData<Value_t>::SizeOfInstance(fCapacity); }
+
+  /** @brief Maximum number of elements */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  int Capacity() const { return fCapacity; }
+
+  /** @brief Clear the content */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  void Clear()
+  {
+    fNused.store(0);
+    fNbooked.store(0);
+  }
+
+  /** @brief Read-only index operator */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  Type const &operator[](const int index) const { return fData[index]; }
+
+  /** @brief Read/write index operator */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  Type &operator[](const int index) { return fData[index]; }
+
+  /** @brief Dispatch next free element, nullptr if none left */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  Type *NextElement()
+  {
+    int index = fNbooked.fetch_add(1);
+    if (index >= fCapacity) return nullptr;
+    fNused++;
+    return &fData[index];
+  }
+
+  /** @brief Number of elements currently distributed */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  int GetNused() { return fNused.load(); }
+
+  /** @brief Check if container is fully distributed */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  bool IsFull() const { return (GetNused() == fCapacity); }
+
+}; // End BlockData
+} // End namespace adept
+
+#endif // ADEPT_BLOCKDATA_H_

--- a/base/inc/AdePT/Utils.h
+++ b/base/inc/AdePT/Utils.h
@@ -10,6 +10,8 @@
 #ifndef ADEPT_UTILS_H_
 #define ADEPT_UTILS_H_
 
+#include <string.h> // For memset and memcpy
+
 namespace adept {
 namespace utils {
 /**
@@ -17,11 +19,35 @@ namespace utils {
  * @param value Value to round-up
  */
 template <typename Type>
-VECCORE_ATT_HOST_DEVICE static Type round_up_align(Type value, size_t padding)
+VECCORE_ATT_HOST_DEVICE Type round_up_align(Type value, size_t padding)
 {
   size_t remainder = ((size_t)value) % padding;
   if (remainder == 0) return value;
   return (value + padding - remainder);
+}
+
+/** @brief CPP/CUDA Portable memset operation */
+VECCORE_ATT_HOST_DEVICE
+VECCORE_FORCE_INLINE
+void memset(void *ptr, int value, size_t num)
+{
+#ifndef VECCORE_CUDA_DEVICE_COMPILATION
+  memset(ptr, value, num);
+#else
+  cudaMemset(ptr, value, num);
+#endif
+}
+
+/** @brief CPP/CUDA Portable memcpy operation */
+VECCORE_ATT_HOST_DEVICE
+VECCORE_FORCE_INLINE
+void memcpy(void *destination, const void *source, size_t num, int type = 0)
+{
+#ifndef VECCORE_CUDA_DEVICE_COMPILATION
+  memcpy(destination, source, num);
+#else
+  cudaMemcpy(destination, source, num, (cudaMemcpyKind)type);
+#endif
 }
 
 } // End namespace utils

--- a/base/inc/AdePT/Utils.h
+++ b/base/inc/AdePT/Utils.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file Utils.h
+ * @brief General utility functions.
+ * @author Andrei Gheata (andrei.gheata@cern.ch)
+ */
+
+#ifndef ADEPT_UTILS_H_
+#define ADEPT_UTILS_H_
+
+#ifndef VECCORE_CUDA_DEVICE_COMPILATION
+#include <atomic>
+#endif
+
+namespace adept {
+namespace utils {
+/**
+ * @brief Rounds up a value to upper aligned version
+ * @param value Value to round-up
+ */
+template <typename Type>
+VECCORE_ATT_HOST_DEVICE static Type round_up_align(Type value, size_t padding = 32)
+{
+  size_t remainder = ((size_t)value) % padding;
+  if (remainder == 0) return value;
+  return (value + padding - remainder);
+}
+
+} // End namespace utils
+} // End namespace adept
+
+#endif // ADEPT_UTILS_H_

--- a/base/inc/AdePT/Utils.h
+++ b/base/inc/AdePT/Utils.h
@@ -10,10 +10,6 @@
 #ifndef ADEPT_UTILS_H_
 #define ADEPT_UTILS_H_
 
-#ifndef VECCORE_CUDA_DEVICE_COMPILATION
-#include <atomic>
-#endif
-
 namespace adept {
 namespace utils {
 /**
@@ -21,7 +17,7 @@ namespace utils {
  * @param value Value to round-up
  */
 template <typename Type>
-VECCORE_ATT_HOST_DEVICE static Type round_up_align(Type value, size_t padding = 32)
+VECCORE_ATT_HOST_DEVICE static Type round_up_align(Type value, size_t padding)
 {
   size_t remainder = ((size_t)value) % padding;
   if (remainder == 0) return value;

--- a/base/inc/AdePT/mpmc_bounded_queue.h
+++ b/base/inc/AdePT/mpmc_bounded_queue.h
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file mpmc_bounded_queue.h
+ * @brief Implementation of CUDA-aware multi-producer, multi-consumer bounded queue
+ * @author Andrei Gheata
+ * based on http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue
+ */
+
+#ifndef ADEPT_MPMC_BOUNDED_QUEUE
+#define ADEPT_MPMC_BOUNDED_QUEUE
+
+#include <stdint.h>
+#include <cassert>
+#include <AdePT/Atomic.h>
+#include <VecGeom/base/VariableSizeObj.h>
+
+namespace adept {
+namespace internal {
+/** @brief Internal data structure to handle the data sequence */
+template <typename Type>
+struct Cell_t {
+  adept::Atomic_t<int> fSequence; ///< Atomic sequence counter
+  Type fData;                     ///< Data stored in the cell
+
+  /** @brief Cell constructor */
+  Cell_t() {}
+};
+} // namespace internal
+
+/** @brief Class MPMC bounded queue */
+template <typename Type>
+class mpmc_bounded_queue
+    : protected vecgeom::VariableSizeObjectInterface<mpmc_bounded_queue<Type>, internal::Cell_t<Type>> {
+public:
+  using AtomicInt_t = adept::Atomic_t<int>;
+  using Value_t     = internal::Cell_t<Type>;
+  using Base_t      = vecgeom::VariableSizeObjectInterface<mpmc_bounded_queue<Type>, Value_t>;
+  using ArrayData_t = vecgeom::VariableSizeObj<Value_t>;
+
+private:
+  int const fCapacity;  ///< Capacity of the queue
+  int const fMask;      ///< Mask used to navigate fast in the circular buffer
+  AtomicInt_t fEnqueue; ///< Enqueueing index
+  AtomicInt_t fDequeue; ///< Dequeueing index
+  AtomicInt_t fNstored; ///< Number of stored elements
+  ArrayData_t fBuffer;  ///< Buffer of cells with atomic access to data elements
+
+private:
+  friend Base_t;
+
+  /** @brief Functions required by VariableSizeObjectInterface */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  ArrayData_t &GetVariableData() { return fBuffer; }
+
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  const ArrayData_t &GetVariableData() const { return fBuffer; }
+
+  // constructors and assignment operators are private
+  // states have to be constructed using MakeInstance() function
+
+  /**
+   * @brief MPMC bounded queue constructor
+   * @param fBuffersize Maximum number of elements in the queue
+   * @param addr Address where the queue is allocated.
+   * The user should make sure to allocate at least SizeofInstance(fBuffersize) bytes
+   */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  mpmc_bounded_queue(int nvalues) : fCapacity(nvalues), fMask(nvalues - 1), fBuffer(nvalues)
+  {
+    // The queue size must be a power of 2 (for fast access)
+    assert((nvalues >= 2) && ((nvalues & (nvalues - 1)) == 0) && "buffer size has to be a power of 2");
+    for (int i = 0; i < nvalues; ++i)
+      fBuffer[i].fSequence.store(i);
+  }
+
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  mpmc_bounded_queue(int /*nvalues*/, mpmc_bounded_queue const & /*other*/) {}
+
+public:
+  ///< Enumerate the part of the private interface, we want to expose.
+  using Base_t::MakeCopy;
+  using Base_t::MakeCopyAt;
+  using Base_t::MakeInstance;
+  using Base_t::MakeInstanceAt;
+  using Base_t::ReleaseInstance;
+  using Base_t::SizeOf;
+  using Base_t::SizeOfAlignAware;
+
+  /** @brief Returns the size in bytes of a BlockData object with given capacity */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  static size_t SizeOfInstance(int capacity) { return Base_t::SizeOf(capacity); }
+
+  /** @brief Size of container in bytes */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  int SizeOf() const { return mpmc_bounded_queue<Type>::SizeOfInstance(fCapacity); }
+
+  /** @brief Maximum number of elements */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  int Capacity() const { return fCapacity; }
+
+  /** @brief Size function */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  int size() const { return fNstored.load(); }
+
+  /** @brief MPMC enqueue function */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  bool enqueue(Type const &data)
+  {
+    Value_t *cell;
+    int pos = fEnqueue.load();
+    for (;;) {
+      cell         = &fBuffer[pos & fMask];
+      int seq      = cell->fSequence.load();
+      intptr_t dif = (intptr_t)seq - (intptr_t)pos;
+      if (dif == 0) {
+        if (fEnqueue.compare_exchange_strong(pos, pos + 1)) break;
+      } else if (dif < 0)
+        return false;
+      else
+        pos = fEnqueue.load();
+    }
+    cell->fData = data;
+    fNstored++;
+    cell->fSequence.store(pos + 1);
+    return true;
+  }
+
+  /** @brief MPMC dequeue function */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  bool dequeue(Type &data)
+  {
+    Value_t *cell;
+    int pos = fDequeue.load();
+    for (;;) {
+      cell         = &fBuffer[pos & fMask];
+      int seq      = cell->fSequence.load();
+      intptr_t dif = (intptr_t)seq - (intptr_t)(pos + 1);
+      if (dif == 0) {
+        if (fDequeue.compare_exchange_strong(pos, pos + 1)) break;
+      } else if (dif < 0)
+        return false;
+      else
+        pos = fDequeue.load();
+    }
+    data = cell->fData;
+    fNstored--;
+    cell->fSequence.store(pos + fMask + 1);
+    return true;
+  }
+
+  /** @brief MPMC bounded queue copy constructor */
+  mpmc_bounded_queue(mpmc_bounded_queue const &) = delete;
+
+  /** @brief Operator = */
+  void operator=(mpmc_bounded_queue const &) = delete;
+}; // End mpmc_bounded_queue
+} // End namespace adept
+#endif // ADEPT_MPMC_BOUNDED_QUEUE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ target_include_directories(test_atomic PUBLIC
   $<INSTALL_INTERFACE:base>
 )
 target_link_libraries(test_atomic VecCore::VecCore VecGeom::vecgeom)
+add_test(NAME test_atomic COMMAND test_atomic)
 
 # Unit test for BlockData
 add_executable(test_track_block test_track_block.cu)
@@ -25,6 +26,7 @@ target_include_directories(test_track_block PUBLIC
   $<INSTALL_INTERFACE:base>
 )
 target_link_libraries(test_track_block VecCore::VecCore VecGeom::vecgeom)
+add_test(NAME test_track_block COMMAND test_track_block)
 
 # Unit test for mpmc_bounded_queue
 add_executable(test_queue test_queue.cu)
@@ -33,3 +35,4 @@ target_include_directories(test_queue PUBLIC
   $<INSTALL_INTERFACE:base>
 )
 target_link_libraries(test_queue VecCore::VecCore VecGeom::vecgeom)
+add_test(NAME test_queue COMMAND test_queue)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,8 +13,16 @@ target_link_libraries(cufisher_price PRIVATE CUDA::curand)
 # Unit test for atomic ops
 add_executable(test_atomic test_atomic.cu)
 target_include_directories(test_atomic PUBLIC
-  ${VecCore_INCLUDE_DIRS}
-  ${VECGEOM_INCLUDE_DIR}
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
-  $<INSTALL_INTERFACE:base/inc>
+  $<INSTALL_INTERFACE:base>
 )
+
+target_link_libraries(test_atomic VecCore::VecCore VecGeom::vecgeom)
+
+# Unit test for BlockData
+add_executable(test_track_block test_track_block.cu)
+target_include_directories(test_track_block PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
+  $<INSTALL_INTERFACE:base>
+)
+target_link_libraries(test_track_block VecCore::VecCore VecGeom::vecgeom)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,6 @@ target_include_directories(test_atomic PUBLIC
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
   $<INSTALL_INTERFACE:base>
 )
-
 target_link_libraries(test_atomic VecCore::VecCore VecGeom::vecgeom)
 
 # Unit test for BlockData
@@ -26,3 +25,11 @@ target_include_directories(test_track_block PUBLIC
   $<INSTALL_INTERFACE:base>
 )
 target_link_libraries(test_track_block VecCore::VecCore VecGeom::vecgeom)
+
+# Unit test for mpmc_bounded_queue
+add_executable(test_queue test_queue.cu)
+target_include_directories(test_queue PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
+  $<INSTALL_INTERFACE:base>
+)
+target_link_libraries(test_queue VecCore::VecCore VecGeom::vecgeom)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2020 CERN
 # SPDX-License-Identifier: Apache-2.0
 
+
 # - Minimal test of cuda compilation
 add_executable(example_add example_add.cu)
 
@@ -9,3 +10,11 @@ add_executable(fisher_price fisher_price.cpp)
 # Noddy example of particle processing with GPU
 add_executable(cufisher_price cufisher_price.cu)
 target_link_libraries(cufisher_price PRIVATE CUDA::curand)
+# Unit test for atomic ops
+add_executable(test_atomic test_atomic.cu)
+target_include_directories(test_atomic PUBLIC
+  ${VecCore_INCLUDE_DIRS}
+  ${VECGEOM_INCLUDE_DIR}
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
+  $<INSTALL_INTERFACE:base/inc>
+)

--- a/test/test_atomic.cu
+++ b/test/test_atomic.cu
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file test_atomic.cu
+ * @brief Unit test for atomic operations.
+ * @author Andrei Gheata (andrei.gheata@cern.ch)
+ */
+
+#include <iostream>
+#include <cassert>
+#include <AdePT/Atomic.h>
+#include <VecGeom/backend/cuda/Interface.h>
+
+// Example data structure containing several atomics
+struct SomeStruct {
+  adept::Atomic_t<int> var_int{nullptr};
+  adept::Atomic_t<float> var_float{nullptr};
+
+  void EmplaceDataAt(void *addr)
+  {
+    char *add_next = (char *)addr;
+    // Recipe of calculating next free address in the buffer
+    add_next = var_int.EmplaceDataAt(add_next) + adept::Atomic_t<int>::SizeOfData();
+    add_next = var_float.EmplaceDataAt(add_next) + adept::Atomic_t<float>::SizeOfData();
+  }
+
+  static size_t SizeOfData() { return adept::Atomic_t<int>::SizeOfData() + adept::Atomic_t<float>::SizeOfData(); }
+};
+
+// Kernel function to perform atomic addition
+__global__ void testAdd(SomeStruct s)
+{
+  // Test fetch_add, fetch_sub
+  s.var_int.fetch_add(1);
+  s.var_float.fetch_add(1);
+}
+
+// Kernel function to perform atomic subtraction
+__global__ void testSub(SomeStruct s)
+{
+  // Test fetch_add, fetch_sub
+  s.var_int.fetch_sub(1);
+  s.var_float.fetch_sub(1);
+}
+
+// Kernel function to test compare_exchange
+__global__ void testCompareExchange(SomeStruct s)
+{
+  // Read the content of the atomic
+  auto expected = s.var_int.load();
+  bool success  = false;
+  while (!success) {
+    // Try to decrement the content, if zero try to replace it with 100
+    while (expected > 0) {
+      success = s.var_int.compare_exchange_strong(expected, expected - 1);
+      if (success) return;
+    }
+    while (expected == 0) {
+      success = s.var_int.compare_exchange_strong(expected, 100);
+    }
+  }
+}
+
+///______________________________________________________________________________________
+int main(void)
+{
+  const char *result[2] = {"FAILED", "OK"};
+  SomeStruct a;
+  bool success = true;
+
+  // Allocate the content of SomeStruct in a buffer
+  auto buff_size = SomeStruct::SizeOfData();
+  char *buffer   = nullptr;
+  cudaMallocManaged(&buffer, buff_size);
+
+  a.EmplaceDataAt(buffer);
+
+  // Wait for GPU to finish before accessing on host
+
+  // Launch a kernel doing additions (10K blocks of 32 treads each)
+  bool testOK = true;
+  dim3 nblocks(10000), nthreads(32);
+  std::cout << "   testAdd ... ";
+  // Wait memory to reach device/host
+  cudaDeviceSynchronize();
+  testAdd<<<nblocks, nthreads>>>(a);
+  cudaDeviceSynchronize();
+
+  testOK &= a.var_int.load() == nblocks.x * nthreads.x;
+  testOK &= a.var_float.load() == float(nblocks.x * nthreads.x);
+  std::cout << result[testOK] << "\n";
+  success &= testOK;
+
+  // Launch a kernel doing subtraction (10K blocks of 32 treads each)
+  testOK = true;
+  std::cout << "   testSub ... ";
+  a.var_int.store(nblocks.x * nthreads.x);
+  a.var_float.store(nblocks.x * nthreads.x);
+  cudaDeviceSynchronize();
+  testSub<<<nblocks, nthreads>>>(a);
+  cudaDeviceSynchronize();
+
+  testOK &= a.var_int.load() == 0;
+  testOK &= a.var_float.load() == 0;
+  std::cout << result[testOK] << "\n";
+  success &= testOK;
+
+  // Launch a kernel testing compare and swap operations
+  std::cout << "   testCAS ... ";
+  a.var_int.store(99);
+  cudaDeviceSynchronize();
+  testCompareExchange<<<nblocks, nthreads>>>(a);
+  cudaDeviceSynchronize();
+  testOK = a.var_int.load() == 99;
+  std::cout << result[testOK] << "\n";
+  success &= testOK;
+
+  cudaFree(buffer);
+  if (!success) return 1;
+  return 0;
+}

--- a/test/test_atomic.cu
+++ b/test/test_atomic.cu
@@ -10,54 +10,53 @@
 #include <iostream>
 #include <cassert>
 #include <AdePT/Atomic.h>
-#include <VecGeom/backend/cuda/Interface.h>
 
 // Example data structure containing several atomics
 struct SomeStruct {
-  adept::Atomic_t<int> var_int{nullptr};
-  adept::Atomic_t<float> var_float{nullptr};
+  adept::Atomic_t<int> var_int;
+  adept::Atomic_t<float> var_float;
 
-  void EmplaceDataAt(void *addr)
+  VECCORE_ATT_HOST_DEVICE
+  SomeStruct() {}
+
+  VECCORE_ATT_HOST_DEVICE
+  static SomeStruct *MakeInstanceAt(void *addr)
   {
-    char *add_next = (char *)addr;
-    // Recipe of calculating next free address in the buffer
-    add_next = var_int.EmplaceDataAt(add_next) + adept::Atomic_t<int>::SizeOfData();
-    add_next = var_float.EmplaceDataAt(add_next) + adept::Atomic_t<float>::SizeOfData();
+    SomeStruct *obj = new (addr) SomeStruct();
+    return obj;
   }
-
-  static size_t SizeOfData() { return adept::Atomic_t<int>::SizeOfData() + adept::Atomic_t<float>::SizeOfData(); }
 };
 
 // Kernel function to perform atomic addition
-__global__ void testAdd(SomeStruct s)
+__global__ void testAdd(SomeStruct *s)
 {
   // Test fetch_add, fetch_sub
-  s.var_int.fetch_add(1);
-  s.var_float.fetch_add(1);
+  s->var_int.fetch_add(1);
+  s->var_float.fetch_add(1);
 }
 
 // Kernel function to perform atomic subtraction
-__global__ void testSub(SomeStruct s)
+__global__ void testSub(SomeStruct *s)
 {
   // Test fetch_add, fetch_sub
-  s.var_int.fetch_sub(1);
-  s.var_float.fetch_sub(1);
+  s->var_int.fetch_sub(1);
+  s->var_float.fetch_sub(1);
 }
 
 // Kernel function to test compare_exchange
-__global__ void testCompareExchange(SomeStruct s)
+__global__ void testCompareExchange(SomeStruct *s)
 {
   // Read the content of the atomic
-  auto expected = s.var_int.load();
+  auto expected = s->var_int.load();
   bool success  = false;
   while (!success) {
     // Try to decrement the content, if zero try to replace it with 100
     while (expected > 0) {
-      success = s.var_int.compare_exchange_strong(expected, expected - 1);
+      success = s->var_int.compare_exchange_strong(expected, expected - 1);
       if (success) return;
     }
     while (expected == 0) {
-      success = s.var_int.compare_exchange_strong(expected, 100);
+      success = s->var_int.compare_exchange_strong(expected, 100);
     }
   }
 }
@@ -66,53 +65,50 @@ __global__ void testCompareExchange(SomeStruct s)
 int main(void)
 {
   const char *result[2] = {"FAILED", "OK"};
-  SomeStruct a;
-  bool success = true;
+  bool success          = true;
+  // Define the kernels granularity: 10K blocks of 32 treads each
+  dim3 nblocks(10000), nthreads(32);
 
   // Allocate the content of SomeStruct in a buffer
-  auto buff_size = SomeStruct::SizeOfData();
-  char *buffer   = nullptr;
-  cudaMallocManaged(&buffer, buff_size);
+  char *buffer = nullptr;
+  cudaMallocManaged(&buffer, sizeof(SomeStruct));
+  SomeStruct *a = SomeStruct::MakeInstanceAt(buffer);
 
-  a.EmplaceDataAt(buffer);
-
-  // Wait for GPU to finish before accessing on host
-
-  // Launch a kernel doing additions (10K blocks of 32 treads each)
+  // Launch a kernel doing additions
   bool testOK = true;
-  dim3 nblocks(10000), nthreads(32);
   std::cout << "   testAdd ... ";
-  // Wait memory to reach device/host
+  // Wait memory to reach device
   cudaDeviceSynchronize();
   testAdd<<<nblocks, nthreads>>>(a);
+  // Wait all warps to finish and sync memory
   cudaDeviceSynchronize();
 
-  testOK &= a.var_int.load() == nblocks.x * nthreads.x;
-  testOK &= a.var_float.load() == float(nblocks.x * nthreads.x);
+  testOK &= a->var_int.load() == nblocks.x * nthreads.x;
+  testOK &= a->var_float.load() == float(nblocks.x * nthreads.x);
   std::cout << result[testOK] << "\n";
   success &= testOK;
 
-  // Launch a kernel doing subtraction (10K blocks of 32 treads each)
+  // Launch a kernel doing subtraction
   testOK = true;
   std::cout << "   testSub ... ";
-  a.var_int.store(nblocks.x * nthreads.x);
-  a.var_float.store(nblocks.x * nthreads.x);
+  a->var_int.store(nblocks.x * nthreads.x);
+  a->var_float.store(nblocks.x * nthreads.x);
   cudaDeviceSynchronize();
   testSub<<<nblocks, nthreads>>>(a);
   cudaDeviceSynchronize();
 
-  testOK &= a.var_int.load() == 0;
-  testOK &= a.var_float.load() == 0;
+  testOK &= a->var_int.load() == 0;
+  testOK &= a->var_float.load() == 0;
   std::cout << result[testOK] << "\n";
   success &= testOK;
 
   // Launch a kernel testing compare and swap operations
   std::cout << "   testCAS ... ";
-  a.var_int.store(99);
+  a->var_int.store(99);
   cudaDeviceSynchronize();
   testCompareExchange<<<nblocks, nthreads>>>(a);
   cudaDeviceSynchronize();
-  testOK = a.var_int.load() == 99;
+  testOK = a->var_int.load() == 99;
   std::cout << result[testOK] << "\n";
   success &= testOK;
 

--- a/test/test_queue.cu
+++ b/test/test_queue.cu
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file test_atomic.cu
+ * @brief Unit test for atomic operations.
+ * @author Andrei Gheata (andrei.gheata@cern.ch)
+ */
+
+#include <iostream>
+#include <cassert>
+#include <AdePT/mpmc_bounded_queue.h>
+
+// Kernel function to perform atomic addition
+__global__ void pushData(adept::mpmc_bounded_queue<int> *queue)
+{
+  // Push the thread index in the queue
+  int id = blockIdx.x * blockDim.x + threadIdx.x;
+  queue->enqueue(id);
+}
+
+// Kernel function to dequeue a value and add it atomically
+__global__ void popAndAdd(adept::mpmc_bounded_queue<int> *queue, adept::Atomic_t<unsigned long long> *sum)
+{
+  // Push the thread index in the queue
+  int id = 0;
+  if (!queue->dequeue(id)) id = 0;
+  sum->fetch_add(id);
+}
+
+///______________________________________________________________________________________
+int main(void)
+{
+  using Queue_t      = adept::mpmc_bounded_queue<int>;
+  using AtomicLong_t = adept::Atomic_t<unsigned long long>;
+
+  const char *result[2] = {"FAILED", "OK"};
+  bool success          = true;
+  // Define the kernels granularity: 10K blocks of 32 treads each
+  dim3 nblocks(1000), nthreads(32);
+
+  int capacity      = 1 << 15; // 32768 - accomodates values pushed by all threads
+  size_t buffersize = Queue_t::SizeOfInstance(capacity);
+  char *buffer      = nullptr;
+  cudaMallocManaged(&buffer, buffersize);
+  auto queue = Queue_t::MakeInstanceAt(capacity, buffer);
+
+  char *buffer_atomic = nullptr;
+  cudaMallocManaged(&buffer_atomic, sizeof(AtomicLong_t));
+  auto sum = new (buffer_atomic) AtomicLong_t;
+
+  bool testOK = true;
+  std::cout << "   test_queue ... ";
+  // Allow memory to reach the device
+  cudaDeviceSynchronize();
+  // Launch a kernel queueing thread id's
+  pushData<<<nblocks, nthreads>>>(queue);
+  // Allow all warps in the stream to finish
+  cudaDeviceSynchronize();
+  // Make sure all threads managed to queue their id
+  testOK &= queue->size() == nblocks.x * nthreads.x;
+  // Launch a kernel top collect queued data
+  popAndAdd<<<nblocks, nthreads>>>(queue, sum);
+  // Wait work to finish and memory to reach the host
+  cudaDeviceSynchronize();
+  // Check if all data was dequeued
+  testOK &= queue->size() == 0;
+  // Check if the sum of all dequeued id's matches the sum of thread indices
+  unsigned long long sumref = 0;
+  for (auto i = 0; i < nblocks.x * nthreads.x; ++i)
+    sumref += i;
+  testOK &= sum->load() == sumref;
+  std::cout << result[testOK] << "\n";
+  success &= testOK;
+
+  cudaFree(buffer);
+  cudaFree(buffer_atomic);
+  if (!success) return 1;
+  return 0;
+}

--- a/test/test_queue.cu
+++ b/test/test_queue.cu
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * @file test_atomic.cu
- * @brief Unit test for atomic operations.
+ * @file test_queue.cu
+ * @brief Unit test for queue operations.
  * @author Andrei Gheata (andrei.gheata@cern.ch)
  */
 

--- a/test/test_track_block.cu
+++ b/test/test_track_block.cu
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file test_track_block.cu
+ * @brief Unit test for the BlockData concurrent container.
+ * @author Andrei Gheata (andrei.gheata@cern.ch)
+ */
+
+#include <iostream>
+#include <cassert>
+#include <AdePT/BlockData.h>
+
+struct MyTrack {
+  int index{0};
+  double pos[3]{0};
+  double dir[3]{0};
+  bool flag1;
+  bool flag2;
+};
+
+// Kernel function to process the next free track in a block
+__global__ void testTrackBlock(adept::BlockData<MyTrack> *block)
+{
+  auto track = block->NextElement();
+  if (!track) return;
+  int id       = blockIdx.x * blockDim.x + threadIdx.x;
+  track->index = id;
+}
+
+///______________________________________________________________________________________
+int main(void)
+{
+  using Block_t         = adept::BlockData<MyTrack>;
+  const char *result[2] = {"FAILED", "OK"};
+  // Track capacity of the block
+  constexpr int capacity = 1000000;
+
+  // Define the kernels granularity: 10K blocks of 32 treads each
+  constexpr dim3 nblocks(10000), nthreads(32);
+
+  // Allocate a block of tracks with capacity larger than the total number of spawned threads
+  // Note that if we want to allocate several consecutive block in a buffer, we have to use
+  // Block_t::SizeOfAlignAware rather than SizeOfInstance to get the space needed per block
+  size_t blocksize = Block_t::SizeOfAlignAware(capacity);
+  char *buffer     = nullptr;
+  cudaMallocManaged(&buffer, blocksize);
+  auto block = adept::BlockData<MyTrack>::MakeInstanceAt(capacity, buffer);
+
+  bool testOK = true;
+  std::cout << "   test_track_block ... ";
+  // Allow memory to reach the device
+  cudaDeviceSynchronize();
+  // Launch a kernel processing tracks
+  testTrackBlock<<<nblocks, nthreads>>>(block);
+  // Allow all warps to finish
+  cudaDeviceSynchronize();
+  // The number of used tracks should be equal to the number of spawned threads
+  testOK &= block->GetNused() == nblocks.x * nthreads.x;
+
+  // Compute the sum of assigned track indices, which has to match the sum from 0 to nthreads-1
+  // (the execution order is arbitrary, but all thread indices must be distributed)
+  unsigned long long counter1 = 0, counter2 = 0;
+
+  for (auto i = 0; i < nblocks.x * nthreads.x; ++i) {
+    counter1 += i;
+    counter2 += (*block)[i].index;
+  }
+
+  testOK &= counter1 == counter2;
+  std::cout << result[testOK] << "\n";
+
+  cudaFree(buffer);
+  if (!testOK) return 1;
+  return 0;
+}


### PR DESCRIPTION
The templated type adept::Atomic_t dispatches std::atomic interfaces to the appropriate backend (CPU or CUDA). Atomic_t objects adopt pre-allocated memory, using the static function MakeInstanceAt, on a buffer of length sizeof(Atomic_t<Type>). Unit test: test_atomic.
This adds also a new concurrent container adept::BlockData. The block is templated on the data type, allocating the demanded number of elements in a pre-allocated buffer. The number of bytes to be allocated is returned by the static method BlockData<Type>::SizeOfInstance. The method SizeOfAlignAware should be used for allocating multiple blocks in the same buffer. The method NextElement gives write access to the next unused element, and the bracket operator can be used for read access. Unit test: test_track_block
A new concurrent queue adept::mpmc_bounded_queue was added. The queue is templated on the data type, to be created using its static MakeInstanceAt(int nelements, void *buffer). The number of elements must be a power of 2 (for fast index finding in the stored circular buffer) and the buffer size has to use SizeOfInstance (or SizeOfAlignAware for multiple contiguous queues). Unit test: test_queue