### PR TITLE
Correct number of secondaries for example1

### DIFF
--- a/examples/Example1/example1.cu
+++ b/examples/Example1/example1.cu
@@ -67,12 +67,15 @@ __global__ void CallAlongStepProcesses(adept::BlockData<track> *block, process_l
         {
           // get particles index from the queue
           particle_index = (*(queues[process_id]))[i];
+          int preNumber  = (*block)[particle_index].number_of_secondaries; // For scoring too
+
           // and call the process for it
           ((*proclist)->list)[process_id]->GenerateInteraction(particle_index, block);
 
           // a simple version of scoring
           scor->totalEnergyLoss.fetch_add((*block)[particle_index].energy_loss);
-          scor->secondaries.fetch_add((*block)[particle_index].number_of_secondaries);
+          int postNumber = (*block)[particle_index].number_of_secondaries;
+          scor->secondaries.fetch_add(postNumber - preNumber);
 
           // if particles returns with 'dead' status, release the element from the block
           if ((*block)[particle_index].status == dead) block->ReleaseElement(particle_index);

--- a/examples/Example2/example2.cu
+++ b/examples/Example2/example2.cu
@@ -90,12 +90,9 @@ __global__ void CallAlongStepProcesses(adept::BlockData<track> *block, process_l
       proclist->list[process_id]->GenerateInteraction(particle_index, block);
 
       // a simple version of scoring
-      int postNumber = (*block)[particle_index].number_of_secondaries;
       scor->totalEnergyLoss.fetch_add((*block)[particle_index].energy_loss);
-      int secondaries_in_step = postNumber - preNumber;
-      if (secondaries_in_step > 0) {
-        scor->secondaries.fetch_add(secondaries_in_step);
-      }
+      int postNumber = (*block)[particle_index].number_of_secondaries;
+      scor->secondaries.fetch_add(postNumber - preNumber);
 
       // if particles returns with 'dead' status, release the element from the block
       if ((*block)[particle_index].status == dead) block->ReleaseElement(particle_index);


### PR DESCRIPTION
`number_of_secondaries` is the total number of secondaries produced by this track. To accumulate a global value, `example1` must only add the difference produced in the current step.
Also change the code in `example2` to match the other two and always add to the atomic (we need a more performant version of the scoring anyway).