### PR TITLE
Quieten CMake warnings when not finding Alpaka

### DIFF
--- a/test/FisherPrice_Alpaka/CMakeLists.txt
+++ b/test/FisherPrice_Alpaka/CMakeLists.txt
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #We must specify that we want to use alpaka
-find_package(alpaka)
+find_package(alpaka QUIET)
 
 if(NOT alpaka_FOUND)
   message(STATUS "No alpaka install found, disabling build of FisherPrice_Alpaka")
   return()
-else()  
+else()
   alpaka_add_executable(FisherPriceAlpaka alpaka_fisher_price.cu)
   target_link_libraries(FisherPriceAlpaka PUBLIC alpaka::alpaka)
 


### PR DESCRIPTION
This addresses the question in one of our catchups about whether Alpaka is required or not. It isn't, but CMake will moan if it's not found. This just quietens that warning, but the behaviour is otherwise unchanged