### PR TITLE
Separate TransportElectrons and TransportPositrons

### DIFF
--- a/examples/Example9/electrons.cu
+++ b/examples/Example9/electrons.cu
@@ -26,8 +26,9 @@ __device__ struct G4HepEmElectronManager electronManager;
 // applying the continuous effects and maybe a discrete process that could
 // generate secondaries.
 template <bool IsElectron>
-__global__ void TransportElectrons(Track *electrons, const adept::MParray *active, Secondaries secondaries,
-                                   adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring)
+static __device__ __forceinline__ void TransportElectrons(Track *electrons, const adept::MParray *active,
+                                                          Secondaries &secondaries, adept::MParray *activeQueue,
+                                                          adept::MParray *relocateQueue, GlobalScoring *scoring)
 {
   constexpr int Charge  = IsElectron ? -1 : 1;
   constexpr double Mass = copcore::units::kElectronMassC2;
@@ -231,11 +232,14 @@ __global__ void TransportElectrons(Track *electrons, const adept::MParray *activ
   }
 }
 
-// Instantiate template for electrons and positrons.
-template __global__ void TransportElectrons</*IsElectron*/ true>(Track *electrons, const adept::MParray *active,
-                                                                 Secondaries secondaries, adept::MParray *activeQueue,
-                                                                 adept::MParray *relocateQueue, GlobalScoring *scoring);
-template __global__ void TransportElectrons</*IsElectron*/ false>(Track *electrons, const adept::MParray *active,
-                                                                  Secondaries secondaries, adept::MParray *activeQueue,
-                                                                  adept::MParray *relocateQueue,
-                                                                  GlobalScoring *scoring);
+// Instantiate kernels for electrons and positrons.
+__global__ void TransportElectrons(Track *electrons, const adept::MParray *active, Secondaries secondaries,
+                                   adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring)
+{
+  TransportElectrons</*IsElectron*/ true>(electrons, active, secondaries, activeQueue, relocateQueue, scoring);
+}
+__global__ void TransportPositrons(Track *positrons, const adept::MParray *active, Secondaries secondaries,
+                                   adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring)
+{
+  TransportElectrons</*IsElectron*/ false>(positrons, active, secondaries, activeQueue, relocateQueue, scoring);
+}

