### PR TITLE
WIP: Migrate CopCore/AdePT to Allen-style target device choice

### DIFF
--- a/base/inc/AdePT/BlockData.h
+++ b/base/inc/AdePT/BlockData.h
@@ -41,18 +41,18 @@ private:
   friend Base_t;
 
   /** @brief Functions required by VariableSizeObjectInterface */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   ArrayData_t &GetVariableData() { return fData; }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   const ArrayData_t &GetVariableData() const { return fData; }
 
   // constructors and assignment operators are private
   // states have to be constructed using MakeInstance() function
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   BlockData(size_t nvalues) : fCapacity(nvalues), fData(nvalues)
   {
     char *address = (char *)this + Base_t::SizeOfAlignAware(nvalues) - BlockData<Type>::SizeOfExtra(nvalues);
@@ -60,12 +60,12 @@ private:
     Queue_t::MakeInstanceAt(nvalues, address);
   }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   BlockData(BlockData const &other) : BlockData(other.fCapacity, other) {}
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   BlockData(size_t new_size, BlockData const &other) : Base_t(other), fCapacity(new_size), fData(new_size, other.fData)
   {
     char *address = (char *)this + Base_t::SizeOfAlignAware(new_size) - BlockData<Type>::SizeOfExtra(new_size);
@@ -73,13 +73,13 @@ private:
     Queue_t::MakeCopyAt(new_size, *other.fHoles, address);
   }
 
-  VECCORE_FORCE_INLINE
-  VECCORE_ATT_HOST_DEVICE
+  COPCORE_FORCE_INLINE
+  __host__ __device__
   ~BlockData() {}
 
   /** @brief Returns the size in bytes of extra queue data needed by BlockData object with given capacity */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   static size_t SizeOfExtra(int capacity) { return Queue_t::SizeOfAlignAware(capacity); }
 
 public:
@@ -93,18 +93,18 @@ public:
   using Base_t::SizeOfAlignAware;
 
   /** @brief Returns the size in bytes of a BlockData object with given capacity */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   static size_t SizeOfInstance(int capacity) { return Base_t::SizeOf(capacity); }
 
   /** @brief Maximum number of elements */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   int Capacity() const { return fCapacity; }
 
   /** @brief Clear the content */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   void Clear()
   {
     fNused.store(0);
@@ -112,18 +112,18 @@ public:
   }
 
   /** @brief Read-only index operator */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   Type const &operator[](const int index) const { return fData[index]; }
 
   /** @brief Read/write index operator */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   Type &operator[](const int index) { return fData[index]; }
 
   /** @brief Dispatch next free element, nullptr if none left */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   Type *NextElement()
   {
     // Try to get a hole index if any
@@ -139,8 +139,8 @@ public:
   }
 
   /** @brief Release an element */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   void ReleaseElement(int index)
   {
     // No checks currently done that the index was given via NextElement
@@ -150,18 +150,18 @@ public:
   }
 
   /** @brief Number of elements currently distributed */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   int GetNused() { return fNused.load(); }
 
   /** @brief Number of holes in the block */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   int GetNholes() { return fHoles->size(); }
 
   /** @brief Check if container is fully distributed */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   bool IsFull() const { return (GetNused() == fCapacity); }
 
 }; // End BlockData

--- a/base/inc/AdePT/MParray.h
+++ b/base/inc/AdePT/MParray.h
@@ -40,30 +40,30 @@ private:
   friend Base_t;
 
   /** @brief Functions required by VariableSizeObjectInterface */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   ArrayData_t &GetVariableData() { return fData; }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   const ArrayData_t &GetVariableData() const { return fData; }
 
   // constructors and assignment operators are private
   // states have to be constructed using MakeInstance() function
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   MParray(size_t nvalues) : fCapacity(nvalues), fData(nvalues) {}
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   MParray(MParray const &other) : MParray(other.fCapacity, other) {}
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   MParray(size_t new_size, MParray const &other) : Base_t(other), fCapacity(new_size), fData(new_size, other.fData) {}
 
-  VECCORE_FORCE_INLINE
-  VECCORE_ATT_HOST_DEVICE
+  COPCORE_FORCE_INLINE
+  __host__ __device__
   ~MParray() {}
 
 public:
@@ -77,18 +77,18 @@ public:
   using Base_t::SizeOfAlignAware;
 
   /** @brief Maximum number of elements */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   size_t size() const { return fNused.load(); }
 
   /** @brief Maximum number of elements */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   constexpr size_t max_size() const { return fCapacity; }
 
   /** @brief Clear the content */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   void clear()
   {
     fNused.store(0);
@@ -96,13 +96,13 @@ public:
   }
 
   /** @brief Read-only index operator */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   const_reference operator[](size_t index) const { return fData[index]; }
 
   /** @brief Dispatch next free element, nullptr if none left */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   bool push_back(value_type val)
   {
     // Operation may fail if the max size is exceeded. Has to be checked by the user.
@@ -114,33 +114,33 @@ public:
   }
 
   /** @brief Check if container is fully distributed */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   bool full() const { return (size() == fCapacity); }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   const_iterator begin() const { return const_iterator(&fData[0]); }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   const_iterator end() const { return const_iterator(&fData[fNused.load()]); }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   const_reference front() const { return *begin(); }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   const_reference back() const { return fCapacity ? *(end() - 1) : *end(); }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   const_pointer data() const { return &fData[0]; }
 
   /** @brief Returns the size in bytes of a BlockData object with given capacity */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   static size_t SizeOfInstance(int capacity) { return Base_t::SizeOf(capacity); }
 
 }; // End class MParray

--- a/base/inc/AdePT/Utils.h
+++ b/base/inc/AdePT/Utils.h
@@ -12,6 +12,8 @@
 
 #include <string.h> // For memset and memcpy
 
