### PR TITLE
Add reflection and refraction in RaytraceBenchmark

### DIFF
--- a/base/inc/AdePT/SparseVector.h
+++ b/base/inc/AdePT/SparseVector.h
@@ -70,6 +70,7 @@ __device__ inline bool is_used(int index, const SparseVectorInterface<Type> *sve
   return svector->is_used(index);
 }
 
+template <typename Type>
 __device__ void print_mask(unsigned int mask)
 {
   for (int lane = 0; lane < 32; ++lane) {

--- a/examples/Raytracer_Benchmark/CMakeLists.txt
+++ b/examples/Raytracer_Benchmark/CMakeLists.txt
@@ -30,12 +30,22 @@ list(APPEND ADEPT_CUDA_SRCS
 add_library(raytracercu ${ADEPT_CUDA_SRCS})
 target_include_directories(raytracercu PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
 )
-target_link_libraries(raytracercu AdePT CopCore::CopCore VecCore::VecCore VecGeom::vecgeom VecGeom::vecgeomcuda_static)
+
+target_link_libraries(raytracercu VecCore::VecCore VecGeom::vecgeom VecGeom::vecgeomcuda_static CopCore::CopCore)
+target_compile_options(raytracercu PRIVATE "$<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda;-fmad=false>")
 set_target_properties(raytracercu PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 
 #exec RaytraceBenchmark.cpp
 add_executable(RaytraceBenchmark Raytracer.cpp RaytraceBenchmark.cpp)
-target_link_libraries(RaytraceBenchmark PRIVATE raytracercu AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda VecGeom::vgdml)
+target_include_directories(RaytraceBenchmark PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
+  $<INSTALL_INTERFACE:base>
+)
+target_link_libraries(RaytraceBenchmark VecCore::VecCore VecGeom::vecgeom VecGeom::vecgeomcuda VecGeom::vgdml raytracercu CopCore::CopCore)
+target_compile_options(RaytraceBenchmark PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-fmad=false>")
 set_target_properties(RaytraceBenchmark PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 

--- a/examples/Raytracer_Benchmark/Color.h
+++ b/examples/Raytracer_Benchmark/Color.h
@@ -122,11 +122,6 @@ union Color_t {
     if (hue > 360) hue = hue - 360;
   }
 
-  __host__ __device__ void print()
-  {
-    printf("Red: %d. Green: %d, Blue: %d, Alpha: %d\n", fComp.red, fComp.green, fComp.blue, fComp.alpha);
-  }
-
   __host__ __device__ void print() const
   {
     printf("Red: %d. Green: %d, Blue: %d, Alpha: %d\n", fComp.red, fComp.green, fComp.blue, fComp.alpha);
@@ -185,13 +180,13 @@ __host__ __device__ __forceinline__ Color_t operator+(Color_t const &left, Color
   return color;
 }
 
-__host__ __device__ __forceinline__ Color_t mix_vector_color(int index, adept::Atomic_t<unsigned int> *color, int rays_per_pixel)
+__host__ __device__ __forceinline__ Color_t mix_vector_color(int index, adept::Atomic_t<unsigned int> *color,
+                                                             int rays_per_pixel)
 {
   Color_t left_color(0);
-  for (int j = 0; j < rays_per_pixel; ++j)
-  {
-    if (color[10*index + j].load() > 0) {      
-      Color_t right_color(color[10*index + j].load());
+  for (int j = 0; j < rays_per_pixel; ++j) {
+    if (color[10 * index + j].load() > 0) {
+      Color_t right_color(color[10 * index + j].load());
       left_color += right_color;
     }
   }

--- a/examples/Raytracer_Benchmark/Color.h
+++ b/examples/Raytracer_Benchmark/Color.h
@@ -9,6 +9,7 @@
 
 #include <CopCore/Global.h>
 #include <VecGeom/base/Global.h>
+#include <AdePT/Atomic.h>
 
 namespace adept {
 union Color_t {
@@ -121,6 +122,16 @@ union Color_t {
     if (hue > 360) hue = hue - 360;
   }
 
+  __host__ __device__ void print()
+  {
+    printf("Red: %d. Green: %d, Blue: %d, Alpha: %d\n", fComp.red, fComp.green, fComp.blue, fComp.alpha);
+  }
+
+  __host__ __device__ void print() const
+  {
+    printf("Red: %d. Green: %d, Blue: %d, Alpha: %d\n", fComp.red, fComp.green, fComp.blue, fComp.alpha);
+  }
+
   __host__ __device__ void SetHLS(float hue, float light, float satur)
   {
     float rh, rl, rs, rm1, rm2;
@@ -173,6 +184,20 @@ __host__ __device__ __forceinline__ Color_t operator+(Color_t const &left, Color
   color += right;
   return color;
 }
+
+__host__ __device__ __forceinline__ Color_t mix_vector_color(int index, adept::Atomic_t<unsigned int> *color, int rays_per_pixel)
+{
+  Color_t left_color(0);
+  for (int j = 0; j < rays_per_pixel; ++j)
+  {
+    if (color[10*index + j].load() > 0) {      
+      Color_t right_color(color[10*index + j].load());
+      left_color += right_color;
+    }
+  }
+  return left_color;
+}
+
 } // End namespace adept
 
 #endif // RT_BENCHMARK_COLOR_H_

--- a/examples/Raytracer_Benchmark/Material.h
+++ b/examples/Raytracer_Benchmark/Material.h
@@ -1,0 +1,92 @@
+#include "Raytracer.h"
+
+#include <VecGeom/base/Vector3D.h>
+#include <VecGeom/management/GeoManager.h>
+#include <VecGeom/navigation/NavStatePath.h>
+#include <VecGeom/base/Stopwatch.h>
+
+void getMaterialStruct(MyMediumProp *volume_container, std::vector<vecgeom::LogicalVolume *> logicalvolumes,
+                       bool on_gpu)
+{
+
+  int i = 0;
+
+  for (auto lvol : logicalvolumes) {
+    // lvol->Print();
+    if (!strcmp(lvol->GetName(), "World")) {
+      volume_container[i].material            = kRTtransparent;
+      volume_container[i].fObjColor           = 0x0000FF80;
+      volume_container[i].refr_index          = 1.;
+      volume_container[i].transparency_per_cm = 1.;
+    }
+
+    else if (!strncmp(lvol->GetName(), "SphVol", 6)) {
+      volume_container[i].material            = kRTtransparent;
+      volume_container[i].fObjColor           = 0x0000FF80;
+      volume_container[i].refr_index          = 1.1;
+      volume_container[i].transparency_per_cm = 0.82;
+    }
+
+    else if (!strncmp(lvol->GetName(), "BoxVol", 6)) {
+      volume_container[i].material  = kRTspecular;
+      volume_container[i].fObjColor = 0xFF000080;
+    }
+
+    else if (!strcmp(lvol->GetName(), "M12_10")    || !strcmp(lvol->GetName(), "M12_100x2") ||
+             !strcmp(lvol->GetName(), "M12_100x4") || !strcmp(lvol->GetName(), "M12_12")    ||
+             !strcmp(lvol->GetName(), "M12_120x2") || !strcmp(lvol->GetName(), "M12_120x4") ||
+             !strcmp(lvol->GetName(), "M12_2")     || !strcmp(lvol->GetName(), "M12_20x2")  ||
+             !strcmp(lvol->GetName(), "M12_20x4")  || !strcmp(lvol->GetName(), "M12_4")     ||
+             !strcmp(lvol->GetName(), "M12_40x2")  || !strcmp(lvol->GetName(), "M12_40x4")  ||
+             !strcmp(lvol->GetName(), "M12_6")     || !strcmp(lvol->GetName(), "M12_60x2")  ||
+             !strcmp(lvol->GetName(), "M12_60x4")  || !strcmp(lvol->GetName(), "M12_8")     ||
+             !strcmp(lvol->GetName(), "M12_80x2")  || !strcmp(lvol->GetName(), "M12_80x4")  ||
+             !strcmp(lvol->GetName(), "M14_10")    || !strcmp(lvol->GetName(), "M14_100x2") ||
+             !strcmp(lvol->GetName(), "M14_100x4") || !strcmp(lvol->GetName(), "M14_12")    ||
+             !strcmp(lvol->GetName(), "M14_120x2") || !strcmp(lvol->GetName(), "M14_120x4") ||
+             !strcmp(lvol->GetName(), "M13_2")     || !strcmp(lvol->GetName(), "M13_4")     ||
+             !strcmp(lvol->GetName(), "M13_6")     || !strcmp(lvol->GetName(), "M13_8")     ||
+             !strcmp(lvol->GetName(), "M16_6")     || !strcmp(lvol->GetName(), "M16_60x2")  ||
+             !strcmp(lvol->GetName(), "M14_2")     || !strcmp(lvol->GetName(), "M14_20x2")  ||
+             !strcmp(lvol->GetName(), "M14_20x4")  || !strcmp(lvol->GetName(), "M14_4")     ||
+             !strcmp(lvol->GetName(), "M14_40x2")  || !strcmp(lvol->GetName(), "M14_40x4")  ||
+             !strcmp(lvol->GetName(), "M14_6")     || !strcmp(lvol->GetName(), "M14_60x2")  ||
+             !strcmp(lvol->GetName(), "M14_60x4")  || !strcmp(lvol->GetName(), "M14_8")     ||
+             !strcmp(lvol->GetName(), "M14_80x2")  || !strcmp(lvol->GetName(), "M14_80x4")  ||
+             !strcmp(lvol->GetName(), "M16_12")    || !strcmp(lvol->GetName(), "M16_120x2") ||
+             !strcmp(lvol->GetName(), "M16_10")    || !strcmp(lvol->GetName(), "M16_100x2") ||
+             !strcmp(lvol->GetName(), "M16_2")     || !strcmp(lvol->GetName(), "M16_20x2")  ||
+             !strcmp(lvol->GetName(), "M16_4")     || !strcmp(lvol->GetName(), "M16_40x2")  ||
+             !strcmp(lvol->GetName(), "M16_8")     || !strcmp(lvol->GetName(), "M16_80x2")  ||
+             !strcmp(lvol->GetName(), "M17_2")     || !strcmp(lvol->GetName(), "M17_4")     ||
+             !strcmp(lvol->GetName(), "M18_12")    || !strcmp(lvol->GetName(), "M18_120x2") ||
+             !strcmp(lvol->GetName(), "M18_10")    || !strcmp(lvol->GetName(), "M18_100x2") ||
+             !strcmp(lvol->GetName(), "M18_2")     || !strcmp(lvol->GetName(), "M18_20x2")  ||
+             !strcmp(lvol->GetName(), "M18_4")     || !strcmp(lvol->GetName(), "M18_40x2")  ||
+             !strcmp(lvol->GetName(), "M18_6")     || !strcmp(lvol->GetName(), "M18_60x2")  ||
+             !strcmp(lvol->GetName(), "M18_8")     || !strcmp(lvol->GetName(), "M18_80x2")  ||
+             !strcmp(lvol->GetName(), "M7_10")     || !strcmp(lvol->GetName(), "M7_12")     ||
+             !strcmp(lvol->GetName(), "M7_14")     || !strcmp(lvol->GetName(), "M7_2")      ||
+             !strcmp(lvol->GetName(), "M7_4")      || !strcmp(lvol->GetName(), "M7_6")      || 
+             !strcmp(lvol->GetName(), "M8_2")      || !strcmp(lvol->GetName(), "M8_4")      || 
+             !strcmp(lvol->GetName(), "M8_6")      || !strcmp(lvol->GetName(), "M7_8")      ||
+             !strcmp(lvol->GetName(), "M8_8")      || !strcmp(lvol->GetName(), "M9_10")     ||
+             !strcmp(lvol->GetName(), "M9_12")     || !strcmp(lvol->GetName(), "M9_14")     ||
+             !strcmp(lvol->GetName(), "M9_2")      || !strcmp(lvol->GetName(), "M9_4")      || 
+             !strcmp(lvol->GetName(), "M9_6")      || !strcmp(lvol->GetName(), "M9_8")) {
+      volume_container[i].material            = kRTtransparent;
+      volume_container[i].fObjColor           = 0x0000FF80;
+      volume_container[i].refr_index          = 1.5;
+      volume_container[i].transparency_per_cm = 0.7;
+    } else {
+      volume_container[i].material            = kRTtransparent;
+      volume_container[i].fObjColor           = 0x0000FF80;
+      volume_container[i].refr_index          = 1.;
+      volume_container[i].transparency_per_cm = 1.;
+    }
+
+    if (!on_gpu) lvol->SetBasketManagerPtr(&volume_container[i]);
+
+    i++;
+  }
+}

--- a/examples/Raytracer_Benchmark/Material.h
+++ b/examples/Raytracer_Benchmark/Material.h
@@ -1,11 +1,21 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+/// \file Material.h
+/// \author Antonio Petre (antonio.petre@spacescience.ro)
+
+#ifndef RT_BENCHMARK_MATERIAL_H_
+#define RT_BENCHMARK_MATERIAL_H_
+
 #include "Raytracer.h"
 
 #include <VecGeom/base/Vector3D.h>
 #include <VecGeom/management/GeoManager.h>
 #include <VecGeom/navigation/NavStatePath.h>
 #include <VecGeom/base/Stopwatch.h>
+#include <VecGeom/management/CudaManager.h>
 
-void getMaterialStruct(MyMediumProp *volume_container, std::vector<vecgeom::LogicalVolume *> logicalvolumes,
+void SetMaterialStruct(MyMediumProp *volume_container, std::vector<vecgeom::LogicalVolume *> logicalvolumes,
                        bool on_gpu)
 {
 
@@ -24,7 +34,7 @@ void getMaterialStruct(MyMediumProp *volume_container, std::vector<vecgeom::Logi
       volume_container[i].material            = kRTtransparent;
       volume_container[i].fObjColor           = 0x0000FF80;
       volume_container[i].refr_index          = 1.1;
-      volume_container[i].transparency_per_cm = 0.82;
+      volume_container[i].transparency_per_cm = 0.982;
     }
 
     else if (!strncmp(lvol->GetName(), "BoxVol", 6)) {
@@ -68,12 +78,12 @@ void getMaterialStruct(MyMediumProp *volume_container, std::vector<vecgeom::Logi
              !strcmp(lvol->GetName(), "M7_10")     || !strcmp(lvol->GetName(), "M7_12")     ||
              !strcmp(lvol->GetName(), "M7_14")     || !strcmp(lvol->GetName(), "M7_2")      ||
              !strcmp(lvol->GetName(), "M7_4")      || !strcmp(lvol->GetName(), "M7_6")      || 
-             !strcmp(lvol->GetName(), "M8_2")      || !strcmp(lvol->GetName(), "M8_4")      || 
-             !strcmp(lvol->GetName(), "M8_6")      || !strcmp(lvol->GetName(), "M7_8")      ||
+             !strcmp(lvol->GetName(), "M8_4")      || !strcmp(lvol->GetName(), "M8_6")      ||
              !strcmp(lvol->GetName(), "M8_8")      || !strcmp(lvol->GetName(), "M9_10")     ||
              !strcmp(lvol->GetName(), "M9_12")     || !strcmp(lvol->GetName(), "M9_14")     ||
-             !strcmp(lvol->GetName(), "M9_2")      || !strcmp(lvol->GetName(), "M9_4")      || 
-             !strcmp(lvol->GetName(), "M9_6")      || !strcmp(lvol->GetName(), "M9_8")) {
+             !strcmp(lvol->GetName(), "M9_2")      || !strcmp(lvol->GetName(), "M9_4")      ||
+             !strcmp(lvol->GetName(), "M9_8")      || !strcmp(lvol->GetName(), "M8_2")      || 
+             !strcmp(lvol->GetName(), "M7_8")      || !strcmp(lvol->GetName(), "M9_6")) {
       volume_container[i].material            = kRTtransparent;
       volume_container[i].fObjColor           = 0x0000FF80;
       volume_container[i].refr_index          = 1.5;
@@ -85,8 +95,11 @@ void getMaterialStruct(MyMediumProp *volume_container, std::vector<vecgeom::Logi
       volume_container[i].transparency_per_cm = 1.;
     }
 
-    if (!on_gpu) lvol->SetBasketManagerPtr(&volume_container[i]);
+    if (!on_gpu)
+      lvol->SetBasketManagerPtr(&volume_container[i]);
 
     i++;
   }
 }
+
+#endif // RT_BENCHMARK_MATERIAL_H_

--- a/examples/Raytracer_Benchmark/README.md
+++ b/examples/Raytracer_Benchmark/README.md
@@ -5,7 +5,24 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # RaytraceBenchmark
 
-Geometry example using VecGeom
+## Geometry example using VecGeom
+
+RaytraceBenchmark is a raytracer prototype. The rays are shooted from every "pixel", traverse the geometry model and compute the pixel color based on the model.
+
+The current version uses 2 models:
+- transparent with/without reflection (traverse full geometry) 
+- specular reflection (stop ray when reaching a specular object)
+
+It currently works for only 2 gdml files: "trackML.gdml" (placed in the source tree of vecgeom) and "box_sphere.gdml" (placed in RaytraceBenchmark directoy).
+
+
+## Ray transport
+
+Every ray has a parameter called generation. The initial container contains as many rays as pixels and empty containers are created for the reflected rays of higher generations​.
+
+The current version of scheduling is: transport the ray to first boundary only, then generate reflected ray and increase generation, moving to next container. Then, the refracted ray is transported to the next boundary.
+
+The number of generations for the reflected rays is unknown, so 10 containers are created for secondary rays (the rays with generation greater than 10 will be added in the (generation % 10) container). After transporting all the rays from a container, the initial rays are selected and released. This step is repeated for all the containers. In order to be sure that all the secondary rays are transported, the program verifies if there are any secondary rays in the containers. If yes, reiterate over all the containers and transport the rays.
 
 
 ## How to use:
@@ -28,14 +45,21 @@ $ ./RaytraceBenchmark -gdml_name <path to gdml file>
 - upy - Up vector Y-axis (default: 1)
 - upz - Up vector Z-axis (default: 0)
 - bkgcol - Light color (default: 0xFFFFFF80)
-- use_tiles - run on GPU in tiled mode (default: 0)
-- block_size - block size for tiled mode (default: 8)
+- use_tiles - run on GPU in tiled mode (default: 0) (TODO: not working with the current version)
+- block_size - block size for tiled mode (default: 8) (TODO: not working with the current version)
+
 
 
 ## Light models
 
-- transparent with/without reflection (including attenuation of rays)
-- specular reflection
+The light models are applied at the boundary between 2 volumes, depending on their optical properties.
+
+The light models are:
+
+- transparent with/without reflection and refraction (at the interface between 2 transparent volumes and if their refraction indices are greater than 1 and not equal)
+- specular reflection (if the next volume is specular)
+
+The transparent model includes exponential attenuation of rays. Every material has a constant called "transparency per cm" which is the fraction of the incident light passing through after 1 cm of material. Tuning it can make the whole picture more "transparent" or "opaque".
 
 
 ## Volumes
@@ -50,7 +74,7 @@ $ ./RaytraceBenchmark -gdml_name <path to gdml file>
 	- material: transparent
 	- object color: 0x0000FF80
 	- refraction index: 1.1
-	- transparency per cm: 0.82
+	- transparency per cm: 0.982
 
 - Box: 
 	- material: kRTspecular

--- a/examples/Raytracer_Benchmark/README.md
+++ b/examples/Raytracer_Benchmark/README.md
@@ -1,0 +1,69 @@
+<!--
+SPDX-FileCopyrightText: 2020 CERN
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# RaytraceBenchmark
+
+Geometry example using VecGeom
+
+
+## How to use:
+
+```console
+$ ./RaytraceBenchmark -gdml_name <path to gdml file>
+```
+
+## Parameters
+
+- on_gpu - run on GPU (default: 1)
+- px - Image size in pixels X-axis (default: 1840)
+- py - Image size in pixels Y-axis (default: 512)
+- view - RT view as in { kRTVparallel = 0, kRTVperspective } (default: kRTVperspective)
+- reflection - Use reflection and refraction model (default: 0)
+- screenx - Screen position in world coordinates X-axis (default: -5000)
+- screeny - Screen position in world coordinates Y-axis (default: 0)
+- screenz - Screen position in world coordinates Z-axis (default: 0)
+- upx - Up vector X-axis (default: 0)
+- upy - Up vector Y-axis (default: 1)
+- upz - Up vector Z-axis (default: 0)
+- bkgcol - Light color (default: 0xFFFFFF80)
+- use_tiles - run on GPU in tiled mode (default: 0)
+- block_size - block size for tiled mode (default: 8)
+
+
+## Light models
+
+- transparent with/without reflection (including attenuation of rays)
+- specular reflection
+
+
+## Volumes
+
+- World: 
+	 - material: transparent
+	 - object color: 0x0000FF80
+	 - refraction index: 1
+	 - transparency per cm: 1
+
+- Sphere: 
+	- material: transparent
+	- object color: 0x0000FF80
+	- refraction index: 1.1
+	- transparency per cm: 0.82
+
+- Box: 
+	- material: kRTspecular
+	- object color: 0xFF000080
+
+- trackML objects: 
+	- material: transparent
+	- object color: 0x0000FF80
+	- refraction index: 1.5
+	- transparency per cm: 0.7
+
+- Other objects:
+	- material: transparent
+	- object color: 0x0000FF80
+	- refraction index: 1
+	- transparency per cm: 1

--- a/examples/Raytracer_Benchmark/RaytraceBenchmark.cu
+++ b/examples/Raytracer_Benchmark/RaytraceBenchmark.cu
@@ -22,26 +22,27 @@
 
 #include <cassert>
 #include <cstdio>
+#include <vector>
 
-__global__ void RenderTile(adept::BlockData<Ray_t> *rays, RaytracerData_t rtdata, int offset_x, int offset_y,
-                           int tile_size_x, int tile_size_y, unsigned char *tile_in, unsigned char *tile_out)
+__global__ void RenderTile(RaytracerData_t rtdata, int offset_x, int offset_y,
+                           int tile_size_x, int tile_size_y, unsigned char *tile_in, unsigned char *tile_out, int generation)
 {
   int local_px = threadIdx.x + blockIdx.x * blockDim.x;
   int local_py = threadIdx.y + blockIdx.y * blockDim.y;
 
   if (local_px >= tile_size_x || local_py >= tile_size_y) return;
 
-  int ray_index   = local_py * tile_size_x + local_px;
   int pixel_index = 4 * (local_py * tile_size_x + local_px);
 
   int global_px = offset_x + local_px;
   int global_py = offset_y + local_py;
 
-  Ray_t *ray = (Ray_t *)(tile_in + ray_index * sizeof(Ray_t));
-  ray->index = ray_index;
+  int ray_index = global_py*tile_size_x + global_px;
 
-  (*rays)[ray_index]         = *ray;
-  adept::Color_t pixel_color = Raytracer::RaytraceOne(rtdata, rays, global_px, global_py, ray->index);
+  if (!(rtdata.sparse_rays)[generation]->is_used(ray_index)) return;
+  Ray_t *ray = &(*rtdata.sparse_rays[generation])[ray_index];
+
+  auto pixel_color = Raytracer::RaytraceOne(rtdata, *ray, generation);
 
   tile_out[pixel_index + 0] = pixel_color.fComp.red;
   tile_out[pixel_index + 1] = pixel_color.fComp.green;
@@ -50,8 +51,7 @@ __global__ void RenderTile(adept::BlockData<Ray_t> *rays, RaytracerData_t rtdata
 }
 
 // subdivide image in 16 tiles and launch each tile on a separate CUDA stream
-void RenderTiledImage(adept::BlockData<Ray_t> *rays, cuda::RaytracerData_t *rtdata, NavIndex_t *output_buffer,
-                      int block_size)
+void RenderTiledImage(cuda::RaytracerData_t *rtdata, NavIndex_t *output_buffer, int generation, int block_size)
 {
   cudaStream_t streams[4];
 
@@ -87,8 +87,8 @@ void RenderTiledImage(adept::BlockData<Ray_t> *rays, cuda::RaytracerData_t *rtda
       int offset_x = ix * tile_size_x;
       int offset_y = iy * tile_size_y;
 
-      RenderTile<<<blocks, threads, 0, streams[iy]>>>(rays, *rtdata, offset_x, offset_y, tile_size_x, tile_size_y,
-                                                      tile_device_in[idx], tile_device_out[idx]);
+      RenderTile<<<blocks, threads, 0, streams[iy]>>>(*rtdata, offset_x, offset_y, tile_size_x, tile_size_y,
+                                                      tile_device_in[idx], tile_device_out[idx], generation);
     }
   }
 
@@ -137,7 +137,43 @@ void RenderTiledImage(adept::BlockData<Ray_t> *rays, cuda::RaytracerData_t *rtda
   COPCORE_CUDA_CHECK(cudaGetLastError());
 }
 
-void initiliazeCudaWorld(cuda::RaytracerData_t *rtdata) {
+__global__ void getAllLogicalVolumes(vecgeom::VPlacedVolume *currentVolume, vecgeom::Vector<vecgeom::LogicalVolume *> *container)
+{
+  
+  auto lvol = (vecgeom::LogicalVolume *)currentVolume->GetLogicalVolume();
+  bool cond = true;
+
+  for (auto it = container->begin(); it != container->end(); it++) {
+    if (lvol == *it)
+      cond = false;
+  }
+
+  if (cond) {
+    container->reserve(1*sizeof(vecgeom::LogicalVolume *));
+    container->push_back(lvol);
+  }
+
+  const vecgeom::Vector<vecgeom::VPlacedVolume const *> placedvolumes = lvol->GetDaughters();
+
+  for (auto crt: placedvolumes) {
+    getAllLogicalVolumes<<<1,1>>>((vecgeom::VPlacedVolume *)  crt, container);
+  }
+}
+
+
+// Attach material structure to all logical volumes
+__global__ void AttachRegions(const MyMediumProp *volume_container, vecgeom::Vector<vecgeom::LogicalVolume *> *container)
+{
+  int i = 0;
+  for (auto x: *container) {
+    // x->Print();
+    x->SetBasketManagerPtr((void *)&volume_container[i]);
+    i++;
+  }
+}
+
+
+void initiliazeCudaWorld(cuda::RaytracerData_t *rtdata, const MyMediumProp *volume_container) {
   
   // Load and synchronize the geometry on the GPU
   auto &cudaManager = vecgeom::cxx::CudaManager::Instance();
@@ -153,11 +189,19 @@ void initiliazeCudaWorld(cuda::RaytracerData_t *rtdata) {
   rtdata->fVPstate = vpstate;
   rtdata->fWorld   = gpu_world;
 
+  vecgeom::Vector<vecgeom::LogicalVolume *> *container;
+  cudaMallocManaged(&container, sizeof(vecgeom::Vector<vecgeom::LogicalVolume *>));
+
+  getAllLogicalVolumes<<<1,1>>>((vecgeom::VPlacedVolume *)gpu_world, container);
+
+  cudaDeviceSynchronize();
+
+  AttachRegions<<<1,1>>>(volume_container, container);
 }
 
-int executePipelineGPU(const vecgeom::cxx::VPlacedVolume *world, int argc, char *argv[])
+int executePipelineGPU(const MyMediumProp *volume_container, const vecgeom::cxx::VPlacedVolume *world, int argc, char *argv[])
 {
   int result;
-  result = runSimulation<copcore::BackendType::CUDA>(world, argc, argv);
+  result = runSimulation<copcore::BackendType::CUDA>(volume_container, world, argc, argv);
   return result;
 }

--- a/examples/Raytracer_Benchmark/RaytraceBenchmark.hpp
+++ b/examples/Raytracer_Benchmark/RaytraceBenchmark.hpp
@@ -3,11 +3,14 @@
 
 #include "Raytracer.h"
 #include "kernels.h"
+#include <vector>
+#include "Color.h"
 
 #include <CopCore/Global.h>
 #include <AdePT/ArgParser.h>
 #include <AdePT/BlockData.h>
 #include <AdePT/LoopNavigator.h>
+#include <AdePT/SparseVector.h>
 
 #include <VecGeom/base/Vector3D.h>
 #include <VecGeom/management/GeoManager.h>
@@ -16,32 +19,51 @@
 #include <VecGeom/management/CudaManager.h>
 #include <VecGeom/base/Global.h>
 
+#include <atomic>
+
 #ifdef VECGEOM_GDML
 #include <VecGeom/gdml/Frontend.h>
 #endif
 
-void initiliazeCudaWorld(RaytracerData_t *rtdata);
+void initiliazeCudaWorld(RaytracerData_t *rtdata, const MyMediumProp *volume_container);
 
-void RenderTiledImage(adept::BlockData<Ray_t> *rays, RaytracerData_t *rtdata, NavIndex_t *output_buffer,
-                      int block_size);
+void RenderTiledImage(RaytracerData_t *rtdata, NavIndex_t *output_buffer, int generation, int block_size);
 
 template <copcore::BackendType backend>
-void InitRTdata(RaytracerData_t *rtdata)
+void InitRTdata(RaytracerData_t *rtdata, const MyMediumProp *volume_container, int no_generations)
 {
+  Vector_t **x;
 
   if (backend == copcore::BackendType::CUDA) {
-    initiliazeCudaWorld((RaytracerData_t *)rtdata);
+    initiliazeCudaWorld((RaytracerData_t *)rtdata, volume_container);
+    
+    COPCORE_CUDA_CHECK(cudaMalloc(&x, no_generations * sizeof(Vector_t)));
+
+    for (int i = 0; i < no_generations; ++i) {
+      COPCORE_CUDA_CHECK(cudaMalloc(&x[i], sizeof(Vector_t)));
+      Vector_t::MakeInstanceAt(&x[i]);
+    }
+
   } else {
     vecgeom::NavStateIndex vpstate;
     LoopNavigator::LocatePointIn(rtdata->fWorld, rtdata->fStart, vpstate, true);
     rtdata->fVPstate = vpstate;
+
+    COPCORE_CUDA_CHECK(cudaMallocManaged(&x, no_generations * sizeof(Vector_t *)));
+
+    for (int i = 0; i < no_generations; ++i) {
+      COPCORE_CUDA_CHECK(cudaMallocManaged(&(x[i]), sizeof(Vector_t)));
+      Vector_t::MakeInstanceAt(x[i]);
+    }
+    
   }
+  rtdata->sparse_rays = x;
 }
 
 template <copcore::BackendType backend>
-int runSimulation(const vecgeom::cxx::VPlacedVolume *world, int argc, char *argv[])
+int runSimulation(const MyMediumProp *volume_container, const vecgeom::cxx::VPlacedVolume *world, int argc,
+                  char *argv[])
 {
-
   // image size in pixels
   OPTION_INT(px, 1840);
   OPTION_INT(py, 512);
@@ -51,6 +73,9 @@ int runSimulation(const vecgeom::cxx::VPlacedVolume *world, int argc, char *argv
 
   // RT view as in { kRTVparallel = 0, kRTVperspective };
   OPTION_INT(view, 1);
+
+  // Use reflection
+  OPTION_BOOL(reflection, 0);
 
   // zoom w.r.t to the default view mode
   OPTION_DOUBLE(zoom, 3.5);
@@ -66,10 +91,8 @@ int runSimulation(const vecgeom::cxx::VPlacedVolume *world, int argc, char *argv
   OPTION_DOUBLE(upz, 0);
   vecgeom::Vector3D<double> up(upx, upy, upz);
 
-  // Light color, object color (no color per volume yet) - in RGBA chars compressed into an unsigned integer
-  OPTION_INT(bkgcol, 0xFF000080); // red (keep 80 as alpha channel for correct color blending)
-  OPTION_INT(objcol, 0x0000FF80); // blue
-  OPTION_INT(vdepth, 4);          // visible depth
+  // Light color - in RGBA chars compressed into an unsigned integer
+  OPTION_INT(bkgcol, 0xFFFFFF80); // white (keep 80 as alpha channel for correct color blending)
 
   OPTION_INT(use_tiles, 0);  // run on GPU in tiled mode
   OPTION_INT(block_size, 8); // run on GPU in tiled mode
@@ -85,71 +108,119 @@ int runSimulation(const vecgeom::cxx::VPlacedVolume *world, int argc, char *argv
   rtdata->fSize_px  = px;
   rtdata->fSize_py  = py;
   rtdata->fBkgColor = bkgcol;
-  rtdata->fObjColor = objcol;
-  rtdata->fVisDepth = vdepth;
+  rtdata->fReflection = reflection;
 
   Raytracer::InitializeModel((Raytracer::VPlacedVolumePtr_t)world, *rtdata);
 
-  InitRTdata<backend>(rtdata);
-
-  rtdata->Print();
+  constexpr int VectorSize = 1 << 22;
+  const int no_pixels      = rtdata->fSize_py * rtdata->fSize_px;
 
   using RayBlock     = adept::BlockData<Ray_t>;
   using RayAllocator = copcore::VariableSizeObjAllocator<RayBlock, backend>;
   using Launcher_t   = copcore::Launcher<backend>;
   using StreamStruct = copcore::StreamType<backend>;
   using Stream_t     = typename StreamStruct::value_type;
+  using Vector_t     = adept::SparseVector<Ray_t, VectorSize>; // 1<<16 is the default vector size if parameter omitted
+  using VectorInterface = adept::SparseVectorInterface<Ray_t>;
 
-  // initialize BlockData of Ray_t structure
-  int capacity = 1 << 20;
-  RayAllocator hitAlloc(capacity);
-  RayBlock *rays = hitAlloc.allocate(1);
+  int no_generations = 1;
+  if (rtdata->fReflection) no_generations = 10;
+  int rays_per_pixel = 10;  // maximum number of rays per pixel
+
+  InitRTdata<backend>(rtdata, volume_container, no_generations);
+
+  rtdata->Print();
+
+  // rtdata->sparse_rays = array_ptr;
+  COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
 
   // Boilerplate to get the pointers to the device functions to be used
-  COPCORE_CALLABLE_DECLARE(generateFunc, generateRays);
+  COPCORE_CALLABLE_DECLARE(generateRaysFunc, generateRays);
   COPCORE_CALLABLE_DECLARE(renderkernelFunc, renderKernels);
 
   // Create a stream to work with.
   Stream_t stream;
   StreamStruct::CreateStream(stream);
 
-  // Allocate slots for the BlockData
   Launcher_t generate(stream);
-  generate.Run(generateFunc, capacity, {0, 0}, rays);
-
-  generate.WaitStream();
 
   // Allocate and initialize all rays on the host
   size_t raysize = Ray_t::SizeOfInstance();
   printf("=== Allocating %.3f MB of ray data on the %s\n", (float)rtdata->fNrays * raysize / 1048576,
          copcore::BackendName(backend));
 
-  copcore::Allocator<NavIndex_t, backend> charAlloc;
-  NavIndex_t *input_buffer = charAlloc.allocate(rtdata->fNrays * raysize * sizeof(NavIndex_t));
-
   copcore::Allocator<NavIndex_t, backend> ucharAlloc;
   NavIndex_t *output_buffer = ucharAlloc.allocate(4 * rtdata->fNrays * sizeof(NavIndex_t));
 
-  // Construct rays in place
-  for (int iray = 0; iray < rtdata->fNrays; ++iray)
-    Ray_t::MakeInstanceAt(input_buffer + iray * raysize);
+  using Atomic_t = adept::Atomic_t<unsigned int>;
+
+  adept::Atomic_t<unsigned int> *color;
+  COPCORE_CUDA_CHECK(cudaMallocManaged(&color, rays_per_pixel * no_pixels * sizeof(adept::Atomic_t<unsigned int>)));
 
   vecgeom::Stopwatch timer;
   timer.Start();
 
+  unsigned *sel_vector_d;
+  COPCORE_CUDA_CHECK(cudaMallocManaged(&sel_vector_d, VectorSize * sizeof(unsigned)));
+  COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
+
+  unsigned *nselected_hd;
+  COPCORE_CUDA_CHECK(cudaMallocManaged(&nselected_hd, sizeof(unsigned)));
+  COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
+
+  // Add initial rays in container
+  generate.Run(generateRaysFunc, no_pixels, {0, 0}, *rtdata);
+  COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
+
   if (backend == copcore::BackendType::CUDA && use_tiles) {
-    RenderTiledImage(rays, (RaytracerData_t *)rtdata, output_buffer, block_size);
+    RenderTiledImage((RaytracerData_t *)rtdata, output_buffer, 0, block_size);
   } else {
     Launcher_t renderKernel(stream);
-    renderKernel.Run(renderkernelFunc, rays->GetNused(), {0, 0}, rays, *rtdata, input_buffer, output_buffer);
-    renderKernel.WaitStream();
+    while (check_used(*rtdata, no_generations)) {
+      for (int i = 0; i < no_generations; ++i) {
+        renderKernel.Run(renderkernelFunc, VectorSize, {0, 0}, *rtdata, i, rays_per_pixel, color);
+        COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
+
+        auto select_func = [] __device__(int i, const VectorInterface *arr) { return ((*arr)[i].fDone == true); };
+        VectorInterface::select(rtdata->sparse_rays[i], select_func, sel_vector_d, nselected_hd);
+        COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
+
+        VectorInterface::release_selected(rtdata->sparse_rays[i], sel_vector_d, nselected_hd);
+        COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
+
+        VectorInterface::select_used(rtdata->sparse_rays[i], sel_vector_d, nselected_hd);
+        COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
+      }
+      // printf("-----------------------------------------\n");
+    }
   }
+
+  for (int i = 0; i < no_pixels; i++) {
+    int pixel_index = 4 * i;
+    adept::Color_t pixel = mix_vector_color(i, color, rays_per_pixel);
+    output_buffer[pixel_index + 0] = pixel.fComp.red;
+    output_buffer[pixel_index + 1] = pixel.fComp.green;
+    output_buffer[pixel_index + 2] = pixel.fComp.blue;
+    output_buffer[pixel_index + 3] = 255;
+  }
+
+  // Print basic information about containers
+  for (int i = 0; i < no_generations; ++i)
+    print_vector(rtdata->sparse_rays[i]);
 
   auto time_cpu = timer.Stop();
   std::cout << "Run time: " << time_cpu << "\n";
 
   // Write the output
   write_ppm("output.ppm", output_buffer, rtdata->fSize_px, rtdata->fSize_py);
+
+  for (int i = 0; i < no_generations; ++i)
+    COPCORE_CUDA_CHECK(cudaFree(rtdata->sparse_rays[i]));
+
+  COPCORE_CUDA_CHECK(cudaFree(rtdata->sparse_rays));
+  COPCORE_CUDA_CHECK(cudaFree(color));
+  COPCORE_CUDA_CHECK(cudaFree(sel_vector_d));
+  COPCORE_CUDA_CHECK(cudaFree(nselected_hd));
 
   return 0;
 }

--- a/examples/Raytracer_Benchmark/Raytracer.cpp
+++ b/examples/Raytracer_Benchmark/Raytracer.cpp
@@ -196,6 +196,7 @@ void ApplyRTmodel(Ray_t &ray, double step, RaytracerData_t const &rtdata, int ge
   bool exit_transparent        = medium_prop_last->material == kRTtransparent;
   bool transparent_transparent = medium_prop_next->material == kRTtransparent &&
                                  medium_prop_last->material == kRTtransparent &&
+                                 medium_prop_last->refr_index != medium_prop_next->refr_index &&
                                  (medium_prop_next->refr_index * medium_prop_last->refr_index) > 1.;
 
   if (exit_transparent) {
@@ -240,7 +241,7 @@ void ApplyRTmodel(Ray_t &ray, double step, RaytracerData_t const &rtdata, int ge
     ray.generation++; // increase generation before making a copy of the ray, so daughters will inherit the new value
 
     if (kr * initial_int > 0.1) {
-      Ray_t *reflected_ray = (totalreflect) ? &ray : rtdata.sparse_rays[ray.generation % 10]->next_free(ray);
+      Ray_t *reflected_ray = (totalreflect) ? &ray : rtdata.sparse_rays[ray.generation % 10].next_free(ray);
       if (!reflected_ray) COPCORE_EXCEPTION("No available rays left.");
 
       // Update reflected ray direction and state

--- a/examples/Raytracer_Benchmark/Raytracer.h
+++ b/examples/Raytracer_Benchmark/Raytracer.h
@@ -129,29 +129,29 @@ struct RaytracerData_t {
   using VPlacedVolumePtr_t = vecgeom::VPlacedVolume const *;
   using Array_t            = adept::SparseVector<Ray_t, 1 << 22>;
 
-  double fScale     = 0;                ///< Scaling from pixels to world coordinates
-  double fShininess = 1.;               ///< Shininess exponent in the specular model
-  double fZoom      = 1.;               ///< Zoom with respect to the default view
-  vecgeom::Vector3D<double> fSourceDir; ///< Light source direction
-  vecgeom::Vector3D<double> fScreenPos; ///< Screen position
-  vecgeom::Vector3D<double> fStart;     ///< Eye position in perspectove mode
-  vecgeom::Vector3D<double> fDir;       ///< Start direction of all rays in parallel view mode
-  vecgeom::Vector3D<double> fUp;        ///< Up vector in the shooting rectangle plane
-  vecgeom::Vector3D<double> fRight;     ///< Right vector in the shooting rectangle plane
-  vecgeom::Vector3D<double> fLeftC;     ///< left-down corner of the ray shooting rectangle
-  int fVerbosity = 0;                   ///< Verbosity level
-  int fNrays     = 0;                   ///< Number of rays left to propagate
-  int fSize_px   = 1024;                ///< Image pixel size in x
-  int fSize_py   = 1024;                ///< Image pixel size in y
-  adept::Color_t fBkgColor = 0xFFFFFF80; ///< Background color
-  ERTmodel fModel  = kRTxray;         ///< Selected RT model
-  ERTView fView    = kRTVperspective; ///< View type
-  bool fReflection = false;           ///< Reflection model
+  double fScale     = 0;                      ///< Scaling from pixels to world coordinates
+  double fShininess = 1.;                     ///< Shininess exponent in the specular model
+  double fZoom      = 1.;                     ///< Zoom with respect to the default view
+  vecgeom::Vector3D<double> fSourceDir;       ///< Light source direction
+  vecgeom::Vector3D<double> fScreenPos;       ///< Screen position
+  vecgeom::Vector3D<double> fStart;           ///< Eye position in perspectove mode
+  vecgeom::Vector3D<double> fDir;             ///< Start direction of all rays in parallel view mode
+  vecgeom::Vector3D<double> fUp;              ///< Up vector in the shooting rectangle plane
+  vecgeom::Vector3D<double> fRight;           ///< Right vector in the shooting rectangle plane
+  vecgeom::Vector3D<double> fLeftC;           ///< left-down corner of the ray shooting rectangle
+  int fVerbosity           = 0;               ///< Verbosity level
+  int fNrays               = 0;               ///< Number of rays left to propagate
+  int fSize_px             = 1024;            ///< Image pixel size in x
+  int fSize_py             = 1024;            ///< Image pixel size in y
+  adept::Color_t fBkgColor = 0xFFFFFF80;      ///< Background color
+  ERTmodel fModel          = kRTxray;         ///< Selected RT model
+  ERTView fView            = kRTVperspective; ///< View type
+  bool fReflection         = false;           ///< Reflection model
 
   VPlacedVolumePtr_t fWorld = nullptr; ///< World volume
   vecgeom::NavStateIndex fVPstate;     ///< Navigation state corresponding to the viewpoint
 
-  Array_t **sparse_rays = nullptr; ///< pointer to the rays containers
+  Array_t *sparse_rays = nullptr; ///< pointer to the rays containers
 
   __host__ __device__ void Print();
 };
@@ -174,8 +174,8 @@ __host__ __device__ void InitializeModel(VPlacedVolumePtr_t world, RaytracerData
 __host__ __device__ void ApplyRTmodel(Ray_t &ray, double step, RaytracerData_t const &rtdata, int generation);
 
 /// \brief Entry point to propagate all rays
-// __host__ __device__ void PropagateRays(adept::BlockData<Ray_t> *rays, RaytracerData_t &data, unsigned char *rays_buffer,
-                                       // unsigned char *output_buffer);
+// __host__ __device__ void PropagateRays(adept::BlockData<Ray_t> *rays, RaytracerData_t &data, unsigned char
+// *rays_buffer, unsigned char *output_buffer);
 
 __host__ __device__ void InitRay(RaytracerData_t const &rtdata, Ray_t &ray);
 

--- a/examples/Raytracer_Benchmark/box_sphere.gdml
+++ b/examples/Raytracer_Benchmark/box_sphere.gdml
@@ -1,0 +1,156 @@
+<?xml version="1.0"?>
+<!-- SPDX-FileCopyrightText: 2020 CERN -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+  <define>
+    <position name="trbox" x="25" y="10" z="5" unit="cm"/> 
+    <position name="trbox2" x="25" y="-20" z="-10" unit="cm"/>    
+  </define>
+
+  <materials>
+    <isotope N="14" Z="7" name="N14">
+      <atom unit="g/mole" value="14.0031"/>
+    </isotope>
+    <isotope N="15" Z="7" name="N15">
+      <atom unit="g/mole" value="15.0001"/>
+    </isotope>
+    <element name="N">
+      <fraction n="0.99632" ref="N14"/>
+      <fraction n="0.00368" ref="N15"/>
+    </element>
+    <isotope N="16" Z="8" name="O16">
+      <atom unit="g/mole" value="15.9949"/>
+    </isotope>
+    <isotope N="17" Z="8" name="O17">
+      <atom unit="g/mole" value="16.9991"/>
+    </isotope>
+    <isotope N="18" Z="8" name="O18">
+      <atom unit="g/mole" value="17.9992"/>
+    </isotope>
+    <element name="O">
+      <fraction n="0.99757" ref="O16"/>
+      <fraction n="0.00038" ref="O17"/>
+      <fraction n="0.00205" ref="O18"/>
+    </element>
+    <isotope N="36" Z="18" name="Ar36">
+      <atom unit="g/mole" value="35.9675"/>
+    </isotope>
+    <isotope N="38" Z="18" name="Ar38">
+      <atom unit="g/mole" value="37.9627"/>
+    </isotope>
+    <isotope N="40" Z="18" name="Ar40">
+      <atom unit="g/mole" value="39.9624"/>
+    </isotope>
+    <element name="Ar">
+      <fraction n="0.003365" ref="Ar36"/>
+      <fraction n="0.000632" ref="Ar38"/>
+      <fraction n="0.996003" ref="Ar40"/>
+    </element>
+    <isotope N="1" Z="1" name="H1">
+      <atom unit="g/mole" value="1.00782503081372"/>
+    </isotope>
+    <isotope N="2" Z="1" name="H2">
+      <atom unit="g/mole" value="2.01410199966617"/>
+    </isotope>
+    <element name="H">
+      <fraction n="0.999885" ref="H1"/>
+      <fraction n="0.000115" ref="H2"/>
+    </element>
+    <isotope N="28" Z="14" name="Si28">
+      <atom unit="g/mole" value="27.9769"/>
+    </isotope>
+    <isotope N="29" Z="14" name="Si29">
+      <atom unit="g/mole" value="28.9765"/>
+    </isotope>
+    <isotope N="30" Z="14" name="Si30">
+      <atom unit="g/mole" value="29.9738"/>
+    </isotope>
+    <element name="Si">
+      <fraction n="0.922296077703922" ref="Si28"/>
+      <fraction n="0.0468319531680468" ref="Si29"/>
+      <fraction n="0.0308719691280309" ref="Si30"/>
+    </element>
+    <isotope N="10" Z="5" name="B10">
+      <atom unit="g/mole" value="10.0129"/>
+    </isotope>
+    <isotope N="11" Z="5" name="B11">
+      <atom unit="g/mole" value="11.0093"/>
+    </isotope>
+    <element name="B">
+      <fraction n="0.199" ref="B10"/>
+      <fraction n="0.801" ref="B11"/>
+    </element>
+    <isotope N="23" Z="11" name="Na23">
+      <atom unit="g/mole" value="22.9898"/>
+    </isotope>
+    <element name="Na">
+      <fraction n="1" ref="Na23"/>
+    </element>
+    <material name="Air" state="gas">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="85.538"/>
+      <D unit="g/cm3" value="0.001213999361243"/>
+      <fraction n="0.7494" ref="N"/>
+      <fraction n="0.2369" ref="O"/>
+      <fraction n="0.0129" ref="Ar"/>
+      <fraction n="0.0008" ref="H"/>
+    </material>
+    <material Z="13" name="Aluminum" state="solid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="166"/>
+      <D unit="g/cm3" value="2.69999857937074"/>
+      <atom unit="g/mole" value="26.9799858042305"/>
+    </material>
+    <material name="Glass" state="solid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="120.46236050308"/>
+      <D unit="g/cm3" value="2.22999882666546"/>
+      <fraction n="0.36611059" ref="Si"/>
+      <fraction n="0.53173295" ref="O"/>
+      <fraction n="0.042228491" ref="B"/>
+      <fraction n="0.059927964" ref="Na"/>
+    </material>
+  </materials>
+
+  <solids>
+    <box name="world" x="100" y="100" z="100" lunit="cm"/>
+    <sphere name="sphere" rmin="0" rmax="20" startphi="0" deltaphi="360" starttheta="0" deltatheta="180" aunit="deg" lunit="cm"/>
+    <box name="box" x="10" y="30" z="5" lunit="cm"/>
+    <box name="box2" x="10" y="30" z="5" lunit="cm"/>
+  </solids>
+
+  <structure>
+    <volume name="SphVol">
+      <materialref ref="Glass"/>
+      <solidref ref="sphere"/>
+    </volume>
+    <volume name="BoxVoll">
+      <materialref ref="Aluminum"/>
+      <solidref ref="box2"/>
+    </volume>
+    <volume name="BoxVol">
+      <materialref ref="Aluminum"/>
+      <solidref ref="box"/>
+    </volume>
+    <volume name="World">
+      <materialref ref="Air"/>
+      <solidref ref="world"/>
+      <physvol name="sph_0" copynumber="0">
+        <volumeref ref="SphVol"/>
+      </physvol>
+      <physvol name="box_1" copynumber="0">
+        <volumeref ref="BoxVoll"/>
+        <positionref ref="trbox2"/>
+      </physvol>
+      <physvol name="box_0" copynumber="0">
+        <volumeref ref="BoxVol"/>
+        <positionref ref="trbox"/>
+      </physvol>
+      
+    </volume>
+  </structure>
+
+  <setup name="default" version="1.0">
+    <world ref="World"/>
+  </setup>
+</gdml>

--- a/examples/Raytracer_Benchmark/kernels.h
+++ b/examples/Raytracer_Benchmark/kernels.h
@@ -11,18 +11,17 @@
 inline namespace COPCORE_IMPL {
 
 constexpr int VectorSize = 1 << 22;
-using Vector_t = adept::SparseVector<Ray_t, VectorSize>;
+using Vector_t           = adept::SparseVector<Ray_t, VectorSize>;
 
 // Add color in the vector of color (ascending order)
-__host__ __device__ void add_color(int index, int rays_per_pixel, adept::Atomic_t<unsigned int> *color, unsigned int pixel_color)
+__host__ __device__ void add_color(int index, int rays_per_pixel, adept::Atomic_t<unsigned int> *color,
+                                   unsigned int pixel_color)
 {
-  for (int i = index; i < index + rays_per_pixel; ++i)
-  {
+  for (int i = index; i < index + rays_per_pixel; ++i) {
     if (color[i].load() == 0) {
       color[i].store(pixel_color);
       return;
-    }
-    else if (pixel_color < color[i].load()){
+    } else if (pixel_color < color[i].load()) {
       unsigned int x = color[i].load();
       color[i].store(pixel_color);
       pixel_color = x;
@@ -33,7 +32,7 @@ __host__ __device__ void add_color(int index, int rays_per_pixel, adept::Atomic_
 // Add initial rays in SparseVector
 __host__ __device__ void generateRays(int id, const RaytracerData_t &rtdata)
 {
-  Ray_t *ray      = rtdata.sparse_rays[0]->next_free();
+  Ray_t *ray      = rtdata.sparse_rays[0].next_free();
   ray->index      = id;
   ray->generation = 0;
   ray->intensity.store(1.);
@@ -47,19 +46,19 @@ __host__ __device__ void renderKernels(int id, const RaytracerData_t &rtdata, in
                                        adept::Atomic_t<unsigned int> *color)
 {
   // Propagate all rays and write out the image on the backend
-  if (!(rtdata.sparse_rays)[generation]->is_used(id)) return;
+  if (!(rtdata.sparse_rays)[generation].is_used(id)) return;
 
-  Ray_t &ray = (*rtdata.sparse_rays[generation])[id];
+  Ray_t &ray = rtdata.sparse_rays[generation][id];
 
   auto pixel_color = Raytracer::RaytraceOne(rtdata, ray, generation);
-  if (pixel_color.fColor == 0)
-    return;
+  if (pixel_color.fColor == 0) return;
 
-  add_color(rays_per_pixel*ray.index, rays_per_pixel, color, pixel_color.fColor);
+  add_color(rays_per_pixel * ray.index, rays_per_pixel, color, pixel_color.fColor);
 }
 
 COPCORE_CALLABLE_FUNC(renderKernels)
 
+// Print information about containers
 __host__ __device__ void print_vector(Vector_t *vect)
 {
   printf("=== vect: fNshared=%lu/%lu fNused=%lu fNbooked=%lu - shared=%.1f%% sparsity=%.1f%%\n", vect->size(),
@@ -67,14 +66,16 @@ __host__ __device__ void print_vector(Vector_t *vect)
          100. * vect->get_sparsity());
 }
 
+COPCORE_CALLABLE_FUNC(print_vector)
+
 // Check if there are rays in containers
-__host__ __device__ bool check_used(const RaytracerData_t &rtdata, int no_generations)
+__host__ bool check_used_cpp(const RaytracerData_t &rtdata, int no_generations)
 {
 
   auto rays_containers = rtdata.sparse_rays;
 
   for (int i = 0; i < no_generations; ++i) {
-    if (rays_containers[i]->size_used() > 0) return true;
+    if (rays_containers[i].size_used() > 0) return true;
   }
 
   return false;


### PR DESCRIPTION
Add reflection and refraction model for transparent objects. Add exponential attenuation for rays which traverse transparent layers. Structure storing optical properties (transparency, refraction index, object color) for every logical volume.