### PR TITLE
Unify debugging levels for CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,14 @@ else()
   message(STATUS "Did not find Geant4")
 endif()
 
+# Set up debugging levels for CUDA:
+# - For RelWithDebInfo (the default), generate line info to enable profiling.
+add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:RelWithDebInfo>>:--generate-line-info>")
+# - For Debug, generate full debug information - this completely disables optimizations!
+add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:--device-debug>")
+# - For both, interleave the source in PTX to enhance the debugging experience.
+add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<OR:$<CONFIG:RelWithDebInfo>,$<CONFIG:Debug>>>:--source-in-ptx>")
+
 # Add external dependencies before our own code to allow checking for the
 # targets and depend on them.
 add_subdirectory(external)

--- a/examples/Example2/CMakeLists.txt
+++ b/examples/Example2/CMakeLists.txt
@@ -5,7 +5,6 @@
 # and reproducible results using one RANLUX++ state per track.
 add_executable(example2 example2.cpp example2.cu)
 target_link_libraries(example2 PRIVATE AdePT VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml)
-target_compile_options(example2 PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
 set_target_properties(example2 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
 add_test(NAME example2 COMMAND example2 -gdml_name "${TESTING_GDML}")

--- a/examples/Example4/CMakeLists.txt
+++ b/examples/Example4/CMakeLists.txt
@@ -5,7 +5,6 @@
 # and reproducible results using one RANLUX++ state per track.
 add_executable(example4 example4.cpp example4.cu)
 target_link_libraries(example4 PRIVATE AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml)
-target_compile_options(example4 PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
 set_target_properties(example4 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
 add_test(NAME example4 COMMAND example4 -gdml_name "${TESTING_GDML}")

--- a/examples/Example6/CMakeLists.txt
+++ b/examples/Example6/CMakeLists.txt
@@ -8,7 +8,6 @@ endif()
 
 add_executable(example6 example6.cpp example6.cu)
 target_link_libraries(example6 PRIVATE AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml ${Geant4_LIBRARIES} G4HepEm::g4HepEmData G4HepEm::g4HepEmInit G4HepEm::g4HepEmRun)
-target_compile_options(example6 PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
 set_target_properties(example6 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
 add_test(NAME example6 COMMAND example6 -gdml_name "${TESTING_GDML}")

--- a/examples/Example8/CMakeLists.txt
+++ b/examples/Example8/CMakeLists.txt
@@ -8,7 +8,6 @@ endif()
 
 add_executable(example8 example8.cpp example8.cu)
 target_link_libraries(example8 PRIVATE AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml ${Geant4_LIBRARIES} G4HepEm::g4HepEmData G4HepEm::g4HepEmInit G4HepEm::g4HepEmRun)
-target_compile_options(example8 PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
 set_target_properties(example8 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
 add_test(NAME example8 COMMAND example8 -gdml_name "${TESTING_GDML}")

--- a/examples/Example9/CMakeLists.txt
+++ b/examples/Example9/CMakeLists.txt
@@ -8,7 +8,6 @@ endif()
 
 add_executable(example9 example9.cpp example9.cu electrons.cu gammas.cu relocation.cu)
 target_link_libraries(example9 PRIVATE AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml ${Geant4_LIBRARIES} G4HepEm::g4HepEmData G4HepEm::g4HepEmInit G4HepEm::g4HepEmRun)
-target_compile_options(example9 PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
 set_target_properties(example9 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
 add_test(NAME example9 COMMAND example9 -gdml_name "${TESTING_GDML}")

--- a/examples/Raytracer_Benchmark/CMakeLists.txt
+++ b/examples/Raytracer_Benchmark/CMakeLists.txt
@@ -32,12 +32,10 @@ target_include_directories(raytracercu PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 target_link_libraries(raytracercu AdePT CopCore::CopCore VecCore::VecCore VecGeom::vecgeom VecGeom::vecgeomcuda_static)
-target_compile_options(raytracercu PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
 set_target_properties(raytracercu PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 
 #exec RaytraceBenchmark.cpp
 add_executable(RaytraceBenchmark Raytracer.cpp RaytraceBenchmark.cpp)
 target_link_libraries(RaytraceBenchmark PRIVATE raytracercu AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda VecGeom::vgdml)
-target_compile_options(RaytraceBenchmark PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
 set_target_properties(RaytraceBenchmark PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 

--- a/examples/TestEm3/CMakeLists.txt
+++ b/examples/TestEm3/CMakeLists.txt
@@ -9,7 +9,6 @@ endif()
 # TestEm3 for validation of particle transportation with GPUs.
 add_executable(TestEm3 TestEm3.cpp TestEm3.cu electrons.cu gammas.cu relocation.cu)
 target_link_libraries(TestEm3 PRIVATE AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml ${Geant4_LIBRARIES} G4HepEm::g4HepEmData G4HepEm::g4HepEmInit G4HepEm::g4HepEmRun)
-target_compile_options(TestEm3 PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
 set_target_properties(TestEm3 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
 add_test(NAME TestEm3 COMMAND TestEm3)

--- a/examples/field_cu/CMakeLists.txt
+++ b/examples/field_cu/CMakeLists.txt
@@ -3,6 +3,5 @@
 
 add_executable(fieldStep field_step.cu)
 target_link_libraries(fieldStep AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml)
-target_compile_options(fieldStep PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
 set_target_properties(fieldStep PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,5 +45,4 @@ build_tests("${ADEPT_UNIT_TESTS_BASE}")
 add_to_test("${ADEPT_UNIT_TESTS_BASE}")
 
 # Specific options for test_sparsevector
-set_target_properties(test_sparsevector PROPERTIES CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-target_compile_options(test_sparsevector PRIVATE -rdc=true;-lcudadevrt)
+set_target_properties(test_sparsevector PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,7 +32,6 @@ set(ADEPT_UNIT_TESTS_BASE
 )
 
 add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda;>")
-add_compile_options("$<$<AND:$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>,$<COMPILE_LANGUAGE:CUDA>>:-G;-src-in-ptx>")
 
 add_executable(test_launcher test_launcher.cu test_launcher.cpp)
 target_include_directories(test_launcher PUBLIC


### PR DESCRIPTION
Generate line info for the `RelWithDebInfo` configuration and full device debug information only in `Debug` configuration because that completely disables optimizations.