### PR TITLE
Fixes to deal with change of units

### DIFF
--- a/examples/Example1/example1.cu
+++ b/examples/Example1/example1.cu
@@ -146,7 +146,7 @@ int main()
 
   // initializing one track in the block
   auto track    = block->NextElement();
-  track->energy = 100.0f;
+  track->energy      = 100.0 * copcore::units::GeV;
   track->energy_loss = 0.0f;
   //  track->index = 1; // this is not use for the moment, but it should be a unique track index
   init_track<<<1, 1>>>(track);
@@ -154,7 +154,7 @@ int main()
 
   // initializing second track in the block
   auto track2    = block->NextElement();
-  track2->energy = 30.0f;
+  track2->energy      = 30.0 * copcore::units::GeV;
   track2->energy_loss = 0.0f;
   //  track2->index = 2; // this is not use for the moment, but it should be a unique track index
   init_track<<<1, 1>>>(track2);
@@ -187,8 +187,9 @@ int main()
     for (int i = 0; i < numberOfProcesses; i++) queues[i]->clear();
     COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
 
-    std::cout << "Number of tracks in flight: " << std::setw(8) << block->GetNused() << " total energy depostion: " << std::setw(10) << scor->totalEnergyLoss.load()
-    << " total number of secondaries: " << scor->secondaries.load() << std::endl;
+    std::cout << "Number of tracks in flight: " << std::setw(8) << block->GetNused()
+              << " total energy depostion: " << std::setw(10) << scor->totalEnergyLoss.load() / copcore::units::GeV
+              << " total number of secondaries: " << scor->secondaries.load() << std::endl;
   }
 
   auto time_cpu = timer.Stop();

--- a/examples/Example2/example2.cu
+++ b/examples/Example2/example2.cu
@@ -39,7 +39,7 @@ struct Scoring {
   }
 };
 
-constexpr double kPush = 1.e-8;
+constexpr double kPush = 1.e-8 * copcore::units::cm;
 
 // kernel select processes based on interaction lenght and put particles in the appropriate queues
 __global__ void DefinePhysicalStepLength(adept::BlockData<track> *block, process_list *proclist,
@@ -174,7 +174,7 @@ void example2(const vecgeom::cxx::VPlacedVolume *world)
 
   // initializing one track in the block
   auto track1         = block->NextElement();
-  track1->energy      = 100.0f;
+  track1->energy      = 100.0 * copcore::units::GeV;
   track1->energy_loss = 0.0f;
   //  track->index = 1; // this is not use for the moment, but it should be a unique track index
   track1->pos                = {0, 0, 0};
@@ -188,10 +188,10 @@ void example2(const vecgeom::cxx::VPlacedVolume *world)
 
   // initializing second track in the block
   auto track2         = block->NextElement();
-  track2->energy      = 30.0f;
+  track2->energy      = 30.0 * copcore::units::GeV;
   track2->energy_loss = 0.0f;
   //  track2->index = 2; // this is not use for the moment, but it should be a unique track index
-  track2->pos = {0, 0.05, 0};
+  track2->pos = {0, 0.05 * copcore::units::cm, 0};
   track2->dir = {1, 0, 0};
   init_track<<<1, 1>>>(track2, gpu_world);
   COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
@@ -225,8 +225,8 @@ void example2(const vecgeom::cxx::VPlacedVolume *world)
     COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
 
     std::cout << "tracks in flight: " << std::setw(5) << block->GetNused() << " energy depostion: " << std::setw(8)
-              << scor->totalEnergyLoss.load() << " number of secondaries: " << std::setw(5) << scor->secondaries.load()
-              << " number of hits: " << std::setw(4) << scor->hits.load() << std::endl;
+              << scor->totalEnergyLoss.load() / copcore::units::GeV << " number of secondaries: " << std::setw(5)
+              << scor->secondaries.load() << " number of hits: " << std::setw(4) << scor->hits.load() << std::endl;
   }
 
   auto time_cpu = timer.Stop();

--- a/examples/Example6/example6.cpp
+++ b/examples/Example6/example6.cpp
@@ -27,7 +27,8 @@ int main(int argc, char *argv[])
 
 #ifdef VECGEOM_GDML
   vecgeom::GeoManager::Instance().SetTransformationCacheDepth(cache_depth);
-  bool load = vgdml::Frontend::Load(gdml_name.c_str(), false);
+  // The vecgeom millimeter unit is the last parameter of vgdml::Frontend::Load
+  bool load = vgdml::Frontend::Load(gdml_name.c_str(), false, 1);
   if (!load) return 3;
 #endif
 

--- a/examples/Example6/example6.cu
+++ b/examples/Example6/example6.cu
@@ -759,7 +759,7 @@ void example6(const vecgeom::cxx::VPlacedVolume *world)
 
     std::cout << std::fixed << std::setprecision(4) << std::setfill(' ');
     std::cout << "iter " << std::setw(4) << iterNo << " -- tracks in flight: " << std::setw(5) << inFlight
-              << " energy deposition: " << std::setw(10) << scoring->totalEnergyDeposit.load()
+              << " energy deposition: " << std::setw(10) << scoring->totalEnergyDeposit.load() / copcore::units::GeV
               << " number of secondaries: " << std::setw(5) << scoring->secondaries.load()
               << " number of hits: " << std::setw(4) << scoring->hits.load();
     std::cout << std::endl;

--- a/tracking/inc/printTracks.h
+++ b/tracking/inc/printTracks.h
@@ -28,5 +28,6 @@ __host__ void printTracks(adept::BlockData<track> *trackBlock, //     adept::Blo
       if (numPrinted++ < numTracks) printTrack<<<1, 1>>>(trackBlock, i, verbose);
     }
   }
+  cudaDeviceSynchronize();
 }
 #endif


### PR DESCRIPTION
This restores the output of the examples, except for rounding errors. Most of those are in `example4` and `example6` because the global energy deposit is a `float`, which doesn't have enough precision for the range of energies we need. In addition, `example4` doesn't produce two secondaries at the end, probably also because of rounding changes for the threshold energy.