### PR TITLE
example6: Split and parallelize relocation to next volume

### DIFF
--- a/examples/Example6/example6.cu
+++ b/examples/Example6/example6.cu
@@ -239,8 +239,8 @@ __global__ void PerformStep(adept::BlockData<track> *allTracks, adept::MParray *
     // also need to carry them over!
 
     // Check if there's a volume boundary in between.
-    double geometryStepLength =
-        fieldPropagatorBz.ComputeStepAndPropagatedState(currentTrack, geometricalStepLengthFromPhysics);
+    double geometryStepLength = fieldPropagatorBz.ComputeStepAndPropagatedState</*Relocate=*/false>(
+        currentTrack, geometricalStepLengthFromPhysics);
     currentTrack.total_length += geometryStepLength;
 
     if (currentTrack.next_state.IsOnBoundary()) {
@@ -279,6 +279,8 @@ __global__ void PerformStep(adept::BlockData<track> *allTracks, adept::MParray *
     if (currentTrack.next_state.IsOnBoundary()) {
       // For now, just count that we hit something.
       scoring->hits++;
+
+      LoopNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, currentTrack.next_state);
 
       // Move to the next boundary.
       currentTrack.SwapStates();


### PR DESCRIPTION
When a particle leaves the current volume or enters a daughter, we need to relocate to the next volume. This could involve walking the hierarchy which is expensive, at least in the current `LoopNavigator`. The problem is that if only one particle needs relocation, all others have to wait.
As a first step, move the relocation step out of navigation, which is called from the magnetic field, to a common place when a particle is detected to need it. This already improves the total runtime from around 1.4s to 1.3s on my system.

---

As there are usually fewer particles to be relocated than there are threads on the GPU, we can use one level of parallelism to check daughter volumes in parallel. This improves the total runtime from around 1.3s to 1.2s on my system.

---

*Note*: I think it would be good to merge this as two commits (rather than squashing) so that we could go back later and check incremental improvements for other setups etc.