### PR TITLE
Refactor the calling sequence for CPU/GPU to use copcore::Launcher

### DIFF
--- a/examples/Raytracer_Benchmark/ArgParser.h
+++ b/examples/Raytracer_Benchmark/ArgParser.h
@@ -3,7 +3,9 @@
 
 #include <algorithm>
 #include <iostream>
+#include <CopCore/Global.h>
 
+inline namespace COPCORE_IMPL {
 double getDoubleOpt(char **begin, char **end, const std::string &option, double defaultval)
 {
   char **itr = std::find(begin, end, option);
@@ -56,3 +58,4 @@ std::string getStringOpt(char **begin, char **end, const std::string &option, co
 #define OPTION_DOUBLE(name, defaultval) double name = getDoubleOpt(argv, argc + argv, "-" #name, defaultval)
 #define OPTION_BOOL(name, defaultval) bool name = getBoolOpt(argv, argc + argv, "-" #name, defaultval)
 #define OPTION_STRING(name, defaultval) std::string name = getStringOpt(argv, argc + argv, "-" #name, defaultval)
+} // End namespace COPCORE_IMPL

--- a/examples/Raytracer_Benchmark/LoopNavigator.h
+++ b/examples/Raytracer_Benchmark/LoopNavigator.h
@@ -63,7 +63,7 @@ public:
   static VPlacedVolumePtr_t RelocatePoint(vecgeom::Vector3D<vecgeom::Precision> const &localpoint,
                                           vecgeom::NavStateIndex &path)
   {
-    vecgeom::VPlacedVolume const *currentmother = path.Top();
+    vecgeom::VPlacedVolume const *currentmother       = path.Top();
     vecgeom::Vector3D<vecgeom::Precision> transformed = localpoint;
     do {
       path.Pop();

--- a/examples/Raytracer_Benchmark/RaytraceBenchmark.cpp
+++ b/examples/Raytracer_Benchmark/RaytraceBenchmark.cpp
@@ -13,27 +13,23 @@
 #include <VecGeom/navigation/NavStatePath.h>
 #include <VecGeom/base/Stopwatch.h>
 
-#include "ArgParser.h"
 #include "examples/Raytracer_Benchmark/Raytracer.h"
 #include <CopCore/Global.h>
 #include <AdePT/BlockData.h>
-#include "kernels.h"
 #include "examples/Raytracer_Benchmark/LoopNavigator.h"
+#include "RaytraceBenchmark.hpp"
 
 #ifdef VECGEOM_GDML
 #include <VecGeom/gdml/Frontend.h>
 #endif
 
-// forward declarations
-int RaytraceBenchmarkCPU(cxx::RaytracerData_t &rtdata);
+int executePipelineGPU(const vecgeom::cxx::VPlacedVolume *world, int argc, char *argv[]);
 
-#ifdef VECGEOM_ENABLE_CUDA
-namespace cuda {
-struct RaytracerData_t;
-} // namespace cuda
-
-int RaytraceBenchmarkGPU(cuda::RaytracerData_t *, bool, int);
-#endif
+int executePipelineCPU(const vecgeom::cxx::VPlacedVolume *world, int argc, char *argv[])
+{
+  int result = runSimulation<copcore::BackendType::CPU>(world, argc, argv);
+  return result;
+}
 
 int main(int argc, char *argv[])
 {
@@ -46,138 +42,28 @@ int main(int argc, char *argv[])
   return 2;
 #endif
 
-  // geometry file name and global transformation cache depth (affects size of navigation index table)
   OPTION_STRING(gdml_name, "trackML.gdml");
   OPTION_INT(cache_depth, 0); // 0 = full depth
 
-  // image size in pixels
-  OPTION_INT(px, 1840);
-  OPTION_INT(py, 512);
+  OPTION_INT(on_gpu, 1); // run on GPU
 
-  // RT model as in { kRTxray = 0, kRTspecular, kRTtransparent, kRTdiffuse };
-  OPTION_INT(model, 2);
-
-  // RT view as in { kRTVparallel = 0, kRTVperspective };
-  OPTION_INT(view, 1);
-
-  // zoom w.r.t to the default view mode
-  OPTION_DOUBLE(zoom, 3.5);
-
-  // Screen position in world coordinates
-  OPTION_DOUBLE(screenx, -5000);
-  OPTION_DOUBLE(screeny, 0);
-  OPTION_DOUBLE(screenz, 0);
-
-  // Up vector (no need to be normalized)
-  OPTION_DOUBLE(upx, 0);
-  OPTION_DOUBLE(upy, 1);
-  OPTION_DOUBLE(upz, 0);
-  vecgeom::Vector3D<double> up(upx, upy, upz);
-
-  // Light color, object color (no color per volume yet) - in RGBA chars compressed into an unsigned integer
-  OPTION_INT(bkgcol, 0xFF0000FF); // red
-  OPTION_INT(objcol, 0x0000FFFF); // blue
-  OPTION_INT(vdepth, 4);          // visible depth
-
-  OPTION_INT(on_gpu, 1);     // run on GPU
-  OPTION_INT(use_tiles, 0);  // run on GPU in tiled mode
-  OPTION_INT(block_size, 8); // run on GPU in tiled mode
-
-// Try to open the input file
 #ifdef VECGEOM_GDML
   vecgeom::GeoManager::Instance().SetTransformationCacheDepth(cache_depth);
   bool load = vgdml::Frontend::Load(gdml_name.c_str(), false);
   if (!load) return 2;
 #endif
 
-  auto world = vecgeom::GeoManager::Instance().GetWorld();
+  const vecgeom::cxx::VPlacedVolume *world = vecgeom::GeoManager::Instance().GetWorld();
   if (!world) return 3;
 
-  RaytracerData_t rtdata;
-
-  rtdata.fScreenPos.Set(screenx, screeny, screenz);
-  rtdata.fUp.Set(upx, upy, upz);
-  rtdata.fZoom     = zoom;
-  rtdata.fModel    = (ERTmodel)model;
-  rtdata.fView     = (ERTView)view;
-  rtdata.fSize_px  = px;
-  rtdata.fSize_py  = py;
-  rtdata.fBkgColor = bkgcol;
-  rtdata.fObjColor = objcol;
-  rtdata.fVisDepth = vdepth;
-  rtdata.fMaxDepth = vecgeom::GeoManager::Instance().getMaxDepth();
-
-  Raytracer::InitializeModel(world, rtdata);
-  rtdata.Print();
-
   auto ierr = 0;
+
   if (on_gpu) {
-#ifdef VECGEOM_ENABLE_CUDA
-    auto rtdata_cuda = reinterpret_cast<cuda::RaytracerData_t *>(&rtdata);
-    ierr             = RaytraceBenchmarkGPU(rtdata_cuda, use_tiles, block_size);
-#else
-    std::cout << "=== Cannot run RaytracerBenchmark on GPU since VecGeom CUDA support not compiled.\n";
-    return 1;
-#endif
+    ierr = executePipelineGPU(world, argc, argv);
   } else {
-    ierr = RaytraceBenchmarkCPU(rtdata);
+    ierr = executePipelineCPU(world, argc, argv);
   }
   if (ierr) std::cout << "TestNavIndex FAILED\n";
 
   return ierr;
-}
-
-int RaytraceBenchmarkCPU(cxx::RaytracerData_t &rtdata)
-{
-  using RayBlock     = adept::BlockData<Ray_t>;
-  using RayAllocator = copcore::VariableSizeObjAllocator<RayBlock, copcore::BackendType::CPU>;
-  using Launcher_t   = copcore::Launcher<copcore::BackendType::CPU>;
-  using StreamStruct = copcore::StreamType<copcore::BackendType::CPU>;
-  using Stream_t     = typename StreamStruct::value_type;
-
-  // initialize BlockData of Ray_t structure
-  int capacity = 1 << 20;
-  RayAllocator hitAlloc(capacity);
-  RayBlock *rays = hitAlloc.allocate(1);
-
-  // Boilerplate to get the pointers to the device functions to be used
-  COPCORE_CALLABLE_DECLARE(generateFunc, generateRays);
-
-  // Create a stream to work with.
-  Stream_t stream;
-  StreamStruct::CreateStream(stream);
-
-  // Allocate slots for the BlockData
-  Launcher_t generate(stream);
-  generate.Run(generateFunc, capacity, {0, 0}, rays);
-
-  generate.WaitStream();
-
-  // Allocate and initialize all rays on the host
-  size_t raysize = Ray_t::SizeOfInstance();
-  printf("=== Allocating %.3f MB of ray data on the host\n", (float)rtdata.fNrays * raysize / 1048576);
-  unsigned char *input_buffer  = new unsigned char[rtdata.fNrays * raysize];
-  unsigned char *output_buffer = new unsigned char[4 * rtdata.fNrays * sizeof(char)];
-
-  // Initialize the navigation state for the view point
-  vecgeom::NavStateIndex vpstate;
-  LoopNavigator::LocatePointIn(rtdata.fWorld, rtdata.fStart, vpstate, true);
-
-  rtdata.fVPstate = vpstate;
-
-  // Construct rays in place
-  for (int iray = 0; iray < rtdata.fNrays; ++iray)
-    Ray_t::MakeInstanceAt(input_buffer + iray * raysize);
-
-  // Run the CPU propagation kernel
-  vecgeom::Stopwatch timer;
-  timer.Start();
-  Raytracer::PropagateRays(rays, rtdata, input_buffer, output_buffer);
-  auto time_cpu = timer.Stop();
-  std::cout << "Run time on CPU: " << time_cpu << "\n";
-
-  // Write the output
-  write_ppm("output.ppm", output_buffer, rtdata.fSize_px, rtdata.fSize_py);
-
-  return 0;
 }

--- a/examples/Raytracer_Benchmark/RaytraceBenchmark.hpp
+++ b/examples/Raytracer_Benchmark/RaytraceBenchmark.hpp
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include <VecGeom/base/Vector3D.h>
+#include <VecGeom/management/GeoManager.h>
+#include <VecGeom/navigation/NavStatePath.h>
+#include <VecGeom/base/Stopwatch.h>
+#include <VecGeom/management/CudaManager.h>
+#include <VecGeom/base/Global.h>
+
+#include "ArgParser.h"
+#include "examples/Raytracer_Benchmark/Raytracer.h"
+#include <CopCore/Global.h>
+#include <AdePT/BlockData.h>
+#include "kernels.h"
+#include "examples/Raytracer_Benchmark/LoopNavigator.h"
+
+#ifdef VECGEOM_GDML
+#include <VecGeom/gdml/Frontend.h>
+#endif
+
+namespace cuda {
+struct RaytracerData_t;
+}
+
+void initiliazeCudaWorld(cuda::RaytracerData_t *rtdata);
+
+void RenderTiledImage(adept::BlockData<Ray_t> *rays, cuda::RaytracerData_t *rtdata, NavIndex_t *output_buffer,
+                      int block_size);
+
+template <copcore::BackendType backend>
+void InitRTdata(RaytracerData_t *rtdata)
+{
+
+  if (backend == copcore::BackendType::CUDA) {
+    initiliazeCudaWorld((cuda::RaytracerData_t *)rtdata);
+  } else {
+    vecgeom::NavStateIndex vpstate;
+    LoopNavigator::LocatePointIn(rtdata->fWorld, rtdata->fStart, vpstate, true);
+    rtdata->fVPstate = vpstate;
+  }
+}
+
+template <copcore::BackendType backend>
+int runSimulation(const vecgeom::cxx::VPlacedVolume *world, int argc, char *argv[])
+{
+
+  // image size in pixels
+  OPTION_INT(px, 1840);
+  OPTION_INT(py, 512);
+
+  // RT model as in { kRTxray = 0, kRTspecular, kRTtransparent, kRTdiffuse };
+  OPTION_INT(model, 2);
+
+  // RT view as in { kRTVparallel = 0, kRTVperspective };
+  OPTION_INT(view, 1);
+
+  // zoom w.r.t to the default view mode
+  OPTION_DOUBLE(zoom, 3.5);
+
+  // Screen position in world coordinates
+  OPTION_DOUBLE(screenx, -5000);
+  OPTION_DOUBLE(screeny, 0);
+  OPTION_DOUBLE(screenz, 0);
+
+  // Up vector (no need to be normalized)
+  OPTION_DOUBLE(upx, 0);
+  OPTION_DOUBLE(upy, 1);
+  OPTION_DOUBLE(upz, 0);
+  vecgeom::Vector3D<double> up(upx, upy, upz);
+
+  // Light color, object color (no color per volume yet) - in RGBA chars compressed into an unsigned integer
+  OPTION_INT(bkgcol, 0xFF0000FF); // red
+  OPTION_INT(objcol, 0x0000FFFF); // blue
+  OPTION_INT(vdepth, 4);          // visible depth
+
+  OPTION_INT(use_tiles, 0);  // run on GPU in tiled mode
+  OPTION_INT(block_size, 8); // run on GPU in tiled mode
+
+  copcore::Allocator<RaytracerData_t, backend> rayAlloc;
+  RaytracerData_t *rtdata = rayAlloc.allocate(1);
+
+  rtdata->fScreenPos.Set(screenx, screeny, screenz);
+  rtdata->fUp.Set(upx, upy, upz);
+  rtdata->fZoom     = zoom;
+  rtdata->fModel    = (ERTmodel)model;
+  rtdata->fView     = (ERTView)view;
+  rtdata->fSize_px  = px;
+  rtdata->fSize_py  = py;
+  rtdata->fBkgColor = bkgcol;
+  rtdata->fObjColor = objcol;
+  rtdata->fVisDepth = vdepth;
+  rtdata->fMaxDepth = vecgeom::GeoManager::Instance().getMaxDepth();
+
+  Raytracer::InitializeModel((Raytracer::VPlacedVolumePtr_t)world, *rtdata);
+
+  InitRTdata<backend>(rtdata);
+
+  rtdata->Print();
+
+  using RayBlock     = adept::BlockData<Ray_t>;
+  using RayAllocator = copcore::VariableSizeObjAllocator<RayBlock, backend>;
+  using Launcher_t   = copcore::Launcher<backend>;
+  using StreamStruct = copcore::StreamType<backend>;
+  using Stream_t     = typename StreamStruct::value_type;
+
+  // initialize BlockData of Ray_t structure
+  int capacity = 1 << 20;
+  RayAllocator hitAlloc(capacity);
+  RayBlock *rays = hitAlloc.allocate(1);
+
+  // Boilerplate to get the pointers to the device functions to be used
+  COPCORE_CALLABLE_DECLARE(generateFunc, generateRays);
+  COPCORE_CALLABLE_DECLARE(renderkernelFunc, renderKernels);
+
+  // Create a stream to work with.
+  Stream_t stream;
+  StreamStruct::CreateStream(stream);
+
+  // Allocate slots for the BlockData
+  Launcher_t generate(stream);
+  generate.Run(generateFunc, capacity, {0, 0}, rays);
+
+  generate.WaitStream();
+
+  // Allocate and initialize all rays on the host
+  size_t raysize = Ray_t::SizeOfInstance();
+  printf("=== Allocating %.3f MB of ray data on the %s\n", (float)rtdata->fNrays * raysize / 1048576,
+         copcore::BackendName(backend));
+
+  copcore::Allocator<NavIndex_t, backend> charAlloc;
+  NavIndex_t *input_buffer = charAlloc.allocate(rtdata->fNrays * raysize * sizeof(NavIndex_t));
+
+  copcore::Allocator<NavIndex_t, backend> ucharAlloc;
+  NavIndex_t *output_buffer = ucharAlloc.allocate(4 * rtdata->fNrays * sizeof(NavIndex_t));
+
+  // Construct rays in place
+  for (int iray = 0; iray < rtdata->fNrays; ++iray)
+    Ray_t::MakeInstanceAt(input_buffer + iray * raysize);
+
+  vecgeom::Stopwatch timer;
+  timer.Start();
+
+  if (backend == copcore::BackendType::CUDA && use_tiles) {
+    RenderTiledImage(rays, (cuda::RaytracerData_t *)rtdata, output_buffer, block_size);
+  } else {
+    Launcher_t renderKernel(stream);
+    renderKernel.Run(renderkernelFunc, rays->GetNused(), {0, 0}, rays, *rtdata, input_buffer, output_buffer);
+    renderKernel.WaitStream();
+  }
+
+  auto time_cpu = timer.Stop();
+  std::cout << "Run time: " << time_cpu << "\n";
+
+  // Write the output
+  write_ppm("output.ppm", output_buffer, rtdata->fSize_px, rtdata->fSize_py);
+
+  return 0;
+}

--- a/examples/Raytracer_Benchmark/Raytracer.cpp
+++ b/examples/Raytracer_Benchmark/Raytracer.cpp
@@ -231,34 +231,39 @@ void ApplyRTmodel(Ray_t &ray, double step, RaytracerData_t const &rtdata)
   if (ray.fVolume == nullptr) ray.fDone = true;
 }
 
-void PropagateRays(adept::BlockData<Ray_t> *rays, RaytracerData_t &rtdata, unsigned char *input_buffer,
+void PropagateRays(int id, adept::BlockData<Ray_t> *rays, const RaytracerData_t &rtdata, unsigned char *input_buffer,
                    unsigned char *output_buffer)
 {
   // Propagate all rays and write out the image on the CPU
-  size_t n10  = 0.1 * rtdata.fNrays;
-  size_t icrt = 0;
+  size_t n10 = 0.1 * rtdata.fNrays;
+
+  int ray_index = id;
+
+  int px = 0;
+  int py = 0;
+
+  if (ray_index) {
+    px = ray_index % rtdata.fSize_px;
+    py = ray_index / rtdata.fSize_px;
+  }
+
+  if ((px >= rtdata.fSize_px) || (py >= rtdata.fSize_py)) return;
 
   // fprintf(stderr, "P3\n%d %d\n255\n", fSize_px, fSize_py);
-  for (int py = 0; py < rtdata.fSize_py; py++) {
-    for (int px = 0; px < rtdata.fSize_px; px++) {
-      if ((icrt % n10) == 0) printf("%lu %%\n", 10 * icrt / n10);
-      int ray_index = py * rtdata.fSize_px + px;
 
-      Ray_t *ray = (Ray_t *)(input_buffer + ray_index * sizeof(Ray_t));
-      ray->index = ray_index;
+  if ((ray_index % n10) == 0) printf("%lu %%\n", 10 * ray_index / n10);
+  Ray_t *ray = (Ray_t *)(input_buffer + ray_index * sizeof(Ray_t));
+  ray->index = ray_index;
 
-      (*rays)[ray_index] = *ray;
+  (*rays)[ray_index] = *ray;
 
-      auto pixel_color = RaytraceOne(rtdata, rays, px, py, ray->index);
+  auto pixel_color = RaytraceOne(rtdata, rays, px, py, ray->index);
 
-      int pixel_index                = 4 * ray_index;
-      output_buffer[pixel_index + 0] = pixel_color.fComp.red;
-      output_buffer[pixel_index + 1] = pixel_color.fComp.green;
-      output_buffer[pixel_index + 2] = pixel_color.fComp.blue;
-      output_buffer[pixel_index + 3] = 255;
-      icrt++;
-    }
-  }
+  int pixel_index                = 4 * ray_index;
+  output_buffer[pixel_index + 0] = pixel_color.fComp.red;
+  output_buffer[pixel_index + 1] = pixel_color.fComp.green;
+  output_buffer[pixel_index + 2] = pixel_color.fComp.blue;
+  output_buffer[pixel_index + 3] = 255;
 }
 
 /*
@@ -285,7 +290,7 @@ void Raytracer::CreateNavigators()
 } // End namespace COPCORE_IMPL
 
 #ifndef VECGEOM_CUDA_INTERFACE
-void write_ppm(std::string filename, unsigned char *buffer, int px, int py)
+void write_ppm(std::string filename, NavIndex_t *buffer, int px, int py)
 {
   std::ofstream image(filename);
 

--- a/examples/Raytracer_Benchmark/Raytracer.h
+++ b/examples/Raytracer_Benchmark/Raytracer.h
@@ -163,7 +163,7 @@ adept::Color_t RaytraceOne(RaytracerData_t const &rtdata, adept::BlockData<Ray_t
 
 } // End namespace COPCORE_IMPL
 
-void write_ppm(std::string filename, unsigned char *buffer, int px, int py);
+void write_ppm(std::string filename, NavIndex_t *buffer, int px, int py);
 // void RenderCPU(VPlacedVolume const *const world, int px, int py, int maxdepth);
 
 #endif // RT_BENCHMARK_RAYTRACER_H_

--- a/examples/Raytracer_Benchmark/kernels.h
+++ b/examples/Raytracer_Benchmark/kernels.h
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <AdePT/BlockData.h>
+#include <VecGeom/base/Global.h>
+#include "Raytracer.h"
 
 inline namespace COPCORE_IMPL {
 
@@ -11,8 +13,46 @@ void generateRays(int id, adept::BlockData<Ray_t> *rays)
 {
   auto ray = rays->NextElement();
   if (!ray) COPCORE_EXCEPTION("generateRays: Not enough space for rays");
+
+  ray->index = id;
 }
 
 COPCORE_CALLABLE_FUNC(generateRays)
+
+VECCORE_ATT_HOST_DEVICE
+void renderKernels(int id, adept::BlockData<Ray_t> *rays, const RaytracerData_t &rtdata, NavIndex_t *input_buffer,
+                   NavIndex_t *output_buffer)
+{
+  // Propagate all rays and write out the image on the backend
+  // size_t n10  = 0.1 * rtdata.fNrays;
+
+  int ray_index = id;
+
+  int px = 0;
+  int py = 0;
+
+  if (ray_index) {
+    px = ray_index % rtdata.fSize_px;
+    py = ray_index / rtdata.fSize_px;
+  }
+
+  if ((px >= rtdata.fSize_px) || (py >= rtdata.fSize_py)) return;
+
+  // fprintf(stderr, "P3\n%d %d\n255\n", fSize_px, fSize_py);
+  // if ((ray_index % n10) == 0) printf("%lu %%\n", 10 * ray_index / n10);
+  Ray_t *ray = (Ray_t *)(input_buffer + ray_index * sizeof(Ray_t));
+  ray->index = ray_index;
+
+  (*rays)[ray_index] = *ray;
+
+  auto pixel_color = Raytracer::RaytraceOne(rtdata, rays, px, py, ray->index);
+
+  int pixel_index                = 4 * ray_index;
+  output_buffer[pixel_index + 0] = pixel_color.fComp.red;
+  output_buffer[pixel_index + 1] = pixel_color.fComp.green;
+  output_buffer[pixel_index + 2] = pixel_color.fComp.blue;
+  output_buffer[pixel_index + 3] = 255;
+}
+COPCORE_CALLABLE_FUNC(renderKernels)
 
 } // End namespace COPCORE_IMPL


### PR DESCRIPTION
I refactored the calling sequence for CPU and GPU in order to use ```copcore::Launcher``` framework.

In ```kernels.h```, I added the ```renderKernels``` function which propagates the rays and write the image for both backends.

In ```RaytraceBenchmark.hpp```, I added ```runSimulation``` function which is dependent on the backend and replaces ```RaytraceBenchmarkGPU``` or ```RaytraceBenchmarkCPU``` functions.
