### PR TITLE
Work around underestimated register count

### DIFF
--- a/examples/Example9/example9.cu
+++ b/examples/Example9/example9.cu
@@ -33,6 +33,8 @@
 __constant__ __device__ struct G4HepEmParameters g4HepEmPars;
 __constant__ __device__ struct G4HepEmData g4HepEmData;
 
+__constant__ __device__ int Zero = 0;
+
 struct G4HepEmState {
   G4HepEmData data;
   G4HepEmParameters parameters;

--- a/examples/TestEm3/TestEm3.cu
+++ b/examples/TestEm3/TestEm3.cu
@@ -35,6 +35,8 @@ __constant__ __device__ struct G4HepEmData g4HepEmData;
 
 __constant__ __device__ int *MCIndex = nullptr;
 
+__constant__ __device__ int Zero = 0;
+
 struct G4HepEmState {
   G4HepEmData data;
   G4HepEmParameters parameters;

--- a/examples/TestEm3/TestEm3.cuh
+++ b/examples/TestEm3/TestEm3.cuh
@@ -58,10 +58,18 @@ struct Track {
   }
 };
 
+// Defined in TestEm3.cu
+extern __constant__ __device__ int Zero;
+
 class RanluxppDoubleEngine : public G4HepEmRandomEngine {
   // Wrapper functions to call into RanluxppDouble.
-  static __host__ __device__ double FlatWrapper(void *object) { return ((RanluxppDouble *)object)->Rndm(); }
-  static __host__ __device__ void FlatArrayWrapper(void *object, const int size, double *vect)
+  static __host__ __device__ __attribute__((noinline))
+  double FlatWrapper(void *object)
+  {
+    return ((RanluxppDouble *)object)->Rndm();
+  }
+  static __host__ __device__ __attribute__((noinline))
+  void FlatArrayWrapper(void *object, const int size, double *vect)
   {
     for (int i = 0; i < size; i++) {
       vect[i] = ((RanluxppDouble *)object)->Rndm();
@@ -72,6 +80,17 @@ public:
   __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
       : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
   {
+#ifdef __CUDA_ARCH__
+    // This is a hack: The compiler cannot see that we're going to call the
+    // functions through their pointers, so it underestimates the number of
+    // required registers. By including calls to the (non-inlinable) functions
+    // we force the compiler to account for the register usage, even if this
+    // particular set of calls are not executed at runtime.
+    if (Zero) {
+      FlatWrapper(engine);
+      FlatArrayWrapper(engine, 0, nullptr);
+    }
+#endif
   }
 };
 


### PR DESCRIPTION
The compiler cannot see that we're going to call the functions through their pointers, so it underestimates the number of required registers. By including calls to the functions we force the compiler to account for the register usage.