--- a/examples/Example9/example9.cu
+++ b/examples/Example9/example9.cu
@@ -264,7 +264,7 @@ void example9(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double
 
       relocateBlocks = std::min(numElectrons, MaxBlocks);
 
-      TransportElectrons</*IsElectron*/ true><<<transportBlocks, TransportThreads, 0, electrons.stream>>>(
+      TransportElectrons<<<transportBlocks, TransportThreads, 0, electrons.stream>>>(
           electrons.tracks, electrons.queues.currentlyActive, secondaries, electrons.queues.nextActive,
           electrons.queues.relocate, scoring);
 
@@ -283,7 +283,7 @@ void example9(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double
 
       relocateBlocks = std::min(numPositrons, MaxBlocks);
 
-      TransportElectrons</*IsElectron*/ false><<<transportBlocks, TransportThreads, 0, positrons.stream>>>(
+      TransportPositrons<<<transportBlocks, TransportThreads, 0, positrons.stream>>>(
           positrons.tracks, positrons.queues.currentlyActive, secondaries, positrons.queues.nextActive,
           positrons.queues.relocate, scoring);
 

--- a/examples/Example9/example9.cuh
+++ b/examples/Example9/example9.cuh
@@ -130,14 +130,11 @@ struct Secondaries {
 // Kernels in different TUs.
 __global__ void RelocateToNextVolume(Track *allTracks, const adept::MParray *relocateQueue);
 
-template <bool IsElectron>
-__global__ void TransportElectrons(Track *electrons, const adept::MParray *active, Secondaries secondaries,
-                                   adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring);
-extern template __global__ void TransportElectrons</*IsElectron*/true>(
+__global__ void TransportElectrons(
     Track *electrons, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
     adept::MParray *relocateQueue, GlobalScoring *scoring);
-extern template __global__ void TransportElectrons</*IsElectron*/false>(
-    Track *electrons, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
+__global__ void TransportPositrons(
+    Track *positrons, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
     adept::MParray *relocateQueue, GlobalScoring *scoring);
 
 __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries,

--- a/examples/TestEm3/TestEm3.cu
+++ b/examples/TestEm3/TestEm3.cu
@@ -336,7 +336,7 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
 
         relocateBlocks = std::min(numElectrons, MaxBlocks);
 
-        TransportElectrons</*IsElectron*/ true><<<transportBlocks, TransportThreads, 0, electrons.stream>>>(
+        TransportElectrons<<<transportBlocks, TransportThreads, 0, electrons.stream>>>(
             electrons.tracks, electrons.queues.currentlyActive, secondaries, electrons.queues.nextActive,
             electrons.queues.relocate, globalScoring, scoringPerVolume);
 
@@ -355,7 +355,7 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
 
         relocateBlocks = std::min(numPositrons, MaxBlocks);
 
-        TransportElectrons</*IsElectron*/ false><<<transportBlocks, TransportThreads, 0, positrons.stream>>>(
+        TransportPositrons<<<transportBlocks, TransportThreads, 0, positrons.stream>>>(
             positrons.tracks, positrons.queues.currentlyActive, secondaries, positrons.queues.nextActive,
             positrons.queues.relocate, globalScoring, scoringPerVolume);
 

--- a/examples/TestEm3/TestEm3.cuh
+++ b/examples/TestEm3/TestEm3.cuh
@@ -124,15 +124,11 @@ struct Secondaries {
 // Kernels in different TUs.
 __global__ void RelocateToNextVolume(Track *allTracks, const adept::MParray *relocateQueue);
 
-template <bool IsElectron>
-__global__ void TransportElectrons(Track *electrons, const adept::MParray *active, Secondaries secondaries,
-                                   adept::MParray *activeQueue, adept::MParray *relocateQueue,
-                                   GlobalScoring *globalScoring, ScoringPerVolume *scoringPerVolume);
-extern template __global__ void TransportElectrons</*IsElectron*/true>(
+__global__ void TransportElectrons(
     Track *electrons, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
     adept::MParray *relocateQueue, GlobalScoring *globalScoring, ScoringPerVolume *scoringPerVolume);
-extern template __global__ void TransportElectrons</*IsElectron*/false>(
-    Track *electrons, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
+__global__ void TransportPositrons(
+    Track *positrons, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
     adept::MParray *relocateQueue, GlobalScoring *globalScoring, ScoringPerVolume *scoringPerVolume);
 
 __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries,

--- a/examples/TestEm3/electrons.cu
+++ b/examples/TestEm3/electrons.cu
@@ -27,9 +27,10 @@ __device__ struct G4HepEmElectronManager electronManager;
 // applying the continuous effects and maybe a discrete process that could
 // generate secondaries.
 template <bool IsElectron>
-__global__ void TransportElectrons(Track *electrons, const adept::MParray *active, Secondaries secondaries,
-                                   adept::MParray *activeQueue, adept::MParray *relocateQueue,
-                                   GlobalScoring *globalScoring, ScoringPerVolume *scoringPerVolume)
+static __device__ __forceinline__ void TransportElectrons(Track *electrons, const adept::MParray *active,
+                                                          Secondaries &secondaries, adept::MParray *activeQueue,
+                                                          adept::MParray *relocateQueue, GlobalScoring *globalScoring,
+                                                          ScoringPerVolume *scoringPerVolume)
 {
   constexpr int Charge  = IsElectron ? -1 : 1;
   constexpr double Mass = copcore::units::kElectronMassC2;
@@ -245,14 +246,18 @@ __global__ void TransportElectrons(Track *electrons, const adept::MParray *activ
   }
 }
 
-// Instantiate template for electrons and positrons.
-template __global__ void TransportElectrons</*IsElectron*/ true>(Track *electrons, const adept::MParray *active,
-                                                                 Secondaries secondaries, adept::MParray *activeQueue,
-                                                                 adept::MParray *relocateQueue,
-                                                                 GlobalScoring *globalScoring,
-                                                                 ScoringPerVolume *scoringPerVolume);
-template __global__ void TransportElectrons</*IsElectron*/ false>(Track *electrons, const adept::MParray *active,
-                                                                  Secondaries secondaries, adept::MParray *activeQueue,
-                                                                  adept::MParray *relocateQueue,
-                                                                  GlobalScoring *globalScoring,
-                                                                  ScoringPerVolume *scoringPerVolume);
+// Instantiate kernels for electrons and positrons.
+__global__ void TransportElectrons(Track *electrons, const adept::MParray *active, Secondaries secondaries,
+                                   adept::MParray *activeQueue, adept::MParray *relocateQueue,
+                                   GlobalScoring *globalScoring, ScoringPerVolume *scoringPerVolume)
+{
+  TransportElectrons</*IsElectron*/ true>(electrons, active, secondaries, activeQueue, relocateQueue, globalScoring,
+                                          scoringPerVolume);
+}
+__global__ void TransportPositrons(Track *positrons, const adept::MParray *active, Secondaries secondaries,
+                                   adept::MParray *activeQueue, adept::MParray *relocateQueue,
+                                   GlobalScoring *globalScoring, ScoringPerVolume *scoringPerVolume)
+{
+  TransportElectrons</*IsElectron*/ false>(positrons, active, secondaries, activeQueue, relocateQueue, globalScoring,
+                                           scoringPerVolume);
+}


### PR DESCRIPTION
Using templates was a good idea, but is highly confusing for profiling because Nsight Compute doesn't show template parameters for kernels. Split into separate kernels that call the instantiated template. The compiler takes care of inlining, resulting in only minor performance penalties that are barely measurable.