### PR TITLE
RANLUX++ for host and device

### DIFF
--- a/LICENSES/LGPL-2.1-or-later.txt
+++ b/LICENSES/LGPL-2.1-or-later.txt
@@ -1,0 +1,459 @@
+            GNU LESSER GENERAL PUBLIC LICENSE
+                 Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+     51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                   Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+            GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+  
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                   NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+               END OF TERMS AND CONDITIONS
+

--- a/base/inc/CopCore/LICENSES/LGPL-2.1-or-later.txt
+++ b/base/inc/CopCore/LICENSES/LGPL-2.1-or-later.txt
@@ -1,0 +1,459 @@
+            GNU LESSER GENERAL PUBLIC LICENSE
+                 Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+     51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                   Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+            GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+  
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                   NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+               END OF TERMS AND CONDITIONS
+

--- a/base/inc/CopCore/include/CopCore/Ranluxpp.h
+++ b/base/inc/CopCore/include/CopCore/Ranluxpp.h
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#ifndef COPCORE_RANLUXPP_H_
+#define COPCORE_RANLUXPP_H_
+
+#include <VecCore/VecCore>
+
+#include "mulmod.h"
+
+#include <cassert>
+#include <cstdint>
+
+namespace {
+
+VECCORE_ATT_DEVICE
+const uint64_t kA_2048[] = {
+    0xed7faa90747aaad9, 0x4cec2c78af55c101, 0xe64dcb31c48228ec, 0x6d8a15a13bee7cb0, 0x20b2ca60cb78c509,
+    0x256c3d3c662ea36c, 0xff74e54107684ed2, 0x492edfcc0cc8e753, 0xb48c187cf5b22097,
+};
+
+} // end anonymous namespace
+
+template <int w>
+class RanluxppEngineImpl {
+
+private:
+  uint64_t fState[9]; ///< State of the generator
+  int fPosition = 0;  ///< Current position in bits
+
+  static constexpr const uint64_t *kA = kA_2048;
+  static constexpr int kMaxPos        = 9 * 64;
+
+  /// Produce next block of random bits
+  VECCORE_ATT_HOST_DEVICE
+  void Advance()
+  {
+    mulmod(kA, fState);
+    fPosition = 0;
+  }
+
+public:
+  RanluxppEngineImpl() = default;
+
+  /// Return the next random bits, generate a new block if necessary
+  VECCORE_ATT_HOST_DEVICE
+  uint64_t NextRandomBits()
+  {
+    if (fPosition + w > kMaxPos) {
+      Advance();
+    }
+
+    int idx     = fPosition / 64;
+    int offset  = fPosition % 64;
+    int numBits = 64 - offset;
+
+    uint64_t bits = fState[idx] >> offset;
+    if (numBits < w) {
+      bits |= fState[idx + 1] << numBits;
+    }
+    bits &= ((uint64_t(1) << w) - 1);
+
+    fPosition += w;
+    assert(fPosition <= kMaxPos && "position out of range!");
+
+    return bits;
+  }
+
+  /// Initialize and seed the state of the generator
+  VECCORE_ATT_HOST_DEVICE
+  void SetSeed(uint64_t s)
+  {
+    fState[0] = 1;
+    for (int i = 1; i < 9; i++) {
+      fState[i] = 0;
+    }
+
+    uint64_t a_seed[9];
+    // Skip 2 ** 96 states.
+    powermod(kA, a_seed, uint64_t(1) << 48);
+    powermod(a_seed, a_seed, uint64_t(1) << 48);
+    // Skip another s states.
+    powermod(a_seed, a_seed, s);
+    mulmod(a_seed, fState);
+
+    fPosition = 0;
+  }
+
+  /// Skip `n` random numbers without generating them
+  VECCORE_ATT_HOST_DEVICE
+  void Skip(uint64_t n)
+  {
+    int left = (kMaxPos - fPosition) / w;
+    assert(left >= 0 && "position was out of range!");
+    if (n < (uint64_t)left) {
+      // Just skip the next few entries in the currently available bits.
+      fPosition += n * w;
+      assert(fPosition <= kMaxPos && "position out of range!");
+      return;
+    }
+
+    n -= left;
+    // Need to advance and possibly skip over blocks.
+    int nPerState = kMaxPos / w;
+    int skip      = (n / nPerState);
+
+    uint64_t a_skip[9];
+    powermod(kA, a_skip, skip + 1);
+    mulmod(a_skip, fState);
+
+    // Potentially skip numbers in the freshly generated block.
+    int remaining = n - skip * nPerState;
+    assert(remaining >= 0 && "should not end up at a negative position!");
+    fPosition = remaining * w;
+    assert(fPosition <= kMaxPos && "position out of range!");
+  }
+};
+
+class RanluxppDouble : public RanluxppEngineImpl<52> {
+public:
+  VECCORE_ATT_HOST_DEVICE
+  RanluxppDouble(uint64_t seed = 314159265) { this->SetSeed(seed); }
+
+  VECCORE_ATT_HOST_DEVICE
+  double Rndm() { return (*this)(); }
+
+  VECCORE_ATT_HOST_DEVICE
+  double operator()()
+  {
+    // Get 52 bits of randomness.
+    uint64_t bits = this->NextRandomBits();
+
+    // Construct the double in [1, 2), using the random bits as mantissa.
+    static constexpr uint64_t exp = 0x3ff0000000000000;
+    union {
+      double dRandom;
+      uint64_t iRandom;
+    };
+    iRandom = exp | bits;
+
+    // Shift to the right interval of [0, 1).
+    return dRandom - 1;
+  }
+
+  VECCORE_ATT_HOST_DEVICE
+  uint64_t IntRndm() { return this->NextRandomBits(); }
+};
+
+#endif // COPCORE_RANLUXPP_H_

