### PR TITLE
LoopNavigator Class and use rays from BlockData<T> containers

### DIFF
--- a/examples/Raytracer_Benchmark/CMakeLists.txt
+++ b/examples/Raytracer_Benchmark/CMakeLists.txt
@@ -31,7 +31,9 @@ add_library(raytracercu ${ADEPT_CUDA_SRCS})
 target_include_directories(raytracercu PUBLIC
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
+)
 target_link_libraries(raytracercu VecCore::VecCore VecGeom::vecgeom VecGeom::vecgeomcuda_static CopCore::CopCore)
 target_compile_options(raytracercu PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
 set_target_properties(raytracercu PROPERTIES CUDA_SEPARABLE_COMPILATION ON)

--- a/examples/Raytracer_Benchmark/LoopNavigator.h
+++ b/examples/Raytracer_Benchmark/LoopNavigator.h
@@ -1,0 +1,244 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file LoopNavigator.h
+ * @brief Navigation methods for geometry.
+ */
+
+#ifndef RT_LOOP_NAVIGATOR_H_
+#define RT_LOOP_NAVIGATOR_H_
+
+#include <list>
+#include <VecGeom/base/Global.h>
+#include <VecGeom/base/Vector3D.h>
+#include <VecGeom/navigation/NavStateIndex.h>
+
+#include <CopCore/Global.h>
+
+#ifdef VECGEOM_ENABLE_CUDA
+#include <VecGeom/backend/cuda/Interface.h>
+#endif
+
+inline namespace COPCORE_IMPL {
+
+class LoopNavigator {
+
+public:
+  using VPlacedVolumePtr_t = vecgeom::VPlacedVolume const *;
+
+  VECCORE_ATT_HOST_DEVICE
+  static VPlacedVolumePtr_t LocateGlobalPoint(vecgeom::VPlacedVolume const *vol,
+                                              vecgeom::Vector3D<vecgeom::Precision> const &point,
+                                              vecgeom::NavStateIndex &path, bool top)
+  {
+    vecgeom::VPlacedVolume const *candvolume = vol;
+    vecgeom::Vector3D<vecgeom::Precision> currentpoint(point);
+    if (top) {
+      assert(vol != nullptr);
+      if (!vol->UnplacedContains(point)) return nullptr;
+    }
+    path.Push(candvolume);
+    vecgeom::LogicalVolume const *lvol                  = candvolume->GetLogicalVolume();
+    vecgeom::Vector<vecgeom::Daughter> const *daughters = lvol->GetDaughtersp();
+
+    bool godeeper = true;
+    while (daughters->size() > 0 && godeeper) {
+      for (size_t i = 0; i < daughters->size() && godeeper; ++i) {
+        vecgeom::VPlacedVolume const *nextvolume = (*daughters)[i];
+        vecgeom::Vector3D<vecgeom::Precision> transformedpoint;
+        if (nextvolume->Contains(currentpoint, transformedpoint)) {
+          path.Push(nextvolume);
+          currentpoint = transformedpoint;
+          candvolume   = nextvolume;
+          daughters    = candvolume->GetLogicalVolume()->GetDaughtersp();
+          break;
+        }
+      }
+      godeeper = false;
+    }
+    return candvolume;
+  }
+
+  VECCORE_ATT_HOST_DEVICE
+  static VPlacedVolumePtr_t LocateGlobalPointExclVolume(vecgeom::VPlacedVolume const *vol,
+                                                        vecgeom::VPlacedVolume const *excludedvolume,
+                                                        vecgeom::Vector3D<vecgeom::Precision> const &point,
+                                                        vecgeom::NavStateIndex &path, bool top)
+  {
+    vecgeom::VPlacedVolume const *candvolume = vol;
+    vecgeom::Vector3D<vecgeom::Precision> currentpoint(point);
+    if (top) {
+      assert(vol != nullptr);
+      candvolume = (vol->UnplacedContains(point)) ? vol : nullptr;
+    }
+    if (candvolume) {
+      path.Push(candvolume);
+      vecgeom::LogicalVolume const *lvol                  = candvolume->GetLogicalVolume();
+      vecgeom::Vector<vecgeom::Daughter> const *daughters = lvol->GetDaughtersp();
+
+      bool godeeper = true;
+      while (daughters->size() > 0 && godeeper) {
+        godeeper = false;
+        // returns nextvolume; and transformedpoint; modified path
+        for (size_t i = 0; i < daughters->size(); ++i) {
+          vecgeom::VPlacedVolume const *nextvolume = (*daughters)[i];
+          if (nextvolume != excludedvolume) {
+            vecgeom::Vector3D<vecgeom::Precision> transformedpoint;
+            if (nextvolume->Contains(currentpoint, transformedpoint)) {
+              path.Push(nextvolume);
+              currentpoint = transformedpoint;
+              candvolume   = nextvolume;
+              daughters    = candvolume->GetLogicalVolume()->GetDaughtersp();
+              godeeper     = true;
+              break;
+            }
+          } // end if excludedvolume
+        }
+      }
+    }
+    return candvolume;
+  }
+
+  VECCORE_ATT_HOST_DEVICE
+  static VPlacedVolumePtr_t RelocatePointFromPathForceDifferent(vecgeom::Vector3D<vecgeom::Precision> const &localpoint,
+                                                                vecgeom::NavStateIndex &path)
+  {
+    vecgeom::VPlacedVolume const *currentmother = path.Top();
+    vecgeom::VPlacedVolume const *entryvol      = currentmother;
+    if (currentmother != nullptr) {
+      vecgeom::Vector3D<vecgeom::Precision> tmp = localpoint;
+      while (currentmother) {
+        if (currentmother == entryvol || currentmother->GetLogicalVolume()->GetUnplacedVolume()->IsAssembly() ||
+            !currentmother->UnplacedContains(tmp)) {
+          path.Pop();
+          vecgeom::Vector3D<vecgeom::Precision> pointhigherup =
+              currentmother->GetTransformation()->InverseTransform(tmp);
+          tmp           = pointhigherup;
+          currentmother = path.Top();
+        } else {
+          break;
+        }
+      }
+
+      if (currentmother) {
+        path.Pop();
+        return LocateGlobalPointExclVolume(currentmother, entryvol, tmp, path, false);
+      }
+    }
+    return currentmother;
+  }
+
+  VECCORE_ATT_HOST_DEVICE
+  static double ComputeStepAndPropagatedState(vecgeom::Vector3D<vecgeom::Precision> const &globalpoint,
+                                              vecgeom::Vector3D<vecgeom::Precision> const &globaldir,
+                                              vecgeom::Precision step_limit, vecgeom::NavStateIndex const &in_state,
+                                              vecgeom::NavStateIndex &out_state)
+  {
+    // calculate local point/dir from global point/dir
+    // call the static function for this provided/specialized by the Impl
+    vecgeom::Vector3D<vecgeom::Precision> localpoint;
+    vecgeom::Vector3D<vecgeom::Precision> localdir;
+    // Impl::DoGlobalToLocalTransformation(in_state, globalpoint, globaldir, localpoint, localdir);
+    vecgeom::Transformation3D m;
+    in_state.TopMatrix(m);
+    localpoint = m.Transform(globalpoint);
+    localdir   = m.TransformDirection(globaldir);
+
+    vecgeom::Precision step                    = step_limit;
+    vecgeom::VPlacedVolume const *hitcandidate = nullptr;
+    auto pvol                                  = in_state.Top();
+    auto lvol                                  = pvol->GetLogicalVolume();
+
+    // need to calc DistanceToOut first
+    // step = Impl::TreatDistanceToMother(pvol, localpoint, localdir, step_limit);
+    step = lvol->GetUnplacedVolume()->DistanceToOut(localpoint, localdir, step_limit);
+    // step = pvol->DistanceToOut(localpoint, localdir, step_limit);
+
+    if (step < 0) step = 0;
+    // "suck in" algorithm from Impl and treat hit detection in local coordinates for daughters
+    //((Impl *)this)
+    //    ->Impl::CheckDaughterIntersections(lvol, localpoint, localdir, &in_state, &out_state, step, hitcandidate);
+    auto *daughters = lvol->GetDaughtersp();
+    auto ndaughters = daughters->size();
+    for (decltype(ndaughters) d = 0; d < ndaughters; ++d) {
+      auto daughter    = daughters->operator[](d);
+      double ddistance = daughter->DistanceToIn(localpoint, localdir, step);
+
+      // if distance is negative; we are inside that daughter and should relocate
+      // unless distance is minus infinity
+      const bool valid = (ddistance < step && !vecgeom::IsInf(ddistance)) &&
+                         !((ddistance <= 0.) && in_state.GetLastExited() == daughter);
+      hitcandidate = valid ? daughter : hitcandidate;
+      step         = valid ? ddistance : step;
+    }
+
+    // fix state
+    bool done;
+    // step = Impl::PrepareOutState(in_state, out_state, step, step_limit, hitcandidate, done);
+    // now we have the candidates and we prepare the out_state
+    in_state.CopyTo(&out_state);
+    done = false;
+    if (step == vecgeom::kInfLength && step_limit > 0.) {
+      step = vecgeom::kTolerance;
+      out_state.SetBoundaryState(true);
+      do {
+        out_state.Pop();
+      } while (out_state.Top()->GetLogicalVolume()->GetUnplacedVolume()->IsAssembly());
+      done = true;
+    } else {
+      // is geometry further away than physics step?
+      // this is a physics step
+      if (step > step_limit) {
+        // don't need to do anything
+        step = step_limit;
+        out_state.SetBoundaryState(false);
+      } else {
+        // otherwise it is a geometry step
+        out_state.SetBoundaryState(true);
+        if (hitcandidate) out_state.Push(hitcandidate);
+
+        if (step < 0.) {
+          // std::cerr << "WARNING: STEP NEGATIVE; NEXTVOLUME " << nexthitvolume << std::endl;
+          // InspectEnvironmentForPointAndDirection( globalpoint, globaldir, currentstate );
+          step = 0.;
+        }
+      }
+    }
+
+    if (done) {
+      if (out_state.Top() != nullptr) {
+        assert(!out_state.Top()->GetLogicalVolume()->GetUnplacedVolume()->IsAssembly());
+      }
+      return step;
+    }
+    // step was physics limited
+    if (!out_state.IsOnBoundary()) return step;
+
+    // otherwise if necessary do a relocation
+    // try relocation to refine out_state to correct location after the boundary
+
+    // ((Impl *)this)->Impl::Relocate(MovePointAfterBoundary(localpoint, localdir, step), in_state, out_state);
+    localpoint += (step + 1.E-6) * localdir;
+
+    if (out_state.Top() == in_state.Top()) {
+      RelocatePointFromPathForceDifferent(localpoint, out_state);
+    } else {
+      // continue directly further down ( next volume should have been stored in out_state already )
+      vecgeom::VPlacedVolume const *nextvol = out_state.Top();
+      out_state.Pop();
+      LoopNavigator::LocateGlobalPoint(nextvol, nextvol->GetTransformation()->Transform(localpoint), out_state, false);
+    }
+
+    if (out_state.Top() != nullptr) {
+      while (out_state.Top()->IsAssembly()) {
+        out_state.Pop();
+      }
+      assert(!out_state.Top()->GetLogicalVolume()->GetUnplacedVolume()->IsAssembly());
+    }
+    return step;
+  }
+};
+
+} // End namespace COPCORE_IMPL
+#endif // RT_LOOP_NAVIGATOR_H_

--- a/examples/Raytracer_Benchmark/RaytraceBenchmark.cpp
+++ b/examples/Raytracer_Benchmark/RaytraceBenchmark.cpp
@@ -16,6 +16,9 @@
 #include "ArgParser.h"
 #include "examples/Raytracer_Benchmark/Raytracer.h"
 #include <CopCore/Global.h>
+#include <AdePT/BlockData.h>
+#include "kernels.h"
+#include "examples/Raytracer_Benchmark/LoopNavigator.h"
 
 #ifdef VECGEOM_GDML
 #include <VecGeom/gdml/Frontend.h>
@@ -126,6 +129,30 @@ int main(int argc, char *argv[])
 
 int RaytraceBenchmarkCPU(cxx::RaytracerData_t &rtdata)
 {
+  using RayBlock     = adept::BlockData<Ray_t>;
+  using RayAllocator = copcore::VariableSizeObjAllocator<RayBlock, copcore::BackendType::CPU>;
+  using Launcher_t   = copcore::Launcher<copcore::BackendType::CPU>;
+  using StreamStruct = copcore::StreamType<copcore::BackendType::CPU>;
+  using Stream_t     = typename StreamStruct::value_type;
+
+  // initialize BlockData of Ray_t structure
+  int capacity = 1 << 20;
+  RayAllocator hitAlloc(capacity);
+  RayBlock *rays = hitAlloc.allocate(1);
+
+  // Boilerplate to get the pointers to the device functions to be used
+  COPCORE_CALLABLE_DECLARE(generateFunc, generateRays);
+
+  // Create a stream to work with.
+  Stream_t stream;
+  StreamStruct::CreateStream(stream);
+
+  // Allocate slots for the BlockData
+  Launcher_t generate(stream);
+  generate.Run(generateFunc, capacity, {0, 0}, rays);
+
+  generate.WaitStream();
+
   // Allocate and initialize all rays on the host
   size_t raysize = Ray_t::SizeOfInstance();
   printf("=== Allocating %.3f MB of ray data on the host\n", (float)rtdata.fNrays * raysize / 1048576);
@@ -134,7 +161,7 @@ int RaytraceBenchmarkCPU(cxx::RaytracerData_t &rtdata)
 
   // Initialize the navigation state for the view point
   vecgeom::NavStateIndex vpstate;
-  Raytracer::LocateGlobalPoint(rtdata.fWorld, rtdata.fStart, vpstate, true);
+  LoopNavigator::LocateGlobalPoint(rtdata.fWorld, rtdata.fStart, vpstate, true);
 
   rtdata.fVPstate = vpstate;
 
@@ -145,7 +172,7 @@ int RaytraceBenchmarkCPU(cxx::RaytracerData_t &rtdata)
   // Run the CPU propagation kernel
   vecgeom::Stopwatch timer;
   timer.Start();
-  Raytracer::PropagateRays(rtdata, input_buffer, output_buffer);
+  Raytracer::PropagateRays(rays, rtdata, input_buffer, output_buffer);
   auto time_cpu = timer.Stop();
   std::cout << "Run time on CPU: " << time_cpu << "\n";
 

--- a/examples/Raytracer_Benchmark/Raytracer.cpp
+++ b/examples/Raytracer_Benchmark/Raytracer.cpp
@@ -5,10 +5,11 @@
 /// \author Andrei Gheata (andrei.gheata@cern.ch)
 /// Adapted from VecGeom for AdePT by antonio.petre@spacescience.ro
 
-
 #include "examples/Raytracer_Benchmark/Raytracer.h"
 #include "examples/Raytracer_Benchmark/Color.h"
+#include "examples/Raytracer_Benchmark/LoopNavigator.h"
 #include <CopCore/Global.h>
+#include <AdePT/BlockData.h>
 
 #include <VecGeom/base/Transformation3D.h>
 #include <VecGeom/base/Stopwatch.h>
@@ -43,6 +44,7 @@ size_t Ray_t::SizeOfInstance(int maxdepth)
   return size;
 }
 */
+
 void RaytracerData_t::Print()
 {
   printf("  screen_pos(%g, %g, %g) screen_size(%d, %d)\n", fScreenPos[0], fScreenPos[1], fScreenPos[2], fSize_px,
@@ -102,10 +104,12 @@ void InitializeModel(vecgeom::VPlacedVolume const *world, RaytracerData_t &rtdat
   rtdata.fNrays = rtdata.fSize_px * rtdata.fSize_py;
 }
 
-adept::Color_t RaytraceOne(RaytracerData_t const &rtdata, Ray_t &ray, int px, int py)
+adept::Color_t RaytraceOne(RaytracerData_t const &rtdata, adept::BlockData<Ray_t> *rays, int px, int py, int index)
 {
   constexpr int kMaxTries = 10;
   constexpr double kPush  = 1.e-8;
+
+  Ray_t ray = (*rays)[index];
 
   vecgeom::Vector3D<double> pos_onscreen = rtdata.fLeftC + rtdata.fScale * (px * rtdata.fRight + py * rtdata.fUp);
   vecgeom::Vector3D<double> start        = (rtdata.fView == kRTVperspective) ? rtdata.fStart : pos_onscreen;
@@ -117,7 +121,7 @@ adept::Color_t RaytraceOne(RaytracerData_t const &rtdata, Ray_t &ray, int px, in
     ray.fCrtState = rtdata.fVPstate;
     ray.fVolume   = (Ray_t::VPlacedVolumePtr_t)rtdata.fVPstate.Top();
   } else {
-    ray.fVolume = Raytracer::LocateGlobalPoint(rtdata.fWorld, ray.fPos, ray.fCrtState, true);
+    ray.fVolume = LoopNavigator::LocateGlobalPoint(rtdata.fWorld, ray.fPos, ray.fCrtState, true);
   }
   int itry = 0;
   while (!ray.fVolume && itry < kMaxTries) {
@@ -126,7 +130,7 @@ adept::Color_t RaytraceOne(RaytracerData_t const &rtdata, Ray_t &ray, int px, in
     if (ray.fDone) return ray.fColor;
     // Propagate to the world volume (but do not increment the boundary count)
     ray.fPos += (snext + kPush) * ray.fDir;
-    ray.fVolume = Raytracer::LocateGlobalPoint(rtdata.fWorld, ray.fPos, ray.fCrtState, true);
+    ray.fVolume = LoopNavigator::LocateGlobalPoint(rtdata.fWorld, ray.fPos, ray.fCrtState, true);
   }
   ray.fDone = ray.fVolume == nullptr;
   if (ray.fDone) return ray.fColor;
@@ -138,8 +142,8 @@ adept::Color_t RaytraceOne(RaytracerData_t const &rtdata, Ray_t &ray, int px, in
     int nsmall   = 0;
 
     while (nextvol == ray.fVolume && nsmall < kMaxTries) {
-      snext   = Raytracer::ComputeStepAndPropagatedState(ray.fPos, ray.fDir, vecgeom::kInfLength, ray.fCrtState,
-                                                       ray.fNextState);
+      snext   = LoopNavigator::ComputeStepAndPropagatedState(ray.fPos, ray.fDir, vecgeom::kInfLength, ray.fCrtState,
+                                                           ray.fNextState);
       nextvol = (Ray_t::VPlacedVolumePtr_t)ray.fNextState.Top();
       ray.fPos += (snext + kPush) * ray.fDir;
       nsmall++;
@@ -227,19 +231,25 @@ void ApplyRTmodel(Ray_t &ray, double step, RaytracerData_t const &rtdata)
   if (ray.fVolume == nullptr) ray.fDone = true;
 }
 
-void PropagateRays(RaytracerData_t &rtdata, unsigned char *input_buffer, unsigned char *output_buffer)
+void PropagateRays(adept::BlockData<Ray_t> *rays, RaytracerData_t &rtdata, unsigned char *input_buffer,
+                   unsigned char *output_buffer)
 {
   // Propagate all rays and write out the image on the CPU
   size_t n10  = 0.1 * rtdata.fNrays;
   size_t icrt = 0;
+
   // fprintf(stderr, "P3\n%d %d\n255\n", fSize_px, fSize_py);
   for (int py = 0; py < rtdata.fSize_py; py++) {
     for (int px = 0; px < rtdata.fSize_px; px++) {
       if ((icrt % n10) == 0) printf("%lu %%\n", 10 * icrt / n10);
       int ray_index = py * rtdata.fSize_px + px;
-      Ray_t *ray    = (Ray_t *)(input_buffer + ray_index * sizeof(Ray_t));
 
-      auto pixel_color = RaytraceOne(rtdata, *ray, px, py);
+      Ray_t *ray = (Ray_t *)(input_buffer + ray_index * sizeof(Ray_t));
+      ray->index = ray_index;
+
+      (*rays)[ray_index] = *ray;
+
+      auto pixel_color = RaytraceOne(rtdata, rays, px, py, ray->index);
 
       int pixel_index                = 4 * ray_index;
       output_buffer[pixel_index + 0] = pixel_color.fComp.red;
@@ -249,214 +259,6 @@ void PropagateRays(RaytracerData_t &rtdata, unsigned char *input_buffer, unsigne
       icrt++;
     }
   }
-}
-
-///< Explicit navigation functions, we should be using the navigator functionality when it works
-vecgeom::VPlacedVolume const *LocateGlobalPoint(vecgeom::VPlacedVolume const *vol,
-                                                vecgeom::Vector3D<vecgeom::Precision> const &point,
-                                                vecgeom::NavStateIndex &path, bool top)
-{
-  vecgeom::VPlacedVolume const *candvolume = vol;
-  vecgeom::Vector3D<vecgeom::Precision> currentpoint(point);
-  if (top) {
-    assert(vol != nullptr);
-    if (!vol->UnplacedContains(point)) return nullptr;
-  }
-  path.Push(candvolume);
-  vecgeom::LogicalVolume const *lvol                  = candvolume->GetLogicalVolume();
-  vecgeom::Vector<vecgeom::Daughter> const *daughters = lvol->GetDaughtersp();
-
-  bool godeeper = true;
-  while (daughters->size() > 0 && godeeper) {
-    for (size_t i = 0; i < daughters->size() && godeeper; ++i) {
-      vecgeom::VPlacedVolume const *nextvolume = (*daughters)[i];
-      vecgeom::Vector3D<vecgeom::Precision> transformedpoint;
-      if (nextvolume->Contains(currentpoint, transformedpoint)) {
-        path.Push(nextvolume);
-        currentpoint = transformedpoint;
-        candvolume   = nextvolume;
-        daughters    = candvolume->GetLogicalVolume()->GetDaughtersp();
-        break;
-      }
-    }
-    godeeper = false;
-  }
-  return candvolume;
-}
-
-vecgeom::VPlacedVolume const *LocateGlobalPointExclVolume(vecgeom::VPlacedVolume const *vol,
-                                                          vecgeom::VPlacedVolume const *excludedvolume,
-                                                          vecgeom::Vector3D<vecgeom::Precision> const &point,
-                                                          vecgeom::NavStateIndex &path, bool top)
-{
-  vecgeom::VPlacedVolume const *candvolume = vol;
-  vecgeom::Vector3D<vecgeom::Precision> currentpoint(point);
-  if (top) {
-    assert(vol != nullptr);
-    candvolume = (vol->UnplacedContains(point)) ? vol : nullptr;
-  }
-  if (candvolume) {
-    path.Push(candvolume);
-    vecgeom::LogicalVolume const *lvol                  = candvolume->GetLogicalVolume();
-    vecgeom::Vector<vecgeom::Daughter> const *daughters = lvol->GetDaughtersp();
-
-    bool godeeper = true;
-    while (daughters->size() > 0 && godeeper) {
-      godeeper = false;
-      // returns nextvolume; and transformedpoint; modified path
-      for (size_t i = 0; i < daughters->size(); ++i) {
-        vecgeom::VPlacedVolume const *nextvolume = (*daughters)[i];
-        if (nextvolume != excludedvolume) {
-          vecgeom::Vector3D<vecgeom::Precision> transformedpoint;
-          if (nextvolume->Contains(currentpoint, transformedpoint)) {
-            path.Push(nextvolume);
-            currentpoint = transformedpoint;
-            candvolume   = nextvolume;
-            daughters    = candvolume->GetLogicalVolume()->GetDaughtersp();
-            godeeper     = true;
-            break;
-          }
-        } // end if excludedvolume
-      }
-    }
-  }
-  return candvolume;
-}
-
-vecgeom::VPlacedVolume const *RelocatePointFromPathForceDifferent(
-    vecgeom::Vector3D<vecgeom::Precision> const &localpoint, vecgeom::NavStateIndex &path)
-{
-  vecgeom::VPlacedVolume const *currentmother = path.Top();
-  vecgeom::VPlacedVolume const *entryvol      = currentmother;
-  if (currentmother != nullptr) {
-    vecgeom::Vector3D<vecgeom::Precision> tmp = localpoint;
-    while (currentmother) {
-      if (currentmother == entryvol || currentmother->GetLogicalVolume()->GetUnplacedVolume()->IsAssembly() ||
-          !currentmother->UnplacedContains(tmp)) {
-        path.Pop();
-        vecgeom::Vector3D<vecgeom::Precision> pointhigherup = currentmother->GetTransformation()->InverseTransform(tmp);
-        tmp                                                 = pointhigherup;
-        currentmother                                       = path.Top();
-      } else {
-        break;
-      }
-    }
-
-    if (currentmother) {
-      path.Pop();
-      return LocateGlobalPointExclVolume(currentmother, entryvol, tmp, path, false);
-    }
-  }
-  return currentmother;
-}
-
-double ComputeStepAndPropagatedState(vecgeom::Vector3D<vecgeom::Precision> const &globalpoint,
-                                     vecgeom::Vector3D<vecgeom::Precision> const &globaldir,
-                                     vecgeom::Precision step_limit, vecgeom::NavStateIndex const &in_state,
-                                     vecgeom::NavStateIndex &out_state)
-{
-  // calculate local point/dir from global point/dir
-  // call the static function for this provided/specialized by the Impl
-  vecgeom::Vector3D<vecgeom::Precision> localpoint;
-  vecgeom::Vector3D<vecgeom::Precision> localdir;
-  // Impl::DoGlobalToLocalTransformation(in_state, globalpoint, globaldir, localpoint, localdir);
-  vecgeom::Transformation3D m;
-  in_state.TopMatrix(m);
-  localpoint = m.Transform(globalpoint);
-  localdir   = m.TransformDirection(globaldir);
-
-  vecgeom::Precision step                    = step_limit;
-  vecgeom::VPlacedVolume const *hitcandidate = nullptr;
-  auto pvol                                  = in_state.Top();
-  auto lvol                                  = pvol->GetLogicalVolume();
-
-  // need to calc DistanceToOut first
-  // step = Impl::TreatDistanceToMother(pvol, localpoint, localdir, step_limit);
-  step = lvol->GetUnplacedVolume()->DistanceToOut(localpoint, localdir, step_limit);
-  // step = pvol->DistanceToOut(localpoint, localdir, step_limit);
-
-  if (step < 0) step = 0;
-  // "suck in" algorithm from Impl and treat hit detection in local coordinates for daughters
-  //((Impl *)this)
-  //    ->Impl::CheckDaughterIntersections(lvol, localpoint, localdir, &in_state, &out_state, step, hitcandidate);
-  auto *daughters = lvol->GetDaughtersp();
-  auto ndaughters = daughters->size();
-  for (decltype(ndaughters) d = 0; d < ndaughters; ++d) {
-    auto daughter    = daughters->operator[](d);
-    double ddistance = daughter->DistanceToIn(localpoint, localdir, step);
-
-    // if distance is negative; we are inside that daughter and should relocate
-    // unless distance is minus infinity
-    const bool valid = (ddistance < step && !vecgeom::IsInf(ddistance)) &&
-                       !((ddistance <= 0.) && in_state.GetLastExited() == daughter);
-    hitcandidate = valid ? daughter : hitcandidate;
-    step         = valid ? ddistance : step;
-  }
-
-  // fix state
-  bool done;
-  // step = Impl::PrepareOutState(in_state, out_state, step, step_limit, hitcandidate, done);
-  // now we have the candidates and we prepare the out_state
-  in_state.CopyTo(&out_state);
-  done = false;
-  if (step == vecgeom::kInfLength && step_limit > 0.) {
-    step = vecgeom::kTolerance;
-    out_state.SetBoundaryState(true);
-    do {
-      out_state.Pop();
-    } while (out_state.Top()->GetLogicalVolume()->GetUnplacedVolume()->IsAssembly());
-    done = true;
-  } else {
-    // is geometry further away than physics step?
-    // this is a physics step
-    if (step > step_limit) {
-      // don't need to do anything
-      step = step_limit;
-      out_state.SetBoundaryState(false);
-    } else {
-      // otherwise it is a geometry step
-      out_state.SetBoundaryState(true);
-      if (hitcandidate) out_state.Push(hitcandidate);
-
-      if (step < 0.) {
-        // std::cerr << "WARNING: STEP NEGATIVE; NEXTVOLUME " << nexthitvolume << std::endl;
-        // InspectEnvironmentForPointAndDirection( globalpoint, globaldir, currentstate );
-        step = 0.;
-      }
-    }
-  }
-
-  if (done) {
-    if (out_state.Top() != nullptr) {
-      assert(!out_state.Top()->GetLogicalVolume()->GetUnplacedVolume()->IsAssembly());
-    }
-    return step;
-  }
-  // step was physics limited
-  if (!out_state.IsOnBoundary()) return step;
-
-  // otherwise if necessary do a relocation
-  // try relocation to refine out_state to correct location after the boundary
-
-  // ((Impl *)this)->Impl::Relocate(MovePointAfterBoundary(localpoint, localdir, step), in_state, out_state);
-  localpoint += (step + 1.E-6) * localdir;
-
-  if (out_state.Top() == in_state.Top()) {
-    RelocatePointFromPathForceDifferent(localpoint, out_state);
-  } else {
-    // continue directly further down ( next volume should have been stored in out_state already )
-    vecgeom::VPlacedVolume const *nextvol = out_state.Top();
-    out_state.Pop();
-    Raytracer::LocateGlobalPoint(nextvol, nextvol->GetTransformation()->Transform(localpoint), out_state, false);
-  }
-
-  if (out_state.Top() != nullptr) {
-    while (out_state.Top()->IsAssembly()) {
-      out_state.Pop();
-    }
-    assert(!out_state.Top()->GetLogicalVolume()->GetUnplacedVolume()->IsAssembly());
-  }
-  return step;
 }
 
 /*

--- a/examples/Raytracer_Benchmark/Raytracer.h
+++ b/examples/Raytracer_Benchmark/Raytracer.h
@@ -12,6 +12,7 @@
 #include <VecGeom/base/Global.h>
 #include <VecGeom/base/Vector3D.h>
 #include <VecGeom/navigation/NavStateIndex.h>
+#include <AdePT/BlockData.h>
 
 #include "Color.h"
 #include <CopCore/Global.h>
@@ -19,7 +20,6 @@
 #ifdef VECGEOM_ENABLE_CUDA
 #include <VecGeom/backend/cuda/Interface.h>
 #endif
-
 
 inline namespace COPCORE_IMPL {
 
@@ -39,8 +39,9 @@ struct Ray_t {
   vecgeom::NavStateIndex fNextState;    ///< navigation state for the next volume
   VPlacedVolumePtr_t fVolume = nullptr; ///< current volume
   int fNcrossed              = 0;       ///< number of crossed boundaries
-  adept::Color_t fColor    = 0;       ///< pixel color
+  adept::Color_t fColor      = 0;       ///< pixel color
   bool fDone                 = false;   ///< done flag
+  int index                  = -1;      ///< index flag
 
   VECCORE_ATT_HOST_DEVICE
   static Ray_t *MakeInstanceAt(void *addr) { return new (addr) Ray_t(); }
@@ -103,26 +104,26 @@ struct RaytracerData_t {
 
   using VPlacedVolumePtr_t = vecgeom::VPlacedVolume const *;
 
-  double fScale     = 0;                        ///< Scaling from pixels to world coordinates
-  double fShininess = 1.;                       ///< Shininess exponent in the specular model
-  double fZoom      = 1.;                       ///< Zoom with respect to the default view
-  vecgeom::Vector3D<double> fSourceDir;         ///< Light source direction
-  vecgeom::Vector3D<double> fScreenPos;         ///< Screen position
-  vecgeom::Vector3D<double> fStart;             ///< Eye position in perspectove mode
-  vecgeom::Vector3D<double> fDir;               ///< Start direction of all rays in parallel view mode
-  vecgeom::Vector3D<double> fUp;                ///< Up vector in the shooting rectangle plane
-  vecgeom::Vector3D<double> fRight;             ///< Right vector in the shooting rectangle plane
-  vecgeom::Vector3D<double> fLeftC;             ///< left-down corner of the ray shooting rectangle
-  int fVerbosity             = 0;               ///< Verbosity level
-  int fNrays                 = 0;               ///< Number of rays left to propagate
-  int fSize_px               = 1024;            ///< Image pixel size in x
-  int fSize_py               = 1024;            ///< Image pixel size in y
-  int fVisDepth              = 1;               ///< Visible geometry depth
-  int fMaxDepth              = 0;               ///< Maximum geometry depth
+  double fScale     = 0;                      ///< Scaling from pixels to world coordinates
+  double fShininess = 1.;                     ///< Shininess exponent in the specular model
+  double fZoom      = 1.;                     ///< Zoom with respect to the default view
+  vecgeom::Vector3D<double> fSourceDir;       ///< Light source direction
+  vecgeom::Vector3D<double> fScreenPos;       ///< Screen position
+  vecgeom::Vector3D<double> fStart;           ///< Eye position in perspectove mode
+  vecgeom::Vector3D<double> fDir;             ///< Start direction of all rays in parallel view mode
+  vecgeom::Vector3D<double> fUp;              ///< Up vector in the shooting rectangle plane
+  vecgeom::Vector3D<double> fRight;           ///< Right vector in the shooting rectangle plane
+  vecgeom::Vector3D<double> fLeftC;           ///< left-down corner of the ray shooting rectangle
+  int fVerbosity           = 0;               ///< Verbosity level
+  int fNrays               = 0;               ///< Number of rays left to propagate
+  int fSize_px             = 1024;            ///< Image pixel size in x
+  int fSize_py             = 1024;            ///< Image pixel size in y
+  int fVisDepth            = 1;               ///< Visible geometry depth
+  int fMaxDepth            = 0;               ///< Maximum geometry depth
   adept::Color_t fBkgColor = 0xFFFFFFFF;      ///< Light color
   adept::Color_t fObjColor = 0x0000FFFF;      ///< Object color
-  ERTmodel fModel            = kRTxray;         ///< Selected RT model
-  ERTView fView              = kRTVperspective; ///< View type
+  ERTmodel fModel          = kRTxray;         ///< Selected RT model
+  ERTView fView            = kRTVperspective; ///< View type
 
   VPlacedVolumePtr_t fWorld = nullptr; ///< World volume
   vecgeom::NavStateIndex fVPstate;     ///< Navigation state corresponding to the viewpoint
@@ -152,30 +153,11 @@ void ApplyRTmodel(Ray_t &ray, double step, RaytracerData_t const &rtdata);
 
 /// \brief Entry point to propagate all rays
 VECCORE_ATT_HOST_DEVICE
-void PropagateRays(RaytracerData_t &data, unsigned char *rays_buffer, unsigned char *output_buffer);
+void PropagateRays(adept::BlockData<Ray_t> *rays, RaytracerData_t &data, unsigned char *rays_buffer,
+                   unsigned char *output_buffer);
 
 VECCORE_ATT_HOST_DEVICE
-adept::Color_t RaytraceOne(RaytracerData_t const &rtdata, Ray_t &ray, int px, int py);
-
-// Navigation methods (just temporary here)
-VECCORE_ATT_HOST_DEVICE
-VPlacedVolumePtr_t LocateGlobalPoint(vecgeom::VPlacedVolume const *vol,
-                                     vecgeom::Vector3D<vecgeom::Precision> const &point, vecgeom::NavStateIndex &path,
-                                     bool top);
-VECCORE_ATT_HOST_DEVICE
-VPlacedVolumePtr_t LocateGlobalPointExclVolume(vecgeom::VPlacedVolume const *vol,
-                                               vecgeom::VPlacedVolume const *excludedvolume,
-                                               vecgeom::Vector3D<vecgeom::Precision> const &point,
-                                               vecgeom::NavStateIndex &path, bool top);
-VECCORE_ATT_HOST_DEVICE
-VPlacedVolumePtr_t RelocatePointFromPathForceDifferent(vecgeom::Vector3D<vecgeom::Precision> const &localpoint,
-                                                       vecgeom::NavStateIndex &path);
-
-VECCORE_ATT_HOST_DEVICE
-double ComputeStepAndPropagatedState(vecgeom::Vector3D<vecgeom::Precision> const &globalpoint,
-                                     vecgeom::Vector3D<vecgeom::Precision> const &globaldir,
-                                     vecgeom::Precision step_limit, vecgeom::NavStateIndex const &in_state,
-                                     vecgeom::NavStateIndex &out_state);
+adept::Color_t RaytraceOne(RaytracerData_t const &rtdata, adept::BlockData<Ray_t> *rays, int px, int py, int index);
 
 } // End namespace Raytracer
 

--- a/examples/Raytracer_Benchmark/kernels.h
+++ b/examples/Raytracer_Benchmark/kernels.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include <AdePT/BlockData.h>
+
+inline namespace COPCORE_IMPL {
+
+// Alocate slots for the BlockData
+VECCORE_ATT_HOST_DEVICE
+void generateRays(int id, adept::BlockData<Ray_t> *rays)
+{
+  auto ray = rays->NextElement();
+  if (!ray) COPCORE_EXCEPTION("generateRays: Not enough space for rays");
+}
+
+COPCORE_CALLABLE_FUNC(generateRays)
+
+} // End namespace COPCORE_IMPL


### PR DESCRIPTION
I added two new files: ```LoopNavigator.h``` and ```kernels.h```.

I refactored the navigation methods as a separate class ```LoopNavigator```. These methods were defined before in ```Raytracer.cpp```.

The rays are used now from ```BlockData<T>``` containers. ```kernels.h``` contains the function ```generateRays``` which is responsible to allocate slots for the ```BlockData```.