### PR TITLE
Allocators

### DIFF
--- a/base/inc/CopCore/include/CopCore/Allocator.h
+++ b/base/inc/CopCore/include/CopCore/Allocator.h
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file Allocator.h
+ * @brief Backend-aware allocator for objects and arrays of types not doing internal allocations.
+ * @author Andrei Gheata (andrei.gheata@cern.ch).
+ *
+ * @details A standard allocator providing allocate/deallocate interface.
+ * Specializations are provided for CPU, CUDA and *TODO* HIP.
+ */
+
+#include <cstddef>
+#include <stdexcept>
+#include <iostream>
+
+namespace copcore {
+
+template <class T, BackendType backend>
+class Allocator {
+};
+
+#ifdef VECCORE_CUDA
+
+/** @brief Partial allocator specialization for the CUDA backend */
+template <class T>
+class Allocator<T, BackendType::CUDA> {
+public:
+  using value_type = T;
+
+  Allocator(int device = 0) : fDeviceId(device) {}
+
+  Allocator(const Allocator &) = default;
+
+  template <class U>
+  Allocator(const Allocator<U, BackendType::CUDA> &other) : fDeviceId(other.device())
+  {
+  }
+
+  bool operator==(const Allocator &other) const { return fDeviceId == other.fDeviceId; }
+
+  bool operator!=(const Allocator &other) const { return !(*this == other); }
+
+  template <typename... P>
+  value_type *allocate(std::size_t n, const P &... params) const
+  {
+    int old_device = SetDevice(fDeviceId);
+
+    value_type *result = nullptr;
+    auto obj_size      = sizeof(T);
+    COPCORE_CUDA_CHECK(cudaMallocManaged(&result, n * obj_size));
+    value_type *current = result;
+
+    // allocate all objects at their aligned positions in the buffer
+    for (auto i = 0; i < n; ++i)
+      new (current++) T(params...);
+
+    SetDevice(old_device);
+
+    return result;
+  }
+
+  void deallocate(value_type *ptr, std::size_t n = 0) const
+  {
+    int old_device = SetDevice(fDeviceId);
+
+    // Call destructor for all allocated objects
+    value_type *current = ptr;
+    for (auto i = 0; i < n; ++i) {
+      current->~T();
+      current++;
+    }
+
+    // Release the memory
+    COPCORE_CUDA_CHECK(cudaFree(ptr));
+    SetDevice(old_device);
+  }
+
+  int GetDevice() const { return fDeviceId; }
+
+private:
+  static int SetDevice(int new_device)
+  {
+    int old_device = -1;
+    COPCORE_CUDA_CHECK(cudaGetDevice(&old_device));
+    COPCORE_CUDA_CHECK(cudaSetDevice(new_device));
+    return old_device;
+  }
+
+  int fDeviceId{0}; ///< Device id
+};
+#endif
+
+/** @brief Partial allocator specialization for the CPU backend */
+template <class T>
+class Allocator<T, BackendType::CPU> {
+public:
+  using value_type = T;
+
+  Allocator(int device = 0) : fDeviceId(device) {}
+
+  Allocator(const Allocator &) = default;
+
+  template <class U>
+  Allocator(const Allocator<U, BackendType::CPU> &other) : fDeviceId(other.device())
+  {
+  }
+
+  bool operator==(const Allocator &other) const { return fDeviceId == other.fDeviceId; }
+
+  bool operator!=(const Allocator &other) const { return !(*this == other); }
+
+  template <typename... P>
+  value_type *allocate(std::size_t n, const P &... params) const
+  {
+    auto obj_size       = sizeof(T);
+    value_type *result  = (value_type *)malloc(n * obj_size);
+    value_type *current = result;
+
+    // allocate all objects at their aligned positions in the buffer
+    for (auto i = 0; i < n; ++i)
+      new (current++) T(params...);
+
+    return result;
+  }
+
+  void deallocate(value_type *ptr, std::size_t n = 0) const
+  {
+    // Call destructor for all allocated objects
+    value_type *current = ptr;
+    for (auto i = 0; i < n; ++i) {
+      current->~T();
+      current++;
+    }
+
+    // Release the memory
+    free(ptr);
+  }
+
+  int GetDevice() const { return fDeviceId; }
+
+private:
+  int fDeviceId{0}; ///< Device id
+};
+
+} // End namespace copcore

