### PR TITLE
Fix BlockData allocation and copying on host.

### DIFF
--- a/base/inc/AdePT/Atomic.h
+++ b/base/inc/AdePT/Atomic.h
@@ -27,6 +27,14 @@ struct Atomic_t {
   VECCORE_ATT_HOST_DEVICE
   Atomic_t() : fData{0} {}
 
+  /** @brief Copy constructor */
+  VECCORE_ATT_HOST_DEVICE
+  Atomic_t(Atomic_t const &other) { store(other.load()); }
+
+  /** @brief Assignment */
+  VECCORE_ATT_HOST_DEVICE
+  Atomic_t &operator=(Atomic_t const &other) { store(other.load()); }
+
   /** @brief Emplace the data at a given address */
   VECCORE_ATT_HOST_DEVICE
   static Atomic_t *MakeInstanceAt(void *addr)

--- a/base/inc/AdePT/BlockData.h
+++ b/base/inc/AdePT/BlockData.h
@@ -10,9 +10,9 @@
 #ifndef ADEPT_BLOCKDATA_H_
 #define ADEPT_BLOCKDATA_H_
 
+#include <CopCore/CopCore.h>
 #include <AdePT/Atomic.h>
 #include <AdePT/mpmc_bounded_queue.h>
-#include <VecGeom/base/VariableSizeObj.h>
 
 namespace adept {
 
@@ -21,14 +21,14 @@ namespace adept {
   Write access to data elements in the block is given atomically, up to the capacity.
  */
 template <typename Type>
-class BlockData : protected vecgeom::VariableSizeObjectInterface<BlockData<Type>, Type> {
+class BlockData : protected copcore::VariableSizeObjectInterface<BlockData<Type>, Type> {
 
 public:
   using AtomicInt_t = adept::Atomic_t<int>;
   using Queue_t     = adept::mpmc_bounded_queue<int>;
   using Value_t     = Type;
-  using Base_t      = vecgeom::VariableSizeObjectInterface<BlockData<Value_t>, Value_t>;
-  using ArrayData_t = vecgeom::VariableSizeObj<Value_t>;
+  using Base_t      = copcore::VariableSizeObjectInterface<BlockData<Value_t>, Value_t>;
+  using ArrayData_t = copcore::VariableSizeObj<Value_t>;
 
 private:
   int fCapacity{0};         ///< Maximum number of elements
@@ -73,7 +73,7 @@ private:
     Queue_t::MakeCopyAt(new_size, *other.fHoles, address);
   }
 
-  VECGEOM_FORCE_INLINE
+  VECCORE_FORCE_INLINE
   VECCORE_ATT_HOST_DEVICE
   ~BlockData() {}
 

--- a/base/inc/AdePT/mpmc_bounded_queue.h
+++ b/base/inc/AdePT/mpmc_bounded_queue.h
@@ -81,6 +81,23 @@ private:
   VECCORE_ATT_HOST_DEVICE
   VECCORE_FORCE_INLINE
   mpmc_bounded_queue(int /*nvalues*/, mpmc_bounded_queue const & /*other*/) {}
+  /** @brief MPMC bounded queue copy constructor */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  mpmc_bounded_queue(mpmc_bounded_queue const &other) : mpmc_bounded_queue(other.fCapacity, other) {}
+
+  /** @brief MPMC bounded queue copy constructor with given size */
+  VECCORE_ATT_HOST_DEVICE
+  VECCORE_FORCE_INLINE
+  mpmc_bounded_queue(size_t new_size, mpmc_bounded_queue const &other)
+      : fCapacity(new_size), fMask(new_size - 1), fEnqueue(other.fEnqueue), fDequeue(other.fDequeue),
+        fNstored(other.fNstored), fBuffer(new_size, other.fBuffer)
+  {
+    assert((new_size >= 2) && ((new_size & (new_size - 1)) == 0) && "buffer size has to be a power of 2");
+  }
+
+  /** @brief Operator = */
+  void operator=(mpmc_bounded_queue const &) = delete;
 
 public:
   ///< Enumerate the part of the private interface, we want to expose.
@@ -159,12 +176,6 @@ public:
     cell->fSequence.store(pos + fMask + 1);
     return true;
   }
-
-  /** @brief MPMC bounded queue copy constructor */
-  mpmc_bounded_queue(mpmc_bounded_queue const &) = delete;
-
-  /** @brief Operator = */
-  void operator=(mpmc_bounded_queue const &) = delete;
 }; // End mpmc_bounded_queue
 } // End namespace adept
 #endif // ADEPT_MPMC_BOUNDED_QUEUE

--- a/base/inc/AdePT/mpmc_bounded_queue.h
+++ b/base/inc/AdePT/mpmc_bounded_queue.h
@@ -14,7 +14,7 @@
 #include <stdint.h>
 #include <cassert>
 #include <AdePT/Atomic.h>
-#include <VecGeom/base/VariableSizeObj.h>
+#include <CopCore/CopCore.h>
 
 namespace adept {
 namespace internal {
@@ -32,12 +32,12 @@ struct Cell_t {
 /** @brief Class MPMC bounded queue */
 template <typename Type>
 class mpmc_bounded_queue
-    : protected vecgeom::VariableSizeObjectInterface<mpmc_bounded_queue<Type>, internal::Cell_t<Type>> {
+    : protected copcore::VariableSizeObjectInterface<mpmc_bounded_queue<Type>, internal::Cell_t<Type>> {
 public:
   using AtomicInt_t = adept::Atomic_t<int>;
   using Value_t     = internal::Cell_t<Type>;
-  using Base_t      = vecgeom::VariableSizeObjectInterface<mpmc_bounded_queue<Type>, Value_t>;
-  using ArrayData_t = vecgeom::VariableSizeObj<Value_t>;
+  using Base_t      = copcore::VariableSizeObjectInterface<mpmc_bounded_queue<Type>, Value_t>;
+  using ArrayData_t = copcore::VariableSizeObj<Value_t>;
 
 private:
   int const fCapacity;  ///< Capacity of the queue

--- a/base/inc/AdePT/mpmc_bounded_queue.h
+++ b/base/inc/AdePT/mpmc_bounded_queue.h
@@ -114,11 +114,6 @@ public:
   VECCORE_FORCE_INLINE
   static size_t SizeOfInstance(int capacity) { return Base_t::SizeOf(capacity); }
 
-  /** @brief Size of container in bytes */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
-  int SizeOf() const { return mpmc_bounded_queue<Type>::SizeOfInstance(fCapacity); }
-
   /** @brief Maximum number of elements */
   VECCORE_ATT_HOST_DEVICE
   VECCORE_FORCE_INLINE

--- a/base/inc/CopCore/include/CopCore/CopCore.h
+++ b/base/inc/CopCore/include/CopCore/CopCore.h
@@ -9,4 +9,6 @@
 #ifndef COPCORE_COPCORE_H_
 #define COPCORE_COPCORE_H_
 
+#include "CopCore/VariableSizeObj.h"
+
 #endif // COPCORE_COPCORE_H_

--- a/base/inc/CopCore/include/CopCore/VariableSizeObj.h
+++ b/base/inc/CopCore/include/CopCore/VariableSizeObj.h
@@ -1,0 +1,324 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file VariableSizeObj.h
+ * @brief Array/vector of items with all information stored contiguously in memory.
+ * @author Philippe Canal (pcanal@fnal.gov). Copied/adapted for VecGeom library (andrei.gheata@cern.ch).
+ *
+ * @details Resizing operations require explicit new creation and copy.
+ * This is decomposed in the content part (VariableSizeObj) and the interface
+ * part (VariableSizeObjectInterface) so that the variable size part can be placed
+ * at the end of the object. Derived types must decorate the implementation methods with
+ * appropriate __host__ __device__ qualifiers (or use the macros pre-defined in VecCore) for
+ * usage on GPU.
+ *
+ * Use in derived classes
+ * ======================
+ * The derivation should be done on `VariableSizeObjectInterface` like:
+ *
+ *    class MyVariableSizeType : protected copcore::VariableSizeObjectInterface<MyVariableSizeType, V>
+ *
+ * where `V` is the variable data type. The derived class must have the LAST data member (say fData)
+ * of type `copcore::VariableSizeObj<V>`. It has to declare the base class as friend to its private
+ * methods, and has to mandatory implement the following private methods:
+ *
+ *    using ArrayData_t = copcore::VariableSizeObj<Value_t>;
+ *    ArrayData_t &GetVariableData() { return fData; }
+ *    const ArrayData_t &GetVariableData() const { return fData; }
+ *
+ * but also a private constructor initializing the capacity of the variable size array:
+ *
+ *    MyVariableSizeType(size_t nvalues, ...param) : ... , fData(nvalues)
+ *
+ * The derived class should have no public constructors, but should enumerate the public base class
+ * static construction methods:
+ *
+ *    using Base_t = copcore::VariableSizeObjectInterface<MyVariableSizeType, V>;
+ *    using Base_t::MakeInstance;
+ *    using Base_t::MakeInstanceAt;
+ *
+ * These methods internally invoke the private constructor, their invokation being dependent on the
+ * extra parameters taken by this constructor and explained in the `Usage` section.
+ *
+ * In case the derived type should be copiable, it has to expose the Base_t copy interfaces:
+ *
+ *      using Base_t::MakeCopy;
+ *      using Base_t::MakeCopyAt;
+ *
+ * and implement private copy constructors:
+ *
+ *    MyVariableSizeType(MyVariableSizeType const &other) : MyVariableSizeType(other.fData.fN, other) {...}
+ *    // Copy and resize
+ *    MyVariableSizeType(size_t new_size, MyVariableSizeType const &other) : fData(new_size, other.fData) {...}
+ *
+ * Derived types must implement a public static method returning the size of objects for a given number
+ * of elements, which must be called mandatory by the user before allocating memory for the object. This may
+ * be just an alias to the SizeOf helper method from the base class as below, or has to be extended to handle
+ * additional custom requirements:
+ *
+ *     static size_t SizeOfInstance(int capacity) { return Base_t::SizeOf(capacity); }
+ *
+ * Important note: the derived type should not contain any pointer data members that have to be dynamically
+ * allocated, or if it does then it has to be supported in the constructors and in the SizeOfInstance method.
+ * The base helper class is taylored for data member types for which the size can be computed at compilation
+ * time (i.e. sizeof will return the actual object size).
+ *
+ * Composition using data members of types derived from VariableSizeObject is allowed. In such case it is
+ * mandatory to implement the private method:
+ *
+ *    static size_t SizeOfExtra(int capacity) { ...; return extra_size; }
+ *
+ * The extra size has to be computed by summing the sizes of all VariableSizeObjectInterface-derived data
+ * members as returned by their method SizeOfAlignedAware(capacity).
+ *
+ * Implementation examples for derived VariableSizeObjectInterface types can be seen
+ * [here](https://github.com/apt-sim/AdePT/tree/master/base/inc/AdePT)
+ *
+ *
+ *   Usage of VariableSize objects
+ *   =============================
+ *
+ * The most important use case the helper was designed for is allocation of variable size objects in a
+ * pre-allocated memory buffer. To do this, one needs to reteive the container size for the desired array
+ * capacity via:
+ *
+ *    size_t buffer_size = MyVariableSizeType::SizeOfInstance(size_t capacity);
+ *
+ * or:
+ *
+ *    size_t buffer_size = MyVariableSizeType::SizeOfAlignAware(size_t capacity);
+ *
+ * The latter version has to be used for allocating multiple objects of type MyVariableSizeType in a
+ * contiguous buffer.
+ *
+ *    char *buffer = nullptr;
+ *    host_or_device_malloc_method(buffer, [N *] buffer_size);
+ *
+ * To allocate a single object, use:
+ *
+ *    auto obj = MyVariableSizeType::MakeInstanceAt(capacity, buffer, params...);
+ *
+ * where params... are the private constructor parameters. In case of multiple contiguous objects, the
+ * padding in the buffer must be equal to buffer_size.
+ *
+ * In case standard allocation on the heap is needed, one has to use the method:
+ *
+ *    auto obj = MyVariableSizeType::MakeInstance(capacity, param...);
+ *
+ * The cleanup of VariableSize objects should not be done via `delete`, but rather using:
+ *
+ *    MyVariableSizeType::ReleaseInstance(obj);
+ *
+ * This will call the actual `delete` in case the object is allocated on the heap, or do nothing for the
+ * buffer adoption case, when the buffer has to be de-allocated separately.
+ *
+ * Copying VariableSize objects is possible in case the copy constructors are defined as described above.
+ * The copying can be done together with resizing the container, using:
+ *
+ *    auto copy = MyVariableSizeType::MakeCopy([new_size], MyVariableSizeType const &source); // using malloc
+ *    auto copy = MyVariableSizeType::MakeCopy([new_size], MyVariableSizeType const &source, void *addr); // adopting
+ * memory
+ *
+ * If omitting new_size above, the copy will have the same size as the source.
+ */
+
+#ifndef COPCORE_VARIABLESIZEOBJ_H
+#define COPCORE_VARIABLESIZEOBJ_H
+
+#include <VecCore/VecCore>
+
+// For memset and memcpy
+#include <string.h>
+
+class TRootIOCtor;
+
+namespace copcore {
+
+template <typename V>
+class VariableSizeObj {
+public:
+  using Index_t = unsigned int;
+
+  bool fSelfAlloc : 1;   //! Record whether the memory is externally managed.
+  const Index_t fN : 31; // Number of elements.
+  V fRealArray[1];       //! Beginning address of the array values -- real size: [fN]
+
+  VariableSizeObj(TRootIOCtor *) : fSelfAlloc(false), fN(0) {}
+
+  VECCORE_FORCE_INLINE
+  VECCORE_ATT_HOST_DEVICE
+  VariableSizeObj(unsigned int nvalues) : fSelfAlloc(false), fN(nvalues) {}
+
+  VECCORE_FORCE_INLINE
+  VECCORE_ATT_HOST_DEVICE
+  VariableSizeObj(const VariableSizeObj &other) : fSelfAlloc(false), fN(other.fN)
+  {
+    if (other.fN) memcpy(GetValues(), other.GetValues(), (other.fN) * sizeof(V));
+  }
+
+  VECCORE_FORCE_INLINE
+  VECCORE_ATT_HOST_DEVICE
+  VariableSizeObj(size_t new_size, const VariableSizeObj &other) : fSelfAlloc(false), fN(new_size)
+  {
+    if (other.fN) memcpy(GetValues(), other.GetValues(), (other.fN) * sizeof(V));
+  }
+
+  VECCORE_FORCE_INLINE VECCORE_ATT_HOST_DEVICE V *GetValues() { return &fRealArray[0]; }
+  VECCORE_FORCE_INLINE VECCORE_ATT_HOST_DEVICE const V *GetValues() const { return &fRealArray[0]; }
+
+  VECCORE_FORCE_INLINE VECCORE_ATT_HOST_DEVICE V &operator[](Index_t index) { return GetValues()[index]; };
+  VECCORE_FORCE_INLINE VECCORE_ATT_HOST_DEVICE const V &operator[](Index_t index) const { return GetValues()[index]; };
+
+  VECCORE_FORCE_INLINE VECCORE_ATT_HOST_DEVICE VariableSizeObj &operator=(const VariableSizeObj &rhs)
+  {
+    // Copy data content using memcpy, limited by the respective size
+    // of the the object.  If this is smaller there is data truncation,
+    // if this is larger the extra datum are zero to zero.
+
+    if (rhs.fN == fN) {
+      memcpy(GetValues(), rhs.GetValues(), rhs.fN * sizeof(V));
+    } else if (rhs.fN < fN) {
+      memcpy(GetValues(), rhs.GetValues(), rhs.fN * sizeof(V));
+      memset(GetValues() + rhs.fN, 0, (fN - rhs.fN) * sizeof(V));
+    } else {
+      // Truncation!
+      memcpy(GetValues(), rhs.GetValues(), fN * sizeof(V));
+    }
+    return *this;
+  }
+};
+
+template <typename Cont, typename V>
+class VariableSizeObjectInterface {
+protected:
+  VariableSizeObjectInterface()  = default;
+  ~VariableSizeObjectInterface() = default;
+
+public:
+  // The static maker to be used to create an instance of the variable size object.
+
+  template <typename... T>
+  VECCORE_ATT_HOST_DEVICE static Cont *MakeInstance(size_t nvalues, const T &... params)
+  {
+    // Make an instance of the class which allocates the node array. To be
+    // released using ReleaseInstance.
+    size_t needed = SizeOf(nvalues);
+    char *ptr     = new char[needed];
+    if (!ptr) return 0;
+    assert((((unsigned long long)ptr) % alignof(Cont)) == 0 && "alignment error");
+    Cont *obj                         = new (ptr) Cont(nvalues, params...);
+    obj->GetVariableData().fSelfAlloc = true;
+    return obj;
+  }
+
+  template <typename... T>
+  VECCORE_ATT_HOST_DEVICE static Cont *MakeInstanceAt(size_t nvalues, void *addr, const T &... params)
+  {
+    // Make an instance of the class which allocates the node array. To be
+    // released using ReleaseInstance. If addr is non-zero, the user promised that
+    // addr contains at least that many bytes:  size_t needed = SizeOf(nvalues);
+    if (!addr) {
+      return MakeInstance(nvalues, params...);
+    } else {
+      assert((((unsigned long long)addr) % alignof(Cont)) == 0 && "addr does not satisfy alignment");
+      Cont *obj                         = new (addr) Cont(nvalues, params...);
+      obj->GetVariableData().fSelfAlloc = false;
+      return obj;
+    }
+  }
+
+  // The equivalent of the copy constructor
+  VECCORE_ATT_HOST_DEVICE
+  static Cont *MakeCopy(const Cont &other)
+  {
+    // Make a copy of the variable size array and its container.
+
+    size_t needed = SizeOf(other.GetVariableData().fN);
+    char *ptr     = new char[needed];
+    if (!ptr) return 0;
+    Cont *copy                         = new (ptr) Cont(other);
+    copy->GetVariableData().fSelfAlloc = true;
+    return copy;
+  }
+
+  VECCORE_ATT_HOST_DEVICE
+  static Cont *MakeCopy(size_t new_size, const Cont &other)
+  {
+    // Make a copy of a the variable size array and its container with
+    // a new_size of the content.
+
+    size_t needed = SizeOf(new_size);
+    char *ptr     = new char[needed];
+    if (!ptr) return 0;
+    Cont *copy                         = new (ptr) Cont(new_size, other);
+    copy->GetVariableData().fSelfAlloc = true;
+    return copy;
+  }
+
+  // The equivalent of the copy constructor
+  VECCORE_ATT_HOST_DEVICE
+  static Cont *MakeCopyAt(const Cont &other, void *addr)
+  {
+    // Make a copy of a the variable size array and its container at the location (if indicated)
+    if (addr) {
+      Cont *copy                         = new (addr) Cont(other);
+      copy->GetVariableData().fSelfAlloc = false;
+      return copy;
+    } else {
+      return MakeCopy(other);
+    }
+  }
+
+  // The equivalent of the copy constructor
+  VECCORE_ATT_HOST_DEVICE
+  static Cont *MakeCopyAt(size_t new_size, const Cont &other, void *addr)
+  {
+    // Make a copy of a the variable size array and its container at the location (if indicated)
+    if (addr) {
+      Cont *copy                         = new (addr) Cont(new_size, other);
+      copy->GetVariableData().fSelfAlloc = false;
+      return copy;
+    } else {
+      return MakeCopy(new_size, other);
+    }
+  }
+
+  // The equivalent of the destructor
+  VECCORE_ATT_HOST_DEVICE
+  static void ReleaseInstance(Cont *obj)
+  {
+    // Releases the space allocated for the object
+    obj->~Cont();
+    if (obj->GetVariableData().fSelfAlloc) delete[](char *) obj;
+  }
+
+  // Equivalent of sizeof function (not taking into account padding for alignment)
+  VECCORE_ATT_HOST_DEVICE
+  static constexpr size_t SizeOf(size_t nvalues)
+  {
+    return (sizeof(Cont) + Cont::SizeOfExtra(nvalues) + sizeof(V) * (nvalues - 1));
+  }
+
+  // Size of the allocated derived type data members that are also variable size
+  VECCORE_ATT_HOST_DEVICE
+  static constexpr size_t SizeOfExtra(size_t nvalues) { return 0; }
+
+  // equivalent of sizeof function taking into account padding for alignment
+  // this function should be used when making arrays of VariableSizeObjects
+  VECCORE_ATT_HOST_DEVICE
+  static constexpr size_t SizeOfAlignAware(size_t nvalues) { return SizeOf(nvalues) + RealFillUp(nvalues); }
+
+private:
+  VECCORE_ATT_HOST_DEVICE
+  static constexpr size_t FillUp(size_t nvalues) { return alignof(Cont) - SizeOf(nvalues) % alignof(Cont); }
+
+  VECCORE_ATT_HOST_DEVICE
+  static constexpr size_t RealFillUp(size_t nvalues)
+  {
+    return (FillUp(nvalues) == alignof(Cont)) ? 0 : FillUp(nvalues);
+  }
+};
+} // namespace copcore
+
+#endif //  COPCORE_VARIABLESIZEOBJ_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,14 +1,45 @@
 # SPDX-FileCopyrightText: 2020 CERN
 # SPDX-License-Identifier: Apache-2.0
 
-# - Test that linkage to CopCore target works
-add_executable(test_copcore_link test_copcore_link.cpp)
-target_link_libraries(test_copcore_link PRIVATE CopCore::CopCore)
+# Helper Macros/Functions
+macro(build_tests TESTS)
+  foreach(TEST ${TESTS})
+    get_filename_component(TARGET_NAME ${TEST} NAME_WE)
+    add_executable(${TARGET_NAME} ${TEST})
+    target_include_directories(${TARGET_NAME} PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
+      $<INSTALL_INTERFACE:base>
+    )
+    target_link_libraries(${TARGET_NAME} VecCore::VecCore CopCore::CopCore)
+    target_compile_options(${TARGET_NAME} PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
+   endforeach()
+endmacro()
 
+macro(add_to_test TESTS)
+  foreach(TEST ${TESTS})
+    get_filename_component(TARGET_NAME ${TEST} NAME_WE)
+    add_test(NAME ${TARGET_NAME} COMMAND ${TARGET_NAME})
+   endforeach()
+endmacro()
 
 # - Minimal test of cuda compilation
 add_executable(example_add example_add.cu)
 
+# - Test that linkage to CopCore target works
+add_executable(test_copcore_link test_copcore_link.cpp)
+target_link_libraries(test_copcore_link PRIVATE VecCore::VecCore CopCore::CopCore)
+
+# - Unit tests
+set(ADEPT_UNIT_TESTS_BASE
+  test_atomic.cu               # Unit test for atomic ops
+  test_queue.cu                # Unit test for mpmc_bounded_queue
+  test_track_block.cu          # Unit test for BlockData
+)
+
+build_tests("${ADEPT_UNIT_TESTS_BASE}")
+add_to_test("${ADEPT_UNIT_TESTS_BASE}")
+
+# - Examples
 # Noddy example of particle processing on CPU
 add_executable(fisher_price fisher_price.cpp)
 # Noddy example of particle processing with GPU
@@ -16,31 +47,5 @@ add_executable(cufisher_price cufisher_price.cu)
 target_include_directories(cufisher_price PUBLIC
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
   $<INSTALL_INTERFACE:base>
-  )
-target_link_libraries(cufisher_price PRIVATE CUDA::curand VecCore::VecCore VecGeom::vecgeom)
-# Unit test for atomic ops
-add_executable(test_atomic test_atomic.cu)
-target_include_directories(test_atomic PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
-  $<INSTALL_INTERFACE:base>
 )
-target_link_libraries(test_atomic VecCore::VecCore VecGeom::vecgeom)
-add_test(NAME test_atomic COMMAND test_atomic)
-
-# Unit test for BlockData
-add_executable(test_track_block test_track_block.cu)
-target_include_directories(test_track_block PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
-  $<INSTALL_INTERFACE:base>
-)
-target_link_libraries(test_track_block VecCore::VecCore VecGeom::vecgeom)
-add_test(NAME test_track_block COMMAND test_track_block)
-
-# Unit test for mpmc_bounded_queue
-add_executable(test_queue test_queue.cu)
-target_include_directories(test_queue PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
-  $<INSTALL_INTERFACE:base>
-)
-target_link_libraries(test_queue VecCore::VecCore VecGeom::vecgeom)
-add_test(NAME test_queue COMMAND test_queue)
+target_link_libraries(cufisher_price PRIVATE CUDA::curand VecCore::VecCore CopCore::CopCore)

--- a/test/test_track_block.cu
+++ b/test/test_track_block.cu
@@ -49,34 +49,106 @@ int main(void)
   // Allocate a block of tracks with capacity larger than the total number of spawned threads
   // Note that if we want to allocate several consecutive block in a buffer, we have to use
   // Block_t::SizeOfAlignAware rather than SizeOfInstance to get the space needed per block
+
+  bool testOK  = true;
+  bool success = true;
+
+  // Test simple allocation/de-allocation on host
+  std::cout << "   host allocation MakeInstance ... ";
+  auto h_block = Block_t::MakeInstance(1024);
+  testOK &= h_block != nullptr;
+  std::cout << result[testOK] << "\n";
+  success &= testOK;
+
+  // Test using the slots on the block (more than existing)
+  std::cout << "   host NextElement             ... ";
+  testOK           = true;
+  size_t checksum1 = 0;
+  for (auto i = 0; i < 2048; ++i) {
+    auto track = h_block->NextElement();
+    if (i >= 1024) testOK &= track == nullptr;
+    // Assign current index to the current track
+    if (track) {
+      track->index = i;
+      checksum1 += i;
+    }
+  }
+  testOK = h_block->GetNused() == 1024;
+  std::cout << result[testOK] << "\n";
+  success &= testOK;
+
+  // Create another block into adopted memory on host
+  testOK          = true;
+  char *buff_host = new char[Block_t::SizeOfInstance(2048)];
+  std::cout << "   host MakeCopyAt              ... ";
+  // Test copying a block into another
+  auto h_block2    = Block_t::MakeCopyAt(*h_block, buff_host);
+  size_t checksum2 = 0;
+  for (auto i = 0; i < 1024; ++i) {
+    auto track = h_block2->NextElement();
+    assert(track);
+    checksum2 += track->index;
+  }
+  testOK = checksum1 == checksum2;
+  std::cout << result[testOK] << "\n";
+  success &= testOK;
+
+  // Release some elements end validate
+  testOK = true;
+  std::cout << "   host ReleaseElement          ... ";
+  for (auto i = 0; i < 10; ++i)
+    h_block2->ReleaseElement(i);
+  testOK &= h_block2->GetNused() == (1024 - 10);
+  testOK &= h_block2->GetNholes() == 10;
+  std::cout << result[testOK] << "\n";
+  success &= testOK;
+
+  // Release allocated blocks
+  Block_t::ReleaseInstance(h_block);  // mandatory, frees memory for blocks allocated with MakeInstance
+  Block_t::ReleaseInstance(h_block2); // will not do anything since block adopted memory
+  delete[] buff_host;                 // Only this will actually free the memory
+
+  // Create a large block on the device
+  testOK = true;
+  std::cout << "   host MakeInstanceAt          ... ";
   size_t blocksize = Block_t::SizeOfInstance(capacity);
   char *buffer     = nullptr;
   cudaMallocManaged(&buffer, blocksize);
-  auto block = adept::BlockData<MyTrack>::MakeInstanceAt(capacity, buffer);
+  auto block = Block_t::MakeInstanceAt(capacity, buffer);
+  testOK &= block != nullptr;
+  std::cout << result[testOK] << "\n";
+  success &= testOK;
 
-  bool testOK = true;
-  std::cout << "   test_track_block ... ";
+  std::cout << "   device NextElement           ... ";
+  testOK = true;
   // Allow memory to reach the device
   cudaDeviceSynchronize();
   // Launch a kernel processing tracks
-  testTrackBlock<<<nblocks, nthreads>>>(block);
+  testTrackBlock<<<nblocks, nthreads>>>(block); ///< note that we are passing a host block type allocated on device
+                                                ///< memory - works because the layout is the same
   // Allow all warps to finish
   cudaDeviceSynchronize();
   // The number of used tracks should be equal to the number of spawned threads
   testOK &= block->GetNused() == nblocks.x * nthreads.x;
+  std::cout << result[testOK] << "\n";
+  success &= testOK;
 
   // Compute the sum of assigned track indices, which has to match the sum from 0 to nthreads-1
   // (the execution order is arbitrary, but all thread indices must be distributed)
   unsigned long long counter1 = 0, counter2 = 0;
-
+  testOK = true;
+  std::cout << "   device concurrency checksum  ... ";
   for (auto i = 0; i < nblocks.x * nthreads.x; ++i) {
     counter1 += i;
     counter2 += (*block)[i].index;
   }
-
   testOK &= counter1 == counter2;
+  std::cout << result[testOK] << "\n";
+  success &= testOK;
 
   // Now release 32K tracks
+  testOK = true;
+  std::cout << "   device ReleaseElement        ... ";
   releaseTrack<<<1000, 32>>>(block);
   cudaDeviceSynchronize();
   testOK &= block->GetNused() == nblocks.x * nthreads.x - 32000;
@@ -87,6 +159,6 @@ int main(void)
   testOK &= block->GetNholes() == (32000 - 320);
   std::cout << result[testOK] << "\n";
   cudaFree(buffer);
-  if (!testOK) return 1;
+  if (!success) return 1;
   return 0;
 }


### PR DESCRIPTION
The PR addresses #18 fixing all types of allocation and copying of BlockData types. The unit test test_track_block was extended to cover more features of BlockData. Closing #18 
A documented version of the VariableSizeObj.h header is now available in CopCore (separate commit), removing the current dependencies of some base types (queues and data blocks) on VecGeom. Closing #14 