### PR TITLE
Adding CTest/Jenkins infrastructure

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,0 +1,14 @@
+## This file should be placed in the root directory of your project.
+## Then modify the CMakeLists.txt file in the root directory of your
+## project to incorporate the testing dashboard.
+## # The following are required to uses Dart and the Cdash dashboard
+## ENABLE_TESTING()
+## INCLUDE(CTest)
+
+set(CTEST_PROJECT_NAME "AdePT")
+set(CTEST_NIGHTLY_START_TIME "00:00:00 UTC")
+
+set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_SITE "cdash.cern.ch")
+set(CTEST_DROP_LOCATION "/submit.php?project=AdePT")
+set(CTEST_DROP_SITE_CDASH TRUE)

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,3 +1,6 @@
+## SPDX-FileCopyrightText: 2020 CERN
+## SPDX-License-Identifier: Apache-2.0
+##
 ## This file should be placed in the root directory of your project.
 ## Then modify the CMakeLists.txt file in the root directory of your
 ## project to incorporate the testing dashboard.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
   parameters {
     string(name: 'EXTERNALS', defaultValue: 'devAdePT/latest', description: 'LCG software stack in CVMFS')
     choice(name: 'MODEL', choices: ['experimental', 'nightly', 'continuous'], description: 'CDash model')
-    choice(name: 'COMPILER', choices: ['gcc7', 'gcc8', 'gcc9', 'gcc10', 'clang8', 'clang10', 'native'])
+    choice(name: 'COMPILER', choices: ['gcc8', 'gcc10', 'clang10', 'native'])
     choice(name: 'BUILDTYPE', choices: ['Release', 'Debug'])
     string(name: 'LABEL', defaultValue: 'TeslaT4', description: 'Jenkins label for physical nodes or container image for docker')
     string(name: 'ExtraCMakeOptions', defaultValue: '', description: 'CMake extra configuration options')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,11 @@ pipeline {
           steps {
             buildAndTest()
           }
+          post {
+            success {
+              deleteDir()
+            }
+          }
         }
       }
     }
