### PR TITLE
Fix compilation with older versions of CUDA

### DIFF
--- a/examples/Example9/example9.cu
+++ b/examples/Example9/example9.cu
@@ -272,7 +272,7 @@ void example9(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double
                                                                                      electrons.queues.relocate);
 
       COPCORE_CUDA_CHECK(cudaEventRecord(electrons.event, electrons.stream));
-      COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, electrons.event));
+      COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, electrons.event, 0));
     }
 
     // *** POSITRONS ***
@@ -291,7 +291,7 @@ void example9(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double
                                                                                      positrons.queues.relocate);
 
       COPCORE_CUDA_CHECK(cudaEventRecord(positrons.event, positrons.stream));
-      COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, positrons.event));
+      COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, positrons.event, 0));
     }
 
     // *** GAMMAS ***
@@ -310,7 +310,7 @@ void example9(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double
                                                                                   gammas.queues.relocate);
 
       COPCORE_CUDA_CHECK(cudaEventRecord(gammas.event, gammas.stream));
-      COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, gammas.event));
+      COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, gammas.event, 0));
     }
 
     // *** END OF TRANSPORT ***

--- a/examples/TestEm3/TestEm3.cu
+++ b/examples/TestEm3/TestEm3.cu
@@ -344,7 +344,7 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
                                                                                        electrons.queues.relocate);
 
         COPCORE_CUDA_CHECK(cudaEventRecord(electrons.event, electrons.stream));
-        COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, electrons.event));
+        COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, electrons.event, 0));
       }
 
       // *** POSITRONS ***
@@ -363,7 +363,7 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
                                                                                        positrons.queues.relocate);
 
         COPCORE_CUDA_CHECK(cudaEventRecord(positrons.event, positrons.stream));
-        COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, positrons.event));
+        COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, positrons.event, 0));
       }
 
       // *** GAMMAS ***
@@ -382,7 +382,7 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
                                                                                     gammas.queues.relocate);
 
         COPCORE_CUDA_CHECK(cudaEventRecord(gammas.event, gammas.stream));
-        COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, gammas.event));
+        COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, gammas.event, 0));
       }
 
       // *** END OF TRANSPORT ***


### PR DESCRIPTION
Before CUDA 11.1.0, `cudaStreamWaitEvent` did not have a default value for the `flags` parameter. Instead the documentation verbally required that the passed argument "must be 0", so pass this value explicitly to allow compilation with older versions.