### PR TITLE
Branch RNG state when generating secondaries

### DIFF
--- a/base/inc/CopCore/include/CopCore/Ranluxpp.h
+++ b/base/inc/CopCore/include/CopCore/Ranluxpp.h
@@ -31,6 +31,23 @@ private:
   static constexpr const uint64_t *kA = kA_2048;
   static constexpr int kMaxPos        = 9 * 64;
 
+protected:
+  __host__ __device__
+  void SaveState(uint64_t *state) const
+  {
+    for (int i = 0; i < 9; i++) {
+      state[i] = fState[i];
+    }
+  }
+
+  __host__ __device__
+  void XORstate(const uint64_t *state)
+  {
+    for (int i = 0; i < 9; i++) {
+      fState[i] ^= state[i];
+    }
+  }
+
   /// Produce next block of random bits
   __host__ __device__
   void Advance()
@@ -144,6 +161,20 @@ public:
 
   __host__ __device__
   uint64_t IntRndm() { return this->NextRandomBits(); }
+
+  /// Branch a new RNG state, also advancing the current one.
+  __host__ __device__
+  RanluxppDouble Branch()
+  {
+    // Save the current state, will be used to branch a new RNG.
+    uint64_t oldState[9];
+    this->SaveState(oldState);
+    this->Advance();
+    // Copy and modify the new RNG state.
+    RanluxppDouble newRNG(*this);
+    newRNG.XORstate(oldState);
+    return newRNG;
+  }
 };
 
 #endif // COPCORE_RANLUXPP_H_

--- a/examples/Example9/electrons.cu
+++ b/examples/Example9/electrons.cu
@@ -114,10 +114,12 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
         sincos(phi, &sinPhi, &cosPhi);
 
         gamma1.InitAsSecondary(/*parent=*/currentTrack);
+        gamma1.rngState = currentTrack.rngState.Branch();
         gamma1.energy = copcore::units::kElectronMassC2;
         gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
 
         gamma2.InitAsSecondary(/*parent=*/currentTrack);
+        gamma2.rngState = currentTrack.rngState.Branch();
         gamma2.energy = copcore::units::kElectronMassC2;
         gamma2.dir    = -gamma1.dir;
       }
@@ -172,6 +174,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       atomicAdd(&scoring->secondaries, 1);
 
       secondary.InitAsSecondary(/*parent=*/currentTrack);
+      secondary.rngState = currentTrack.rngState.Branch();
       secondary.energy = deltaEkin;
       secondary.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
 
@@ -196,6 +199,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       atomicAdd(&scoring->secondaries, 1);
 
       gamma.InitAsSecondary(/*parent=*/currentTrack);
+      gamma.rngState = currentTrack.rngState.Branch();
       gamma.energy = deltaEkin;
       gamma.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
 
@@ -218,10 +222,12 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       atomicAdd(&scoring->secondaries, 2);
 
       gamma1.InitAsSecondary(/*parent=*/currentTrack);
+      gamma1.rngState = currentTrack.rngState.Branch();
       gamma1.energy = theGamma1Ekin;
       gamma1.dir.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
 
       gamma2.InitAsSecondary(/*parent=*/currentTrack);
+      gamma2.rngState = currentTrack.rngState.Branch();
       gamma2.energy = theGamma2Ekin;
       gamma2.dir.Set(theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]);
 

