### PR TITLE
Fix Release build of tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,6 @@ macro(build_tests TESTS)
       $<INSTALL_INTERFACE:base>
     )
     target_link_libraries(${TARGET_NAME} VecCore::VecCore CopCore::CopCore)
-    target_compile_options(${TARGET_NAME} PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx;--extended-lambda>")
    endforeach()
 endmacro()
 
@@ -33,13 +32,15 @@ set(ADEPT_UNIT_TESTS_BASE
   test_track_block.cu          # Unit test for BlockData
 )
 
+add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda>")
+add_compile_options("$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
+
 add_executable(test_launcher test_launcher.cu test_launcher.cpp)
 target_include_directories(test_launcher PUBLIC
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
   $<INSTALL_INTERFACE:base>
 )
 target_link_libraries(test_launcher VecCore::VecCore CopCore::CopCore)
-target_compile_options(test_launcher PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx;--extended-lambda>")
 
 build_tests("${ADEPT_UNIT_TESTS_BASE}")
 add_to_test("${ADEPT_UNIT_TESTS_BASE}")


### PR DESCRIPTION
Move the option --extended-lambda out of the generator expression
guarded by Debug and RelWithDebInfo.