--- a/base/inc/CopCore/include/CopCore/mulmod.h
+++ b/base/inc/CopCore/include/CopCore/mulmod.h
@@ -1,0 +1,351 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <cstdint>
+
+/// Compute `a + b` and set `overflow` accordingly.
+VECCORE_ATT_HOST_DEVICE
+static inline uint64_t add_overflow(uint64_t a, uint64_t b, unsigned &overflow)
+{
+  uint64_t add = a + b;
+  overflow     = (add < a);
+  return add;
+}
+
+/// Compute `a + b` and increment `carry` if there was an overflow
+VECCORE_ATT_HOST_DEVICE
+static inline uint64_t add_carry(uint64_t a, uint64_t b, unsigned &carry)
+{
+  unsigned overflow;
+  uint64_t add = add_overflow(a, b, overflow);
+  // Do NOT branch on overflow to avoid jumping code, just add 0 if there was
+  // no overflow.
+  carry += overflow;
+  return add;
+}
+
+/// Compute `a - b` and set `overflow` accordingly
+VECCORE_ATT_HOST_DEVICE
+static inline uint64_t sub_overflow(uint64_t a, uint64_t b, unsigned &overflow)
+{
+  uint64_t sub = a - b;
+  overflow     = (sub > a);
+  return sub;
+}
+
+/// Compute `a - b` and increment `carry` if there was an overflow
+VECCORE_ATT_HOST_DEVICE
+static inline uint64_t sub_carry(uint64_t a, uint64_t b, unsigned &carry)
+{
+  unsigned overflow;
+  uint64_t sub = sub_overflow(a, b, overflow);
+  // Do NOT branch on overflow to avoid jumping code, just add 0 if there was
+  // no overflow.
+  carry += overflow;
+  return sub;
+}
+
+/// Multiply two 576 bit numbers, stored as 9 numbers of 64 bits each
+///
+/// \param[in] in1 first factor as 9 numbers of 64 bits each
+/// \param[in] in2 second factor as 9 numbers of 64 bits each
+/// \param[out] out result with 18 numbers of 64 bits each
+VECCORE_ATT_HOST_DEVICE
+void multiply9x9(const uint64_t *in1, const uint64_t *in2, uint64_t *out)
+{
+  uint64_t next      = 0;
+  unsigned nextCarry = 0;
+
+#if defined(__clang__) || defined(__INTEL_COMPILER) || defined(__CUDACC__)
+#pragma unroll
+#elif defined(__GNUC__) && __GNUC__ >= 8
+// This pragma was introduced in GCC version 8.
+#pragma GCC unroll 18
+#endif
+  for (int i = 0; i < 18; i++) {
+    uint64_t current = next;
+    unsigned carry   = nextCarry;
+
+    next      = 0;
+    nextCarry = 0;
+
+#if defined(__clang__) || defined(__INTEL_COMPILER) || defined(__CUDACC__)
+#pragma unroll
+#elif defined(__GNUC__) && __GNUC__ >= 8
+// This pragma was introduced in GCC version 8.
+#pragma GCC unroll 9
+#endif
+    for (int j = 0; j < 9; j++) {
+      int k = i - j;
+      if (k < 0 || k >= 9) continue;
+
+      uint64_t fac1 = in1[j];
+      uint64_t fac2 = in2[k];
+#if defined(__SIZEOF_INT128__) && !defined(ROOT_NO_INT128) && !defined(__CUDA_ARCH__)
+      unsigned __int128 prod = fac1;
+      prod                   = prod * fac2;
+
+      uint64_t upper = prod >> 64;
+      uint64_t lower = static_cast<uint64_t>(prod);
+#else
+      uint64_t upper1 = fac1 >> 32;
+      uint64_t lower1 = static_cast<uint32_t>(fac1);
+
+      uint64_t upper2 = fac2 >> 32;
+      uint64_t lower2 = static_cast<uint32_t>(fac2);
+
+      // Multiply 32-bit parts, each product has a maximum value of
+      // (2 ** 32 - 1) ** 2 = 2 ** 64 - 2 * 2 ** 32 + 1.
+      uint64_t upper   = upper1 * upper2;
+      uint64_t middle1 = upper1 * lower2;
+      uint64_t middle2 = lower1 * upper2;
+      uint64_t lower   = lower1 * lower2;
+
+      // When adding the two products, the maximum value for middle is
+      // 2 * 2 ** 64 - 4 * 2 ** 32 + 2, which exceeds a uint64_t.
+      unsigned overflow;
+      uint64_t middle = add_overflow(middle1, middle2, overflow);
+      // Handling the overflow by a multiplication with 0 or 1 is cheaper
+      // than branching with an if statement, which the compiler does not
+      // optimize to this equivalent code. Note that we could do entirely
+      // without this overflow handling when summing up the intermediate
+      // products differently as described in the following SO answer:
+      //    https://stackoverflow.com/a/51587262
+      // However, this approach takes at least the same amount of thinking
+      // why a) the code gives the same results without b) overflowing due
+      // to the mixture of 32 bit arithmetic. Moreover, my tests show that
+      // the scheme implemented here is actually slightly more performant.
+      uint64_t overflow_add = overflow * (uint64_t(1) << 32);
+      // This addition can never overflow because the maximum value of upper
+      // is 2 ** 64 - 2 * 2 ** 32 + 1 (see above). When now adding another
+      // 2 ** 32, the result is 2 ** 64 - 2 ** 32 + 1 and still smaller than
+      // the maximum 2 ** 64 - 1 that can be stored in a uint64_t.
+      upper += overflow_add;
+
+      uint64_t middle_upper = middle >> 32;
+      uint64_t middle_lower = middle << 32;
+
+      lower = add_overflow(lower, middle_lower, overflow);
+      upper += overflow;
+
+      // This still can't overflow since the maximum of middle_upper is
+      //  - 2 ** 32 - 4 if there was an overflow for middle above, bringing
+      //    the maximum value of upper to 2 ** 64 - 2.
+      //  - otherwise upper still has the initial maximum value given above
+      //    and the addition of a value smaller than 2 ** 32 brings it to
+      //    a maximum value of 2 ** 64 - 2 ** 32 + 2.
+      // (Both cases include the increment to handle the overflow in lower.)
+      //
+      // All the reasoning makes perfect sense given that the product of two
+      // 64 bit numbers is smaller than or equal to
+      //     (2 ** 64 - 1) ** 2 = 2 ** 128 - 2 * 2 ** 64 + 1
+      // with the upper bits matching the 2 ** 64 - 2 of the first case.
+      upper += middle_upper;
+#endif
+
+      // Add to current, remember carry.
+      current = add_carry(current, lower, carry);
+
+      // Add to next, remember nextCarry.
+      next = add_carry(next, upper, nextCarry);
+    }
+
+    next = add_carry(next, carry, nextCarry);
+
+    out[i] = current;
+  }
+}
+
+/// Compute a value congruent to mul modulo m less than 2 ** 576
+///
+/// \param[in] mul product from multiply9x9 with 18 numbers of 64 bits each
+/// \param[out] out result with 9 numbers of 64 bits each
+///
+/// \f$ m = 2^{576} - 2^{240} + 1 \f$
+///
+/// Note that this function does *not* return the smallest value congruent to
+/// the modulus, it only guarantees a value smaller than \f$ 2^{576} \$!
+VECCORE_ATT_HOST_DEVICE
+void mod_m(const uint64_t *mul, uint64_t *out)
+{
+  uint64_t r[9] = {0};
+
+  // r = t0 - t1 (24 * 24 = 576 bits)
+  unsigned carry = 0;
+  for (int i = 0; i < 9; i++) {
+    uint64_t t0_i = mul[i];
+    uint64_t r_i  = sub_overflow(t0_i, carry, carry);
+
+    uint64_t t1_i = mul[i + 9];
+    r_i           = sub_carry(r_i, t1_i, carry);
+    r[i]          = r_i;
+  }
+  int64_t c = -((int64_t)carry);
+
+  // r -= t2 (only 240 bits, so need to extend)
+  carry = 0;
+  for (int i = 0; i < 9; i++) {
+    uint64_t r_i = r[i];
+    r_i          = sub_overflow(r_i, carry, carry);
+
+    uint64_t t2_bits = 0;
+    if (i < 4) {
+      t2_bits += mul[i + 14] >> 16;
+      if (i < 3) {
+        t2_bits += mul[i + 15] << 48;
+      }
+    }
+    r_i  = sub_carry(r_i, t2_bits, carry);
+    r[i] = r_i;
+  }
+  c -= carry;
+
+  // r += (t3 + t2) * 2 ** 240
+  carry = 0;
+  {
+    uint64_t r_3 = r[3];
+    // 16 upper bits
+    uint64_t t2_bits = (mul[14] >> 16) << 48;
+    uint64_t t3_bits = (mul[9] << 48);
+
+    r_3 = add_carry(r_3, t2_bits, carry);
+    r_3 = add_carry(r_3, t3_bits, carry);
+
+    r[3] = r_3;
+  }
+  for (int i = 0; i < 3; i++) {
+    uint64_t r_i = r[i + 4];
+    r_i          = add_overflow(r_i, carry, carry);
+
+    uint64_t t2_bits = (mul[14 + i] >> 32) + (mul[15 + i] << 32);
+    uint64_t t3_bits = (mul[9 + i] >> 16) + (mul[10 + i] << 48);
+
+    r_i = add_carry(r_i, t2_bits, carry);
+    r_i = add_carry(r_i, t3_bits, carry);
+
+    r[i + 4] = r_i;
+  }
+  {
+    uint64_t r_7 = r[7];
+    r_7          = add_overflow(r_7, carry, carry);
+
+    uint64_t t2_bits = (mul[17] >> 32);
+    uint64_t t3_bits = (mul[12] >> 16) + (mul[13] << 48);
+
+    r_7 = add_carry(r_7, t2_bits, carry);
+    r_7 = add_carry(r_7, t3_bits, carry);
+
+    r[7] = r_7;
+  }
+  {
+    uint64_t r_8 = r[8];
+    r_8          = add_overflow(r_8, carry, carry);
+
+    uint64_t t3_bits = (mul[13] >> 16) + (mul[14] << 48);
+
+    r_8 = add_carry(r_8, t3_bits, carry);
+
+    r[8] = r_8;
+  }
+  c += carry;
+
+  // c = floor(r / 2 ** 576) has been computed along the way via the carry
+  // flags. Now to update r = r - c * m, it suffices to know c * (-2 ** 240 + 1)
+  // because the 2 ** 576 will cancel out. Also note that c may be zero, but
+  // the operation is still performed to avoid branching.
+
+  // c * (-2 ** 240 + 1) in 576 bits looks as follows, depending on c:
+  //  - if c = 0, the number is zero.
+  //  - if c = 1: bits 576 to 240 are set,
+  //              bits 239 to 1 are zero, and
+  //              the last one is set
+  //  - if c = -1, which corresponds to all bits set (signed int64_t):
+  //              bits 576 to 240 are zero and the rest is set.
+  // Note that all bits except the last are exactly complimentary (unless c = 0)
+  // and the last byte is conveniently represented by c already.
+  // Now construct the three bit patterns from c, their names correspond to the
+  // assembly implementation by Alexei Sibidanov.
+
+  // c = 0 -> t0 = 0; c = 1 -> t0 = 0; c = -1 -> all bits set (sign extension)
+  // (The assembly implementation shifts by 63, which gives the same result.)
+  int64_t t0 = c >> 1;
+
+  // c = 0 -> t2 = 0; c = 1 -> upper 16 bits set; c = -1 -> lower 48 bits set
+  int64_t t2 = t0 - (c << 48);
+
+  // c = 0 -> t1 = 0; c = 1 -> all bits set; c = -1 -> t1 = 0
+  // (The assembly implementation shifts by 63, which gives the same result.)
+  int64_t t1 = t2 >> 48;
+
+  carry = 0;
+  {
+    uint64_t r_0 = r[0];
+
+    uint64_t out_0 = sub_carry(r_0, c, carry);
+    out[0]         = out_0;
+  }
+  for (int i = 1; i < 3; i++) {
+    uint64_t r_i = r[i];
+    r_i          = sub_overflow(r_i, carry, carry);
+
+    uint64_t out_i = sub_carry(r_i, t0, carry);
+    out[i]         = out_i;
+  }
+  {
+    uint64_t r_3 = r[3];
+    r_3          = sub_overflow(r_3, carry, carry);
+
+    uint64_t out_3 = sub_carry(r_3, t2, carry);
+    out[3]         = out_3;
+  }
+  for (int i = 4; i < 9; i++) {
+    uint64_t r_i = r[i];
+    r_i          = sub_overflow(r_i, carry, carry);
+
+    uint64_t out_i = sub_carry(r_i, t1, carry);
+    out[i]         = out_i;
+  }
+}
+
+/// Combine multiply9x9 and mod_m with internal temporary storage
+///
+/// \param[in] in1 first factor with 9 numbers of 64 bits each
+/// \param[inout] inout second factor and also the output of the same size
+VECCORE_ATT_HOST_DEVICE
+void mulmod(const uint64_t *in1, uint64_t *inout)
+{
+  uint64_t mul[2 * 9] = {0};
+  multiply9x9(in1, inout, mul);
+  mod_m(mul, inout);
+}
+
+/// Compute base to the n modulo m
+///
+/// \param[in] base with 9 numbers of 64 bits each
+/// \param[out] res output with 9 numbers of 64 bits each
+/// \param[in] n exponent
+///
+/// The arguments base and res may point to the same location.
+VECCORE_ATT_HOST_DEVICE
+void powermod(const uint64_t *base, uint64_t *res, uint64_t n)
+{
+  uint64_t fac[9] = {0};
+  fac[0]          = base[0];
+  res[0]          = 1;
+  for (int i = 1; i < 9; i++) {
+    fac[i] = base[i];
+    res[i] = 0;
+  }
+
+  uint64_t mul[18] = {0};
+  while (n) {
+    if (n & 1) {
+      multiply9x9(res, fac, mul);
+      mod_m(mul, res);
+    }
+    n >>= 1;
+    if (!n) break;
+    multiply9x9(fac, fac, mul);
+    mod_m(mul, fac);
+  }
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(test_copcore_link PRIVATE VecCore::VecCore CopCore::CopCor
 # - Unit tests
 set(ADEPT_UNIT_TESTS_BASE
   test_atomic.cu               # Unit test for atomic ops
+  test_ranluxpp.cu             # Unit test for RANLUX++
   test_queue.cu                # Unit test for mpmc_bounded_queue
   test_track_block.cu          # Unit test for BlockData
 )

--- a/test/test_ranluxpp.cu
+++ b/test/test_ranluxpp.cu
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include <CopCore/Ranluxpp.h>
+
+#include <iostream>
+
+__global__ void kernel(RanluxppDouble *r, double *d, uint64_t *i, double *d2)
+{
+  *d = r->Rndm();
+  *i = r->IntRndm();
+  r->Skip(42);
+  *d2 = r->Rndm();
+}
+
+int main(void)
+{
+  RanluxppDouble r;
+  std::cout << "double: " << r.Rndm() << std::endl;
+  std::cout << "int: " << r.IntRndm() << std::endl;
+
+  RanluxppDouble *r_dev;
+  cudaMalloc(&r_dev, sizeof(RanluxppDouble));
+  double *d_dev_ptr;
+  uint64_t *i_dev_ptr;
+  double *d2_dev_ptr;
+  cudaMalloc(&d_dev_ptr, sizeof(double));
+  cudaMalloc(&i_dev_ptr, sizeof(uint64_t));
+  cudaMalloc(&d2_dev_ptr, sizeof(double));
+
+  // Transfer the state of the generator to the device.
+  cudaMemcpy(r_dev, &r, sizeof(RanluxppDouble), cudaMemcpyHostToDevice);
+  cudaDeviceSynchronize();
+
+  kernel<<<1, 1>>>(r_dev, d_dev_ptr, i_dev_ptr, d2_dev_ptr);
+  cudaDeviceSynchronize();
+
+  // Generate from the same state on the host.
+  double d   = r.Rndm();
+  uint64_t i = r.IntRndm();
+  r.Skip(42);
+  double d2 = r.Rndm();
+
+  // Fetch the numbers from the device for comparison.
+  double d_dev;
+  uint64_t i_dev;
+  double d2_dev;
+  cudaMemcpy(&d_dev, d_dev_ptr, sizeof(double), cudaMemcpyDeviceToHost);
+  cudaMemcpy(&i_dev, i_dev_ptr, sizeof(uint64_t), cudaMemcpyDeviceToHost);
+  cudaMemcpy(&d2_dev, d2_dev_ptr, sizeof(double), cudaMemcpyDeviceToHost);
+  cudaDeviceSynchronize();
+
+  int ret = 0;
+
+  std::cout << std::endl;
+  std::cout << "double:" << std::endl;
+  std::cout << "   host:   " << d << std::endl;
+  std::cout << "   device: " << d_dev << std::endl;
+  ret += (d != d_dev);
+
+  std::cout << "int:" << std::endl;
+  std::cout << "   host:   " << i << std::endl;
+  std::cout << "   device: " << i_dev << std::endl;
+  ret += (i != i_dev);
+
+  std::cout << "double (after calling Skip(42)):" << std::endl;
+  std::cout << "   host:   " << d2 << std::endl;
+  std::cout << "   device: " << d2_dev << std::endl;
+  ret += (d2 != d2_dev);
+
+  cudaFree(r_dev);
+  cudaFree(d_dev_ptr);
+  cudaFree(i_dev_ptr);
+  cudaFree(d2_dev_ptr);
+
+  return ret;
+}


### PR DESCRIPTION
Copied from ROOT, with support for only one luxury level (`p=2048`). The main interface for now is `RanluxppDouble`, but we can implement more classes that use less random bits to produce a `float`.
The added test shows how the state can be transferred between host and device via a `cudaMemcpy` and checks that the generated numbers on host and device are identical.