@@ -72,6 +77,11 @@ pipeline {
         stage('Build&Test') {
           steps {
             buildAndTest()
+          }
+          post {
+            success {
+              deleteDir()
+            }
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,100 @@
+//----------------------------------------------------------------------------------------------------------------------
+// This declarative Jenkins pipeline encodes all the steps required for the nightly/continuous of a single platform.
+// Other jobs may call this pipeline to execute the build, test and installation of a set platforms.
+//
+// Author: Pere Mato
+//----------------------------------------------------------------------------------------------------------------------
+
+pipeline {
+  parameters {
+    string(name: 'EXTERNALS', defaultValue: 'devAdePT/latest', description: 'LCG software stack in CVMFS')
+    choice(name: 'MODEL', choices: ['experimental', 'nightly', 'continuous'], description: 'CDash model')
+    choice(name: 'COMPILER', choices: ['gcc7', 'gcc8', 'gcc9', 'gcc10', 'clang8', 'clang10', 'native'])
+    choice(name: 'BUILDTYPE', choices: ['Release', 'Debug'])
+    string(name: 'LABEL', defaultValue: 'TeslaT4', description: 'Jenkins label for physical nodes or container image for docker')
+    string(name: 'ExtraCMakeOptions', defaultValue: '', description: 'CMake extra configuration options')
+    string(name: 'DOCKER_LABEL', defaultValue: 'docker-host-noafs', description: 'Label for the the nodes able to launch docker images')
+  }
+
+  environment {
+    CMAKE_SOURCE_DIR     = 'AdePT'
+    CMAKE_BINARY_DIR     = 'build'
+    CMAKE_INSTALL_PREFIX = 'install'
+  }
+
+  agent none
+
+  stages {
+    //------------------------------------------------------------------------------------------------------------------
+    //---Build & Test stages--------------------------------------------------------------------------------------------
+    //------------------------------------------------------------------------------------------------------------------
+    stage('Environment'){
+      steps {
+        setJobName()
+      }
+    }
+    stage('InDocker') {
+      when {
+        beforeAgent true
+        expression { params.LABEL =~ 'centos|ubuntu' }
+      }
+      agent {
+        docker {
+          image "gitlab-registry.cern.ch/sft/docker/$LABEL"
+          label "$DOCKER_LABEL"
+          args  """-v /cvmfs:/cvmfs
+                   -v /ec:/ec
+                   -e SHELL 
+                   --net=host
+                   --hostname ${LABEL}-docker
+                """
+        }
+      }
+      stages {
+        stage('Build&Test') {
+          steps {
+            buildAndTest()
+          }
+          post {
+            success {
+              deleteDir()
+            }
+          }
+        }
+      }
+    }
+    stage('InBareMetal') {
+      when {
+        beforeAgent true
+        expression { params.LABEL =~ 'cuda|physical|TeslaT4' }
+      }
+      agent {
+        label "$LABEL"
+      }
+      stages {
+        stage('Build&Test') {
+          steps {
+            buildAndTest()
+          }
+          post {
+            success {
+              deleteDir()
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+def setJobName() {
+  currentBuild.displayName = "#${BUILD_NUMBER}" + ' ' + params.COMPILER + '-' + params.BUILDTYPE
+}
+
+def buildAndTest() {
+  sh label: 'build_and_test', script: """
+    source /cvmfs/sft.cern.ch/lcg/views/${EXTERNALS}/x86_64-centos7-${COMPILER}-opt/setup.sh
+    env | sort | sed 's/:/:?     /g' | tr '?' '\n'
+    ctest -VV -S AdePT/jenkins/adept-ctest.cmake,$MODEL
+  """
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,8 @@
 // Other jobs may call this pipeline to execute the build, test and installation of a set platforms.
 //
 // Author: Pere Mato
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
 //----------------------------------------------------------------------------------------------------------------------
 
 pipeline {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,11 +57,6 @@ pipeline {
           steps {
             buildAndTest()
           }
-          post {
-            success {
-              deleteDir()
-            }
-          }
         }
       }
     }
@@ -77,11 +72,6 @@ pipeline {
         stage('Build&Test') {
           steps {
             buildAndTest()
-          }
-          post {
-            success {
-              deleteDir()
-            }
           }
         }
       }

--- a/examples/Example1/CMakeLists.txt
+++ b/examples/Example1/CMakeLists.txt
@@ -10,3 +10,4 @@ target_include_directories(example1 PUBLIC
   $<INSTALL_INTERFACE:base>
 )
 target_link_libraries(example1 PRIVATE VecCore::VecCore VecGeom::vecgeom CopCore::CopCore)
+add_test(NAME example1 COMMAND example1)

--- a/jenkins/adept-ctest.cmake
+++ b/jenkins/adept-ctest.cmake
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2020 CERN
+# SPDX-License-Identifier: Apache-2.0
 ################################################################################
 # Before run should be exported next variables:
 # CMAKE_SOURCE_DIR        // CMake source directory
@@ -7,7 +9,6 @@
 # COMPILER                // Compiler keyword: gcc8, clang10
 # MODEL                   // CTest model (Experimental, Continuous, or Nightly)
 # ExtraCMakeOptions       // Additional options
-
 ################################################################################
 
 # Build name settings (CTEST_BUILD_NAME)----------------------------------------

--- a/jenkins/adept-ctest.cmake
+++ b/jenkins/adept-ctest.cmake
@@ -1,0 +1,96 @@
+################################################################################
+# Before run should be exported next variables:
+# CMAKE_SOURCE_DIR        // CMake source directory
+# CMAKE_BINARY_DIR        // CMake binary directory
+# CMAKE_INSTALL_PREFIX    // Installation prefix for CMake (Jenkins trigger)
+# BUILDTYPE               // CMake build type: Debug, Release
+# COMPILER                // Compiler keyword: gcc8, clang10
+# MODEL                   // CTest model (Experimental, Continuous, or Nightly)
+# ExtraCMakeOptions       // Additional options
+
+################################################################################
+
+# Build name settings (CTEST_BUILD_NAME)----------------------------------------
+set(CTEST_BUILD_NAME "AdePT-$ENV{COMPILER}-$ENV{BUILDTYPE}")
+if(NOT "$ENV{gitlabMergedByUser}$ENV{gitlabMergeRequestIid}" STREQUAL "")
+  set(CTEST_BUILD_NAME "$ENV{gitlabMergedByUser}#$ENV{gitlabMergeRequestIid}-${CTEST_BUILD_NAME}")
+endif()
+
+# Site name (CTEST_SITE)--------------------------------------------------------
+if(DEFINED ENV{CTEST_SITE})
+  set(CTEST_SITE $ENV{CTEST_SITE})
+elseif(DEFINED ENV{container} AND DEFINED ENV{NODE_NAME})
+  set(CTEST_SITE "$ENV{NODE_NAME}-$ENV{container}")
+else()
+  find_program(HOSTNAME_CMD NAMES hostname)
+  exec_program(${HOSTNAME_CMD} ARGS OUTPUT_VARIABLE CTEST_SITE)
+endif()
+
+# Cdash Model (CTEST_MODEL)-----------------------------------------------------
+if("$ENV{MODEL}" STREQUAL "")
+  set(CTEST_MODEL Experimental)
+else()
+  set(CTEST_MODEL "$ENV{MODEL}")
+endif()
+
+# Use multiple CPU cores to build-----------------------------------------------
+include(ProcessorCount)
+ProcessorCount(N)
+if(NOT N EQUAL 0)
+  set(ctest_test_args ${ctest_test_args} PARALLEL_LEVEL ${N})
+endif()
+
+# CTest/CMake settings----------------------------------------------------------
+set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_ERRORS "1000")
+set(CTEST_CUSTOM_MAXIMUM_NUMBER_OF_WARNINGS "1000")
+set(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE "50000")
+set(CTEST_TEST_TIMEOUT 900)
+set(CTEST_BUILD_CONFIGURATION "$ENV{BUILDTYPE}")
+set(CMAKE_INSTALL_PREFIX "$ENV{CMAKE_INSTALL_PREFIX}")
+set(CTEST_SOURCE_DIRECTORY "$ENV{CMAKE_SOURCE_DIR}")
+set(CTEST_BINARY_DIRECTORY "$ENV{CMAKE_BINARY_DIR}")
+set(CTEST_INSTALL_PREFIX "$ENV{CMAKE_INSTALL_PREFIX}")
+set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+set(CTEST_BUILD_FLAGS "-j${N}")
+
+# Fixed set of CMake options----------------------------------------------------
+set(config_options -DCMAKE_CUDA_ARCHITECTURES=75 
+                   $ENV{ExtraCMakeOptions})
+
+# Print summary information-----------------------------------------------------
+foreach(v
+    CTEST_SITE
+    CTEST_BUILD_NAME
+    CTEST_SOURCE_DIRECTORY
+    CTEST_BINARY_DIRECTORY
+    CTEST_CMAKE_GENERATOR
+    )
+  set(vars "${vars}  ${v}=[${${v}}]\n")
+endforeach(v)
+message("Dashboard script configuration (check if everything is declared correctly):\n${vars}\n")
+
+include("${CTEST_SOURCE_DIRECTORY}/CTestConfig.cmake")
+
+# ctest_empty_binary_directory--------------------------------------------------
+file(REMOVE_RECURSE ${CTEST_BINARY_DIRECTORY})
+
+# Execute all the steps---------------------------------------------------------
+ctest_start(${CTEST_MODEL} TRACK ${CTEST_MODEL})
+ctest_update(SOURCE ${CTEST_SOURCE_DIRECTORY})
+
+ctest_configure(BUILD   ${CTEST_BINARY_DIRECTORY}
+                SOURCE  ${CTEST_SOURCE_DIRECTORY}
+                OPTIONS "${config_options}"
+                APPEND)
+ctest_submit(PARTS Update Configure Notes)
+
+ctest_build(BUILD ${CTEST_BINARY_DIRECTORY} 
+            TARGET install
+            APPEND)
+ctest_submit(PARTS Build)
+
+ctest_test(BUILD ${CTEST_BINARY_DIRECTORY}
+          ${ctest_test_args}
+          APPEND)
+ctest_submit(PARTS Test)
+

--- a/jenkins/adept-ctest.cmake
+++ b/jenkins/adept-ctest.cmake
@@ -54,7 +54,8 @@ set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 set(CTEST_BUILD_FLAGS "-j${N}")
 
 # Fixed set of CMake options----------------------------------------------------
-set(config_options -DCMAKE_CUDA_ARCHITECTURES=75 
+set(config_options -DCMAKE_INSTALL_PREFIX=${CTEST_INSTALL_PREFIX}
+                   -DCMAKE_CUDA_ARCHITECTURES=75 
                    $ENV{ExtraCMakeOptions})
 
 # Print summary information-----------------------------------------------------
@@ -63,6 +64,7 @@ foreach(v
     CTEST_BUILD_NAME
     CTEST_SOURCE_DIRECTORY
     CTEST_BINARY_DIRECTORY
+    CTEST_INSTALL_PREFIX
     CTEST_CMAKE_GENERATOR
     )
   set(vars "${vars}  ${v}=[${${v}}]\n")

--- a/jenkins/adept-ctest.cmake
+++ b/jenkins/adept-ctest.cmake
@@ -59,6 +59,21 @@ set(config_options -DCMAKE_INSTALL_PREFIX=${CTEST_INSTALL_PREFIX}
                    -DCMAKE_CUDA_ARCHITECTURES=75 
                    $ENV{ExtraCMakeOptions})
 
+# git command configuration------------------------------------------------------
+find_program(CTEST_GIT_COMMAND NAMES git)
+set(CTEST_GIT_UPDATE_COMMAND "${CTEST_GIT_COMMAND}")
+if(${CTEST_MODEL} MATCHES Nightly OR Experimental)
+  if(NOT "$ENV{GIT_COMMIT}" STREQUAL "")
+    set(CTEST_CHECKOUT_COMMAND "cmake -E chdir ${CTEST_SOURCE_DIRECTORY} ${CTEST_GIT_COMMAND} checkout -f $ENV{GIT_PREVIOUS_COMMIT}")
+    set(CTEST_GIT_UPDATE_CUSTOM  ${CTEST_GIT_COMMAND} checkout -f $ENV{GIT_COMMIT})
+  endif()
+else()
+  if(NOT "$ENV{GIT_COMMIT}" STREQUAL "")
+    set(CTEST_CHECKOUT_COMMAND "cmake -E chdir ${CTEST_SOURCE_DIRECTORY} ${CTEST_GIT_COMMAND} checkout -f $ENV{GIT_COMMIT}")
+    set(CTEST_GIT_UPDATE_CUSTOM  ${CTEST_GIT_COMMAND} checkout -f $ENV{GIT_COMMIT})
+  endif()
+endif()
+
 # Print summary information-----------------------------------------------------
 foreach(v
     CTEST_SITE

--- a/jenkins/adept-ctest.cmake
+++ b/jenkins/adept-ctest.cmake
@@ -111,4 +111,3 @@ ctest_test(BUILD ${CTEST_BINARY_DIRECTORY}
           ${ctest_test_args}
           APPEND)
 ctest_submit(PARTS Test)
-


### PR DESCRIPTION
Added Jenkinsfile with the basic pipeline.
Added the script jenkins/adept-ctest.cmake to drive the update, configuration, build and test and publish results to [Cdash](https://cdash.cern.ch/index.php?project=AdePT)
The initial jenkins jobs (nightly for the time being) are available at https://lcgapp-services.cern.ch/spi-jenkins/view/AdePT/