--- a/base/inc/CopCore/include/CopCore/CopCore.h
+++ b/base/inc/CopCore/include/CopCore/CopCore.h
@@ -9,10 +9,11 @@
 #ifndef COPCORE_COPCORE_H_
 #define COPCORE_COPCORE_H_
 
-#include "CopCore/Global.h"
-#include "CopCore/VariableSizeObj.h"
-#include "CopCore/VariableSizeObjAllocator.h"
-#include "CopCore/launch_grid.h"
-#include "CopCore/Launcher.h"
+#include <CopCore/Global.h>
+#include <CopCore/Allocator.h>
+#include <CopCore/VariableSizeObj.h>
+#include <CopCore/VariableSizeObjAllocator.h>
+#include <CopCore/launch_grid.h>
+#include <CopCore/Launcher.h>
 
 #endif // COPCORE_COPCORE_H_

--- a/base/inc/CopCore/include/CopCore/VariableSizeObjAllocator.h
+++ b/base/inc/CopCore/include/CopCore/VariableSizeObjAllocator.h
@@ -43,7 +43,8 @@ public:
 
   bool operator!=(const VariableSizeObjAllocator &other) const { return !(*this == other); }
 
-  value_type *allocate(std::size_t n) const
+  template <typename... P>
+  value_type *allocate(std::size_t n, const P &... params) const
   {
     int old_device = SetDevice(fDeviceId);
 
@@ -54,7 +55,7 @@ public:
 
     // allocate all objects at their aligned positions in the buffer
     for (auto i = 0; i < n; ++i) {
-      T::MakeInstanceAt(fCapacity, buff);
+      T::MakeInstanceAt(fCapacity, buff, params...);
       buff += obj_size;
     }
 
@@ -63,7 +64,7 @@ public:
     return result;
   }
 
-  void deallocate(value_type *ptr, std::size_t n) const
+  void deallocate(value_type *ptr, std::size_t n = 0) const
   {
     int old_device       = SetDevice(fDeviceId);
     std::size_t obj_size = T::SizeOfAlignAware(fCapacity);
@@ -119,7 +120,8 @@ public:
 
   bool operator!=(const VariableSizeObjAllocator &other) const { return !(*this == other); }
 
-  value_type *allocate(std::size_t n) const
+  template <typename... P>
+  value_type *allocate(std::size_t n, const P &... params) const
   {
     value_type *result   = nullptr;
     std::size_t obj_size = T::SizeOfAlignAware(fCapacity);
@@ -128,14 +130,14 @@ public:
 
     // allocate all objects at their aligned positions in the buffer
     for (auto i = 0; i < n; ++i) {
-      T::MakeInstanceAt(fCapacity, buff);
+      T::MakeInstanceAt(fCapacity, buff, params...);
       buff += obj_size;
     }
 
     return result;
   }
 
-  void deallocate(value_type *ptr, std::size_t n) const
+  void deallocate(value_type *ptr, std::size_t n = 0) const
   {
     std::size_t obj_size = T::SizeOfAlignAware(fCapacity);
     char *buff           = (char *)ptr;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,7 +39,7 @@ target_include_directories(test_launcher PUBLIC
   $<INSTALL_INTERFACE:base>
 )
 target_link_libraries(test_launcher VecCore::VecCore CopCore::CopCore)
-target_compile_options(test_launcher PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
+target_compile_options(test_launcher PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx;--extended-lambda>")
 
 build_tests("${ADEPT_UNIT_TESTS_BASE}")
 add_to_test("${ADEPT_UNIT_TESTS_BASE}")

--- a/test/sim_kernels.h
+++ b/test/sim_kernels.h
@@ -10,6 +10,9 @@
 struct MyTrack {
   int index{0};
   float energy{0};
+
+  MyTrack() {}
+  MyTrack(float e) { energy = e; }
 };
 
 struct MyHit {


### PR DESCRIPTION
* A general allocator utility specialised on the backend being used. Usage:
```
copcore::Allocator<Type, backend> myAlloc; // backends defined in Global.h, constructor takes optional device id
Type *obj_ptr = myAlloc.allocate(10, params...); // allocates an array of 10 Type objects, passing params... to their constructor
...
myAlloc.deallocate(obj_ptr, 10); // deallocates the array, calling optionally ~Type (if number of elements passed) 
```

* test_launcher extended to demonstrate usage of the new allocator for (basic) types. Added an example for launching lambda functions.