--- a/examples/Example9/example9.cuh
+++ b/examples/Example9/example9.cuh
@@ -39,11 +39,7 @@ struct Track {
 
   __host__ __device__ void InitAsSecondary(const Track &parent)
   {
-    // Initialize a new PRNG state.
-    this->rngState = parent.rngState;
-    this->rngState.Skip(1 << 15);
-
-    // The caller is responsible to set the energy.
+    // The caller is responsible to branch a new RNG state and to set the energy.
     this->numIALeft[0] = -1.0;
     this->numIALeft[1] = -1.0;
     this->numIALeft[2] = -1.0;

--- a/examples/Example9/gammas.cu
+++ b/examples/Example9/gammas.cu
@@ -123,10 +123,12 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
       atomicAdd(&scoring->secondaries, 2);
 
       electron.InitAsSecondary(/*parent=*/currentTrack);
+      electron.rngState = currentTrack.rngState.Branch();
       electron.energy = elKinEnergy;
       electron.dir.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
 
       positron.InitAsSecondary(/*parent=*/currentTrack);
+      positron.rngState = currentTrack.rngState.Branch();
       positron.energy = posKinEnergy;
       positron.dir.Set(dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]);
 
@@ -152,6 +154,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
         atomicAdd(&scoring->secondaries, 1);
 
         electron.InitAsSecondary(/*parent=*/currentTrack);
+        electron.rngState = currentTrack.rngState.Branch();
         electron.energy = energyEl;
         electron.dir = energy * currentTrack.dir - newEnergyGamma * newDirGamma;
         electron.dir.Normalize();

--- a/examples/TestEm3/TestEm3.cuh
+++ b/examples/TestEm3/TestEm3.cuh
@@ -41,11 +41,7 @@ struct Track {
 
   __host__ __device__ void InitAsSecondary(const Track &parent)
   {
-    // Initialize a new PRNG state.
-    this->rngState = parent.rngState;
-    this->rngState.Skip(1 << 15);
-
-    // The caller is responsible to set the energy.
+    // The caller is responsible to branch a new RNG state and to set the energy.
     this->numIALeft[0] = -1.0;
     this->numIALeft[1] = -1.0;
     this->numIALeft[2] = -1.0;

--- a/examples/TestEm3/electrons.cu
+++ b/examples/TestEm3/electrons.cu
@@ -128,10 +128,12 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
         sincos(phi, &sinPhi, &cosPhi);
 
         gamma1.InitAsSecondary(/*parent=*/currentTrack);
+        gamma1.rngState = currentTrack.rngState.Branch();
         gamma1.energy = copcore::units::kElectronMassC2;
         gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
 
         gamma2.InitAsSecondary(/*parent=*/currentTrack);
+        gamma2.rngState = currentTrack.rngState.Branch();
         gamma2.energy = copcore::units::kElectronMassC2;
         gamma2.dir    = -gamma1.dir;
       }
@@ -186,6 +188,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       atomicAdd(&globalScoring->numElectrons, 1);
 
       secondary.InitAsSecondary(/*parent=*/currentTrack);
+      secondary.rngState = currentTrack.rngState.Branch();
       secondary.energy = deltaEkin;
       secondary.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
 
@@ -210,6 +213,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       atomicAdd(&globalScoring->numGammas, 1);
 
       gamma.InitAsSecondary(/*parent=*/currentTrack);
+      gamma.rngState = currentTrack.rngState.Branch();
       gamma.energy = deltaEkin;
       gamma.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
 
@@ -232,10 +236,12 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       atomicAdd(&globalScoring->numGammas, 2);
 
       gamma1.InitAsSecondary(/*parent=*/currentTrack);
+      gamma1.rngState = currentTrack.rngState.Branch();
       gamma1.energy = theGamma1Ekin;
       gamma1.dir.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
 
       gamma2.InitAsSecondary(/*parent=*/currentTrack);
+      gamma2.rngState = currentTrack.rngState.Branch();
       gamma2.energy = theGamma2Ekin;
       gamma2.dir.Set(theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]);
 

--- a/examples/TestEm3/gammas.cu
+++ b/examples/TestEm3/gammas.cu
@@ -125,10 +125,12 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
       atomicAdd(&globalScoring->numPositrons, 1);
 
       electron.InitAsSecondary(/*parent=*/currentTrack);
+      electron.rngState = currentTrack.rngState.Branch();
       electron.energy = elKinEnergy;
       electron.dir.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
 
       positron.InitAsSecondary(/*parent=*/currentTrack);
+      positron.rngState = currentTrack.rngState.Branch();
       positron.energy = posKinEnergy;
       positron.dir.Set(dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]);
 
@@ -154,6 +156,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
         atomicAdd(&globalScoring->numElectrons, 1);
 
         electron.InitAsSecondary(/*parent=*/currentTrack);
+        electron.rngState = currentTrack.rngState.Branch();
         electron.energy = energyEl;
         electron.dir    = energy * currentTrack.dir - newEnergyGamma * newDirGamma;
         electron.dir.Normalize();


### PR DESCRIPTION
This is more correct because static skipping leads to overlapping sequences and more efficient because there is only one `Advance`.