### PR TITLE
Create and use minimal interface target for AdePT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,20 @@ endif()
 add_subdirectory(external)
 
 # Builds...
+# Target for use of AdePT
+# NB: NOT complete yet due to dependence of AdePT/LoopNavigator.h on VecGeom
+#     This would be another INTERFACE link library, but needs care because it
+#     involves VecGeom+CUDA, so usage requirements need some care and thought
+add_library(AdePT INTERFACE)
+target_include_directories(AdePT
+  INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/base/inc>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/magneticfield/inc>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/physics/processes/inc>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/tracking/inc>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+target_link_libraries(AdePT INTERFACE CopCore::CopCore)
+
 add_subdirectory(tracking)
 add_subdirectory(physics)
 add_subdirectory(test)

--- a/examples/Example1/CMakeLists.txt
+++ b/examples/Example1/CMakeLists.txt
@@ -3,13 +3,7 @@
 
 # Example 1 of particle processing with GPU
 add_executable(example1 example1.cu)
-target_include_directories(example1 PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/physics/processes/inc>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/tracking/inc>
-  $<INSTALL_INTERFACE:base>
-)
-target_link_libraries(example1 PRIVATE VecCore::VecCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml CopCore::CopCore)
+target_link_libraries(example1 PRIVATE AdePT VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml)
 set_target_properties(example1 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 add_test(NAME example1 COMMAND example1)
 

--- a/examples/Example2/CMakeLists.txt
+++ b/examples/Example2/CMakeLists.txt
@@ -4,13 +4,7 @@
 # Example 2 of particle processing with GPU, including geometry
 # and reproducible results using one RANLUX++ state per track.
 add_executable(example2 example2.cpp example2.cu)
-target_include_directories(example2 PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/physics/processes/inc>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/tracking/inc>
-  $<INSTALL_INTERFACE:base>
-)
-target_link_libraries(example2 PRIVATE VecCore::VecCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml CopCore::CopCore)
+target_link_libraries(example2 PRIVATE AdePT VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml)
 target_compile_options(example2 PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
 set_target_properties(example2 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 # add_test(NAME example2 COMMAND example2)

--- a/examples/Example4/CMakeLists.txt
+++ b/examples/Example4/CMakeLists.txt
@@ -4,13 +4,6 @@
 # Example 4 of particle processing with GPU, including geometry, magnetic field
 # and reproducible results using one RANLUX++ state per track.
 add_executable(example4 example4.cpp example4.cu)
-target_include_directories(example4 PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/physics/processes/inc>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/tracking/inc>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/magneticfield/inc>
-  $<INSTALL_INTERFACE:base>
-)
-target_link_libraries(example4 PRIVATE VecCore::VecCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml CopCore::CopCore)
+target_link_libraries(example4 PRIVATE AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml)
 target_compile_options(example4 PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
 set_target_properties(example4 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)

--- a/examples/Example5/CMakeLists.txt
+++ b/examples/Example5/CMakeLists.txt
@@ -7,4 +7,4 @@ if(NOT TARGET G4HepEm::g4HepEm)
 endif()
 
 add_executable(example5 example5.cu)
-target_link_libraries(example5 PRIVATE ${Geant4_LIBRARIES} g4HepEmData g4HepEmInit g4HepEmRun CopCore::CopCore)
+target_link_libraries(example5 PRIVATE CopCore::CopCore ${Geant4_LIBRARIES} G4HepEm::g4HepEmData G4HepEm::g4HepEmInit G4HepEm::g4HepEmRun)

--- a/examples/Example5/CMakeLists.txt
+++ b/examples/Example5/CMakeLists.txt
@@ -1,14 +1,10 @@
 # SPDX-FileCopyrightText: 2020 CERN
 # SPDX-License-Identifier: Apache-2.0
 
-if(NOT TARGET g4HepEm)
+if(NOT TARGET G4HepEm::g4HepEm)
   message(STATUS "Disabling example5 (needs G4HepEm)")
   return()
 endif()
 
 add_executable(example5 example5.cu)
-target_include_directories(example5 PRIVATE
-  $<TARGET_PROPERTY:g4HepEmRun,INCLUDE_DIRECTORIES>
-)
-target_compile_definitions(example5 PRIVATE G4HepEm_CUDA_BUILD)
-target_link_libraries(example5 PRIVATE ${Geant4_LIBRARIES} g4HepEmData g4HepEmInit CopCore::CopCore)
+target_link_libraries(example5 PRIVATE ${Geant4_LIBRARIES} g4HepEmData g4HepEmInit g4HepEmRun CopCore::CopCore)

--- a/examples/Example6/CMakeLists.txt
+++ b/examples/Example6/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2020 CERN
 # SPDX-License-Identifier: Apache-2.0
 
-if(NOT TARGET g4HepEm)
+if(NOT TARGET G4HepEm::g4HepEm)
   message(STATUS "Disabling example6 (needs G4HepEm)")
   return()
 endif()
@@ -11,6 +11,6 @@ endif()
 # Photons immediately pair-produce if allowed or deposit their energy. Results
 # are reproducible using one RANLUX++ state per track.
 add_executable(example6 example6.cpp example6.cu)
-target_link_libraries(example6 PRIVATE AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml ${Geant4_LIBRARIES} g4HepEmData g4HepEmInit g4HepEmRun)
+target_link_libraries(example6 PRIVATE AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml ${Geant4_LIBRARIES} G4HepEm::g4HepEmData G4HepEm::g4HepEmInit G4HepEm::g4HepEmRun)
 target_compile_options(example6 PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
 set_target_properties(example6 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)

--- a/examples/Example6/CMakeLists.txt
+++ b/examples/Example6/CMakeLists.txt
@@ -11,15 +11,6 @@ endif()
 # Photons immediately pair-produce if allowed or deposit their energy. Results
 # are reproducible using one RANLUX++ state per track.
 add_executable(example6 example6.cpp example6.cu)
-target_include_directories(example6 PUBLIC
-  $<TARGET_PROPERTY:g4HepEmRun,INCLUDE_DIRECTORIES>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/physics/processes/inc>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/tracking/inc>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/magneticfield/inc>
-  $<INSTALL_INTERFACE:base>
-)
-target_compile_definitions(example6 PRIVATE G4HepEm_CUDA_BUILD)
-target_link_libraries(example6 PRIVATE VecCore::VecCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml ${Geant4_LIBRARIES} g4HepEmData g4HepEmInit CopCore::CopCore)
+target_link_libraries(example6 PRIVATE AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml ${Geant4_LIBRARIES} g4HepEmData g4HepEmInit g4HepEmRun)
 target_compile_options(example6 PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
 set_target_properties(example6 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)

--- a/examples/FisherPrice_cu/CMakeLists.txt
+++ b/examples/FisherPrice_cu/CMakeLists.txt
@@ -3,17 +3,9 @@
 
 # Noddy example 1 of particle processing with GPU
 add_executable(cufisher_price cufisher_price.cu)
-target_include_directories(cufisher_price PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
-  $<INSTALL_INTERFACE:base>
-)
-target_link_libraries(cufisher_price PRIVATE CUDA::curand VecCore::VecCore CopCore::CopCore)
+target_link_libraries(cufisher_price PRIVATE AdePT CUDA::curand)
 
 # Noddy example 2 of particle processing with GPU
 add_executable(cufisher_price_v2 cufisher_price_v2.cu)
-target_include_directories(cufisher_price_v2 PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
-  $<INSTALL_INTERFACE:base>
-  )
-target_link_libraries(cufisher_price_v2 PRIVATE CUDA::curand VecCore::VecCore CopCore::CopCore)
+target_link_libraries(cufisher_price_v2 PRIVATE AdePT CUDA::curand)
 

--- a/examples/Raytracer_Benchmark/CMakeLists.txt
+++ b/examples/Raytracer_Benchmark/CMakeLists.txt
@@ -30,21 +30,14 @@ list(APPEND ADEPT_CUDA_SRCS
 add_library(raytracercu ${ADEPT_CUDA_SRCS})
 target_include_directories(raytracercu PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
 )
-target_link_libraries(raytracercu VecCore::VecCore VecGeom::vecgeom VecGeom::vecgeomcuda_static CopCore::CopCore)
+target_link_libraries(raytracercu AdePT CopCore::CopCore VecCore::VecCore VecGeom::vecgeom VecGeom::vecgeomcuda_static)
 target_compile_options(raytracercu PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
 set_target_properties(raytracercu PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 
 #exec RaytraceBenchmark.cpp
 add_executable(RaytraceBenchmark Raytracer.cpp RaytraceBenchmark.cpp)
-target_include_directories(RaytraceBenchmark PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
-  $<INSTALL_INTERFACE:base>
-)
-target_link_libraries(RaytraceBenchmark VecCore::VecCore VecGeom::vecgeom VecGeom::vecgeomcuda VecGeom::vgdml raytracercu CopCore::CopCore)
+target_link_libraries(RaytraceBenchmark PRIVATE raytracercu AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda VecGeom::vgdml)
 target_compile_options(RaytraceBenchmark PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
 set_target_properties(RaytraceBenchmark PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 

--- a/examples/field_cu/CMakeLists.txt
+++ b/examples/field_cu/CMakeLists.txt
@@ -2,14 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_executable(fieldStep field_step.cu)
-target_include_directories(fieldStep PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/tracking/inc>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/magneticfield/inc>
-  $<INSTALL_INTERFACE:base>
-)
-target_link_libraries(fieldStep VecCore::VecCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml CopCore::CopCore)
+target_link_libraries(fieldStep AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml)
 target_compile_options(fieldStep PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
 set_target_properties(fieldStep PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,11 +6,7 @@ macro(build_tests TESTS)
   foreach(TEST ${TESTS})
     get_filename_component(TARGET_NAME ${TEST} NAME_WE)
     add_executable(${TARGET_NAME} ${TEST})
-    target_include_directories(${TARGET_NAME} PUBLIC
-      $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
-      $<INSTALL_INTERFACE:base>
-    )
-    target_link_libraries(${TARGET_NAME} VecCore::VecCore CopCore::CopCore VecGeom::vecgeom)
+    target_link_libraries(${TARGET_NAME} AdePT VecCore::VecCore VecGeom::vecgeom)
    endforeach()
 endmacro()
 


### PR DESCRIPTION
Add a CMake `INTERFACE` target for AdePT with main locations of headers and dependency on CopCore as usage requirements. This allows all of the examples and tests to use `target_link_libraries` to pick up all the headers (and pave the way to simplify the repo layout in a separate PR), and these have been updated accordingly.

The AdePT target is not totally complete in that it doesn't declare its dependence on VecGeom (through `LoopNavigator.h` in the base, and others in magneticfield/tracking/physics) yet. That's deliberate as how to correctly declare the CUDA vs CPU only usage requirements needs some thought, but the target as implemented here is a good first step.