### PR TITLE
adding cuda version of fisher_price example

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,11 @@ add_executable(example_add example_add.cu)
 add_executable(fisher_price fisher_price.cpp)
 # Noddy example of particle processing with GPU
 add_executable(cufisher_price cufisher_price.cu)
-target_link_libraries(cufisher_price PRIVATE CUDA::curand)
+target_include_directories(cufisher_price PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
+  $<INSTALL_INTERFACE:base>
+  )
+target_link_libraries(cufisher_price PRIVATE CUDA::curand VecCore::VecCore VecGeom::vecgeom)
 # Unit test for atomic ops
 add_executable(test_atomic test_atomic.cu)
 target_include_directories(test_atomic PUBLIC

--- a/test/cufisher_price.cu
+++ b/test/cufisher_price.cu
@@ -62,7 +62,7 @@ __global__ void process(adept::BlockData<MyTrack> *block, Scoring *scor, curandS
 
     // here I need to create a new particle
     auto secondary_track = block->NextElement();
-    assert (secondary_track != nullptr && "No slot available for secondary track" );
+    assert(secondary_track != nullptr && "No slot available for secondary track");
     secondary_track->energy = eloss;
 
     // increase the counter of secondaries

--- a/test/cufisher_price.cu
+++ b/test/cufisher_price.cu
@@ -2,12 +2,132 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <curand.h>
+#include <curand_kernel.h>
+#include <iostream>
+
+#include <AdePT/BlockData.h>
+
+struct MyTrack {
+  int index{0};
+  int pdg{0};
+  double energy{0};
+  double pos[3]{0};
+  double dir[3]{0};
+  bool flag1;
+  bool flag2;
+};
+
+struct Scoring {
+  adept::Atomic_t<int> secondaries;
+  adept::Atomic_t<float> totalEnergyLoss;
+
+  VECCORE_ATT_HOST_DEVICE
+  Scoring() {}
+
+  VECCORE_ATT_HOST_DEVICE
+  static Scoring *MakeInstanceAt(void *addr)
+  {
+    Scoring *obj = new (addr) Scoring();
+    return obj;
+  }
+};
+
+// kernel function that does energy loss or pair production
+__global__ void process(adept::BlockData<MyTrack> *block, Scoring *scor, curandState_t *states)
+{
+  int particle_index = blockIdx.x * blockDim.x + threadIdx.x;
+
+  // check if you are not outside the used block
+  if (particle_index > block->GetNused() + block->GetNholes()) return;
+
+  // check if the particle is still alive (E>0)
+  if ((*block)[particle_index].energy == 0) return;
+
+  // generate random number
+  float r = curand_uniform(states);
+
+  // call the 'process'
+  if (r < 0.5f) {
+    // energy loss
+    float eloss = 0.2f * (*block)[particle_index].energy;
+    scor->totalEnergyLoss.fetch_add(eloss < 0.001f ? (*block)[particle_index].energy : eloss);
+    (*block)[particle_index].energy = (eloss < 0.001f ? 0.0f : ((*block)[particle_index].energy - eloss));
+
+    // if particle dies (E=0) release the slot
+    if ((*block)[particle_index].energy == 0) block->ReleaseElement(particle_index);
+  } else {
+    // pair production
+    float eloss = 0.5f * (*block)[particle_index].energy;
+    (*block)[particle_index].energy -= eloss;
+
+    // here I need to create a new particle
+    auto secondary_track = block->NextElement();
+    if (!secondary_track) return;
+    secondary_track->energy = eloss;
+
+    // increase the counter of secondaries
+    scor->secondaries.fetch_add(1);
+  }
+}
+
+/* this GPU kernel function is used to initialize the random states */
+__global__ void init(curandState_t *states)
+{
+  /* we have to initialize the state */
+  curand_init(0, 0, 0, states);
+}
+
+//
 
 int main()
 {
-  // What are the ways to transform the CPU `fisher_price` to CUDA/GPU
-  // An obvious branch/divergence (eloss vs pair), but good exercise
-  // As first steps in microkernel workflow.
 
-  return 0;
+  curandState_t *state;
+  cudaMalloc((void **)&state, sizeof(curandState_t));
+  init<<<1, 1>>>(state);
+  cudaDeviceSynchronize();
+
+  // Track capacity of the block
+  constexpr int capacity = 1 << 20;
+
+  // Allocate the content of Scoring in a buffer
+  char *buffer1 = nullptr;
+  cudaMallocManaged(&buffer1, sizeof(Scoring));
+  Scoring *scor = Scoring::MakeInstanceAt(buffer1);
+  // Initialize scoring
+  scor->secondaries     = 0;
+  scor->totalEnergyLoss = 0;
+
+  // Allocate a block of tracks with capacity larger than the total number of spawned threads
+  // Note that if we want to allocate several consecutive block in a buffer, we have to use
+  // Block_t::SizeOfAlignAware rather than SizeOfInstance to get the space needed per block
+  using Block_t    = adept::BlockData<MyTrack>;
+  size_t blocksize = Block_t::SizeOfInstance(capacity);
+  char *buffer2    = nullptr;
+  cudaMallocManaged(&buffer2, blocksize);
+  auto block = adept::BlockData<MyTrack>::MakeInstanceAt(capacity, buffer2);
+
+  // initializing one track in the block
+  auto track    = block->NextElement();
+  track->energy = 100.0f;
+
+  // initializing second track in the block
+  auto track2    = block->NextElement();
+  track2->energy = 30.0f;
+
+  cudaDeviceSynchronize();
+  //
+  constexpr dim3 nthreads(32);
+  dim3 numBlocks;
+
+  while (block->GetNused()) {
+    numBlocks.x = (block->GetNused() + block->GetNholes() + nthreads.x - 1) / nthreads.x;
+    // call the kernels
+    process<<<numBlocks, nthreads>>>(block, scor, state);
+    // Wait for GPU to finish before accessing on host
+    cudaDeviceSynchronize();
+
+    std::cout << "Total energy loss " << scor->totalEnergyLoss.load() << " number of secondaries "
+              << scor->secondaries.load() << " blocks used " << block->GetNused() << std::endl;
+  }
 }

--- a/test/cufisher_price.cu
+++ b/test/cufisher_price.cu
@@ -62,7 +62,7 @@ __global__ void process(adept::BlockData<MyTrack> *block, Scoring *scor, curandS
 
     // here I need to create a new particle
     auto secondary_track = block->NextElement();
-    if (!secondary_track) return;
+    assert (secondary_track != nullptr && "No slot available for secondary track" );
     secondary_track->energy = eloss;
 
     // increase the counter of secondaries

--- a/test/cufisher_price.cu
+++ b/test/cufisher_price.cu
@@ -105,7 +105,7 @@ int main()
   size_t blocksize = Block_t::SizeOfInstance(capacity);
   char *buffer2    = nullptr;
   cudaMallocManaged(&buffer2, blocksize);
-  auto block = adept::BlockData<MyTrack>::MakeInstanceAt(capacity, buffer2);
+  auto block = Block_t::MakeInstanceAt(capacity, buffer2);
 
   // initializing one track in the block
   auto track    = block->NextElement();

--- a/test/cufisher_price.cu
+++ b/test/cufisher_price.cu
@@ -54,7 +54,7 @@ __global__ void process(adept::BlockData<MyTrack> *block, Scoring *scor, curandS
     (*block)[particle_index].energy = (eloss < 0.001f ? 0.0f : ((*block)[particle_index].energy - eloss));
 
     // if particle dies (E=0) release the slot
-    if ((*block)[particle_index].energy == 0) block->ReleaseElement(particle_index);
+    if ((*block)[particle_index].energy < 0.001f) block->ReleaseElement(particle_index);
   } else {
     // pair production
     float eloss = 0.5f * (*block)[particle_index].energy;


### PR DESCRIPTION
This pull request adds the CUDA version of the fisher_price example. The CUDA kernel consists of the 'process' (energy loss and pair production) run for each particle/step. For each iteration the 'main' schedules as many CUDA threads as particles in flight. New particle which are created during the pair-production process are pushed into the common BlockData container. Particles which die (E=0) are released from the container and the slots are used by new ones.
  