### PR TITLE
Adding the Alpaka version of FisherPrice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,3 +53,4 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${VECGEOM_CXX_FLAGS}")
 
 # Builds...
 add_subdirectory(test)
+add_subdirectory(test/FisherPrice_Alpaka)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ As <otherargs> one needs to provide the paths to the dependence librarties VecCo
    -DVecCore_DIR=<path_to_veccore_installation>/share/VecCore/cmake \
    -DVecGeom_DIR=<path_to_vecgeom_installation>/lib/cmake/VecGeom \
    [-DVc_DIR=<path_to_vc_installation/lib/cmake/Vc] #only in case VecGeom was compiled using Vc backend
+   [-DCMAKE_PREFIX_PATH=<alpakaInstallDir>] #only in case you want to build FisherPrice_Alpaka. <alpakaInstallDir> should point at the folder in which "include/alpaka/" is found.
 ```
 
 To build, run:

--- a/test/FisherPrice_Alpaka/CMakeLists.txt
+++ b/test/FisherPrice_Alpaka/CMakeLists.txt
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2020 CERN
-// SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2020 CERN
+# SPDX-License-Identifier: Apache-2.0
 
 #We must specify that we want to use alpaka
 find_package(alpaka)

--- a/test/FisherPrice_Alpaka/CMakeLists.txt
+++ b/test/FisherPrice_Alpaka/CMakeLists.txt
@@ -1,7 +1,11 @@
-# This makes sure cmake knows where to find alpaka
-set(CMAKE_PREFIX_PATH "/install")
-# Then we must specify that we want to use alpaka
-find_package(alpaka REQUIRED)
-alpaka_add_executable(FisherPriceAlpaka alpaka_fisher_price.cu)
-target_link_libraries(FisherPriceAlpaka PUBLIC alpaka::alpaka)
+#We must specify that we want to use alpaka
+find_package(alpaka)
+
+if(NOT alpaka_FOUND)
+  message(STATUS "No alpaka install found, disabling build of FisherPrice_Alpaka")
+  return()
+else()  
+  alpaka_add_executable(FisherPriceAlpaka alpaka_fisher_price.cu)
+  target_link_libraries(FisherPriceAlpaka PUBLIC alpaka::alpaka)
+endif()
 

--- a/test/FisherPrice_Alpaka/CMakeLists.txt
+++ b/test/FisherPrice_Alpaka/CMakeLists.txt
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
 #We must specify that we want to use alpaka
 find_package(alpaka)
 

--- a/test/FisherPrice_Alpaka/CMakeLists.txt
+++ b/test/FisherPrice_Alpaka/CMakeLists.txt
@@ -1,0 +1,7 @@
+# This makes sure cmake knows where to find alpaka
+set(CMAKE_PREFIX_PATH "/install")
+# Then we must specify that we want to use alpaka
+find_package(alpaka REQUIRED)
+alpaka_add_executable(FisherPriceAlpaka alpaka_fisher_price.cu)
+target_link_libraries(FisherPriceAlpaka PUBLIC alpaka::alpaka)
+

--- a/test/FisherPrice_Alpaka/alpaka_fisher_price.cu
+++ b/test/FisherPrice_Alpaka/alpaka_fisher_price.cu
@@ -3,9 +3,97 @@
 
 //This is the main include file to give us all of the alpaka classes, functions etc.
 #include <alpaka/alpaka.hpp>
+
+#include <iostream>
+
 #include "particleProcessor.h"
+
+// This processes one event on the device. A list of particles is passed through
+// For each particle we call process(*partList, iTh) 
+// process will then work the same was as in the C++ version
+struct processEvent {
+  template<typename Acc> ALPAKA_FN_ACC void operator() (Acc const& acc, part *partList, int* steps) const{
+
+    using namespace alpaka;
+    // iTh is the thread number we use this throughout 
+    uint32_t iTh = idx::getIdx<Grid, Threads>(acc)[0];
+    //dummy sensitive, not used yet 
+    sensitive SD(400.,500.);  
+
+    //Create an alpaka random generator using a seed of 1984
+    auto generator = rand::generator::createDefault(acc,1984,iTh); 
+    
+    // Here we split threads that start immediatly, from threads that will have to wait until the shower is under way 
+    particleProcessor particleProcessor;
+    int ns=particleProcessor.processParticle(acc,partList, iTh, generator, SD); 
+    steps[iTh] = ns;
+  }
+};
+
+
 
 int main()
 {
+
+  using namespace alpaka; //alpaka functionality all lives in this namespace
+
+  using Dim = dim::DimInt<1>;
+  using Idx = uint32_t;
+
+  //Define the alpaka accelerator to be Nvidia GPU
+  using Acc = acc::AccGpuCudaRt<Dim,Idx>;
+
+  //Get the first device available of type GPU (i.e should be our sole GPU)/device
+  auto const device = pltf::getDevByIdx<Acc>(0u);
+  // Create a device for host for memory allocation, using the first CPU available
+  auto devHost = pltf::getDevByIdx<dev::DevCpu>(0u);
+
+  //Allocate memory on both the host and device for part objects and numbers of steps
+  uint32_t NPART = 200;
+  vec::Vec<Dim, Idx> bufferExtent{NPART};
+  auto d_event = mem::buf::alloc<part,Idx>(device,bufferExtent);
+  auto h_event = mem::buf::alloc<part, Idx>(devHost,bufferExtent);
+  auto d_steps = mem::buf::alloc<int,Idx>(device, bufferExtent);
+  auto h_steps = mem::buf::alloc<int,Idx>(devHost,bufferExtent);
+
+  int size = NPART*sizeof(part);  // memory size to use
+  std::cout << "memory allocated " << size << std::endl;
+
+  // All photons have momentum 20 GeV along z
+  vec3 mom=vec3(0.,0.,20000.);
+
+  // create NPART particles:
+  for (int ii=0; ii< NPART; ii++) {
+     vec3 pos=vec3(0.,0.,(float) ii );
+     mem::view::getPtrNative(h_event)[ii] = part(pos, mom, 22);
+  }
+
+  // Copy particles to the GPU
+  auto queue = queue::Queue<Acc, queue::Blocking>{device};
+  mem::view::copy(queue,d_event,h_event,bufferExtent);
+
+  // Check that this makes sense on CPU
+  for (int ii=0; ii<NPART; ii++) {
+    std::cout << __CUDACC__ << "  "  << ii << ", " << mem::view::getPtrNative(h_event)[ii].getPos().z() << std::endl;
+  } 
+
+  // Launch one thread per particle for NPART particles
+  uint32_t blocksPerGrid = NPART;
+  uint32_t threadsPerBlock = 1;
+  uint32_t elementsPerThread = 1;
+
+  auto workDiv = workdiv::WorkDivMembers<Dim, Idx>{blocksPerGrid, threadsPerBlock, elementsPerThread};
+
+  //Create a task for processEvent, that we can run and then run it via a queue
+  processEvent processEvent;
+  
+  auto taskRunProcessEvent = kernel::createTaskKernel<Acc>(workDiv,processEvent,mem::view::getPtrNative(d_event), mem::view::getPtrNative(d_steps));
+
+  queue::enqueue(queue, taskRunProcessEvent);
+
+  mem::view::copy(queue,h_steps,d_steps,bufferExtent);
+  std::cout << "Thread, nsteps" << std::endl;
+  for (int ii=0; ii<NPART; ii++) std::cout << ii << ", " << mem::view::getPtrNative(h_steps)[ii] << std::endl; 
+
   return 0;
 }

--- a/test/FisherPrice_Alpaka/alpaka_fisher_price.cu
+++ b/test/FisherPrice_Alpaka/alpaka_fisher_price.cu
@@ -3,6 +3,7 @@
 
 //This is the main include file to give us all of the alpaka classes, functions etc.
 #include <alpaka/alpaka.hpp>
+#include "particleProcessor.h"
 
 int main()
 {

--- a/test/FisherPrice_Alpaka/alpaka_fisher_price.cu
+++ b/test/FisherPrice_Alpaka/alpaka_fisher_price.cu
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+//This is the main include file to give us all of the alpaka classes, functions etc.
+#include <alpaka/alpaka.hpp>
+
+int main()
+{
+  return 0;
+}

--- a/test/FisherPrice_Alpaka/part.h
+++ b/test/FisherPrice_Alpaka/part.h
@@ -1,0 +1,27 @@
+#include <math.h>
+#include <stdlib.h>
+#include <iostream>
+#include "vec3.h"
+
+#ifdef __CUDACC__
+#include "cuda.h"
+#endif
+
+#ifndef PART_H
+#define PART_H
+
+class part {
+  public:
+        part() {}
+        // put this in the public for now ;( 
+        vec3 m_pos; // position x, y, z in mm
+        vec3 m_mom;  // momentum px, py, pz in MeV
+        char m_ptype; // type (should be an enum) 22 = gamma, 11=e-, -11=e+
+        // c'tor
+        part(vec3 pos, vec3 mom, char ptype) { m_pos = pos; m_mom = mom; m_ptype = ptype; }
+
+        float momentum() const {return m_mom.length(); }
+};
+  
+#endif // PART_H
+

--- a/test/FisherPrice_Alpaka/part.h
+++ b/test/FisherPrice_Alpaka/part.h
@@ -1,26 +1,41 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+
+/**
+ * @file part.h
+ * @brief class to represent electrons, positrons and photons. It stores a 3-momentum and 3-position vector and has a type
+ * to denote the particle type. All data is public.
+ * @author Davide Costanzo (d.costanzo@sheffield.ac.uk) and Mark Hodgkinson (d.costanzo@sheffield.ac.uk)
+*/
+
+#ifndef PART_H
+#define PART_H
+
 #include <math.h>
 #include <stdlib.h>
 #include <iostream>
 #include "vec3.h"
 
-#ifdef __CUDACC__
-#include "cuda.h"
-#endif
-
-#ifndef PART_H
-#define PART_H
-
 class part {
   public:
-        part() {}
-        // put this in the public for now ;( 
-        vec3 m_pos; // position x, y, z in mm
-        vec3 m_mom;  // momentum px, py, pz in MeV
-        char m_ptype; // type (should be an enum) 22 = gamma, 11=e-, -11=e+
-        // c'tor
-        part(vec3 pos, vec3 mom, char ptype) { m_pos = pos; m_mom = mom; m_ptype = ptype; }
+    /** @brief Nominal constructor */  
+    part() {}
 
-        float momentum() const {return m_mom.length(); }
+    /** @brief Constructor which sets the position 3-vector, momentum 3-vector and type.
+     * Takes a @sa vec3 position and momentum and a char type as arguments.
+     */
+    part(vec3 pos, vec3 mom, char ptype) { m_pos = pos; m_mom = mom; m_ptype = ptype; }
+
+    /** @brief Returns the magnitude of the momentum 3-vector
+     * Returns a float representing the magnitude, which is computed via @sa vec3::length()
+     */
+    float momentum() const {return m_mom.length(); }
+
+    vec3 m_pos; ///< position x, y, z in mm
+    vec3 m_mom;  ///< momentum px, py, pz in MeV
+    char m_ptype; ///< type (should be an enum) 22 = gamma, 11=e-, -11=e+
+              
 };
   
 #endif // PART_H

--- a/test/FisherPrice_Alpaka/part.h
+++ b/test/FisherPrice_Alpaka/part.h
@@ -1,13 +1,12 @@
 // SPDX-FileCopyrightText: 2020 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-
 /**
  * @file part.h
- * @brief class to represent electrons, positrons and photons. It stores a 3-momentum and 3-position vector and has a type
- * to denote the particle type. All data is public.
+ * @brief class to represent electrons, positrons and photons. It stores a 3-momentum and 3-position vector and has a
+ * type to denote the particle type. All data is public.
  * @author Davide Costanzo (d.costanzo@sheffield.ac.uk) and Mark Hodgkinson (d.costanzo@sheffield.ac.uk)
-*/
+ */
 
 #ifndef PART_H
 #define PART_H
@@ -18,25 +17,37 @@
 #include "vec3.h"
 
 class part {
-  public:
-    /** @brief Nominal constructor */  
-    part() {}
+public:
+  /** @brief Nominal constructor */
+  ALPAKA_FN_ACC part() {}
 
-    /** @brief Constructor which sets the position 3-vector, momentum 3-vector and type.
-     * Takes a @sa vec3 position and momentum and a char type as arguments.
-     */
-    part(vec3 pos, vec3 mom, char ptype) { m_pos = pos; m_mom = mom; m_ptype = ptype; }
+  /** @brief Constructor which sets the position 3-vector, momentum 3-vector and type.
+   * Takes a @sa vec3 position and momentum and a char type as arguments.
+   */
+  ALPAKA_FN_ACC part(vec3 pos, vec3 mom, char ptype)
+  {
+    m_pos   = pos;
+    m_mom   = mom;
+    m_ptype = ptype;
+  }
 
-    /** @brief Returns the magnitude of the momentum 3-vector
-     * Returns a float representing the magnitude, which is computed via @sa vec3::length()
-     */
-    float momentum() const {return m_mom.length(); }
+  /** @brief Returns the magnitude of the momentum 3-vector
+   * Returns a float representing the magnitude, which is computed via @sa vec3::length()
+   */
+  ALPAKA_FN_ACC float momentum() const { return m_mom.length(); }
 
-    vec3 m_pos; ///< position x, y, z in mm
-    vec3 m_mom;  ///< momentum px, py, pz in MeV
-    char m_ptype; ///< type (should be an enum) 22 = gamma, 11=e-, -11=e+
-              
+  ALPAKA_FN_ACC vec3 getPos() const { return m_pos; }
+  ALPAKA_FN_ACC vec3 getMom() const { return m_mom; }
+  ALPAKA_FN_ACC char getPType() const { return m_ptype; }
+
+  ALPAKA_FN_ACC void setPos(const vec3 &pos) { m_pos = pos; }
+  ALPAKA_FN_ACC void setMom(const vec3 &mom) { m_mom = mom; }
+  ALPAKA_FN_ACC void setPType(const char &ptype) { m_ptype = ptype; }
+
+private:
+  vec3 m_pos;   ///< position x, y, z in mm
+  vec3 m_mom;   ///< momentum px, py, pz in MeV
+  char m_ptype; ///< type (should be an enum) 22 = gamma, 11=e-, -11=e+
 };
-  
-#endif // PART_H
 
+#endif // PART_H

--- a/test/FisherPrice_Alpaka/particleProcessor.h
+++ b/test/FisherPrice_Alpaka/particleProcessor.h
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file particleProcessor.h
+ * @brief simulates electrons and photons - it can calculate ionisaton energy loss, make a particle undergo brehmstrahhlung or pair production and move a particle along the x-direction. 
+ * All class functions are specified to run the accelerator (device) only.
+ * @author Davide Costanzo (d.costanzo@sheffield.ac.uk) and Mark Hodgkinson (d.costanzo@sheffield.ac.uk)
+ * */
+
+#ifndef PARTICLEPROCESSOR_H
+#define PARTICLEPROCESSOR_H
+
+#include "part.h"
+#include "particleStack.h"
+#include "sensitive.h"
+#include <alpaka/alpaka.hpp>
+
+class particleProcessor {
+
+  public:
+    /** @brief A minimal constructor */
+    ALPAKA_FN_ACC particleProcessor (){}
+
+    /** @brief A minimal destructor */
+    ALPAKA_FN_ACC ~particleProcessor(){}
+
+    /**
+     * @brief calculates the energy loss of a particle, mypart, in the range 0 to 0.2 MeV in the direction of the momentum.
+     * Acc is the Alpaka acceleraror type (e.g. CPU or GPU), mypart is the part to calculate the energy loss for and generator is a random number generator provided by alpaka.
+     * Assumes the generator has already been initialised with a seed by the client.
+     * Returns a float value representing the energy lost, which is calculated as a randum number (between zero and one) multiplied by 0.2 MeV.
+     * */
+    template<typename Acc> ALPAKA_FN_ACC float energyLoss(Acc const& acc, part& mypart, alpaka::rand::generator::uniform_cuda_hip::Xor& generator);
+
+    /**
+     * @brief Takes a list of particles on a specific thread and processes them. Processing means that the particles moves along the x-direction in finite steps. In each step
+     * a new particle(s) may or may not be generated - if so it is added to an internal. to this function, array of particles on the stack. The function continues to step
+     * until the initial particles momentum drops below 1 MeV.
+     * Acc is the Alpaka acceleraror type (e.g. CPU or GPU), partList is a list of part, iTh is the thread being used, generator is a random number generator provided by alpaka and
+     * SD is an instance of a c++ class, of type sensitive, representing a sensitive detector.
+     * Returns an unsigned integer representing the number of steps undertaken.
+     */
+    template<typename Acc>  ALPAKA_FN_ACC unsigned int processParticle(Acc const& acc,part* partList, const int& iTh, alpaka::rand::generator::uniform_cuda_hip::Xor& generator, sensitive& SD);
+
+  /**
+   * @brief throws a random number to determine whether to generate secondary particles. An electron will always generate a photon and a photon will always generate
+   * an electron-positron pair. Momentum is conserved such that the initial particle reduces in momentum by the momentum of the additional particles.
+   * Acc is the Alpaka acceleraror type (e.g. CPU or GPU), mypart is the particle to consider and generator is a random number generator provided by alpaka.
+   * Returns a new particle representing either the photon (in e -> gamma brehmstrahhlung case) or positron (in the photon -> e+e- case). If we don't produce
+   * any additional particles 0 is returned.
+   */
+    template<typename Acc> ALPAKA_FN_ACC part* splitParticle(Acc const& acc, part& mypart, alpaka::rand::generator::uniform_cuda_hip::Xor& generator);
+
+    /**
+     * @brief steps the particle 0.1 mm in the x-direction. Additionally determines how much energy it loses via @sa particleProcessor::energyLoss and whether it produces secondary particles
+     * via @sa particleProcessor::splitParticle.
+     * Acc is the Alpaka acceleraror type (e.g. CPU or GPU), processPart is the part to process, generator is a random number generator provided by alpaka and
+     * SD is an instance of a c++ class, of type sensitive, representing a sensitive detector.
+     * Returns the output of @sa particleProcessor::splitParticle, which is a pointer to a c++ class of type part.
+     */
+    template<typename Acc> ALPAKA_FN_ACC part* step(Acc const& acc, part& processPart, alpaka::rand::generator::uniform_cuda_hip::Xor& generator,sensitive& SD);
+
+};
+
+#endif
+
+template<typename Acc> ALPAKA_FN_ACC float particleProcessor::energyLoss(Acc const& acc, part& mypart, alpaka::rand::generator::uniform_cuda_hip::Xor& generator) {
+    // take off a random 0 to 0.2 MeV in the direction of momentum
+    auto func(alpaka::rand::distribution::createUniformReal<float>(acc)); 
+    float enLoss= 0.02*func(generator);
+    mypart.m_mom.energyLoss(enLoss );
+    return enLoss;
+}
+
+template<typename Acc> ALPAKA_FN_ACC  unsigned int particleProcessor::processParticle(Acc const& acc, part* partList, const int& iTh, 
+alpaka::rand::generator::uniform_cuda_hip::Xor& generator, sensitive& SD){
+  // Create a particleStack for this thread:
+  particleStack<100> PS;
+  // And push in the particle corresponding to this thread:
+  PS.push(&partList[iTh]);
+
+  part *mypart = PS.top();
+
+  unsigned int nsteps=0;
+  int maxsize=0;
+  while(!PS.empty() ) {
+   part* processPart=PS.top();
+   PS.pop();
+   do {
+     nsteps++;
+     part* newPart=this->step(acc, *processPart, generator, SD);
+     if(newPart) PS.push(newPart); // if a new particle is generated we add it to the stack
+     if (PS.size() > maxsize) maxsize = PS.size();
+    } while(processPart->momentum() > 1. ) ;
+    delete processPart;
+  }
+
+  return nsteps;
+}
+
+
+template<typename Acc> ALPAKA_FN_ACC part* particleProcessor::splitParticle(Acc const& acc, part& mypart, alpaka::rand::generator::uniform_cuda_hip::Xor& generator) {
+  // throw a random number if >0.99 do a splitting (e.g. a Brem or pair production)
+  auto func(alpaka::rand::distribution::createUniformReal<float>(acc));
+
+  if (func(generator) > 0.99) {
+    // This is a dummy splitter. We do a process a->b+c
+    // b will take fracb of momentum with fracb betweek 0.5 and 0.9
+    // c will take fracc of the momentum with fracc between 0. and 1-fracb
+    // fracb+fracc has to be < 1 !!
+    float fracb=func(generator)*0.4+0.5; // number between 0.5 and 0.9
+    float fracc=1-fracb;
+    if (fracb+fracc > 1.0) printf("ARGHHH I MADE A MISTAKE \n");
+    // copy momentum and scale it
+    vec3 mom = mypart.m_mom;
+    mom.scaleLength(fracc); 
+    // Create a new particle in this position with the scaled down momentum
+    part* newpart = new part(mypart.m_pos, mom, 22 );
+    // scale the momentum of the original particle
+    mypart.m_mom.scaleLength(fracb);       
+    // To make it look like an EM shower, if the particle is a photon we split into e+ e-
+    if (mypart.m_ptype == 22) {
+      mypart.m_ptype = 13;
+      newpart->m_ptype=-13;
+    } 
+    return newpart;
+  }
+  return 0;
+}
+
+
+
+template<typename Acc> ALPAKA_FN_ACC part* particleProcessor::step(Acc const& acc, part& processPart, alpaka::rand::generator::uniform_cuda_hip::Xor& generator, sensitive& SD) {
+  // Move the particle by a deltaX=0.1mm in the momentum direction
+  float deltaX=0.1;
+  float mom = processPart.momentum();
+  processPart.m_pos = processPart.m_pos + (deltaX/mom) * processPart.m_mom;  
+  float enLoss = this->energyLoss(acc, processPart, generator);
+
+  return this->splitParticle(acc, processPart, generator); // randomly see if we split the particle      
+}
+
+
+

--- a/test/FisherPrice_Alpaka/particleProcessor.h
+++ b/test/FisherPrice_Alpaka/particleProcessor.h
@@ -43,13 +43,13 @@ class particleProcessor {
      */
     template<typename Acc>  ALPAKA_FN_ACC unsigned int processParticle(Acc const& acc,part* partList, const int& iTh, alpaka::rand::generator::uniform_cuda_hip::Xor& generator, sensitive& SD);
 
-  /**
-   * @brief throws a random number to determine whether to generate secondary particles. An electron will always generate a photon and a photon will always generate
-   * an electron-positron pair. Momentum is conserved such that the initial particle reduces in momentum by the momentum of the additional particles.
-   * Acc is the Alpaka acceleraror type (e.g. CPU or GPU), mypart is the particle to consider and generator is a random number generator provided by alpaka.
-   * Returns a new particle representing either the photon (in e -> gamma brehmstrahhlung case) or positron (in the photon -> e+e- case). If we don't produce
-   * any additional particles 0 is returned.
-   */
+    /**
+    * @brief throws a random number to determine whether to generate secondary particles. An electron will always generate a photon and a photon will always generate
+    * an electron-positron pair. Momentum is conserved such that the initial particle reduces in momentum by the momentum of the additional particles.
+    * Acc is the Alpaka acceleraror type (e.g. CPU or GPU), mypart is the particle to consider and generator is a random number generator provided by alpaka.
+    * Returns a new particle representing either the photon (in e -> gamma brehmstrahhlung case) or positron (in the photon -> e+e- case). If we don't produce
+    * any additional particles 0 is returned.
+    */
     template<typename Acc> ALPAKA_FN_ACC part* splitParticle(Acc const& acc, part& mypart, alpaka::rand::generator::uniform_cuda_hip::Xor& generator);
 
     /**

--- a/test/FisherPrice_Alpaka/particleProcessor.h
+++ b/test/FisherPrice_Alpaka/particleProcessor.h
@@ -84,7 +84,9 @@ ALPAKA_FN_ACC float particleProcessor::energyLoss(Acc const &acc, part &mypart,
   // take off a random 0 to 0.2 MeV in the direction of momentum
   auto func(alpaka::rand::distribution::createUniformReal<float>(acc));
   float enLoss = 0.02 * func(generator);
-  mypart.getMom().energyLoss(enLoss);
+  vec3 theMom  = mypart.getMom();
+  theMom.energyLoss(enLoss);
+  mypart.setMom(theMom);
   return enLoss;
 }
 
@@ -138,7 +140,9 @@ ALPAKA_FN_ACC part *particleProcessor::splitParticle(Acc const &acc, part &mypar
     // Create a new particle in this position with the scaled down momentum
     part *newpart = new part(mypart.getPos(), mom, 22);
     // scale the momentum of the original particle
-    mypart.getMom().scaleLength(fracb);
+    vec3 origMom = mypart.getMom();
+    origMom.scaleLength(fracb);
+    mypart.setMom(origMom);
     // To make it look like an EM shower, if the particle is a photon we split into e+ e-
     if (mypart.getPType() == 22) {
       mypart.setPType(13);

--- a/test/FisherPrice_Alpaka/particleProcessor.h
+++ b/test/FisherPrice_Alpaka/particleProcessor.h
@@ -3,8 +3,9 @@
 
 /**
  * @file particleProcessor.h
- * @brief simulates electrons and photons - it can calculate ionisaton energy loss, make a particle undergo brehmstrahhlung or pair production and move a particle along the x-direction. 
- * All class functions are specified to run the accelerator (device) only.
+ * @brief simulates electrons and photons - it can calculate ionisaton energy loss, make a particle undergo
+ * brehmstrahhlung or pair production and move a particle along the x-direction. All class functions are specified to
+ * run the accelerator (device) only.
  * @author Davide Costanzo (d.costanzo@sheffield.ac.uk) and Mark Hodgkinson (d.costanzo@sheffield.ac.uk)
  * */
 
@@ -18,63 +19,80 @@
 
 class particleProcessor {
 
-  public:
-    /** @brief A minimal constructor */
-    ALPAKA_FN_ACC particleProcessor (){}
+public:
+  /** @brief A minimal constructor */
+  ALPAKA_FN_ACC particleProcessor() {}
 
-    /** @brief A minimal destructor */
-    ALPAKA_FN_ACC ~particleProcessor(){}
+  /** @brief A minimal destructor */
+  ALPAKA_FN_ACC ~particleProcessor() {}
 
-    /**
-     * @brief calculates the energy loss of a particle, mypart, in the range 0 to 0.2 MeV in the direction of the momentum.
-     * Acc is the Alpaka acceleraror type (e.g. CPU or GPU), mypart is the part to calculate the energy loss for and generator is a random number generator provided by alpaka.
-     * Assumes the generator has already been initialised with a seed by the client.
-     * Returns a float value representing the energy lost, which is calculated as a randum number (between zero and one) multiplied by 0.2 MeV.
-     * */
-    template<typename Acc> ALPAKA_FN_ACC float energyLoss(Acc const& acc, part& mypart, alpaka::rand::generator::uniform_cuda_hip::Xor& generator);
+  /**
+   * @brief calculates the energy loss of a particle, mypart, in the range 0 to 0.2 MeV in the direction of the
+   * momentum. Acc is the Alpaka acceleraror type (e.g. CPU or GPU), mypart is the part to calculate the energy loss for
+   * and generator is a random number generator provided by alpaka. Assumes the generator has already been initialised
+   * with a seed by the client. Returns a float value representing the energy lost, which is calculated as a randum
+   * number (between zero and one) multiplied by 0.2 MeV.
+   * */
+  template <typename Acc>
+  ALPAKA_FN_ACC float energyLoss(Acc const &acc, part &mypart,
+                                 alpaka::rand::generator::uniform_cuda_hip::Xor &generator);
 
-    /**
-     * @brief Takes a list of particles on a specific thread and processes them. Processing means that the particles moves along the x-direction in finite steps. In each step
-     * a new particle(s) may or may not be generated - if so it is added to an internal. to this function, array of particles on the stack. The function continues to step
-     * until the initial particles momentum drops below 1 MeV.
-     * Acc is the Alpaka acceleraror type (e.g. CPU or GPU), partList is a list of part, iTh is the thread being used, generator is a random number generator provided by alpaka and
-     * SD is an instance of a c++ class, of type sensitive, representing a sensitive detector.
-     * Returns an unsigned integer representing the number of steps undertaken.
-     */
-    template<typename Acc>  ALPAKA_FN_ACC unsigned int processParticle(Acc const& acc,part* partList, const int& iTh, alpaka::rand::generator::uniform_cuda_hip::Xor& generator, sensitive& SD);
+  /**
+   * @brief Takes a list of particles on a specific thread and processes them. Processing means that the particles moves
+   * along the x-direction in finite steps. In each step a new particle(s) may or may not be generated - if so it is
+   * added to an internal. to this function, array of particles on the stack. The function continues to step until the
+   * initial particles momentum drops below 1 MeV. Acc is the Alpaka acceleraror type (e.g. CPU or GPU), partList is a
+   * list of part, iTh is the thread being used, generator is a random number generator provided by alpaka and SD is an
+   * instance of a c++ class, of type sensitive, representing a sensitive detector. Returns an unsigned integer
+   * representing the number of steps undertaken.
+   */
+  template <typename Acc>
+  ALPAKA_FN_ACC unsigned int processParticle(Acc const &acc, part *partList, const int &iTh,
+                                             alpaka::rand::generator::uniform_cuda_hip::Xor &generator, sensitive &SD);
 
-    /**
-    * @brief throws a random number to determine whether to generate secondary particles. An electron will always generate a photon and a photon will always generate
-    * an electron-positron pair. Momentum is conserved such that the initial particle reduces in momentum by the momentum of the additional particles.
-    * Acc is the Alpaka acceleraror type (e.g. CPU or GPU), mypart is the particle to consider and generator is a random number generator provided by alpaka.
-    * Returns a new particle representing either the photon (in e -> gamma brehmstrahhlung case) or positron (in the photon -> e+e- case). If we don't produce
-    * any additional particles 0 is returned.
-    */
-    template<typename Acc> ALPAKA_FN_ACC part* splitParticle(Acc const& acc, part& mypart, alpaka::rand::generator::uniform_cuda_hip::Xor& generator);
+  /**
+   * @brief throws a random number to determine whether to generate secondary particles. An electron will always
+   * generate a photon and a photon will always generate an electron-positron pair. Momentum is conserved such that the
+   * initial particle reduces in momentum by the momentum of the additional particles. Acc is the Alpaka acceleraror
+   * type (e.g. CPU or GPU), mypart is the particle to consider and generator is a random number generator provided by
+   * alpaka. Returns a new particle representing either the photon (in e -> gamma brehmstrahhlung case) or positron (in
+   * the photon -> e+e- case). If we don't produce any additional particles 0 is returned.
+   */
+  template <typename Acc>
+  ALPAKA_FN_ACC part *splitParticle(Acc const &acc, part &mypart,
+                                    alpaka::rand::generator::uniform_cuda_hip::Xor &generator);
 
-    /**
-     * @brief steps the particle 0.1 mm in the x-direction. Additionally determines how much energy it loses via @sa particleProcessor::energyLoss and whether it produces secondary particles
-     * via @sa particleProcessor::splitParticle.
-     * Acc is the Alpaka acceleraror type (e.g. CPU or GPU), processPart is the part to process, generator is a random number generator provided by alpaka and
-     * SD is an instance of a c++ class, of type sensitive, representing a sensitive detector.
-     * Returns the output of @sa particleProcessor::splitParticle, which is a pointer to a c++ class of type part.
-     */
-    template<typename Acc> ALPAKA_FN_ACC part* step(Acc const& acc, part& processPart, alpaka::rand::generator::uniform_cuda_hip::Xor& generator,sensitive& SD);
-
+  /**
+   * @brief steps the particle 0.1 mm in the x-direction. Additionally determines how much energy it loses via @sa
+   * particleProcessor::energyLoss and whether it produces secondary particles via @sa particleProcessor::splitParticle.
+   * Acc is the Alpaka acceleraror type (e.g. CPU or GPU), processPart is the part to process, generator is a random
+   * number generator provided by alpaka and SD is an instance of a c++ class, of type sensitive, representing a
+   * sensitive detector. Returns the output of @sa particleProcessor::splitParticle, which is a pointer to a c++ class
+   * of type part.
+   */
+  template <typename Acc>
+  ALPAKA_FN_ACC part *step(Acc const &acc, part &processPart, alpaka::rand::generator::uniform_cuda_hip::Xor &generator,
+                           sensitive &SD);
 };
 
 #endif
 
-template<typename Acc> ALPAKA_FN_ACC float particleProcessor::energyLoss(Acc const& acc, part& mypart, alpaka::rand::generator::uniform_cuda_hip::Xor& generator) {
-    // take off a random 0 to 0.2 MeV in the direction of momentum
-    auto func(alpaka::rand::distribution::createUniformReal<float>(acc)); 
-    float enLoss= 0.02*func(generator);
-    mypart.m_mom.energyLoss(enLoss );
-    return enLoss;
+template <typename Acc>
+ALPAKA_FN_ACC float particleProcessor::energyLoss(Acc const &acc, part &mypart,
+                                                  alpaka::rand::generator::uniform_cuda_hip::Xor &generator)
+{
+  // take off a random 0 to 0.2 MeV in the direction of momentum
+  auto func(alpaka::rand::distribution::createUniformReal<float>(acc));
+  float enLoss = 0.02 * func(generator);
+  mypart.getMom().energyLoss(enLoss);
+  return enLoss;
 }
 
-template<typename Acc> ALPAKA_FN_ACC  unsigned int particleProcessor::processParticle(Acc const& acc, part* partList, const int& iTh, 
-alpaka::rand::generator::uniform_cuda_hip::Xor& generator, sensitive& SD){
+template <typename Acc>
+ALPAKA_FN_ACC unsigned int particleProcessor::processParticle(Acc const &acc, part *partList, const int &iTh,
+                                                              alpaka::rand::generator::uniform_cuda_hip::Xor &generator,
+                                                              sensitive &SD)
+{
   // Create a particleStack for this thread:
   particleStack<100> PS;
   // And push in the particle corresponding to this thread:
@@ -82,25 +100,27 @@ alpaka::rand::generator::uniform_cuda_hip::Xor& generator, sensitive& SD){
 
   part *mypart = PS.top();
 
-  unsigned int nsteps=0;
-  int maxsize=0;
-  while(!PS.empty() ) {
-   part* processPart=PS.top();
-   PS.pop();
-   do {
-     nsteps++;
-     part* newPart=this->step(acc, *processPart, generator, SD);
-     if(newPart) PS.push(newPart); // if a new particle is generated we add it to the stack
-     if (PS.size() > maxsize) maxsize = PS.size();
-    } while(processPart->momentum() > 1. ) ;
+  unsigned int nsteps = 0;
+  int maxsize         = 0;
+  while (!PS.empty()) {
+    part *processPart = PS.top();
+    PS.pop();
+    do {
+      nsteps++;
+      part *newPart = this->step(acc, *processPart, generator, SD);
+      if (newPart) PS.push(newPart); // if a new particle is generated we add it to the stack
+      if (PS.size() > maxsize) maxsize = PS.size();
+    } while (processPart->momentum() > 1.);
     delete processPart;
   }
 
   return nsteps;
 }
 
-
-template<typename Acc> ALPAKA_FN_ACC part* particleProcessor::splitParticle(Acc const& acc, part& mypart, alpaka::rand::generator::uniform_cuda_hip::Xor& generator) {
+template <typename Acc>
+ALPAKA_FN_ACC part *particleProcessor::splitParticle(Acc const &acc, part &mypart,
+                                                     alpaka::rand::generator::uniform_cuda_hip::Xor &generator)
+{
   // throw a random number if >0.99 do a splitting (e.g. a Brem or pair production)
   auto func(alpaka::rand::distribution::createUniformReal<float>(acc));
 
@@ -109,37 +129,35 @@ template<typename Acc> ALPAKA_FN_ACC part* particleProcessor::splitParticle(Acc 
     // b will take fracb of momentum with fracb betweek 0.5 and 0.9
     // c will take fracc of the momentum with fracc between 0. and 1-fracb
     // fracb+fracc has to be < 1 !!
-    float fracb=func(generator)*0.4+0.5; // number between 0.5 and 0.9
-    float fracc=1-fracb;
-    if (fracb+fracc > 1.0) printf("ARGHHH I MADE A MISTAKE \n");
+    float fracb = func(generator) * 0.4 + 0.5; // number between 0.5 and 0.9
+    float fracc = 1 - fracb;
+    if (fracb + fracc > 1.0) printf("ARGHHH I MADE A MISTAKE \n");
     // copy momentum and scale it
-    vec3 mom = mypart.m_mom;
-    mom.scaleLength(fracc); 
+    vec3 mom = mypart.getMom();
+    mom.scaleLength(fracc);
     // Create a new particle in this position with the scaled down momentum
-    part* newpart = new part(mypart.m_pos, mom, 22 );
+    part *newpart = new part(mypart.getPos(), mom, 22);
     // scale the momentum of the original particle
-    mypart.m_mom.scaleLength(fracb);       
+    mypart.getMom().scaleLength(fracb);
     // To make it look like an EM shower, if the particle is a photon we split into e+ e-
-    if (mypart.m_ptype == 22) {
-      mypart.m_ptype = 13;
-      newpart->m_ptype=-13;
-    } 
+    if (mypart.getPType() == 22) {
+      mypart.setPType(13);
+      newpart->setPType(-13);
+    }
     return newpart;
   }
   return 0;
 }
 
-
-
-template<typename Acc> ALPAKA_FN_ACC part* particleProcessor::step(Acc const& acc, part& processPart, alpaka::rand::generator::uniform_cuda_hip::Xor& generator, sensitive& SD) {
+template <typename Acc>
+ALPAKA_FN_ACC part *particleProcessor::step(Acc const &acc, part &processPart,
+                                            alpaka::rand::generator::uniform_cuda_hip::Xor &generator, sensitive &SD)
+{
   // Move the particle by a deltaX=0.1mm in the momentum direction
-  float deltaX=0.1;
-  float mom = processPart.momentum();
-  processPart.m_pos = processPart.m_pos + (deltaX/mom) * processPart.m_mom;  
+  float deltaX = 0.1;
+  float mom    = processPart.momentum();
+  processPart.setPos(processPart.getPos() + (deltaX / mom) * processPart.getMom());
   float enLoss = this->energyLoss(acc, processPart, generator);
 
-  return this->splitParticle(acc, processPart, generator); // randomly see if we split the particle      
+  return this->splitParticle(acc, processPart, generator); // randomly see if we split the particle
 }
-
-
-

--- a/test/FisherPrice_Alpaka/particleProcessor.h
+++ b/test/FisherPrice_Alpaka/particleProcessor.h
@@ -84,11 +84,7 @@ ALPAKA_FN_ACC float particleProcessor::energyLoss(Acc const &acc, part &mypart,
   // take off a random 0 to 0.2 MeV in the direction of momentum
   auto func(alpaka::rand::distribution::createUniformReal<float>(acc));
   float enLoss = 0.02 * func(generator);
-<<<<<<< HEAD
   mypart.getMom().energyLoss(enLoss);
-=======
-  mypart.m_mom.energyLoss(enLoss);
->>>>>>> 85af853c5698e95e5887a6b150d57ace733d7e25
   return enLoss;
 }
 

--- a/test/FisherPrice_Alpaka/particleStack.h
+++ b/test/FisherPrice_Alpaka/particleStack.h
@@ -1,0 +1,28 @@
+#include "part.h"
+
+#ifndef PARTICLESTACK_H
+#define PARTICLESTACK_H
+
+#include <alpaka/alpaka.hpp>
+
+template <unsigned int ARRAYSIZE> class particleStack {
+  private:
+    part *m_stack[ARRAYSIZE]; // allocate space for ARRAYSIZE pointers in the stack
+    int nPart; 
+
+  public:
+        ALPAKA_FN_ACC particleStack() {nPart=0; for (int ii=0; ii< ARRAYSIZE; ii++) m_stack[ii]=0; } // set all pointers to zero
+
+        ALPAKA_FN_ACC bool empty() {if (nPart ==0 ) return true; else return false; }
+
+        ALPAKA_FN_ACC part* top() { return m_stack[nPart-1]; } // FIXME If stack is empty we are in big trouble!
+
+        ALPAKA_FN_ACC void pop() {m_stack[nPart-1]=0; nPart--; }
+
+        ALPAKA_FN_ACC void push(part *myPart) { m_stack[nPart]=myPart; nPart++; }
+
+        ALPAKA_FN_ACC int size() {return nPart;}
+
+};
+#endif // PARTICLESTACK
+

--- a/test/FisherPrice_Alpaka/particleStack.h
+++ b/test/FisherPrice_Alpaka/particleStack.h
@@ -1,27 +1,51 @@
-#include "part.h"
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+* @file particleStack.h
+* @brief stores an array of particles, part, of size @t ARRAYSIZE
+* @author Davide Costanzo (d.costanzo@sheffield.ac.uk) and Mark Hodgkinson (d.costanzo@sheffield.ac.uk)
+ */
 
 #ifndef PARTICLESTACK_H
 #define PARTICLESTACK_H
+
+#include "part.h"
 
 #include <alpaka/alpaka.hpp>
 
 template <unsigned int ARRAYSIZE> class particleStack {
   private:
-    part *m_stack[ARRAYSIZE]; // allocate space for ARRAYSIZE pointers in the stack
-    int nPart; 
+    /** An array, of part, of size ARRAYSIZE */
+    part *m_stack[ARRAYSIZE]; 
+    /** integer to track how many part are currently contained in the array */
+    int m_nPart; 
 
   public:
-        ALPAKA_FN_ACC particleStack() {nPart=0; for (int ii=0; ii< ARRAYSIZE; ii++) m_stack[ii]=0; } // set all pointers to zero
+    /** @brief constructor which sets all array elements to zero */
+    ALPAKA_FN_ACC particleStack() {m_nPart=0; for (int ii=0; ii< ARRAYSIZE; ii++) m_stack[ii]=0; }
 
-        ALPAKA_FN_ACC bool empty() {if (nPart ==0 ) return true; else return false; }
+    /** @brief check whether the number of part currently stored is zero or not.
+     * returns the result of the query as bool
+     */
+    ALPAKA_FN_ACC bool empty() {if (0 == m_nPart) return true; else return false; }
 
-        ALPAKA_FN_ACC part* top() { return m_stack[nPart-1]; } // FIXME If stack is empty we are in big trouble!
+    /** @brief gets the particle at the end of the array
+     * returns a pointer of type part directly from the stored array m_stack.
+     * @remark assumes the array m_stack is NOT empty.
+     */
+    ALPAKA_FN_ACC part* top() { return m_stack[m_nPart-1]; }
 
-        ALPAKA_FN_ACC void pop() {m_stack[nPart-1]=0; nPart--; }
+    /** @brief set the part pointer stored at the end of the array to zero */
+    ALPAKA_FN_ACC void pop() {m_stack[m_nPart-1]=0; m_nPart--; }
 
-        ALPAKA_FN_ACC void push(part *myPart) { m_stack[nPart]=myPart; nPart++; }
+    /** @brief add a part to the array.
+     * myPart is a pointer to a part */
+    ALPAKA_FN_ACC void push(part *myPart) { m_stack[m_nPart]=myPart; m_nPart++; }
 
-        ALPAKA_FN_ACC int size() {return nPart;}
+    /** @brief gets the stored arrays size.
+     * returns the stored integer m_nPart */
+    ALPAKA_FN_ACC int size() {return m_nPart;}
 
 };
 #endif // PARTICLESTACK

--- a/test/FisherPrice_Alpaka/sensitive.h
+++ b/test/FisherPrice_Alpaka/sensitive.h
@@ -5,36 +5,43 @@
  * @file sensitive.h
  * @brief represents a sensitive particle detector
  * @author Davide Costanzo (d.costanzo@sheffield.ac.uk) and Mark Hodgkinson (d.costanzo@sheffield.ac.uk)
-*/
+ */
 
 #ifndef SENSITIVE_H
 #define SENSITIVE_H
 
 #include "part.h"
 
-class sensitive{ 
-   public:
-     /** @brief nominal constructor sets the class data to default values */
-     sensitive() {m_zmin=0.0; m_zmax=1000.; m_totalE=0.0; }
-     
-     /** @brief constructor sets user supplied values of zmin and zmaz. m_totalE
-      * is set to zero
-      * */
-     sensitive(float zmin, float zmax) {m_zmin = zmin; m_zmax = zmax; m_totalE=0.0; }
+class sensitive {
+public:
+  /** @brief nominal constructor sets the class data to default values */
+  ALPAKA_FN_ACC sensitive()
+  {
+    m_zmin   = 0.0;
+    m_zmax   = 1000.;
+    m_totalE = 0.0;
+  }
 
-     float m_zmin, m_zmax; ///< variables to represent extent of detector in z direction
-     float m_totalE; ///< total energy depoisted in this detector 
+  /** @brief constructor sets user supplied values of zmin and zmaz. m_totalE
+   * is set to zero
+   * */
+  ALPAKA_FN_ACC sensitive(float zmin, float zmax)
+  {
+    m_zmin   = zmin;
+    m_zmax   = zmax;
+    m_totalE = 0.0;
+  }
 
-     /** @brief add energy to the sensitive detector from a particle.
-      * mypart is the particle being considered and E is its energy loss.
-      */ 
-     inline void add(const part *mypart, float E ) { if (mypart->m_pos.z() > m_zmin && mypart->m_pos.z() < m_zmax) m_totalE += E; }
+  float m_zmin, m_zmax; ///< variables to represent extent of detector in z direction
+  float m_totalE;       ///< total energy depoisted in this detector
 
-}; 
+  /** @brief add energy to the sensitive detector from a particle.
+   * mypart is the particle being considered and E is its energy loss.
+   */
+  ALPAKA_FN_ACC inline void add(const part *mypart, float E)
+  {
+    if (mypart->getPos().z() > m_zmin && mypart->getPos().z() < m_zmax) m_totalE += E;
+  }
+};
 
 #endif // SENSITIVE_H
-    
-
-
-
-

--- a/test/FisherPrice_Alpaka/sensitive.h
+++ b/test/FisherPrice_Alpaka/sensitive.h
@@ -1,19 +1,35 @@
-#include "part.h"
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file sensitive.h
+ * @brief represents a sensitive particle detector
+ * @author Davide Costanzo (d.costanzo@sheffield.ac.uk) and Mark Hodgkinson (d.costanzo@sheffield.ac.uk)
+*/
 
 #ifndef SENSITIVE_H
 #define SENSITIVE_H
 
+#include "part.h"
 
 class sensitive{ 
    public:
+     /** @brief nominal constructor sets the class data to default values */
      sensitive() {m_zmin=0.0; m_zmax=1000.; m_totalE=0.0; }
-     #ifdef __CUDACC__
-     __device__ 
-     #endif 
+     
+     /** @brief constructor sets user supplied values of zmin and zmaz. m_totalE
+      * is set to zero
+      * */
      sensitive(float zmin, float zmax) {m_zmin = zmin; m_zmax = zmax; m_totalE=0.0; }
+
+     /** variables to represent extent of detector in z direction */ 
      float m_zmin, m_zmax;
+     /** total energy depoisted in this detector */
      float m_totalE;
 
+     /** @brief add energy to the sensitive detector from a particle.
+      * mypart is the particle being considered and E is its energy loss.
+      */ 
      inline void add(const part *mypart, float E ) { if (mypart->m_pos.z() > m_zmin && mypart->m_pos.z() < m_zmax) m_totalE += E; }
 
 }; 

--- a/test/FisherPrice_Alpaka/sensitive.h
+++ b/test/FisherPrice_Alpaka/sensitive.h
@@ -22,10 +22,8 @@ class sensitive{
       * */
      sensitive(float zmin, float zmax) {m_zmin = zmin; m_zmax = zmax; m_totalE=0.0; }
 
-     /** variables to represent extent of detector in z direction */ 
-     float m_zmin, m_zmax;
-     /** total energy depoisted in this detector */
-     float m_totalE;
+     float m_zmin, m_zmax; ///< variables to represent extent of detector in z direction
+     float m_totalE; ///< total energy depoisted in this detector 
 
      /** @brief add energy to the sensitive detector from a particle.
       * mypart is the particle being considered and E is its energy loss.

--- a/test/FisherPrice_Alpaka/sensitive.h
+++ b/test/FisherPrice_Alpaka/sensitive.h
@@ -1,0 +1,26 @@
+#include "part.h"
+
+#ifndef SENSITIVE_H
+#define SENSITIVE_H
+
+
+class sensitive{ 
+   public:
+     sensitive() {m_zmin=0.0; m_zmax=1000.; m_totalE=0.0; }
+     #ifdef __CUDACC__
+     __device__ 
+     #endif 
+     sensitive(float zmin, float zmax) {m_zmin = zmin; m_zmax = zmax; m_totalE=0.0; }
+     float m_zmin, m_zmax;
+     float m_totalE;
+
+     inline void add(const part *mypart, float E ) { if (mypart->m_pos.z() > m_zmin && mypart->m_pos.z() < m_zmax) m_totalE += E; }
+
+}; 
+
+#endif // SENSITIVE_H
+    
+
+
+
+

--- a/test/FisherPrice_Alpaka/vec3.h
+++ b/test/FisherPrice_Alpaka/vec3.h
@@ -5,7 +5,7 @@
  * @file vec3.h
  * @brief represents a 3-vector and provides functionality to manipulate 3-vectors.
  * @author Davide Costanzo (d.costanzo@sheffield.ac.uk) and Mark Hodgkinson (d.costanzo@sheffield.ac.uk)
-*/
+ */
 
 #ifndef VEC3_H
 #define VEC3_H
@@ -15,106 +15,122 @@
 #include <iostream>
 
 class vec3 {
-  public:
-    /** @brief nominal constructor */
-    vec3() {}
+public:
+  /** @brief nominal constructor */
+  ALPAKA_FN_ACC vec3() {}
 
-    /** @brief constructor which sets the 3 components of the vector.
-     * e0, e1 and e2 are the components of a 3-vector
-     */
-    vec3(float e0, float e1, float e2) { m_e[0] = e0; m_e[1] = e1; m_e[2] = e2; }
+  /** @brief constructor which sets the 3 components of the vector.
+   * e0, e1 and e2 are the components of a 3-vector
+   */
+  ALPAKA_FN_ACC vec3(float e0, float e1, float e2)
+  {
+    m_e[0] = e0;
+    m_e[1] = e1;
+    m_e[2] = e2;
+  }
 
-    /** @brief returns the stored first component of the 3-vector */
-    inline float x() const { return m_e[0]; }
+  /** @brief returns the stored first component of the 3-vector */
+  ALPAKA_FN_ACC inline float x() const { return m_e[0]; }
 
-    /** @brief returns the stored second component of the 3-vector */
-    inline float y() const { return m_e[1]; }
+  /** @brief returns the stored second component of the 3-vector */
+  ALPAKA_FN_ACC inline float y() const { return m_e[1]; }
 
-    /** @brief returns the stored third component of the 3-vector */
-    inline float z() const { return m_e[2]; }
+  /** @brief returns the stored third component of the 3-vector */
+  ALPAKA_FN_ACC inline float z() const { return m_e[2]; }
 
-    /** @brief returns reference to this vector */
-    inline const vec3& operator+() const { return *this; }
+  /** @brief returns reference to this vector */
+  ALPAKA_FN_ACC inline const vec3 &operator+() const { return *this; }
 
-    /** @brief returns reference to this vector, after adding an other vector to it.
-     * v2 is the vector to be added to this vecor.
-     * */
-    inline vec3& operator+=(const vec3 &v2);
+  /** @brief returns reference to this vector, after adding an other vector to it.
+   * v2 is the vector to be added to this vecor.
+   * */
+  ALPAKA_FN_ACC inline vec3 &operator+=(const vec3 &v2);
 
-    /** @brief returns reference to this vector, after multiplying it by a value.
-     * t is the value to multiple this vector by.
-     * */
-    inline vec3& operator*=(const float t);
+  /** @brief returns reference to this vector, after multiplying it by a value.
+   * t is the value to multiple this vector by.
+   * */
+  ALPAKA_FN_ACC inline vec3 &operator*=(const float t);
 
-    /** @brief returns the magnitude of the vector */
-    inline float length() const { return sqrt(m_e[0]*m_e[0] + m_e[1]*m_e[1] + m_e[2]*m_e[2]); }
+  /** @brief returns the magnitude of the vector */
+  ALPAKA_FN_ACC inline float length() const { return sqrt(m_e[0] * m_e[0] + m_e[1] * m_e[1] + m_e[2] * m_e[2]); }
 
-    /** @brief reduces this vector by the energy a particle loses
-     * en is the energy lost.
-     * Each component of the vector is reduced by en * 1/magnitude * component.
-     */
-    inline void energyLoss(float en);
+  /** @brief reduces this vector by the energy a particle loses
+   * en is the energy lost.
+   * Each component of the vector is reduced by en * 1/magnitude * component.
+   */
+  ALPAKA_FN_ACC inline void energyLoss(float en);
 
-    /** @brief scale each component of the vector by a value.
-     * scale is the value to scale each component by
-     */
-    inline void scaleLength(float scale) {m_e[0]*=scale; m_e[1]*=scale; m_e[2]*=scale;  }
+  /** @brief scale each component of the vector by a value.
+   * scale is the value to scale each component by
+   */
+  ALPAKA_FN_ACC inline void scaleLength(float scale)
+  {
+    m_e[0] *= scale;
+    m_e[1] *= scale;
+    m_e[2] *= scale;
+  }
 
-    float m_e[3]; ///< array to represent the 3-vector.
- };
+  float m_e[3]; ///< array to represent the 3-vector.
+};
 
 /** @brief returns an output stream that prints the components of the vector
  * os is the ostream operator and t is the 3vec to print components of.
  */
-inline std::ostream& operator<<(std::ostream &os, const vec3 &t) {
+inline std::ostream &operator<<(std::ostream &os, const vec3 &t)
+{
   os << t.m_e[0] << " " << t.m_e[1] << " " << t.m_e[2];
   return os;
 }
 
-inline void vec3::energyLoss(float en) {
-  float k = 1 / sqrt(m_e[0]*m_e[0] + m_e[1]*m_e[1] + m_e[2]*m_e[2]);
-  m_e[0]=m_e[0]-en*k*m_e[0];
-  m_e[1]=m_e[1]-en*k*m_e[1];
-  m_e[2]=m_e[2]-en*k*m_e[2];
+ALPAKA_FN_ACC inline void vec3::energyLoss(float en)
+{
+  float k = 1 / sqrt(m_e[0] * m_e[0] + m_e[1] * m_e[1] + m_e[2] * m_e[2]);
+  m_e[0]  = m_e[0] - en * k * m_e[0];
+  m_e[1]  = m_e[1] - en * k * m_e[1];
+  m_e[2]  = m_e[2] - en * k * m_e[2];
 }
 
 /** @brief add two vectors together.
  * v1 and v2 are the vec3 to add.
  * returns the sum of the two vectors v1 and v2.
- */ 
-inline vec3 operator+(const vec3 &v1, const vec3 &v2) {
+ */
+ALPAKA_FN_ACC inline vec3 operator+(const vec3 &v1, const vec3 &v2)
+{
   return vec3(v1.m_e[0] + v2.m_e[0], v1.m_e[1] + v2.m_e[1], v1.m_e[2] + v2.m_e[2]);
 }
 
 /** @brief multiply a vector by a value.
  * t is the value to multiply a 3-vector v by.
  * returns a new vector, which is the result of the operation.
- */ 
-inline vec3 operator*(float t, const vec3 &v) {
-  return vec3(t*v.m_e[0], t*v.m_e[1], t*v.m_e[2]);
+ */
+ALPAKA_FN_ACC inline vec3 operator*(float t, const vec3 &v)
+{
+  return vec3(t * v.m_e[0], t * v.m_e[1], t * v.m_e[2]);
 }
 
 /** @brief multiply a vector by a value.
  * t is the value to multiply a 3-vector v by.
  * returns a new vector, which is the result of the operation.
- */ 
-inline vec3 operator*(const vec3 &v, float t) {
-  return vec3(t*v.m_e[0], t*v.m_e[1], t*v.m_e[2]);
+ */
+ALPAKA_FN_ACC inline vec3 operator*(const vec3 &v, float t)
+{
+  return vec3(t * v.m_e[0], t * v.m_e[1], t * v.m_e[2]);
 }
 
-inline vec3& vec3::operator+=(const vec3 &v){
-  m_e[0]  += v.m_e[0];
-  m_e[1]  += v.m_e[1];
-  m_e[2]  += v.m_e[2];
+ALPAKA_FN_ACC inline vec3 &vec3::operator+=(const vec3 &v)
+{
+  m_e[0] += v.m_e[0];
+  m_e[1] += v.m_e[1];
+  m_e[2] += v.m_e[2];
   return *this;
 }
 
-inline vec3& vec3::operator*=(const float t) {
-  m_e[0]  *= t;
-  m_e[1]  *= t;
-  m_e[2]  *= t;
+ALPAKA_FN_ACC inline vec3 &vec3::operator*=(const float t)
+{
+  m_e[0] *= t;
+  m_e[1] *= t;
+  m_e[2] *= t;
   return *this;
 }
 
 #endif // VEC3_H
-

--- a/test/FisherPrice_Alpaka/vec3.h
+++ b/test/FisherPrice_Alpaka/vec3.h
@@ -1,0 +1,79 @@
+#include <math.h>
+#include <stdlib.h>
+#include <iostream>
+#ifdef __CUDACC__
+#include "cuda.h"
+#endif
+
+#ifndef VEC3_H
+#define VEC3_H
+
+
+class vec3 {
+  public:
+        vec3() {}
+
+        vec3(float e0, float e1, float e2) { e[0] = e0; e[1] = e1; e[2] = e2; }
+
+        inline float x() const { return e[0]; }
+
+        inline float y() const { return e[1]; }
+
+        inline float z() const { return e[2]; }
+
+        inline const vec3& operator+() const { return *this; }
+
+        inline vec3& operator+=(const vec3 &v2);
+
+        inline vec3& operator*=(const float t);
+
+        inline float length() const { return sqrt(e[0]*e[0] + e[1]*e[1] + e[2]*e[2]); }
+
+        inline void energyLoss(float en);
+
+        inline void scaleLength(float scale) {e[0]*=scale; e[1]*=scale; e[2]*=scale;  }
+
+        float e[3];
+ };
+
+
+inline std::ostream& operator<<(std::ostream &os, const vec3 &t) {
+    os << t.e[0] << " " << t.e[1] << " " << t.e[2];
+    return os;
+}
+
+inline void vec3::energyLoss(float en) {
+    float k = 1 / sqrt(e[0]*e[0] + e[1]*e[1] + e[2]*e[2]);
+    e[0]=e[0]-en*k*e[0];
+    e[1]=e[1]-en*k*e[1];
+    e[2]=e[2]-en*k*e[2];
+}
+
+inline vec3 operator+(const vec3 &v1, const vec3 &v2) {
+    return vec3(v1.e[0] + v2.e[0], v1.e[1] + v2.e[1], v1.e[2] + v2.e[2]);
+}
+
+inline vec3 operator*(float t, const vec3 &v) {
+    return vec3(t*v.e[0], t*v.e[1], t*v.e[2]);
+}
+
+inline vec3 operator*(const vec3 &v, float t) {
+    return vec3(t*v.e[0], t*v.e[1], t*v.e[2]);
+}
+
+inline vec3& vec3::operator+=(const vec3 &v){
+     e[0]  += v.e[0];
+    e[1]  += v.e[1];
+    e[2]  += v.e[2];
+    return *this;
+}
+
+inline vec3& vec3::operator*=(const float t) {
+    e[0]  *= t;
+    e[1]  *= t;
+    e[2]  *= t;
+    return *this;
+}
+
+#endif // VEC3_H
+

--- a/test/FisherPrice_Alpaka/vec3.h
+++ b/test/FisherPrice_Alpaka/vec3.h
@@ -1,78 +1,119 @@
-#include <math.h>
-#include <stdlib.h>
-#include <iostream>
-#ifdef __CUDACC__
-#include "cuda.h"
-#endif
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file vec3.h
+ * @brief represents a 3-vector and provides functionality to manipulate 3-vectors.
+ * @author Davide Costanzo (d.costanzo@sheffield.ac.uk) and Mark Hodgkinson (d.costanzo@sheffield.ac.uk)
+*/
 
 #ifndef VEC3_H
 #define VEC3_H
 
+#include <math.h>
+#include <stdlib.h>
+#include <iostream>
 
 class vec3 {
   public:
-        vec3() {}
+    /** @brief nominal constructor */
+    vec3() {}
 
-        vec3(float e0, float e1, float e2) { e[0] = e0; e[1] = e1; e[2] = e2; }
+    /** @brief constructor which sets the 3 components of the vector.
+     * e0, e1 and e2 are the components of a 3-vector
+     */
+    vec3(float e0, float e1, float e2) { m_e[0] = e0; m_e[1] = e1; m_e[2] = e2; }
 
-        inline float x() const { return e[0]; }
+    /** @brief returns the stored first component of the 3-vector */
+    inline float x() const { return m_e[0]; }
 
-        inline float y() const { return e[1]; }
+    /** @brief returns the stored second component of the 3-vector */
+    inline float y() const { return m_e[1]; }
 
-        inline float z() const { return e[2]; }
+    /** @brief returns the stored third component of the 3-vector */
+    inline float z() const { return m_e[2]; }
 
-        inline const vec3& operator+() const { return *this; }
+    /** @brief returns reference to this vector */
+    inline const vec3& operator+() const { return *this; }
 
-        inline vec3& operator+=(const vec3 &v2);
+    /** @brief returns reference to this vector, after adding an other vector to it.
+     * v2 is the vector to be added to this vecor.
+     * */
+    inline vec3& operator+=(const vec3 &v2);
 
-        inline vec3& operator*=(const float t);
+    /** @brief returns reference to this vector, after multiplying it by a value.
+     * t is the value to multiple this vector by.
+     * */
+    inline vec3& operator*=(const float t);
 
-        inline float length() const { return sqrt(e[0]*e[0] + e[1]*e[1] + e[2]*e[2]); }
+    /** @brief returns the magnitude of the vector */
+    inline float length() const { return sqrt(m_e[0]*m_e[0] + m_e[1]*m_e[1] + m_e[2]*m_e[2]); }
 
-        inline void energyLoss(float en);
+    /** @brief reduces this vector by the energy a particle loses
+     * en is the energy lost.
+     * Each component of the vector is reduced by en * 1/magnitude * component.
+     */
+    inline void energyLoss(float en);
 
-        inline void scaleLength(float scale) {e[0]*=scale; e[1]*=scale; e[2]*=scale;  }
+    /** @brief scale each component of the vector by a value.
+     * scale is the value to scale each component by
+     */
+    inline void scaleLength(float scale) {m_e[0]*=scale; m_e[1]*=scale; m_e[2]*=scale;  }
 
-        float e[3];
+    float m_e[3]; ///< array to represent the 3-vector.
  };
 
-
+/** @brief returns an output stream that prints the components of the vector
+ * os is the ostream operator and t is the 3vec to print components of.
+ */
 inline std::ostream& operator<<(std::ostream &os, const vec3 &t) {
-    os << t.e[0] << " " << t.e[1] << " " << t.e[2];
-    return os;
+  os << t.m_e[0] << " " << t.m_e[1] << " " << t.m_e[2];
+  return os;
 }
 
 inline void vec3::energyLoss(float en) {
-    float k = 1 / sqrt(e[0]*e[0] + e[1]*e[1] + e[2]*e[2]);
-    e[0]=e[0]-en*k*e[0];
-    e[1]=e[1]-en*k*e[1];
-    e[2]=e[2]-en*k*e[2];
+  float k = 1 / sqrt(m_e[0]*m_e[0] + m_e[1]*m_e[1] + m_e[2]*m_e[2]);
+  m_e[0]=m_e[0]-en*k*m_e[0];
+  m_e[1]=m_e[1]-en*k*m_e[1];
+  m_e[2]=m_e[2]-en*k*m_e[2];
 }
 
+/** @brief add two vectors together.
+ * v1 and v2 are the vec3 to add.
+ * returns the sum of the two vectors v1 and v2.
+ */ 
 inline vec3 operator+(const vec3 &v1, const vec3 &v2) {
-    return vec3(v1.e[0] + v2.e[0], v1.e[1] + v2.e[1], v1.e[2] + v2.e[2]);
+  return vec3(v1.m_e[0] + v2.m_e[0], v1.m_e[1] + v2.m_e[1], v1.m_e[2] + v2.m_e[2]);
 }
 
+/** @brief multiply a vector by a value.
+ * t is the value to multiply a 3-vector v by.
+ * returns a new vector, which is the result of the operation.
+ */ 
 inline vec3 operator*(float t, const vec3 &v) {
-    return vec3(t*v.e[0], t*v.e[1], t*v.e[2]);
+  return vec3(t*v.m_e[0], t*v.m_e[1], t*v.m_e[2]);
 }
 
+/** @brief multiply a vector by a value.
+ * t is the value to multiply a 3-vector v by.
+ * returns a new vector, which is the result of the operation.
+ */ 
 inline vec3 operator*(const vec3 &v, float t) {
-    return vec3(t*v.e[0], t*v.e[1], t*v.e[2]);
+  return vec3(t*v.m_e[0], t*v.m_e[1], t*v.m_e[2]);
 }
 
 inline vec3& vec3::operator+=(const vec3 &v){
-     e[0]  += v.e[0];
-    e[1]  += v.e[1];
-    e[2]  += v.e[2];
-    return *this;
+  m_e[0]  += v.m_e[0];
+  m_e[1]  += v.m_e[1];
+  m_e[2]  += v.m_e[2];
+  return *this;
 }
 
 inline vec3& vec3::operator*=(const float t) {
-    e[0]  *= t;
-    e[1]  *= t;
-    e[2]  *= t;
-    return *this;
+  m_e[0]  *= t;
+  m_e[1]  *= t;
+  m_e[2]  *= t;
+  return *this;
 }
 
 #endif // VEC3_H


### PR DESCRIPTION
Hello,

This PR includes the current version of the FisherPrice code reworked to interface with Alpaka.

At the moment I put authors of all the c++ headers as Dvaide/myself. I think some/all of the classes might have contributions from @drbenmorgan - should I therefore add you as an author to some/all of them too? (also I don't know if the versions I started from have any other authors I'm not aware of to add).

This is a WIP for now, but starting it so as to coordinate with code from @drbenmorgan. In particular I added doxygen (as requested in the contribution requirements) to the c++ classes I picked up from FisherPrice. These classes are the same as the ones in the CUDA/c++ branch, so presumably we don't want people independently spending time to add doxygen. This also brings a general question about the fact we are going to end up with same code once for alpaka and once for the version that ifdefs between cuda and c++. I'm not sure the best way to handle that going forward, but if FisherPrice ends up with a lot of code in the future it could become painful to maintain (I suppose its not so hard right now with little code).

The requirements also specify we should provide Unit Tests for any new code in a PR - again there would be the same issue of presumably not wanting to design this twice independently for the cuda/c++ and alpaka versions of code. 

I suspect some of the things we have currently used (e.g. particleStack.h) already have more advanced equivalents in this repository (from @agheata), so we could setup issues to migrate where relevant.

Cheers,

Mark