+#include <CopCore/backend/BackendCommon.h>
+
 namespace adept {
 namespace utils {
 /**
@@ -19,7 +21,7 @@ namespace utils {
  * @param value Value to round-up
  */
 template <typename Type>
-VECCORE_ATT_HOST_DEVICE Type round_up_align(Type value, size_t padding)
+__host__ __device__ Type round_up_align(Type value, size_t padding)
 {
   size_t remainder = ((size_t)value) % padding;
   if (remainder == 0) return value;
@@ -27,11 +29,11 @@ VECCORE_ATT_HOST_DEVICE Type round_up_align(Type value, size_t padding)
 }
 
 /** @brief CPP/CUDA Portable memset operation */
-VECCORE_ATT_HOST_DEVICE
-VECCORE_FORCE_INLINE
+__host__ __device__
+COPCORE_FORCE_INLINE
 void memset(void *ptr, int value, size_t num)
 {
-#ifndef VECCORE_CUDA_DEVICE_COMPILATION
+#ifndef DEVICE_COMPILATION_TRAJECTORY
   memset(ptr, value, num);
 #else
   cudaMemset(ptr, value, num);
@@ -39,11 +41,11 @@ void memset(void *ptr, int value, size_t num)
 }
 
 /** @brief CPP/CUDA Portable memcpy operation */
-VECCORE_ATT_HOST_DEVICE
-VECCORE_FORCE_INLINE
+__host__ __device__
+COPCORE_FORCE_INLINE
 void memcpy(void *destination, const void *source, size_t num, int type = 0)
 {
-#ifndef VECCORE_CUDA_DEVICE_COMPILATION
+#ifndef DEVICE_COMPILATION_TRAJECTORY
   memcpy(destination, source, num);
 #else
   cudaMemcpy(destination, source, num, (cudaMemcpyKind)type);

--- a/base/inc/AdePT/mpmc_bounded_queue.h
+++ b/base/inc/AdePT/mpmc_bounded_queue.h
@@ -51,12 +51,12 @@ private:
   friend Base_t;
 
   /** @brief Functions required by VariableSizeObjectInterface */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   ArrayData_t &GetVariableData() { return fBuffer; }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   const ArrayData_t &GetVariableData() const { return fBuffer; }
 
   // constructors and assignment operators are private
@@ -68,8 +68,8 @@ private:
    * @param addr Address where the queue is allocated.
    * The user should make sure to allocate at least SizeofInstance(fBuffersize) bytes
    */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   mpmc_bounded_queue(int nvalues) : fCapacity(nvalues), fMask(nvalues - 1), fBuffer(nvalues)
   {
     // The queue size must be a power of 2 (for fast access)
@@ -78,17 +78,17 @@ private:
       fBuffer[i].fSequence.store(i);
   }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   mpmc_bounded_queue(int /*nvalues*/, mpmc_bounded_queue const & /*other*/) {}
   /** @brief MPMC bounded queue copy constructor */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   mpmc_bounded_queue(mpmc_bounded_queue const &other) : mpmc_bounded_queue(other.fCapacity, other) {}
 
   /** @brief MPMC bounded queue copy constructor with given size */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   mpmc_bounded_queue(size_t new_size, mpmc_bounded_queue const &other)
       : fCapacity(new_size), fMask(new_size - 1), fEnqueue(other.fEnqueue), fDequeue(other.fDequeue),
         fNstored(other.fNstored), fBuffer(new_size, other.fBuffer)
@@ -110,18 +110,18 @@ public:
   using Base_t::SizeOfAlignAware;
 
   /** @brief Returns the size in bytes of a BlockData object with given capacity */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   static size_t SizeOfInstance(int capacity) { return Base_t::SizeOf(capacity); }
 
   /** @brief Maximum number of elements */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   int Capacity() const { return fCapacity; }
 
   /** @brief Size function */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   void clear()
   {
     fEnqueue.store(0);
@@ -132,13 +132,13 @@ public:
   }
 
   /** @brief Size function */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   int size() const { return fNstored.load(); }
 
   /** @brief MPMC enqueue function */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   bool enqueue(Type const &data)
   {
     Value_t *cell;
@@ -161,8 +161,8 @@ public:
   }
 
   /** @brief MPMC dequeue function */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   bool dequeue(Type &data)
   {
     Value_t *cell;
@@ -189,8 +189,8 @@ public:
         The index should be smaller than the number of stored elements. The range is only
         checked in debug mode.
     */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   Type &operator[](const int index)
   {
     assert(index >= 0 && index < fNstored.load() && "Index in queue out of range");
@@ -198,8 +198,8 @@ public:
     return fBuffer[pos & fMask].fData;
   }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  COPCORE_FORCE_INLINE
   Type const &operator[](const int index) const
   {
     assert(index >= 0 && index < fNstored.load() && "Index in queue out of range");

--- a/base/inc/CopCore/CMakeLists.txt
+++ b/base/inc/CopCore/CMakeLists.txt
@@ -6,12 +6,29 @@ project(CopCore VERSION 0.1.0)
 
 include(GNUInstallDirs)
 
+# ---------------------
+# Device Target Options:
+# These can be set from the external project (Namespaced?)
+# ---------------------
+# Device target architecture
+set(TARGET_DEVICE CUDA CACHE STRING "Target architecture of the device")
+set_property(CACHE TARGET_DEVICE PROPERTY STRINGS CPU CUDA)
+set(TARGET_DEFINITION "TARGET_DEVICE_${TARGET_DEVICE}")
+
+# Enable selected Backend
+if(TARGET_DEVICE STREQUAL "CUDA")
+  enable_language(CUDA)
+  find_package(CUDAToolkit 10.0 REQUIRED)
+endif()
+
 # Core library
-add_library(CopCore INTERFACE)
+add_library(CopCore STATIC src/CPUBackend.cpp)
+target_compile_definitions(CopCore PUBLIC ${TARGET_DEFINITION})
 target_compile_features(CopCore INTERFACE cxx_std_14)
 target_include_directories(CopCore INTERFACE
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+target_link_libraries(CopCore PUBLIC $<$<STREQUAL:"${TARGET_DEVICE}","CUDA">:CUDA::cudart_static>)
 
 # Alias to assist in use as a subproject
 add_library(CopCore::CopCore ALIAS CopCore)

--- a/base/inc/CopCore/include/CopCore/Allocator.h
+++ b/base/inc/CopCore/include/CopCore/Allocator.h
@@ -14,13 +14,15 @@
 #include <stdexcept>
 #include <iostream>
 
+#include <CopCore/backend/BackendCommon.h>
+
 namespace copcore {
 
 template <class T, BackendType backend>
 class Allocator {
 };
 
-#ifdef VECCORE_CUDA
+#ifdef TARGET_DEVICE_CUDA
 
 /** @brief Partial allocator specialization for the CUDA backend */
 template <class T>

--- a/base/inc/CopCore/include/CopCore/CopCore.h
+++ b/base/inc/CopCore/include/CopCore/CopCore.h
@@ -9,6 +9,7 @@
 #ifndef COPCORE_COPCORE_H_
 #define COPCORE_COPCORE_H_
 
+#include <CopCore/backend/BackendCommon.h>
 #include <CopCore/Global.h>
 #include <CopCore/Allocator.h>
 #include <CopCore/VariableSizeObj.h>

--- a/base/inc/CopCore/include/CopCore/Global.h
+++ b/base/inc/CopCore/include/CopCore/Global.h
@@ -11,9 +11,9 @@
 
 #include <cstdio>
 #include <type_traits>
-#include <VecCore/VecCore>
+#include <CopCore/backend/BackendCommon.h>
 
-#if (defined(__CUDACC__) || defined(__NVCC__))
+#ifdef TARGET_DEVICE_CUDA
 // Compiling with nvcc
 #define COPCORE_IMPL cuda
 #else
@@ -26,7 +26,7 @@ namespace copcore {
 enum BackendType { CPU = 0, CUDA, HIP };
 
 /** @brief CUDA error checking */
-#ifndef VECCORE_CUDA
+#ifndef TARGET_DEVICE_CUDA
 inline void error_check(int, const char *, int) {}
 #else
 inline void error_check(cudaError_t err, const char *file, int line)
@@ -43,7 +43,7 @@ inline void error_check(cudaError_t err, const char *file, int line)
   } while (0)
 
 /** @brief Trigger a runtime error depending on the backend */
-#ifndef VECCORE_CUDA_DEVICE_COMPILATION
+#ifndef DEVICE_COMPILATION_TRAJECTORY
 #define COPCORE_EXCEPTION(message) throw std::runtime_error(message)
 #else
 #define COPCORE_EXCEPTION(message) asm("trap;") // can do better here
@@ -55,7 +55,7 @@ struct StreamType {
   static void CreateStream(value_type &stream) { stream = 0; }
 };
 
-#ifdef VECCORE_CUDA
+#ifdef TARGET_DEVICE_CUDA
 template <>
 struct StreamType<BackendType::CUDA> {
   using value_type = cudaStream_t;
@@ -85,10 +85,10 @@ const char *BackendName(Backend const &backend)
 #define COPCORE_REQUIRES(...) typename std::enable_if<(__VA_ARGS__)>::type * = nullptr
 
 /** @brief macro to declare device callable functions usable in executors */
-#define COPCORE_CALLABLE_FUNC(FUNC) VECCORE_ATT_DEVICE auto _ptr_##FUNC = FUNC;
+#define COPCORE_CALLABLE_FUNC(FUNC) __device__ auto _ptr_##FUNC = FUNC;
 
 /** @brief macro to pass callable function to executors */
-#ifdef VECCORE_CUDA
+#ifdef TARGET_DEVICE_CUDA
 #define COPCORE_CALLABLE_DECLARE(HVAR, FUNC)                    \
   auto HVAR = FUNC;                                             \
   /*printf("cudaMemcpyFromSymbol for function: %s\n", #FUNC);*/ \
@@ -97,7 +97,7 @@ const char *BackendName(Backend const &backend)
 #define COPCORE_CALLABLE_DECLARE(HVAR, FUNC) auto HVAR = FUNC;
 #endif
 
-#ifdef VECCORE_CUDA
+#ifdef TARGET_DEVICE_CUDA
 #define COPCORE_CALLABLE_IN_NAMESPACE_DECLARE(HVAR, NAMESPACE, FUNC)            \
   auto HVAR = NAMESPACE::FUNC;                                                  \
   /*printf("cudaMemcpyFromSymbol for function: %s::%s\n", #NAMESPACE, #FUNC);*/ \

--- a/base/inc/CopCore/include/CopCore/Launcher.h
+++ b/base/inc/CopCore/include/CopCore/Launcher.h
@@ -14,7 +14,7 @@
 
 namespace copcore {
 
-#ifdef VECCORE_CUDA
+#ifdef TARGET_DEVICE_CUDA
 namespace kernel_launcher_impl {
 
 template <class Function, class... Args>
@@ -67,7 +67,7 @@ public:
   }
 };
 
-#ifdef VECCORE_CUDA
+#ifdef TARGET_DEVICE_CUDA
 /** @brief Specialization of Launcher for the CUDA backend */
 template <>
 class Launcher<BackendType::CUDA> : public LauncherBase<BackendType::CUDA> {

--- a/base/inc/CopCore/include/CopCore/Ranluxpp.h
+++ b/base/inc/CopCore/include/CopCore/Ranluxpp.h
@@ -4,7 +4,7 @@
 #ifndef COPCORE_RANLUXPP_H_
 #define COPCORE_RANLUXPP_H_
 
-#include <VecCore/VecCore>
+#include <CopCore/backend/BackendCommon.h>
 
 #include "mulmod.h"
 
@@ -13,7 +13,7 @@
 
 namespace {
 
-VECCORE_ATT_DEVICE
+__device__
 const uint64_t kA_2048[] = {
     0xed7faa90747aaad9, 0x4cec2c78af55c101, 0xe64dcb31c48228ec, 0x6d8a15a13bee7cb0, 0x20b2ca60cb78c509,
     0x256c3d3c662ea36c, 0xff74e54107684ed2, 0x492edfcc0cc8e753, 0xb48c187cf5b22097,
@@ -32,7 +32,7 @@ private:
   static constexpr int kMaxPos        = 9 * 64;
 
   /// Produce next block of random bits
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   void Advance()
   {
     mulmod(kA, fState);
@@ -43,7 +43,7 @@ public:
   RanluxppEngineImpl() = default;
 
   /// Return the next random bits, generate a new block if necessary
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   uint64_t NextRandomBits()
   {
     if (fPosition + w > kMaxPos) {
@@ -67,7 +67,7 @@ public:
   }
 
   /// Initialize and seed the state of the generator
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   void SetSeed(uint64_t s)
   {
     fState[0] = 1;
@@ -87,7 +87,7 @@ public:
   }
 
   /// Skip `n` random numbers without generating them
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   void Skip(uint64_t n)
   {
     int left = (kMaxPos - fPosition) / w;
@@ -118,13 +118,13 @@ public:
 
 class RanluxppDouble : public RanluxppEngineImpl<52> {
 public:
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   RanluxppDouble(uint64_t seed = 314159265) { this->SetSeed(seed); }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   double Rndm() { return (*this)(); }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   double operator()()
   {
     // Get 52 bits of randomness.
@@ -142,7 +142,7 @@ public:
     return dRandom - 1;
   }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   uint64_t IntRndm() { return this->NextRandomBits(); }
 };
 

--- a/base/inc/CopCore/include/CopCore/VariableSizeObj.h
+++ b/base/inc/CopCore/include/CopCore/VariableSizeObj.h
@@ -126,7 +126,7 @@
 #ifndef COPCORE_VARIABLESIZEOBJ_H
 #define COPCORE_VARIABLESIZEOBJ_H
 
-#include <VecCore/VecCore>
+#include <CopCore/backend/BackendCommon.h>
 
 // For memset and memcpy
 #include <string.h>
@@ -146,31 +146,31 @@ public:
 
   VariableSizeObj(TRootIOCtor *) : fSelfAlloc(false), fN(0) {}
 
-  VECCORE_FORCE_INLINE
-  VECCORE_ATT_HOST_DEVICE
+  COPCORE_FORCE_INLINE
+  __host__ __device__
   VariableSizeObj(unsigned int nvalues) : fSelfAlloc(false), fN(nvalues) {}
 
-  VECCORE_FORCE_INLINE
-  VECCORE_ATT_HOST_DEVICE
+  COPCORE_FORCE_INLINE
+  __host__ __device__
   VariableSizeObj(const VariableSizeObj &other) : fSelfAlloc(false), fN(other.fN)
   {
     if (other.fN) memcpy(GetValues(), other.GetValues(), (other.fN) * sizeof(V));
   }
 
-  VECCORE_FORCE_INLINE
-  VECCORE_ATT_HOST_DEVICE
+  COPCORE_FORCE_INLINE
+  __host__ __device__
   VariableSizeObj(size_t new_size, const VariableSizeObj &other) : fSelfAlloc(false), fN(new_size)
   {
     if (other.fN) memcpy(GetValues(), other.GetValues(), (other.fN) * sizeof(V));
   }
 
-  VECCORE_FORCE_INLINE VECCORE_ATT_HOST_DEVICE V *GetValues() { return &fRealArray[0]; }
-  VECCORE_FORCE_INLINE VECCORE_ATT_HOST_DEVICE const V *GetValues() const { return &fRealArray[0]; }
+  COPCORE_FORCE_INLINE __host__ __device__ V *GetValues() { return &fRealArray[0]; }
+  COPCORE_FORCE_INLINE __host__ __device__ const V *GetValues() const { return &fRealArray[0]; }
 
-  VECCORE_FORCE_INLINE VECCORE_ATT_HOST_DEVICE V &operator[](Index_t index) { return GetValues()[index]; };
-  VECCORE_FORCE_INLINE VECCORE_ATT_HOST_DEVICE const V &operator[](Index_t index) const { return GetValues()[index]; };
+  COPCORE_FORCE_INLINE __host__ __device__ V &operator[](Index_t index) { return GetValues()[index]; };
+  COPCORE_FORCE_INLINE __host__ __device__ const V &operator[](Index_t index) const { return GetValues()[index]; };
 
-  VECCORE_FORCE_INLINE VECCORE_ATT_HOST_DEVICE VariableSizeObj &operator=(const VariableSizeObj &rhs)
+  COPCORE_FORCE_INLINE __host__ __device__ VariableSizeObj &operator=(const VariableSizeObj &rhs)
   {
     // Copy data content using memcpy, limited by the respective size
     // of the the object.  If this is smaller there is data truncation,
@@ -199,7 +199,7 @@ public:
   // The static maker to be used to create an instance of the variable size object.
 
   template <typename... T>
-  VECCORE_ATT_HOST_DEVICE static Cont *MakeInstance(size_t nvalues, const T &... params)
+  __host__ __device__ static Cont *MakeInstance(size_t nvalues, const T &... params)
   {
     // Make an instance of the class which allocates the node array. To be
     // released using ReleaseInstance.
@@ -213,7 +213,7 @@ public:
   }
 
   template <typename... T>
-  VECCORE_ATT_HOST_DEVICE static Cont *MakeInstanceAt(size_t nvalues, void *addr, const T &... params)
+  __host__ __device__ static Cont *MakeInstanceAt(size_t nvalues, void *addr, const T &... params)
   {
     // Make an instance of the class which allocates the node array. To be
     // released using ReleaseInstance. If addr is non-zero, the user promised that
@@ -229,7 +229,7 @@ public:
   }
 
   // The equivalent of the copy constructor
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static Cont *MakeCopy(const Cont &other)
   {
     // Make a copy of the variable size array and its container.
@@ -242,7 +242,7 @@ public:
     return copy;
   }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static Cont *MakeCopy(size_t new_size, const Cont &other)
   {
     // Make a copy of a the variable size array and its container with
@@ -257,7 +257,7 @@ public:
   }
 
   // The equivalent of the copy constructor
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static Cont *MakeCopyAt(const Cont &other, void *addr)
   {
     // Make a copy of a the variable size array and its container at the location (if indicated)
@@ -271,7 +271,7 @@ public:
   }
 
   // The equivalent of the copy constructor
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static Cont *MakeCopyAt(size_t new_size, const Cont &other, void *addr)
   {
     // Make a copy of a the variable size array and its container at the location (if indicated)
@@ -285,7 +285,7 @@ public:
   }
 
   // The equivalent of the destructor
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static void ReleaseInstance(Cont *obj)
   {
     // Releases the space allocated for the object
@@ -294,26 +294,26 @@ public:
   }
 
   // Equivalent of sizeof function (not taking into account padding for alignment)
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static constexpr size_t SizeOf(size_t nvalues)
   {
     return (sizeof(Cont) + Cont::SizeOfExtra(nvalues) + sizeof(V) * (nvalues - 1));
   }
 
   // Size of the allocated derived type data members that are also variable size
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static constexpr size_t SizeOfExtra(size_t nvalues) { return 0; }
 
   // equivalent of sizeof function taking into account padding for alignment
   // this function should be used when making arrays of VariableSizeObjects
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static constexpr size_t SizeOfAlignAware(size_t nvalues) { return SizeOf(nvalues) + RealFillUp(nvalues); }
 
 private:
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static constexpr size_t FillUp(size_t nvalues) { return alignof(Cont) - SizeOf(nvalues) % alignof(Cont); }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static constexpr size_t RealFillUp(size_t nvalues)
   {
     return (FillUp(nvalues) == alignof(Cont)) ? 0 : FillUp(nvalues);

--- a/base/inc/CopCore/include/CopCore/VariableSizeObjAllocator.h
+++ b/base/inc/CopCore/include/CopCore/VariableSizeObjAllocator.h
@@ -14,13 +14,15 @@
 #include <stdexcept>
 #include <iostream>
 
+#include <CopCore/backend/BackendCommon.h>
+
 namespace copcore {
 
 template <class T, BackendType backend>
 class VariableSizeObjAllocator {
 };
 
-#ifdef VECCORE_CUDA
+#ifdef TARGET_DEVICE_CUDA
 
 /** @brief Partial variable-size allocator specialization for the CUDA backend */
 template <class T>

--- a/base/inc/CopCore/include/CopCore/backend/BackendCommon.h
+++ b/base/inc/CopCore/include/CopCore/backend/BackendCommon.h
@@ -1,0 +1,32 @@
+/*****************************************************************************\
+* (c) Copyright 2018-2020 CERN for the benefit of the LHCb Collaboration      *
+\*****************************************************************************/
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <cassert>
+
+// Host / device compiler identification
+#if defined(TARGET_DEVICE_CPU) || (defined(TARGET_DEVICE_CUDA) && defined(__CUDACC__)) || \
+    (defined(TARGET_DEVICE_CUDACLANG) && defined(__clang__) && defined(__CUDA__)) ||      \
+    (defined(TARGET_DEVICE_HIP) && (defined(__HCC__) || defined(__HIP__)))
+#define DEVICE_COMPILER
+#endif
+
+// Host / device compilation trajectory identification
+// Only for CUDA at present...
+#if defined(TARGET_DEVICE_CUDA) && defined(__CUDA_ARCH__)
+#define DEVICE_COMPILATION_TRAJECTORY
+#endif
+
+// Dispatch to the right backend
+#if defined(TARGET_DEVICE_CPU)
+#include "CPUBackend.h"
+#elif defined(TARGET_DEVICE_HIP)
+#include "HIPBackend.h"
+#elif defined(TARGET_DEVICE_CUDA) || defined(TARGET_DEVICE_CUDACLANG)
+#include "CUDABackend.h"
+#endif
+

--- a/base/inc/CopCore/include/CopCore/backend/BackendCommon.h
+++ b/base/inc/CopCore/include/CopCore/backend/BackendCommon.h
@@ -30,3 +30,11 @@
 #include "CUDABackend.h"
 #endif
 
+// Additional inlinesfrom VecCore
+#ifdef _MSC_VER
+#define COPCORE_FORCE_NOINLINE __declspec(noinline)
+#define COPCORE_FORCE_INLINE inline __forceinline
+#else
+#define COPCORE_FORCE_NOINLINE __attribute__((noinline))
+#define COPCORE_FORCE_INLINE inline __attribute__((always_inline))
+#endif

--- a/base/inc/CopCore/include/CopCore/backend/CPUBackend.h
+++ b/base/inc/CopCore/include/CopCore/backend/CPUBackend.h
@@ -1,0 +1,238 @@
+/*****************************************************************************\
+* (c) Copyright 2018-2020 CERN for the benefit of the LHCb Collaboration      *
+\*****************************************************************************/
+
+#pragma once
+
+#ifdef TARGET_DEVICE_CPU
+
+#include <stdexcept>
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <algorithm>
+
+using std::copysignf;
+using std::signbit;
+
+#define __host__
+#define __device__
+#define __shared__
+#define __global__
+#define __constant__
+#define __syncthreads()
+#define __syncwarp()
+#define __launch_bounds__(_i)
+#define cudaError_t int
+#define cudaEvent_t int
+#define cudaStream_t int
+#define cudaSuccess 0
+#define cudaErrorMemoryAllocation 2
+#define __popc __builtin_popcount
+#define __popcll __builtin_popcountll
+#define __ffs __builtin_ffs
+#define __clz __builtin_clz
+#define cudaEventBlockingSync 0x01
+#define __forceinline__ inline
+#define CUDART_PI_F M_PI
+
+enum cudaMemcpyKind {
+  cudaMemcpyHostToHost,
+  cudaMemcpyHostToDevice,
+  cudaMemcpyDeviceToHost,
+  cudaMemcpyDeviceToDevice,
+  cudaMemcpyDefault
+};
+
+struct float3 {
+  float x;
+  float y;
+  float z;
+};
+
+struct float2 {
+  float x;
+  float y;
+};
+
+struct dim3 {
+  unsigned int x = 1;
+  unsigned int y = 1;
+  unsigned int z = 1;
+
+  dim3()             = default;
+  dim3(const dim3 &) = default;
+
+  dim3(const unsigned int &x);
+  dim3(const unsigned int &x, const unsigned int &y);
+  dim3(const unsigned int &x, const unsigned int &y, const unsigned int &z);
+};
+
+struct GridDimensions {
+  unsigned int x;
+  unsigned int y;
+  unsigned int z;
+};
+
+struct BlockIndices {
+  unsigned int x;
+  unsigned int y;
+  unsigned int z;
+};
+
+struct BlockDimensions {
+  unsigned int x = 1;
+  unsigned int y = 1;
+  unsigned int z = 1;
+};
+
+struct ThreadIndices {
+  unsigned int x = 0;
+  unsigned int y = 0;
+  unsigned int z = 0;
+};
+
+extern thread_local GridDimensions gridDim;
+extern thread_local BlockIndices blockIdx;
+constexpr BlockDimensions blockDim{1, 1, 1};
+constexpr ThreadIndices threadIdx{0, 0, 0};
+
+cudaError_t cudaMalloc(void **devPtr, size_t size);
+cudaError_t cudaMallocHost(void **ptr, size_t size);
+cudaError_t cudaMemcpy(void *dst, const void *src, size_t count, enum cudaMemcpyKind kind);
+cudaError_t cudaMemcpyAsync(void *dst, const void *src, size_t count, enum cudaMemcpyKind kind, cudaStream_t stream);
+cudaError_t cudaMemset(void *devPtr, int value, size_t count);
+cudaError_t cudaMemsetAsync(void *devPtr, int value, size_t count, cudaStream_t stream);
+cudaError_t cudaPeekAtLastError();
+cudaError_t cudaEventCreate(cudaEvent_t *event);
+cudaError_t cudaEventCreateWithFlags(cudaEvent_t *event, int flags);
+cudaError_t cudaEventSynchronize(cudaEvent_t event);
+cudaError_t cudaEventRecord(cudaEvent_t event, cudaStream_t stream);
+cudaError_t cudaFreeHost(void *ptr);
+cudaError_t cudaFree(void *ptr);
+cudaError_t cudaDeviceReset();
+cudaError_t cudaStreamCreate(cudaStream_t *pStream);
+cudaError_t cudaMemcpyToSymbol(void *symbol, const void *src, size_t count, size_t offset = 0,
+                               enum cudaMemcpyKind kind = cudaMemcpyDefault);
+cudaError_t cudaHostUnregister(void *ptr);
+cudaError_t cudaHostRegister(void *ptr, size_t size, unsigned int flags);
+
+// CUDA accepts more bindings to cudaMemcpyTo/FromSymbol
+template <class T>
+cudaError_t cudaMemcpyToSymbol(T &symbol, const void *src, size_t count, size_t offset = 0,
+                               enum cudaMemcpyKind = cudaMemcpyHostToDevice)
+{
+  std::memcpy(reinterpret_cast<void *>(((char *)&symbol) + offset), src, count);
+  return 0;
+}
+
+template <class T>
+cudaError_t cudaMemcpyFromSymbol(void *dst, const T &symbol, size_t count, size_t offset = 0,
+                                 enum cudaMemcpyKind = cudaMemcpyHostToDevice)
+{
+  std::memcpy(dst, reinterpret_cast<void *>(((char *)&symbol) + offset), count);
+  return 0;
+}
+
+template <class T, class S>
+T atomicAdd(T *address, S val)
+{
+  const T old = *address;
+  *address += val;
+  return old;
+}
+
+template <class T, class S>
+T atomicOr(T *address, S val)
+{
+  const T old = *address;
+  *address |= val;
+  return old;
+}
+
+template <class T>
+T max(const T &a, const T &b)
+{
+  return std::max(a, b);
+}
+
+template <class T>
+T min(const T &a, const T &b)
+{
+  return std::min(a, b);
+}
+
+unsigned int atomicInc(unsigned int *address, unsigned int val);
+
+uint16_t __float2half(const float f);
+
+float __half2float(const uint16_t h);
+
+#ifdef CPU_USE_REAL_HALF
+
+/**
+ * @brief half_t with int16_t backend (real half).
+ */
+struct half_t {
+private:
+  uint16_t m_value;
+
+public:
+  half_t()               = default;
+  half_t(const half_t &) = default;
+
+  half_t(const float f) { m_value = __float2half(f); }
+
+  inline operator float() const { return __half2float(m_value); }
+
+  inline bool operator<(const half_t &a) const
+  {
+    const auto sign   = (m_value >> 15) & 0x01;
+    const auto sign_a = (a.get() >> 15) & 0x01;
+    return (sign & sign_a & operator!=(a)) ^ (m_value < a.get());
+  }
+
+  inline bool operator>(const half_t &a) const
+  {
+    const auto sign   = (m_value >> 15) & 0x01;
+    const auto sign_a = (a.get() >> 15) & 0x01;
+    return (sign & sign_a & operator!=(a)) ^ (m_value > a.get());
+  }
+
+  inline bool operator<=(const half_t &a) const { return !operator>(a); }
+
+  inline bool operator>=(const half_t &a) const { return !operator<(a); }
+
+  inline bool operator==(const half_t &a) const { return m_value == a.get(); }
+
+  inline bool operator!=(const half_t &a) const { return !operator==(a); }
+};
+
+#else
+
+/**
+ * @brief half_t with float backend.
+ */
+using half_t = float;
+
+#endif
+
+#define cudaCheck(stmt)                                \
+  {                                                    \
+    cudaError_t err = stmt;                            \
+    if (err != cudaSuccess) {                          \
+      std::cerr << "Failed to run " << #stmt << "\n";  \
+      throw std::invalid_argument("cudaCheck failed"); \
+    }                                                  \
+  }
+
+#define cudaCheckKernelCall(stmt)                                \
+  {                                                              \
+    cudaError_t err = stmt;                                      \
+    if (err != cudaSuccess) {                                    \
+      std::cerr << "Failed to invoke kernel.\n";                 \
+      throw std::invalid_argument("cudaCheckKernelCall failed"); \
+    }                                                            \
+  }
+
+#endif

--- a/base/inc/CopCore/include/CopCore/backend/CUDABackend.h
+++ b/base/inc/CopCore/include/CopCore/backend/CUDABackend.h
@@ -1,0 +1,49 @@
+/*****************************************************************************\
+* (c) Copyright 2018-2020 CERN for the benefit of the LHCb Collaboration      *
+\*****************************************************************************/
+
+#pragma once
+
+#if defined(TARGET_DEVICE_CUDA) || defined(TARGET_DEVICE_CUDACLANG)
+
+#if !defined(DEVICE_COMPILER)
+#include <cuda_runtime_api.h>
+
+#if defined(TARGET_DEVICE_CUDACLANG)
+inline const char *cudaGetErrorString(cudaError_t error)
+{
+  return "";
+}
+#endif
+
+#endif
+
+#include <cuda_fp16.h>
+#define half_t half
+
+#include "math_constants.h"
+
+/**
+ * @brief Macro to check cuda calls.
+ */
+#define cudaCheck(stmt)                                \
+  {                                                    \
+    cudaError_t err = stmt;                            \
+    if (err != cudaSuccess) {                          \
+      std::cerr << "Failed to run " << #stmt << "\n";  \
+      std::cerr << cudaGetErrorString(err) << "\n";    \
+      throw std::invalid_argument("cudaCheck failed"); \
+    }                                                  \
+  }
+
+#define cudaCheckKernelCall(stmt)                                                                             \
+  {                                                                                                           \
+    cudaError_t err = stmt;                                                                                   \
+    if (err != cudaSuccess) {                                                                                 \
+      fprintf(stderr, "Failed to invoke kernel\n%s (%d) at %s: %d\n", cudaGetErrorString(err), err, __FILE__, \
+              __LINE__);                                                                                      \
+      throw std::invalid_argument("cudaCheckKernelCall failed");                                              \
+    }                                                                                                         \
+  }
+
+#endif

--- a/base/inc/CopCore/include/CopCore/backend/HIPBackend.h
+++ b/base/inc/CopCore/include/CopCore/backend/HIPBackend.h
@@ -1,0 +1,79 @@
+/*****************************************************************************\
+* (c) Copyright 2018-2020 CERN for the benefit of the LHCb Collaboration      *
+\*****************************************************************************/
+
+#pragma once
+
+#ifdef TARGET_DEVICE_HIP
+
+#if !defined(__HCC__) && !defined(__HIP__)
+#define __HIP_PLATFORM_HCC__
+#include <hip/hip_runtime_api.h>
+#else
+#include <hip/hip_runtime.h>
+#include <hip/math_functions.h>
+#endif
+
+#include <hip/hip_fp16.h>
+#define half_t half
+
+#include <cmath>
+#define CUDART_PI_F M_PI
+
+// CUDA to HIP conversion
+#define cudaMalloc hipMalloc
+#define cudaMallocHost hipHostMalloc
+#define cudaMemcpy hipMemcpy
+#define cudaMemcpyAsync hipMemcpyAsync
+#define cudaMemset hipMemset
+#define cudaMemsetAsync hipMemsetAsync
+#define cudaPeekAtLastError hipPeekAtLastError
+#define cudaEventCreate hipEventCreate
+#define cudaEventCreateWithFlags hipEventCreateWithFlags
+#define cudaEventSynchronize hipEventSynchronize
+#define cudaEventRecord hipEventRecord
+#define cudaFreeHost hipHostFree
+#define cudaDeviceReset hipDeviceReset
+#define cudaStreamCreate hipStreamCreate
+#define cudaMemGetInfo hipMemGetInfo
+#define cudaGetDeviceCount hipGetDeviceCount
+#define cudaSetDevice hipSetDevice
+#define cudaGetDeviceProperties hipGetDeviceProperties
+#define cudaDeviceProp hipDeviceProp_t
+#define cudaError_t hipError_t
+#define cudaEvent_t hipEvent_t
+#define cudaStream_t hipStream_t
+#define cudaSuccess hipSuccess
+#define cudaErrorMemoryAllocation hipErrorMemoryAllocation
+#define cudaEventBlockingSync hipEventBlockingSync
+#define cudaMemcpyHostToHost hipMemcpyHostToHost
+#define cudaMemcpyHostToDevice hipMemcpyHostToDevice
+#define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
+#define cudaMemcpyDeviceToDevice hipMemcpyDeviceToDevice
+#define cudaMemcpyDefault hipMemcpyDefault
+#define cudaFuncCachePreferL1 hipFuncCachePreferL1
+#define cudaDeviceGetByPCIBusId hipDeviceGetByPCIBusId
+#define cudaDeviceSetCacheConfig hipDeviceSetCacheConfig
+#define cudaHostUnregister hipHostUnregister
+
+#define cudaCheck(stmt)                                                                                      \
+  {                                                                                                          \
+    hipError_t err = stmt;                                                                                   \
+    if (err != hipSuccess) {                                                                                 \
+      fprintf(stderr, "Failed to run %s\n%s (%d) at %s: %d\n", #stmt, hipGetErrorString(err), err, __FILE__, \
+              __LINE__);                                                                                     \
+      throw std::invalid_argument("cudaCheck failed");                                                       \
+    }                                                                                                        \
+  }
+
+#define cudaCheckKernelCall(stmt)                                                                            \
+  {                                                                                                          \
+    cudaError_t err = stmt;                                                                                  \
+    if (err != cudaSuccess) {                                                                                \
+      fprintf(stderr, "Failed to invoke kernel\n%s (%d) at %s: %d\n", hipGetErrorString(err), err, __FILE__, \
+              __LINE__);                                                                                     \
+      throw std::invalid_argument("cudaCheckKernelCall failed");                                             \
+    }                                                                                                        \
+  }
+
+#endif

--- a/base/inc/CopCore/include/CopCore/launch_grid.h
+++ b/base/inc/CopCore/include/CopCore/launch_grid.h
@@ -28,16 +28,16 @@ public:
   launch_grid(int n_blocks, int n_threads) : fGrid{n_blocks, n_threads} {}
 
   /** @brief Access either block [0] or thread [1] grid */
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   int operator[](int index) { return fGrid[index]; }
 
   /** @brief Access either block [0] or thread [1] grid */
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   int operator[](int index) const { return fGrid[index]; }
 
 }; // End class launch_grid<BackendType::CPU>
 
-#ifdef VECCORE_CUDA
+#ifdef TARGET_DEVICE_CUDA
 template <>
 class launch_grid<BackendType::CUDA> {
 private:
@@ -45,19 +45,19 @@ private:
 
 public:
   /** @brief Construct from block and thread grids */
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   launch_grid(const dim3 &block_index, const dim3 &thread_index) : fGrid{block_index, thread_index} {}
 
   /** @brief Default constructor */
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   launch_grid() : launch_grid(dim3(), dim3()) {}
 
   /** @brief Access either block [0] or thread [1] grid */
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   dim3 &operator[](int index) { return fGrid[index]; }
 
   /** @brief Access either block [0] or thread [1] grid */
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   const dim3 &operator[](int index) const { return fGrid[index]; }
 }; // End class launch_grid<BackendType::CUDA>
 #endif

--- a/base/inc/CopCore/include/CopCore/mulmod.h
+++ b/base/inc/CopCore/include/CopCore/mulmod.h
@@ -3,8 +3,10 @@
 
 #include <cstdint>
 
+#include <CopCore/backend/BackendCommon.h>
+
 /// Compute `a + b` and set `overflow` accordingly.
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 static inline uint64_t add_overflow(uint64_t a, uint64_t b, unsigned &overflow)
 {
   uint64_t add = a + b;
@@ -13,7 +15,7 @@ static inline uint64_t add_overflow(uint64_t a, uint64_t b, unsigned &overflow)
 }
 
 /// Compute `a + b` and increment `carry` if there was an overflow
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 static inline uint64_t add_carry(uint64_t a, uint64_t b, unsigned &carry)
 {
   unsigned overflow;
@@ -25,7 +27,7 @@ static inline uint64_t add_carry(uint64_t a, uint64_t b, unsigned &carry)
 }
 
 /// Compute `a - b` and set `overflow` accordingly
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 static inline uint64_t sub_overflow(uint64_t a, uint64_t b, unsigned &overflow)
 {
   uint64_t sub = a - b;
@@ -34,7 +36,7 @@ static inline uint64_t sub_overflow(uint64_t a, uint64_t b, unsigned &overflow)
 }
 
 /// Compute `a - b` and increment `carry` if there was an overflow
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 static inline uint64_t sub_carry(uint64_t a, uint64_t b, unsigned &carry)
 {
   unsigned overflow;
@@ -50,7 +52,7 @@ static inline uint64_t sub_carry(uint64_t a, uint64_t b, unsigned &carry)
 /// \param[in] in1 first factor as 9 numbers of 64 bits each
 /// \param[in] in2 second factor as 9 numbers of 64 bits each
 /// \param[out] out result with 18 numbers of 64 bits each
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void multiply9x9(const uint64_t *in1, const uint64_t *in2, uint64_t *out)
 {
   uint64_t next      = 0;
@@ -165,7 +167,7 @@ void multiply9x9(const uint64_t *in1, const uint64_t *in2, uint64_t *out)
 ///
 /// Note that this function does *not* return the smallest value congruent to
 /// the modulus, it only guarantees a value smaller than \f$ 2^{576} \$!
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void mod_m(const uint64_t *mul, uint64_t *out)
 {
   uint64_t r[9] = {0};
@@ -311,7 +313,7 @@ void mod_m(const uint64_t *mul, uint64_t *out)
 ///
 /// \param[in] in1 first factor with 9 numbers of 64 bits each
 /// \param[inout] inout second factor and also the output of the same size
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void mulmod(const uint64_t *in1, uint64_t *inout)
 {
   uint64_t mul[2 * 9] = {0};
@@ -326,7 +328,7 @@ void mulmod(const uint64_t *in1, uint64_t *inout)
 /// \param[in] n exponent
 ///
 /// The arguments base and res may point to the same location.
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void powermod(const uint64_t *base, uint64_t *res, uint64_t n)
 {
   uint64_t fac[9] = {0};

--- a/base/inc/CopCore/src/CPUBackend.cpp
+++ b/base/inc/CopCore/src/CPUBackend.cpp
@@ -1,0 +1,128 @@
+/*****************************************************************************\
+* (c) Copyright 2018-2020 CERN for the benefit of the LHCb Collaboration      *
+\*****************************************************************************/
+
+#ifdef TARGET_DEVICE_CPU
+
+#include "CopCore/backend/CPUBackend.h"
+#include <cstring>
+#include <cstdlib>
+
+thread_local GridDimensions gridDim;
+thread_local BlockIndices blockIdx;
+
+dim3::dim3(const unsigned int &x) : x(x) {}
+dim3::dim3(const unsigned int &x, const unsigned int &y) : x(x), y(y) {}
+dim3::dim3(const unsigned int &x, const unsigned int &y, const unsigned int &z) : x(x), y(y), z(z) {}
+
+cudaError_t cudaMalloc(void **devPtr, size_t size)
+{
+  posix_memalign(devPtr, 64, size);
+  return 0;
+}
+
+cudaError_t cudaMallocHost(void **ptr, size_t size)
+{
+  posix_memalign(ptr, 64, size);
+  return 0;
+}
+
+cudaError_t cudaMemcpy(void *dst, const void *src, size_t count, enum cudaMemcpyKind)
+{
+  std::memcpy(dst, src, count);
+  return 0;
+}
+
+cudaError_t cudaMemcpyAsync(void *dst, const void *src, size_t count, enum cudaMemcpyKind, cudaStream_t)
+{
+  std::memcpy(dst, src, count);
+  return 0;
+}
+
+cudaError_t cudaMemset(void *devPtr, int value, size_t count)
+{
+  std::memset(devPtr, value, count);
+  return 0;
+}
+
+cudaError_t cudaMemsetAsync(void *devPtr, int value, size_t count, cudaStream_t)
+{
+  std::memset(devPtr, value, count);
+  return 0;
+}
+
+cudaError_t cudaPeekAtLastError()
+{
+  return 0;
+}
+
+cudaError_t cudaEventCreate(cudaEvent_t *)
+{
+  return 0;
+}
+
+cudaError_t cudaEventCreateWithFlags(cudaEvent_t *, int)
+{
+  return 0;
+}
+
+cudaError_t cudaEventSynchronize(cudaEvent_t)
+{
+  return 0;
+}
+
+cudaError_t cudaEventRecord(cudaEvent_t, cudaStream_t)
+{
+  return 0;
+}
+
+cudaError_t cudaFreeHost(void *ptr)
+{
+  free(ptr);
+  return 0;
+}
+
+cudaError_t cudaFree(void *ptr)
+{
+  free(ptr);
+  return 0;
+}
+
+cudaError_t cudaDeviceReset()
+{
+  return 0;
+}
+
+cudaError_t cudaStreamCreate(cudaStream_t *)
+{
+  return 0;
+}
+
+cudaError_t cudaMemcpyToSymbol(void *symbol, const void *src, size_t count, size_t offset, enum cudaMemcpyKind)
+{
+  std::memcpy(symbol, reinterpret_cast<const char *>(src) + offset, count);
+  return 0;
+}
+
+unsigned int atomicInc(unsigned int *address, unsigned int val)
+{
+  unsigned int old = *address;
+  *address         = ((old >= val) ? 0 : (old + 1));
+  return old;
+}
+
+namespace Configuration {
+unsigned verbosity_level;
+}
+
+cudaError_t cudaHostUnregister(void *)
+{
+  return 0;
+}
+
+cudaError_t cudaHostRegister(void *, size_t, unsigned int)
+{
+  return 0;
+}
+
+#endif

--- a/examples/Example1/example1.cu
+++ b/examples/Example1/example1.cu
@@ -23,10 +23,10 @@ struct Scoring {
   adept::Atomic_t<int> secondaries;
   adept::Atomic_t<float> totalEnergyLoss;
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   Scoring() {}
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static Scoring *MakeInstanceAt(void *addr)
   {
     Scoring *obj = new (addr) Scoring();
@@ -40,7 +40,7 @@ __global__ void DefinePhysicalStepLength(adept::BlockData<track> *block, process
   int n = block->GetNused() + block->GetNholes();
 
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
-    
+
     // skip particles that are already dead
     if ((*block)[i].status == dead) continue;
 
@@ -51,25 +51,25 @@ __global__ void DefinePhysicalStepLength(adept::BlockData<track> *block, process
 }
 
 // kernel to call Along Step function for particles in the queues
-__global__ void CallAlongStepProcesses(adept::BlockData<track> *block, process_list** proclist, adept::MParray **queues, 
+__global__ void CallAlongStepProcesses(adept::BlockData<track> *block, process_list** proclist, adept::MParray **queues,
                                         Scoring *scor, curandState_t *states)
 {
   int particle_index;
 
   // loop over all processes
-  for (int process_id=0 ; process_id < (*proclist)->list_size; process_id++) 
+  for (int process_id=0 ; process_id < (*proclist)->list_size; process_id++)
     {
       // for each process [process_id] consume the associated queue of particles
       int queue_size = queues[process_id]->size();
 
-      for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < queue_size; i += blockDim.x * gridDim.x) 
+      for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < queue_size; i += blockDim.x * gridDim.x)
         {
           // get particles index from the queue
           particle_index = (*(queues[process_id]))[i];
           // and call the process for it
           ((*proclist)->list)[process_id]->GenerateInteraction(particle_index, block, states);
 
-          // a simple version of scoring 
+          // a simple version of scoring
           scor->totalEnergyLoss.fetch_add((*block)[particle_index].energy_loss);
           scor->secondaries.fetch_add((*block)[particle_index].number_of_secondaries);
 
@@ -139,7 +139,7 @@ int main()
   // Initialize scoring
   scor->secondaries     = 0;
   scor->totalEnergyLoss = 0;
-  
+
   // Allocate a block of tracks with capacity larger than the total number of spawned threads
   size_t blocksize = adept::BlockData<track>::SizeOfInstance(capacity);
   char *buffer2    = nullptr;
@@ -166,14 +166,14 @@ int main()
   constexpr dim3 maxBlocks(10);
   dim3 numBlocks;
 
-  while (block->GetNused()>0) 
+  while (block->GetNused()>0)
   {
     numBlocks.x = (block->GetNused() + block->GetNholes() + nthreads.x - 1) / nthreads.x;
     numBlocks.x = std::min(numBlocks.x, maxBlocks.x);
 
     // call the kernel to do check the step lenght and select process
     DefinePhysicalStepLength<<<numBlocks, nthreads>>>(block, proclist, queues, state);
-    
+
     // call the kernel for Along Step Processes
     CallAlongStepProcesses<<<numBlocks, nthreads>>>(block, proclist, queues, scor, state);
 
@@ -182,7 +182,7 @@ int main()
     for (int i = 0; i < numberOfProcesses; i++) queues[i]->clear();
     cudaDeviceSynchronize();
 
-    std::cout << "Number of tracks in flight: " << std::setw(8) << block->GetNused() << " total energy depostion: " << std::setw(10) << scor->totalEnergyLoss.load() 
+    std::cout << "Number of tracks in flight: " << std::setw(8) << block->GetNused() << " total energy depostion: " << std::setw(10) << scor->totalEnergyLoss.load()
     << " total number of secondaries: " << scor->secondaries.load() << std::endl;
   }
 }

--- a/examples/FisherPrice_cu/cufisher_price.cu
+++ b/examples/FisherPrice_cu/cufisher_price.cu
@@ -21,10 +21,10 @@ struct Scoring {
   adept::Atomic_t<int> secondaries;
   adept::Atomic_t<float> totalEnergyLoss;
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   Scoring() {}
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static Scoring *MakeInstanceAt(void *addr)
   {
     Scoring *obj = new (addr) Scoring();

--- a/examples/FisherPrice_cu/cufisher_price_v2.cu
+++ b/examples/FisherPrice_cu/cufisher_price_v2.cu
@@ -23,10 +23,10 @@ struct Scoring {
   adept::Atomic_t<int> secondaries;
   adept::Atomic_t<float> totalEnergyLoss;
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   Scoring() {}
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static Scoring *MakeInstanceAt(void *addr)
   {
     Scoring *obj = new (addr) Scoring();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,9 +21,6 @@ macro(add_to_test TESTS)
    endforeach()
 endmacro()
 
-# - Test that linkage to CopCore target works
-add_executable(test_copcore_link test_copcore_link.cpp)
-target_link_libraries(test_copcore_link PRIVATE VecCore::VecCore CopCore::CopCore)
 
 # - Unit tests
 set(ADEPT_UNIT_TESTS_BASE

--- a/test/run_simulation.hpp
+++ b/test/run_simulation.hpp
@@ -60,7 +60,7 @@ int runSimulation()
 
   // A launcher that runs a lambda function that fills an array with the current thread number
   Launcher_t fillArray(stream);
-  fillArray.Run([] VECCORE_ATT_DEVICE(int thread_id, Atomic_int *index,
+  fillArray.Run([] __device__ (int thread_id, Atomic_int *index,
                                       int *array) { array[thread_id] = (*index)++; }, // lambda being run
                 32,                                                                   // number of elements
                 {2, 16},              // run with 2 block of 16 threads (if backend=CUDA)

--- a/test/sim_kernels.h
+++ b/test/sim_kernels.h
@@ -29,7 +29,7 @@ inline namespace COPCORE_IMPL {
               The current index of the loop over the input data
     @param tracks Pointer to the container of tracks
   */
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void generateAndStorePrimary(int id, adept::BlockData<MyTrack> *tracks)
 {
   auto track = tracks->NextElement();
@@ -46,7 +46,7 @@ COPCORE_CALLABLE_FUNC(generateAndStorePrimary)
 namespace devfunc {
 
 /** @brief Select a track based on its index and add it to a queue */
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void selectTrack(int id, adept::BlockData<MyTrack> *tracks, int each_n, adept::MParray *array)
 {
   auto &track   = (*tracks)[id];
@@ -60,7 +60,7 @@ COPCORE_CALLABLE_FUNC(selectTrack)
 } // end namespace devfunc
 
 /** @brief Process a track and sum-up some energy deposit */
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void elossTrack(int id, adept::MParray *array, adept::BlockData<MyTrack> *tracks, adept::BlockData<MyHit> *hits)
 {
   // Say there are 1024 hit objects and they accumulate energy deposits from specific track id's

--- a/test/test_atomic.cu
+++ b/test/test_atomic.cu
@@ -16,10 +16,10 @@ struct SomeStruct {
   adept::Atomic_t<int> var_int;
   adept::Atomic_t<float> var_float;
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   SomeStruct() {}
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static SomeStruct *MakeInstanceAt(void *addr)
   {
     SomeStruct *obj = new (addr) SomeStruct();

--- a/test/test_copcore_link.cpp
+++ b/test/test_copcore_link.cpp
@@ -1,6 +1,0 @@
-// SPDX-FileCopyrightText: 2020 CERN
-// SPDX-License-Identifier: Apache-2.0
-
-#include <CopCore/CopCore.h>
-
-int main() {}


### PR DESCRIPTION
As we've been discussing, it's useful to try out the host/device portability system from LHCb's Allen project. There were some issues with the initial attempts, but this is now understood, and thus this PR has a go at a using "Allen style" in CopCore/AdePT.

It's quite cut down from @graeme-a-stewart's first import so that it only imports the basic preprocessor macros and CPU backend (though this is not used yet). It adds a new macro `DEVICE_COMPILATION_TRAJECTORY` that's equivalent to VecCore's `VECCORE_CUDA_DEVICE_COMPILATION`, and is defined if and only if the compiler is compiling for the device. 
It's never defined for CPU, and has only been set up for CUDA (there is a HIP equivalent, but later...). It also adds `COPCORE_FORCE_INLINE` to replace the VecCore equivalent.

The major changes in the CopCore/Adept code are relatively straightforward:

- Add a CMake option `TARGET_DEVICE` to CopCore's CMakeLists.txt to select the backend.
  - This is CUDA by default since Adept is (but see below).
- Include the new `CopCore/backend/BackendCommon.h` in `CopCore` headers
- Change `VECCORE_` macros to Allen's `__host__` etc and `COPCORE_` for the inlines

Have to admit I'm not *totally* convinced, but that's likely due to the remaining macros for inlining etc...

*Most* examples and tests then run, but there are a couple of exceptions:

- The RayTracing example. However, this didn't compile for me when starting this branch, so something else is wrong with that (to be checked).
- The `test/test_launcher.cpp` test.
  - The issue appears to be that the Allen style effectively hardcodes CPU/CUDA. In CUDA mode, you can't then use CopCore from a C++ translation unit (at least in the above naive translation). This is logical for Allen's use case as it's explicitly chosen at configure time, and uniform over compile time. We're not doing that in Adept though, at least as the tests/examples are implemented.

Admittedly I'm at the limit of my knowledge on the above, but I think comes down to how to separate C++/CUDA APIs and whether we are doing so in a *library* or an *application*. At least for the initial benchmark of a simple Geant4 app offloading a set of tracks in a calo to GPU, it _feels_ like we'll eventually need a C++ only API, 

```c++
// Adept.h
SomeReturnType offloadTracks(TrackCollection col);

// ---------
// Adept.cu
__global__ offloadTracks_CUDA(...) {
  ...
}

SomeReturnType offloadTracks(TrackCollection col) {
   ... prep data, etc
   offloadTracks_CUDA<<<...>>>(...);
   ... extract data
   return SomeReturnType(...);
}
```

... of course this brings us right back to the problem of compiling/deploying for heterogenous resources...

   
    