### PR TITLE
Fix for the ray-tracer example in debug mode.

### DIFF
--- a/examples/Raytracer_Benchmark/RaytraceBenchmark.hpp
+++ b/examples/Raytracer_Benchmark/RaytraceBenchmark.hpp
@@ -87,7 +87,6 @@ int runSimulation(const vecgeom::cxx::VPlacedVolume *world, int argc, char *argv
   rtdata->fBkgColor = bkgcol;
   rtdata->fObjColor = objcol;
   rtdata->fVisDepth = vdepth;
-  rtdata->fMaxDepth = vecgeom::GeoManager::Instance().getMaxDepth();
 
   Raytracer::InitializeModel((Raytracer::VPlacedVolumePtr_t)world, *rtdata);
 

--- a/examples/Raytracer_Benchmark/Raytracer.cpp
+++ b/examples/Raytracer_Benchmark/Raytracer.cpp
@@ -30,21 +30,6 @@
 #include <utility>
 
 inline namespace COPCORE_IMPL {
-/*
-Ray_t::Ray_t(void *addr, int maxdepth) : fMaxDepth(maxdepth)
-{
-  char *path_addr = round_up_align((char *)addr + sizeof(Ray_t));
-  // Geometry paths follow
-  fCrtState       = NavigationState::MakeInstanceAt(maxdepth, path_addr);
-  path_addr      += round_up_align(NavigationState::SizeOfInstance(maxdepth));
-  fNextState      = NavigationState::MakeInstanceAt(maxdepth, path_addr);
-}
-size_t Ray_t::SizeOfInstance(int maxdepth)
-{
-  size_t size = sizeof(Ray_t) + 2 * round_up_align(NavigationState::SizeOfInstance(maxdepth)) + 64;
-  return size;
-}
-*/
 
 void RaytracerData_t::Print()
 {
@@ -52,8 +37,7 @@ void RaytracerData_t::Print()
          fSize_py);
   printf("  light_dir(%g, %g, %g) light_color(0x%08x) obj_color(0x%08x)\n", fSourceDir[0], fSourceDir[1], fSourceDir[2],
          fBkgColor.fColor, fObjColor.fColor);
-  printf("  zoom_factor(%g) visible_depth(%d/%d) rt_model(%d) rt_view(%d)\n", fZoom, fVisDepth, fMaxDepth, (int)fModel,
-         (int)fView);
+  printf("  zoom_factor(%g) visible_depth(%d) rt_model(%d) rt_view(%d)\n", fZoom, fVisDepth, (int)fModel, (int)fView);
   printf("  viewpoint_state: ");
   fVPstate.Print();
 }

--- a/examples/Raytracer_Benchmark/Raytracer.h
+++ b/examples/Raytracer_Benchmark/Raytracer.h
@@ -115,7 +115,6 @@ struct RaytracerData_t {
   int fSize_px             = 1024;            ///< Image pixel size in x
   int fSize_py             = 1024;            ///< Image pixel size in y
   int fVisDepth            = 1;               ///< Visible geometry depth
-  int fMaxDepth            = 0;               ///< Maximum geometry depth
   adept::Color_t fBkgColor = 0xFFFFFFFF;      ///< Light color
   adept::Color_t fObjColor = 0x0000FFFF;      ///< Object color
   ERTmodel fModel          = kRTxray;         ///< Selected RT model


### PR DESCRIPTION
The backend-dependent launcher part was accessing wrongly cuda::GeoManager. Removed un-needed fMaxDepth, and some dead code.