### PR TITLE
Use Allen/prototype macros for host/device markup

### DIFF
--- a/base/inc/AdePT/Atomic.h
+++ b/base/inc/AdePT/Atomic.h
@@ -10,10 +10,10 @@
 #ifndef ADEPT_ATOMIC_H_
 #define ADEPT_ATOMIC_H_
 
-#include <VecCore/VecCore>
+#include <CopCore/Global.h>
 #include <cassert>
 
-#ifndef VECCORE_CUDA_DEVICE_COMPILATION
+#ifndef COPCORE_DEVICE_COMPILATION
 #include <atomic>
 #endif
 
@@ -24,7 +24,7 @@ namespace adept {
 template <typename Type>
 struct AtomicBase_t {
 
-#ifndef VECCORE_CUDA_DEVICE_COMPILATION
+#ifndef COPCORE_DEVICE_COMPILATION
   /// Standard library atomic behaviour.
   using AtomicType_t = std::atomic<Type>;
 #else
@@ -35,19 +35,19 @@ struct AtomicBase_t {
   AtomicType_t fData{0}; ///< Atomic data
 
   /** @brief Constructor taking an address */
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   AtomicBase_t() : fData{0} {}
 
   /** @brief Copy constructor */
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   AtomicBase_t(AtomicBase_t const &other) { store(other.load()); }
 
   /** @brief Assignment */
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   AtomicBase_t &operator=(AtomicBase_t const &other) { store(other.load()); }
 
   /** @brief Emplace the data at a given address */
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static AtomicBase_t *MakeInstanceAt(void *addr)
   {
     assert(addr != nullptr && "cannot allocate at nullptr address");
@@ -57,7 +57,7 @@ struct AtomicBase_t {
   }
 
   /// Implementation-dependent
-#ifndef VECCORE_CUDA_DEVICE_COMPILATION
+#ifndef COPCORE_DEVICE_COMPILATION
 
   /** @brief Atomically replaces the current value with desired. */
   void store(Type desired) { fData.store(desired); }
@@ -78,11 +78,11 @@ struct AtomicBase_t {
 #else
 
   /** @brief Atomically replaces the current value with desired. */
-  VECCORE_ATT_DEVICE
+  __device__
   void store(Type desired) { atomicExch(&fData, desired); }
 
   /** @brief Atomically loads and returns the current value of the atomic variable. */
-  VECCORE_ATT_DEVICE
+  __device__
   Type load() const
   {
     // There is no atomic load on CUDA. Issue a memory fence to get the required
@@ -92,12 +92,12 @@ struct AtomicBase_t {
   }
 
   /** @brief Atomically replaces the underlying value with desired. */
-  VECCORE_ATT_DEVICE
+  __device__
   Type exchange(Type desired) { return atomicExch(&fData, desired); }
 
   /** @brief Atomically compares the stored value with the expected one, and if equal stores desired.
    * If not loads the old value into expected. Returns true if swap was successful. */
-  VECCORE_ATT_DEVICE
+  __device__
   bool compare_exchange_strong(Type &expected, Type desired)
   {
     Type old    = atomicCAS(&fData, expected, desired);
@@ -107,47 +107,47 @@ struct AtomicBase_t {
   }
 
   /** @brief Atomically replaces the current value with the result of arithmetic addition of the value and arg. */
-  VECCORE_ATT_DEVICE
+  __device__
   Type fetch_add(Type arg) { return atomicAdd(&fData, arg); }
 
   /** @brief Atomically replaces the current value with the result of arithmetic subtraction of the value and arg. */
-  VECCORE_ATT_DEVICE
+  __device__
   Type fetch_sub(Type arg) { return atomicAdd(&fData, -arg); }
 
   /** @brief Atomically replaces the current value with the result of bitwise AND of the value and arg. */
-  VECCORE_ATT_DEVICE
+  __device__
   Type fetch_and(Type arg) { return atomicAnd(&fData, arg); }
 
   /** @brief Atomically replaces the current value with the result of bitwise OR of the value and arg. */
-  VECCORE_ATT_DEVICE
+  __device__
   Type fetch_or(Type arg) { return atomicOr(&fData, arg); }
 
   /** @brief Atomically replaces the current value with the result of bitwise XOR of the value and arg. */
-  VECCORE_ATT_DEVICE
+  __device__
   Type fetch_xor(Type arg) { return atomicXor(&fData, arg); }
 
   /** @brief Performs atomic add. */
-  VECCORE_ATT_DEVICE
+  __device__
   Type operator+=(Type arg) { return (fetch_add(arg) + arg); }
 
   /** @brief Performs atomic subtract. */
-  VECCORE_ATT_DEVICE
+  __device__
   Type operator-=(Type arg) { return (fetch_sub(arg) - arg); }
 
   /** @brief Performs atomic pre-increment. */
-  VECCORE_ATT_DEVICE
+  __device__
   Type operator++() { return (fetch_add(1) + 1); }
 
   /** @brief Performs atomic post-increment. */
-  VECCORE_ATT_DEVICE
+  __device__
   Type operator++(int) { return fetch_add(1); }
 
   /** @brief Performs atomic pre-decrement. */
-  VECCORE_ATT_DEVICE
+  __device__
   Type operator--() { return (fetch_sub(1) - 1); }
 
   /** @brief Performs atomic post-decrement. */
-  VECCORE_ATT_DEVICE
+  __device__
   Type operator--(int) { return fetch_sub(1); }
 
 #endif
@@ -162,7 +162,7 @@ template <typename Type>
 struct Atomic_t<Type, typename std::enable_if<std::is_integral<Type>::value>::type> : public AtomicBase_t<Type> {
   using AtomicBase_t<Type>::fData;
 
-#ifndef VECCORE_CUDA_DEVICE_COMPILATION
+#ifndef COPCORE_DEVICE_COMPILATION
   /// Standard library atomic operations for integral types
 
   /** @brief Atomically assigns the desired value to the atomic variable. */
@@ -202,7 +202,7 @@ struct Atomic_t<Type, typename std::enable_if<std::is_integral<Type>::value>::ty
   Type operator--(int) { return fetch_sub(1); }
 #else
   /** @brief Atomically assigns the desired value to the atomic variable. */
-  VECCORE_ATT_DEVICE
+  __device__
   Type operator=(Type desired)
   {
     atomicExch(&fData, desired);
@@ -219,7 +219,7 @@ struct Atomic_t<Type, typename std::enable_if<!std::is_integral<Type>::value>::t
   using Base_t = AtomicBase_t<Type>;
   using Base_t::fData;
 
-#ifndef VECCORE_CUDA_DEVICE_COMPILATION
+#ifndef COPCORE_DEVICE_COMPILATION
 
   /** @brief Atomically assigns the desired value to the atomic variable. */
   Type operator=(Type desired) { return fData.operator=(desired); }
@@ -257,7 +257,7 @@ struct Atomic_t<Type, typename std::enable_if<!std::is_integral<Type>::value>::t
 #else
 
   /** @brief Atomically assigns the desired value to the atomic variable. */
-  VECCORE_ATT_DEVICE
+  __device__
   Type operator=(Type desired)
   {
     atomicExch(&fData, desired);

--- a/base/inc/AdePT/BlockData.h
+++ b/base/inc/AdePT/BlockData.h
@@ -41,18 +41,18 @@ private:
   friend Base_t;
 
   /** @brief Functions required by VariableSizeObjectInterface */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   ArrayData_t &GetVariableData() { return fData; }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   const ArrayData_t &GetVariableData() const { return fData; }
 
   // constructors and assignment operators are private
   // states have to be constructed using MakeInstance() function
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   BlockData(size_t nvalues) : fCapacity(nvalues), fData(nvalues)
   {
     char *address = (char *)this + Base_t::SizeOfAlignAware(nvalues) - BlockData<Type>::SizeOfExtra(nvalues);
@@ -60,12 +60,12 @@ private:
     Queue_t::MakeInstanceAt(nvalues, address);
   }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   BlockData(BlockData const &other) : BlockData(other.fCapacity, other) {}
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   BlockData(size_t new_size, BlockData const &other) : Base_t(other), fCapacity(new_size), fData(new_size, other.fData)
   {
     char *address = (char *)this + Base_t::SizeOfAlignAware(new_size) - BlockData<Type>::SizeOfExtra(new_size);
@@ -73,13 +73,13 @@ private:
     Queue_t::MakeCopyAt(new_size, *other.fHoles, address);
   }
 
-  VECCORE_FORCE_INLINE
-  VECCORE_ATT_HOST_DEVICE
+  __forceinline__
+  __host__ __device__
   ~BlockData() {}
 
   /** @brief Returns the size in bytes of extra queue data needed by BlockData object with given capacity */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   static size_t SizeOfExtra(int capacity) { return Queue_t::SizeOfAlignAware(capacity); }
 
 public:
@@ -93,18 +93,18 @@ public:
   using Base_t::SizeOfAlignAware;
 
   /** @brief Returns the size in bytes of a BlockData object with given capacity */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   static size_t SizeOfInstance(int capacity) { return Base_t::SizeOf(capacity); }
 
   /** @brief Maximum number of elements */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   int Capacity() const { return fCapacity; }
 
   /** @brief Clear the content */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   void Clear()
   {
     fNused.store(0);
@@ -112,18 +112,18 @@ public:
   }
 
   /** @brief Read-only index operator */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   Type const &operator[](const int index) const { return fData[index]; }
 
   /** @brief Read/write index operator */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   Type &operator[](const int index) { return fData[index]; }
 
   /** @brief Dispatch next free element, nullptr if none left */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   Type *NextElement()
   {
     // Try to get a hole index if any
@@ -139,8 +139,8 @@ public:
   }
 
   /** @brief Release an element */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   void ReleaseElement(int index)
   {
     // No checks currently done that the index was given via NextElement
@@ -150,18 +150,18 @@ public:
   }
 
   /** @brief Number of elements currently distributed */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   int GetNused() { return fNused.load(); }
 
   /** @brief Number of holes in the block */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   int GetNholes() { return fHoles->size(); }
 
   /** @brief Check if container is fully distributed */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   bool IsFull() const { return (GetNused() == fCapacity); }
 
 }; // End BlockData

--- a/base/inc/AdePT/LoopNavigator.h
+++ b/base/inc/AdePT/LoopNavigator.h
@@ -26,7 +26,7 @@ class LoopNavigator {
 public:
   using VPlacedVolumePtr_t = vecgeom::VPlacedVolume const *;
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static VPlacedVolumePtr_t LocatePointIn(vecgeom::VPlacedVolume const *vol,
                                           vecgeom::Vector3D<vecgeom::Precision> const &point,
                                           vecgeom::NavStateIndex &path, bool top)
@@ -58,7 +58,7 @@ public:
     return currentvolume;
   }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static VPlacedVolumePtr_t RelocatePoint(vecgeom::Vector3D<vecgeom::Precision> const &localpoint,
                                           vecgeom::NavStateIndex &path)
   {
@@ -77,7 +77,7 @@ public:
     return currentmother;
   }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static double ComputeStepAndPropagatedState(vecgeom::Vector3D<vecgeom::Precision> const &globalpoint,
                                               vecgeom::Vector3D<vecgeom::Precision> const &globaldir,
                                               vecgeom::Precision step_limit, vecgeom::NavStateIndex const &in_state,

--- a/base/inc/AdePT/MParray.h
+++ b/base/inc/AdePT/MParray.h
@@ -40,30 +40,30 @@ private:
   friend Base_t;
 
   /** @brief Functions required by VariableSizeObjectInterface */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   ArrayData_t &GetVariableData() { return fData; }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   const ArrayData_t &GetVariableData() const { return fData; }
 
   // constructors and assignment operators are private
   // states have to be constructed using MakeInstance() function
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   MParray(size_t nvalues) : fCapacity(nvalues), fData(nvalues) {}
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   MParray(MParray const &other) : MParray(other.fCapacity, other) {}
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   MParray(size_t new_size, MParray const &other) : Base_t(other), fCapacity(new_size), fData(new_size, other.fData) {}
 
-  VECCORE_FORCE_INLINE
-  VECCORE_ATT_HOST_DEVICE
+  __forceinline__
+  __host__ __device__
   ~MParray() {}
 
 public:
@@ -77,18 +77,18 @@ public:
   using Base_t::SizeOfAlignAware;
 
   /** @brief Maximum number of elements */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   size_t size() const { return fNused.load(); }
 
   /** @brief Maximum number of elements */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   constexpr size_t max_size() const { return fCapacity; }
 
   /** @brief Clear the content */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   void clear()
   {
     fNused.store(0);
@@ -96,13 +96,13 @@ public:
   }
 
   /** @brief Read-only index operator */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   const_reference operator[](size_t index) const { return fData[index]; }
 
   /** @brief Dispatch next free element, nullptr if none left */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   bool push_back(value_type val)
   {
     // Operation may fail if the max size is exceeded. Has to be checked by the user.
@@ -114,33 +114,33 @@ public:
   }
 
   /** @brief Check if container is fully distributed */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   bool full() const { return (size() == fCapacity); }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   const_iterator begin() const { return const_iterator(&fData[0]); }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   const_iterator end() const { return const_iterator(&fData[fNused.load()]); }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   const_reference front() const { return *begin(); }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   const_reference back() const { return fCapacity ? *(end() - 1) : *end(); }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   const_pointer data() const { return &fData[0]; }
 
   /** @brief Returns the size in bytes of a BlockData object with given capacity */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   static size_t SizeOfInstance(int capacity) { return Base_t::SizeOf(capacity); }
 
 }; // End class MParray

--- a/base/inc/AdePT/Utils.h
+++ b/base/inc/AdePT/Utils.h
@@ -19,7 +19,7 @@ namespace utils {
  * @param value Value to round-up
  */
 template <typename Type>
-VECCORE_ATT_HOST_DEVICE Type round_up_align(Type value, size_t padding)
+__host__ __device__ Type round_up_align(Type value, size_t padding)
 {
   size_t remainder = ((size_t)value) % padding;
   if (remainder == 0) return value;
@@ -27,11 +27,11 @@ VECCORE_ATT_HOST_DEVICE Type round_up_align(Type value, size_t padding)
 }
 
 /** @brief CPP/CUDA Portable memset operation */
-VECCORE_ATT_HOST_DEVICE
-VECCORE_FORCE_INLINE
+__host__ __device__
+__forceinline__
 void memset(void *ptr, int value, size_t num)
 {
-#ifndef VECCORE_CUDA_DEVICE_COMPILATION
+#ifndef COPCORE_DEVICE_COMPILATION
   memset(ptr, value, num);
 #else
   cudaMemset(ptr, value, num);
@@ -39,11 +39,11 @@ void memset(void *ptr, int value, size_t num)
 }
 
 /** @brief CPP/CUDA Portable memcpy operation */
-VECCORE_ATT_HOST_DEVICE
-VECCORE_FORCE_INLINE
+__host__ __device__
+__forceinline__
 void memcpy(void *destination, const void *source, size_t num, int type = 0)
 {
-#ifndef VECCORE_CUDA_DEVICE_COMPILATION
+#ifndef COPCORE_DEVICE_COMPILATION
   memcpy(destination, source, num);
 #else
   cudaMemcpy(destination, source, num, (cudaMemcpyKind)type);

--- a/base/inc/AdePT/mpmc_bounded_queue.h
+++ b/base/inc/AdePT/mpmc_bounded_queue.h
@@ -51,12 +51,12 @@ private:
   friend Base_t;
 
   /** @brief Functions required by VariableSizeObjectInterface */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   ArrayData_t &GetVariableData() { return fBuffer; }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   const ArrayData_t &GetVariableData() const { return fBuffer; }
 
   // constructors and assignment operators are private
@@ -68,8 +68,8 @@ private:
    * @param addr Address where the queue is allocated.
    * The user should make sure to allocate at least SizeofInstance(fBuffersize) bytes
    */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   mpmc_bounded_queue(int nvalues) : fCapacity(nvalues), fMask(nvalues - 1), fBuffer(nvalues)
   {
     // The queue size must be a power of 2 (for fast access)
@@ -78,17 +78,17 @@ private:
       fBuffer[i].fSequence.store(i);
   }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   mpmc_bounded_queue(int /*nvalues*/, mpmc_bounded_queue const & /*other*/) {}
   /** @brief MPMC bounded queue copy constructor */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   mpmc_bounded_queue(mpmc_bounded_queue const &other) : mpmc_bounded_queue(other.fCapacity, other) {}
 
   /** @brief MPMC bounded queue copy constructor with given size */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   mpmc_bounded_queue(size_t new_size, mpmc_bounded_queue const &other)
       : fCapacity(new_size), fMask(new_size - 1), fEnqueue(other.fEnqueue), fDequeue(other.fDequeue),
         fNstored(other.fNstored), fBuffer(new_size, other.fBuffer)
@@ -110,18 +110,18 @@ public:
   using Base_t::SizeOfAlignAware;
 
   /** @brief Returns the size in bytes of a BlockData object with given capacity */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   static size_t SizeOfInstance(int capacity) { return Base_t::SizeOf(capacity); }
 
   /** @brief Maximum number of elements */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   int Capacity() const { return fCapacity; }
 
   /** @brief Size function */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   void clear()
   {
     fEnqueue.store(0);
@@ -132,13 +132,13 @@ public:
   }
 
   /** @brief Size function */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   int size() const { return fNstored.load(); }
 
   /** @brief MPMC enqueue function */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   bool enqueue(Type const &data)
   {
     Value_t *cell;
@@ -161,8 +161,8 @@ public:
   }
 
   /** @brief MPMC dequeue function */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   bool dequeue(Type &data)
   {
     Value_t *cell;
@@ -189,8 +189,8 @@ public:
         The index should be smaller than the number of stored elements. The range is only
         checked in debug mode.
     */
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   Type &operator[](const int index)
   {
     assert(index >= 0 && index < fNstored.load() && "Index in queue out of range");
@@ -198,8 +198,8 @@ public:
     return fBuffer[pos & fMask].fData;
   }
 
-  VECCORE_ATT_HOST_DEVICE
-  VECCORE_FORCE_INLINE
+  __host__ __device__
+  __forceinline__
   Type const &operator[](const int index) const
   {
     assert(index >= 0 && index < fNstored.load() && "Index in queue out of range");

--- a/base/inc/CopCore/include/CopCore/Allocator.h
+++ b/base/inc/CopCore/include/CopCore/Allocator.h
@@ -14,13 +14,15 @@
 #include <stdexcept>
 #include <iostream>
 
+#include <CopCore/Global.h>
+
 namespace copcore {
 
 template <class T, BackendType backend>
 class Allocator {
 };
 
-#ifdef VECCORE_CUDA
+#ifdef COPCORE_CUDA_COMPILER
 
 /** @brief Partial allocator specialization for the CUDA backend */
 template <class T>

--- a/base/inc/CopCore/include/CopCore/CopCore.h
+++ b/base/inc/CopCore/include/CopCore/CopCore.h
@@ -9,6 +9,7 @@
 #ifndef COPCORE_COPCORE_H_
 #define COPCORE_COPCORE_H_
 
+#include <CopCore/Macros.h>
 #include <CopCore/Global.h>
 #include <CopCore/Allocator.h>
 #include <CopCore/VariableSizeObj.h>

--- a/base/inc/CopCore/include/CopCore/Global.h
+++ b/base/inc/CopCore/include/CopCore/Global.h
@@ -11,9 +11,9 @@
 
 #include <cstdio>
 #include <type_traits>
-#include <VecCore/VecCore>
+#include <CopCore/Macros.h>
 
-#if (defined(__CUDACC__) || defined(__NVCC__))
+#ifdef COPCORE_CUDA_COMPILER
 // Compiling with nvcc
 #define COPCORE_IMPL cuda
 #else
@@ -26,7 +26,7 @@ namespace copcore {
 enum BackendType { CPU = 0, CUDA, HIP };
 
 /** @brief CUDA error checking */
-#ifndef VECCORE_CUDA
+#ifndef COPCORE_CUDA_COMPILER
 inline void error_check(int, const char *, int) {}
 #else
 inline void error_check(cudaError_t err, const char *file, int line)
@@ -43,7 +43,7 @@ inline void error_check(cudaError_t err, const char *file, int line)
   } while (0)
 
 /** @brief Trigger a runtime error depending on the backend */
-#ifndef VECCORE_CUDA_DEVICE_COMPILATION
+#ifndef COPCORE_DEVICE_COMPILATION
 #define COPCORE_EXCEPTION(message) throw std::runtime_error(message)
 #else
 #define COPCORE_EXCEPTION(message) asm("trap;") // can do better here
@@ -55,7 +55,7 @@ struct StreamType {
   static void CreateStream(value_type &stream) { stream = 0; }
 };
 
-#ifdef VECCORE_CUDA
+#ifdef COPCORE_CUDA_COMPILER
 template <>
 struct StreamType<BackendType::CUDA> {
   using value_type = cudaStream_t;
@@ -85,10 +85,10 @@ const char *BackendName(Backend const &backend)
 #define COPCORE_REQUIRES(...) typename std::enable_if<(__VA_ARGS__)>::type * = nullptr
 
 /** @brief macro to declare device callable functions usable in executors */
-#define COPCORE_CALLABLE_FUNC(FUNC) VECCORE_ATT_DEVICE auto _ptr_##FUNC = FUNC;
+#define COPCORE_CALLABLE_FUNC(FUNC) __device__ auto _ptr_##FUNC = FUNC;
 
 /** @brief macro to pass callable function to executors */
-#ifdef VECCORE_CUDA
+#ifdef COPCORE_CUDA_COMPILER
 #define COPCORE_CALLABLE_DECLARE(HVAR, FUNC)                    \
   auto HVAR = FUNC;                                             \
   /*printf("cudaMemcpyFromSymbol for function: %s\n", #FUNC);*/ \
@@ -97,7 +97,7 @@ const char *BackendName(Backend const &backend)
 #define COPCORE_CALLABLE_DECLARE(HVAR, FUNC) auto HVAR = FUNC;
 #endif
 
-#ifdef VECCORE_CUDA
+#ifdef COPCORE_CUDA_COMPILER
 #define COPCORE_CALLABLE_IN_NAMESPACE_DECLARE(HVAR, NAMESPACE, FUNC)            \
   auto HVAR = NAMESPACE::FUNC;                                                  \
   /*printf("cudaMemcpyFromSymbol for function: %s::%s\n", #NAMESPACE, #FUNC);*/ \

--- a/base/inc/CopCore/include/CopCore/Launcher.h
+++ b/base/inc/CopCore/include/CopCore/Launcher.h
@@ -14,7 +14,7 @@
 
 namespace copcore {
 
-#ifdef VECCORE_CUDA
+#ifdef COPCORE_CUDA_COMPILER
 namespace kernel_launcher_impl {
 
 template <class Function, class... Args>
@@ -67,7 +67,7 @@ public:
   }
 };
 
-#ifdef VECCORE_CUDA
+#ifdef COPCORE_CUDA_COMPILER
 /** @brief Specialization of Launcher for the CUDA backend */
 template <>
 class Launcher<BackendType::CUDA> : public LauncherBase<BackendType::CUDA> {

--- a/base/inc/CopCore/include/CopCore/Macros.h
+++ b/base/inc/CopCore/include/CopCore/Macros.h
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * @file CopCore/Macros.h
+ * @brief CopCore global macros
+ *
+ * @details Compiling mixtures of C/C++/CUDA, we run into the cases of compiling for
+ * the host and the device. This involves both marking functions as accessible
+ * from the host/device/both, as well as (potential) different compile paths
+ * when compiling for the host vs for the device. The macros in this file
+ * assist this markup process. Only C/C++ and NVidia CUDA are currently supported,
+ * but other "backends" such as HIP can be added as time goes on.
+ *
+ * CopCore/AdePT follow LHCb's Allen project in using macros for host/device/inline
+ * functions that match the CUDA keywords.
+ */
+/**
+ * @def COPCORE_CUDA_COMPILER
+ * @brief Defined when using a CUDA compiler
+ *
+ * Effectively a proxy for `__CUDACC__`
+ */
+/**
+ * @def COPCORE_DEVICE_COMPILATION
+ * @brief Defined when compiling CUDA code for the device
+ *
+ * Effectively a proxy for `__CUDA_ARCH__`
+ */
+/**
+ * @def __host__
+ * @brief mark a function as accesible from the host
+ *
+ * Expands to nothing when not compiling CUDA
+ */
+/**
+ * @def __device__
+ * @brief mark a function as accesible from the host
+ *
+ * Expands to nothing when not compiling CUDA
+ */
+/**
+ * @def __forceinline__
+ * @brief mark a function to always be inline
+ *
+ * Expands to the relevant CUDA keyword or host compiler attribute
+ */
+
+
+#ifndef COPCORE_MACROS_H_
+#define COPCORE_MACROS_H_
+
+// Macros for separating CUDA compiler from others
+// Checks for
+#ifdef __CUDACC__
+#  define COPCORE_CUDA_COMPILER
+#else
+#  define __host__
+#  define __device__
+#  define __forceinline__ inline __attribute__((always_inline))
+#endif
+
+// Definition of __CUDA_ARCH__ means we are compiling CUDA *and*
+// on the device compile pass
+// COPCORE_DEVICE_COMPILATION is defined in this case
+#ifdef __CUDA_ARCH__
+#  define COPCORE_DEVICE_COMPILATION
+#endif
+
+
+#endif // COPCORE_MACROS_H_

--- a/base/inc/CopCore/include/CopCore/Ranluxpp.h
+++ b/base/inc/CopCore/include/CopCore/Ranluxpp.h
@@ -4,7 +4,7 @@
 #ifndef COPCORE_RANLUXPP_H_
 #define COPCORE_RANLUXPP_H_
 
-#include <VecCore/VecCore>
+#include <CopCore/Global.h>
 
 #include "mulmod.h"
 
@@ -13,7 +13,7 @@
 
 namespace {
 
-VECCORE_ATT_DEVICE
+__device__
 const uint64_t kA_2048[] = {
     0xed7faa90747aaad9, 0x4cec2c78af55c101, 0xe64dcb31c48228ec, 0x6d8a15a13bee7cb0, 0x20b2ca60cb78c509,
     0x256c3d3c662ea36c, 0xff74e54107684ed2, 0x492edfcc0cc8e753, 0xb48c187cf5b22097,
@@ -32,7 +32,7 @@ private:
   static constexpr int kMaxPos        = 9 * 64;
 
   /// Produce next block of random bits
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   void Advance()
   {
     mulmod(kA, fState);
@@ -43,7 +43,7 @@ public:
   RanluxppEngineImpl() = default;
 
   /// Return the next random bits, generate a new block if necessary
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   uint64_t NextRandomBits()
   {
     if (fPosition + w > kMaxPos) {
@@ -67,7 +67,7 @@ public:
   }
 
   /// Initialize and seed the state of the generator
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   void SetSeed(uint64_t s)
   {
     fState[0] = 1;
@@ -87,7 +87,7 @@ public:
   }
 
   /// Skip `n` random numbers without generating them
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   void Skip(uint64_t n)
   {
     int left = (kMaxPos - fPosition) / w;
@@ -118,13 +118,13 @@ public:
 
 class RanluxppDouble : public RanluxppEngineImpl<52> {
 public:
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   RanluxppDouble(uint64_t seed = 314159265) { this->SetSeed(seed); }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   double Rndm() { return (*this)(); }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   double operator()()
   {
     // Get 52 bits of randomness.
@@ -142,7 +142,7 @@ public:
     return dRandom - 1;
   }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   uint64_t IntRndm() { return this->NextRandomBits(); }
 };
 

--- a/base/inc/CopCore/include/CopCore/VariableSizeObj.h
+++ b/base/inc/CopCore/include/CopCore/VariableSizeObj.h
@@ -126,10 +126,11 @@
 #ifndef COPCORE_VARIABLESIZEOBJ_H
 #define COPCORE_VARIABLESIZEOBJ_H
 
-#include <VecCore/VecCore>
+#include <CopCore/Global.h>
 
 // For memset and memcpy
 #include <string.h>
+#include <cassert>
 
 class TRootIOCtor;
 
@@ -146,31 +147,31 @@ public:
 
   VariableSizeObj(TRootIOCtor *) : fSelfAlloc(false), fN(0) {}
 
-  VECCORE_FORCE_INLINE
-  VECCORE_ATT_HOST_DEVICE
+  __forceinline__
+  __host__ __device__
   VariableSizeObj(unsigned int nvalues) : fSelfAlloc(false), fN(nvalues) {}
 
-  VECCORE_FORCE_INLINE
-  VECCORE_ATT_HOST_DEVICE
+  __forceinline__
+  __host__ __device__
   VariableSizeObj(const VariableSizeObj &other) : fSelfAlloc(false), fN(other.fN)
   {
     if (other.fN) memcpy(GetValues(), other.GetValues(), (other.fN) * sizeof(V));
   }
 
-  VECCORE_FORCE_INLINE
-  VECCORE_ATT_HOST_DEVICE
+  __forceinline__
+  __host__ __device__
   VariableSizeObj(size_t new_size, const VariableSizeObj &other) : fSelfAlloc(false), fN(new_size)
   {
     if (other.fN) memcpy(GetValues(), other.GetValues(), (other.fN) * sizeof(V));
   }
 
-  VECCORE_FORCE_INLINE VECCORE_ATT_HOST_DEVICE V *GetValues() { return &fRealArray[0]; }
-  VECCORE_FORCE_INLINE VECCORE_ATT_HOST_DEVICE const V *GetValues() const { return &fRealArray[0]; }
+  __forceinline__ __host__ __device__ V *GetValues() { return &fRealArray[0]; }
+  __forceinline__ __host__ __device__ const V *GetValues() const { return &fRealArray[0]; }
 
-  VECCORE_FORCE_INLINE VECCORE_ATT_HOST_DEVICE V &operator[](Index_t index) { return GetValues()[index]; };
-  VECCORE_FORCE_INLINE VECCORE_ATT_HOST_DEVICE const V &operator[](Index_t index) const { return GetValues()[index]; };
+  __forceinline__ __host__ __device__ V &operator[](Index_t index) { return GetValues()[index]; };
+  __forceinline__ __host__ __device__ const V &operator[](Index_t index) const { return GetValues()[index]; };
 
-  VECCORE_FORCE_INLINE VECCORE_ATT_HOST_DEVICE VariableSizeObj &operator=(const VariableSizeObj &rhs)
+  __forceinline__ __host__ __device__ VariableSizeObj &operator=(const VariableSizeObj &rhs)
   {
     // Copy data content using memcpy, limited by the respective size
     // of the the object.  If this is smaller there is data truncation,
@@ -199,7 +200,7 @@ public:
   // The static maker to be used to create an instance of the variable size object.
 
   template <typename... T>
-  VECCORE_ATT_HOST_DEVICE static Cont *MakeInstance(size_t nvalues, const T &... params)
+  __host__ __device__ static Cont *MakeInstance(size_t nvalues, const T &... params)
   {
     // Make an instance of the class which allocates the node array. To be
     // released using ReleaseInstance.
@@ -213,7 +214,7 @@ public:
   }
 
   template <typename... T>
-  VECCORE_ATT_HOST_DEVICE static Cont *MakeInstanceAt(size_t nvalues, void *addr, const T &... params)
+  __host__ __device__ static Cont *MakeInstanceAt(size_t nvalues, void *addr, const T &... params)
   {
     // Make an instance of the class which allocates the node array. To be
     // released using ReleaseInstance. If addr is non-zero, the user promised that
@@ -229,7 +230,7 @@ public:
   }
 
   // The equivalent of the copy constructor
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static Cont *MakeCopy(const Cont &other)
   {
     // Make a copy of the variable size array and its container.
@@ -242,7 +243,7 @@ public:
     return copy;
   }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static Cont *MakeCopy(size_t new_size, const Cont &other)
   {
     // Make a copy of a the variable size array and its container with
@@ -257,7 +258,7 @@ public:
   }
 
   // The equivalent of the copy constructor
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static Cont *MakeCopyAt(const Cont &other, void *addr)
   {
     // Make a copy of a the variable size array and its container at the location (if indicated)
@@ -271,7 +272,7 @@ public:
   }
 
   // The equivalent of the copy constructor
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static Cont *MakeCopyAt(size_t new_size, const Cont &other, void *addr)
   {
     // Make a copy of a the variable size array and its container at the location (if indicated)
@@ -285,7 +286,7 @@ public:
   }
 
   // The equivalent of the destructor
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static void ReleaseInstance(Cont *obj)
   {
     // Releases the space allocated for the object
@@ -294,26 +295,26 @@ public:
   }
 
   // Equivalent of sizeof function (not taking into account padding for alignment)
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static constexpr size_t SizeOf(size_t nvalues)
   {
     return (sizeof(Cont) + Cont::SizeOfExtra(nvalues) + sizeof(V) * (nvalues - 1));
   }
 
   // Size of the allocated derived type data members that are also variable size
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static constexpr size_t SizeOfExtra(size_t nvalues) { return 0; }
 
   // equivalent of sizeof function taking into account padding for alignment
   // this function should be used when making arrays of VariableSizeObjects
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static constexpr size_t SizeOfAlignAware(size_t nvalues) { return SizeOf(nvalues) + RealFillUp(nvalues); }
 
 private:
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static constexpr size_t FillUp(size_t nvalues) { return alignof(Cont) - SizeOf(nvalues) % alignof(Cont); }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static constexpr size_t RealFillUp(size_t nvalues)
   {
     return (FillUp(nvalues) == alignof(Cont)) ? 0 : FillUp(nvalues);

--- a/base/inc/CopCore/include/CopCore/VariableSizeObjAllocator.h
+++ b/base/inc/CopCore/include/CopCore/VariableSizeObjAllocator.h
@@ -14,13 +14,15 @@
 #include <stdexcept>
 #include <iostream>
 
+#include <CopCore/Global.h>
+
 namespace copcore {
 
 template <class T, BackendType backend>
 class VariableSizeObjAllocator {
 };
 
-#ifdef VECCORE_CUDA
+#ifdef COPCORE_CUDA_COMPILER
 
 /** @brief Partial variable-size allocator specialization for the CUDA backend */
 template <class T>

--- a/base/inc/CopCore/include/CopCore/launch_grid.h
+++ b/base/inc/CopCore/include/CopCore/launch_grid.h
@@ -28,16 +28,16 @@ public:
   launch_grid(int n_blocks, int n_threads) : fGrid{n_blocks, n_threads} {}
 
   /** @brief Access either block [0] or thread [1] grid */
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   int operator[](int index) { return fGrid[index]; }
 
   /** @brief Access either block [0] or thread [1] grid */
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   int operator[](int index) const { return fGrid[index]; }
 
 }; // End class launch_grid<BackendType::CPU>
 
-#ifdef VECCORE_CUDA
+#ifdef COPCORE_CUDA_COMPILER
 template <>
 class launch_grid<BackendType::CUDA> {
 private:
@@ -45,19 +45,19 @@ private:
 
 public:
   /** @brief Construct from block and thread grids */
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   launch_grid(const dim3 &block_index, const dim3 &thread_index) : fGrid{block_index, thread_index} {}
 
   /** @brief Default constructor */
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   launch_grid() : launch_grid(dim3(), dim3()) {}
 
   /** @brief Access either block [0] or thread [1] grid */
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   dim3 &operator[](int index) { return fGrid[index]; }
 
   /** @brief Access either block [0] or thread [1] grid */
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   const dim3 &operator[](int index) const { return fGrid[index]; }
 }; // End class launch_grid<BackendType::CUDA>
 #endif

--- a/base/inc/CopCore/include/CopCore/mulmod.h
+++ b/base/inc/CopCore/include/CopCore/mulmod.h
@@ -3,8 +3,10 @@
 
 #include <cstdint>
 
+#include "CopCore/Global.h"
+
 /// Compute `a + b` and set `overflow` accordingly.
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 static inline uint64_t add_overflow(uint64_t a, uint64_t b, unsigned &overflow)
 {
   uint64_t add = a + b;
@@ -13,7 +15,7 @@ static inline uint64_t add_overflow(uint64_t a, uint64_t b, unsigned &overflow)
 }
 
 /// Compute `a + b` and increment `carry` if there was an overflow
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 static inline uint64_t add_carry(uint64_t a, uint64_t b, unsigned &carry)
 {
   unsigned overflow;
@@ -25,7 +27,7 @@ static inline uint64_t add_carry(uint64_t a, uint64_t b, unsigned &carry)
 }
 
 /// Compute `a - b` and set `overflow` accordingly
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 static inline uint64_t sub_overflow(uint64_t a, uint64_t b, unsigned &overflow)
 {
   uint64_t sub = a - b;
@@ -34,7 +36,7 @@ static inline uint64_t sub_overflow(uint64_t a, uint64_t b, unsigned &overflow)
 }
 
 /// Compute `a - b` and increment `carry` if there was an overflow
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 static inline uint64_t sub_carry(uint64_t a, uint64_t b, unsigned &carry)
 {
   unsigned overflow;
@@ -50,7 +52,7 @@ static inline uint64_t sub_carry(uint64_t a, uint64_t b, unsigned &carry)
 /// \param[in] in1 first factor as 9 numbers of 64 bits each
 /// \param[in] in2 second factor as 9 numbers of 64 bits each
 /// \param[out] out result with 18 numbers of 64 bits each
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void multiply9x9(const uint64_t *in1, const uint64_t *in2, uint64_t *out)
 {
   uint64_t next      = 0;
@@ -165,7 +167,7 @@ void multiply9x9(const uint64_t *in1, const uint64_t *in2, uint64_t *out)
 ///
 /// Note that this function does *not* return the smallest value congruent to
 /// the modulus, it only guarantees a value smaller than \f$ 2^{576} \$!
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void mod_m(const uint64_t *mul, uint64_t *out)
 {
   uint64_t r[9] = {0};
@@ -311,7 +313,7 @@ void mod_m(const uint64_t *mul, uint64_t *out)
 ///
 /// \param[in] in1 first factor with 9 numbers of 64 bits each
 /// \param[inout] inout second factor and also the output of the same size
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void mulmod(const uint64_t *in1, uint64_t *inout)
 {
   uint64_t mul[2 * 9] = {0};
@@ -326,7 +328,7 @@ void mulmod(const uint64_t *in1, uint64_t *inout)
 /// \param[in] n exponent
 ///
 /// The arguments base and res may point to the same location.
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void powermod(const uint64_t *base, uint64_t *res, uint64_t n)
 {
   uint64_t fac[9] = {0};

--- a/examples/Example2/example2.cu
+++ b/examples/Example2/example2.cu
@@ -32,10 +32,10 @@ struct Scoring {
   adept::Atomic_t<int> secondaries;
   adept::Atomic_t<float> totalEnergyLoss;
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   Scoring() {}
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static Scoring *MakeInstanceAt(void *addr)
   {
     Scoring *obj = new (addr) Scoring();

--- a/examples/FisherPrice_cu/cufisher_price.cu
+++ b/examples/FisherPrice_cu/cufisher_price.cu
@@ -21,10 +21,10 @@ struct Scoring {
   adept::Atomic_t<int> secondaries;
   adept::Atomic_t<float> totalEnergyLoss;
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   Scoring() {}
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static Scoring *MakeInstanceAt(void *addr)
   {
     Scoring *obj = new (addr) Scoring();

--- a/examples/FisherPrice_cu/cufisher_price_v2.cu
+++ b/examples/FisherPrice_cu/cufisher_price_v2.cu
@@ -23,10 +23,10 @@ struct Scoring {
   adept::Atomic_t<int> secondaries;
   adept::Atomic_t<float> totalEnergyLoss;
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   Scoring() {}
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static Scoring *MakeInstanceAt(void *addr)
   {
     Scoring *obj = new (addr) Scoring();

--- a/examples/Raytracer_Benchmark/Color.h
+++ b/examples/Raytracer_Benchmark/Color.h
@@ -20,11 +20,11 @@ union Color_t {
     unsigned char red;
   } fComp;
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   Color_t() : fColor(0) {}
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   Color_t(unsigned int col) { fColor = col; }
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   Color_t(unsigned char r, unsigned char g, unsigned char b, unsigned char a)
   {
     fComp.red   = r;
@@ -32,7 +32,7 @@ union Color_t {
     fComp.blue  = b;
     fComp.alpha = a;
   }
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   Color_t(float r, float g, float b, float a)
   {
     fComp.red   = 255 * r;
@@ -41,7 +41,7 @@ union Color_t {
     fComp.alpha = 255 * a;
   }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   Color_t &operator+=(Color_t const &other)
   {
     if ((fComp.alpha == 0) && (other.fComp.alpha == 0)) return *this;
@@ -56,7 +56,7 @@ union Color_t {
     return *this;
   }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   Color_t &operator*=(float val)
   {
     using vecCore::math::Max;
@@ -68,7 +68,7 @@ union Color_t {
     return *this;
   }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   Color_t &operator/=(float val)
   {
     using vecCore::math::Max;
@@ -80,17 +80,17 @@ union Color_t {
     return *this;
   }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   float Red() const { return 1. / 255 * fComp.red; }
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   float Green() const { return 1. / 255 * fComp.green; }
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   float Blue() const { return 1. / 255 * fComp.blue; }
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   float Alpha() const { return 1. / 255 * fComp.alpha; }
   int GetColor() const { return fColor; }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   void MultiplyLightChannel(float fact)
   {
     float hue, light, satur;
@@ -98,7 +98,7 @@ union Color_t {
     SetHLS(hue, fact * light, satur);
   }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   void GetHLS(float &hue, float &light, float &satur) const
   {
     float rnorm, gnorm, bnorm, msum, mdiff;
@@ -134,7 +134,7 @@ union Color_t {
     if (hue > 360) hue = hue - 360;
   }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   void SetHLS(float hue, float light, float satur)
   {
     float rh, rl, rs, rm1, rm2;
@@ -181,8 +181,8 @@ union Color_t {
   }
 };
 
-VECCORE_ATT_HOST_DEVICE
-VECCORE_FORCE_INLINE
+__host__ __device__
+__forceinline__
 Color_t operator+(Color_t const &left, Color_t const &right)
 {
   Color_t color(left);

--- a/examples/Raytracer_Benchmark/Raytracer.h
+++ b/examples/Raytracer_Benchmark/Raytracer.h
@@ -39,22 +39,22 @@ struct Ray_t {
   bool fDone                 = false;   ///< done flag
   int index                  = -1;      ///< index flag
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static Ray_t *MakeInstanceAt(void *addr) { return new (addr) Ray_t(); }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   Ray_t() {}
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static size_t SizeOfInstance() { return sizeof(Ray_t); }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   vecgeom::Vector3D<double> Reflect(vecgeom::Vector3D<double> const &normal)
   {
     return (fDir - 2 * fDir.Dot(normal) * normal);
   }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   vecgeom::Vector3D<double> Refract(vecgeom::Vector3D<double> const &normal, float ior1, float ior2, bool &totalreflect)
   {
     // ior1, ior2 are the refraction indices of the exited and entered volumes respectively
@@ -73,7 +73,7 @@ struct Ray_t {
     return refracted;
   }
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   void Fresnel(vecgeom::Vector3D<double> const &normal, float ior1, float ior2, float &kr)
   {
     float cosi = fDir.Dot(normal);
@@ -123,7 +123,7 @@ struct RaytracerData_t {
   VPlacedVolumePtr_t fWorld = nullptr; ///< World volume
   vecgeom::NavStateIndex fVPstate;     ///< Navigation state corresponding to the viewpoint
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   void Print();
 };
 
@@ -140,18 +140,18 @@ using VPlacedVolumePtr_t = vecgeom::VPlacedVolume const *;
 /// it, normal vector pointing to the origin of the world reference frame \param up_vector the projection of this
 /// vector on the camera plane determines the 'up' direction of the image \param img_size_px image size on X in pixels
 /// \param img_size_py image size on Y in pixels
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void InitializeModel(VPlacedVolumePtr_t world, RaytracerData_t &data);
 
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void ApplyRTmodel(Ray_t &ray, double step, RaytracerData_t const &rtdata);
 
 /// \brief Entry point to propagate all rays
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void PropagateRays(adept::BlockData<Ray_t> *rays, RaytracerData_t &data, unsigned char *rays_buffer,
                    unsigned char *output_buffer);
 
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 adept::Color_t RaytraceOne(RaytracerData_t const &rtdata, adept::BlockData<Ray_t> *rays, int px, int py, int index);
 
 } // End namespace Raytracer

--- a/examples/Raytracer_Benchmark/kernels.h
+++ b/examples/Raytracer_Benchmark/kernels.h
@@ -10,7 +10,7 @@
 inline namespace COPCORE_IMPL {
 
 // Alocate slots for the BlockData
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void generateRays(int id, adept::BlockData<Ray_t> *rays)
 {
   auto ray = rays->NextElement();
@@ -21,7 +21,7 @@ void generateRays(int id, adept::BlockData<Ray_t> *rays)
 
 COPCORE_CALLABLE_FUNC(generateRays)
 
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void renderKernels(int id, adept::BlockData<Ray_t> *rays, const RaytracerData_t &rtdata, NavIndex_t *input_buffer,
                    NavIndex_t *output_buffer)
 {

--- a/test/run_simulation.hpp
+++ b/test/run_simulation.hpp
@@ -60,7 +60,7 @@ int runSimulation()
 
   // A launcher that runs a lambda function that fills an array with the current thread number
   Launcher_t fillArray(stream);
-  fillArray.Run([] VECCORE_ATT_DEVICE(int thread_id, Atomic_int *index,
+  fillArray.Run([] __device__(int thread_id, Atomic_int *index,
                                       int *array) { array[thread_id] = (*index)++; }, // lambda being run
                 32,                                                                   // number of elements
                 {2, 16},              // run with 2 block of 16 threads (if backend=CUDA)

--- a/test/sim_kernels.h
+++ b/test/sim_kernels.h
@@ -29,7 +29,7 @@ inline namespace COPCORE_IMPL {
               The current index of the loop over the input data
     @param tracks Pointer to the container of tracks
   */
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void generateAndStorePrimary(int id, adept::BlockData<MyTrack> *tracks)
 {
   auto track = tracks->NextElement();
@@ -46,7 +46,7 @@ COPCORE_CALLABLE_FUNC(generateAndStorePrimary)
 namespace devfunc {
 
 /** @brief Select a track based on its index and add it to a queue */
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void selectTrack(int id, adept::BlockData<MyTrack> *tracks, int each_n, adept::MParray *array)
 {
   auto &track   = (*tracks)[id];
@@ -60,7 +60,7 @@ COPCORE_CALLABLE_FUNC(selectTrack)
 } // end namespace devfunc
 
 /** @brief Process a track and sum-up some energy deposit */
-VECCORE_ATT_HOST_DEVICE
+__host__ __device__
 void elossTrack(int id, adept::MParray *array, adept::BlockData<MyTrack> *tracks, adept::BlockData<MyHit> *hits)
 {
   // Say there are 1024 hit objects and they accumulate energy deposits from specific track id's

--- a/test/test_atomic.cu
+++ b/test/test_atomic.cu
@@ -16,10 +16,10 @@ struct SomeStruct {
   adept::Atomic_t<int> var_int;
   adept::Atomic_t<float> var_float;
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   SomeStruct() {}
 
-  VECCORE_ATT_HOST_DEVICE
+  __host__ __device__
   static SomeStruct *MakeInstanceAt(void *addr)
   {
     SomeStruct *obj = new (addr) SomeStruct();


### PR DESCRIPTION
Testing and discussion showed that using the full Allen approach would not work immediately for AdePT due to symbol clashes from the requirement for a mix of CPU/GPU code. However, its macro system is still useful to simplify markup of functions and indicate CUDA use and the device-compile pass.

Implement a simple header in CopCore based on Allen and Guilherme Amadio's prototype system. Define macros to indicate:

- Use of a CUDA compiler (i.e. compiling code as CUDA)
- Compilation is on the device pass

Use Allen's style of defining CUDA's `__host__` etc keywords as
empty defines when compiling for a host/non-cuda compiler.

Migrate CopCore, AdePT, example, and tests code to use the new macros.

There are some warnings in the `examples`, but I need to update my VecGeom install with the NavStateIndex to get this fully working. The core behaviour is in the new `Macros.h` header, the rest is simple replacement of the VecCore macros with the new ones.

This replaces #52, which I'll close.