### PR TITLE
Abort simulation if secondary cannot be produced

### DIFF
--- a/base/inc/CopCore/include/CopCore/Global.h
+++ b/base/inc/CopCore/include/CopCore/Global.h
@@ -46,7 +46,11 @@ inline void error_check(cudaError_t err, const char *file, int line)
 #ifndef COPCORE_DEVICE_COMPILATION
 #define COPCORE_EXCEPTION(message) throw std::runtime_error(message)
 #else
-#define COPCORE_EXCEPTION(message) asm("trap;") // can do better here
+#define COPCORE_EXCEPTION(message)      \
+  do {                                  \
+    printf("Exception: %s\n", message); \
+    asm("trap;");                       \
+  } while (0)
 #endif
 
 template <BackendType T>

--- a/physics/processes/inc/pair_production.h
+++ b/physics/processes/inc/pair_production.h
@@ -33,7 +33,9 @@ __device__ void pair_production::GenerateInteraction(int particle_index, adept::
   mytrack->number_of_secondaries = 1;
 
   auto secondary_track = block->NextElement();
-  assert(secondary_track != nullptr && "No slot available for secondary track");
+  if (secondary_track == nullptr) {
+    COPCORE_EXCEPTION("No slot available for secondary track");
+  }
   secondary_track->energy                = eloss;
   secondary_track->status                = alive;
   secondary_track->energy_loss           = 0;


### PR DESCRIPTION
The `assert()` would only be present for Debug builds, leaving Release builds with an "illegal memory access" due to accessing nullptr. Use the existing `COPCORE_EXCEPTION` and extend it to print a message on the device. This still isn't perfect because all threads will print, but better than developers wondering what happened.