### PR TITLE
Optimize RNG some more

### DIFF
--- a/examples/Example9/electrons.cu
+++ b/examples/Example9/electrons.cu
@@ -157,6 +157,8 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
 
     // Perform the discrete interaction.
     RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    // We will need one branched RNG state, prepare while threads are synchronized.
+    RanluxppDouble newRNG(currentTrack.rngState.Branch());
 
     const double energy   = currentTrack.energy;
     const double theElCut = g4HepEmData.fTheMatCutData->fMatCutData[theMCIndex].fSecElProdCutE;
@@ -175,7 +177,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       atomicAdd(&scoring->secondaries, 1);
 
       secondary.InitAsSecondary(/*parent=*/currentTrack);
-      secondary.rngState = currentTrack.rngState.Branch();
+      secondary.rngState = newRNG;
       secondary.energy = deltaEkin;
       secondary.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
 
@@ -200,7 +202,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       atomicAdd(&scoring->secondaries, 1);
 
       gamma.InitAsSecondary(/*parent=*/currentTrack);
-      gamma.rngState = currentTrack.rngState.Branch();
+      gamma.rngState = newRNG;
       gamma.energy = deltaEkin;
       gamma.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
 
@@ -223,7 +225,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       atomicAdd(&scoring->secondaries, 2);
 
       gamma1.InitAsSecondary(/*parent=*/currentTrack);
-      gamma1.rngState = currentTrack.rngState.Branch();
+      gamma1.rngState = newRNG;
       gamma1.energy = theGamma1Ekin;
       gamma1.dir.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
 

--- a/examples/Example9/electrons.cu
+++ b/examples/Example9/electrons.cu
@@ -119,7 +119,8 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
         gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
 
         gamma2.InitAsSecondary(/*parent=*/currentTrack);
-        gamma2.rngState = currentTrack.rngState.Branch();
+        // Reuse the RNG state of the dying track.
+        gamma2.rngState = currentTrack.rngState;
         gamma2.energy = copcore::units::kElectronMassC2;
         gamma2.dir    = -gamma1.dir;
       }
@@ -227,7 +228,8 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       gamma1.dir.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
 
       gamma2.InitAsSecondary(/*parent=*/currentTrack);
-      gamma2.rngState = currentTrack.rngState.Branch();
+      // Reuse the RNG state of the dying track.
+      gamma2.rngState = currentTrack.rngState;
       gamma2.energy = theGamma2Ekin;
       gamma2.dir.Set(theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]);
 

--- a/examples/Example9/gammas.cu
+++ b/examples/Example9/gammas.cu
@@ -99,6 +99,8 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
 
     // Perform the discrete interaction.
     RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    // We might need one branched RNG state, prepare while threads are synchronized.
+    RanluxppDouble newRNG(currentTrack.rngState.Branch());
 
     const double energy   = currentTrack.energy;
 
@@ -123,7 +125,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
       atomicAdd(&scoring->secondaries, 2);
 
       electron.InitAsSecondary(/*parent=*/currentTrack);
-      electron.rngState = currentTrack.rngState.Branch();
+      electron.rngState = newRNG;
       electron.energy = elKinEnergy;
       electron.dir.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
 
@@ -155,7 +157,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
         atomicAdd(&scoring->secondaries, 1);
 
         electron.InitAsSecondary(/*parent=*/currentTrack);
-        electron.rngState = currentTrack.rngState.Branch();
+        electron.rngState = newRNG;
         electron.energy = energyEl;
         electron.dir = energy * currentTrack.dir - newEnergyGamma * newDirGamma;
         electron.dir.Normalize();

--- a/examples/Example9/gammas.cu
+++ b/examples/Example9/gammas.cu
@@ -128,7 +128,8 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
       electron.dir.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
 
       positron.InitAsSecondary(/*parent=*/currentTrack);
-      positron.rngState = currentTrack.rngState.Branch();
+      // Reuse the RNG state of the dying track.
+      positron.rngState = currentTrack.rngState;
       positron.energy = posKinEnergy;
       positron.dir.Set(dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]);
 

--- a/examples/TestEm3/electrons.cu
+++ b/examples/TestEm3/electrons.cu
@@ -133,7 +133,8 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
         gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
 
         gamma2.InitAsSecondary(/*parent=*/currentTrack);
-        gamma2.rngState = currentTrack.rngState.Branch();
+        // Reuse the RNG state of the dying track.
+        gamma2.rngState = currentTrack.rngState;
         gamma2.energy = copcore::units::kElectronMassC2;
         gamma2.dir    = -gamma1.dir;
       }
@@ -241,7 +242,8 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       gamma1.dir.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
 
       gamma2.InitAsSecondary(/*parent=*/currentTrack);
-      gamma2.rngState = currentTrack.rngState.Branch();
+      // Reuse the RNG state of the dying track.
+      gamma2.rngState = currentTrack.rngState;
       gamma2.energy = theGamma2Ekin;
       gamma2.dir.Set(theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]);
 

--- a/examples/TestEm3/electrons.cu
+++ b/examples/TestEm3/electrons.cu
@@ -171,6 +171,8 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
 
     // Perform the discrete interaction.
     RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    // We will need one branched RNG state, prepare while threads are synchronized.
+    RanluxppDouble newRNG(currentTrack.rngState.Branch());
 
     const double energy   = currentTrack.energy;
     const double theElCut = g4HepEmData.fTheMatCutData->fMatCutData[theMCIndex].fSecElProdCutE;
@@ -189,7 +191,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       atomicAdd(&globalScoring->numElectrons, 1);
 
       secondary.InitAsSecondary(/*parent=*/currentTrack);
-      secondary.rngState = currentTrack.rngState.Branch();
+      secondary.rngState = newRNG;
       secondary.energy = deltaEkin;
       secondary.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
 
@@ -214,7 +216,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       atomicAdd(&globalScoring->numGammas, 1);
 
       gamma.InitAsSecondary(/*parent=*/currentTrack);
-      gamma.rngState = currentTrack.rngState.Branch();
+      gamma.rngState = newRNG;
       gamma.energy = deltaEkin;
       gamma.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
 
@@ -237,7 +239,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       atomicAdd(&globalScoring->numGammas, 2);
 
       gamma1.InitAsSecondary(/*parent=*/currentTrack);
-      gamma1.rngState = currentTrack.rngState.Branch();
+      gamma1.rngState = newRNG;
       gamma1.energy = theGamma1Ekin;
       gamma1.dir.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
 

--- a/examples/TestEm3/gammas.cu
+++ b/examples/TestEm3/gammas.cu
@@ -100,6 +100,8 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
 
     // Perform the discrete interaction.
     RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    // We might need one branched RNG state, prepare while threads are synchronized.
+    RanluxppDouble newRNG(currentTrack.rngState.Branch());
 
     const double energy = currentTrack.energy;
 
@@ -125,7 +127,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
       atomicAdd(&globalScoring->numPositrons, 1);
 
       electron.InitAsSecondary(/*parent=*/currentTrack);
-      electron.rngState = currentTrack.rngState.Branch();
+      electron.rngState = newRNG;
       electron.energy = elKinEnergy;
       electron.dir.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
 
@@ -157,7 +159,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
         atomicAdd(&globalScoring->numElectrons, 1);
 
         electron.InitAsSecondary(/*parent=*/currentTrack);
-        electron.rngState = currentTrack.rngState.Branch();
+        electron.rngState = newRNG;
         electron.energy = energyEl;
         electron.dir    = energy * currentTrack.dir - newEnergyGamma * newDirGamma;
         electron.dir.Normalize();

--- a/examples/TestEm3/gammas.cu
+++ b/examples/TestEm3/gammas.cu
@@ -130,7 +130,8 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
       electron.dir.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
 
       positron.InitAsSecondary(/*parent=*/currentTrack);
-      positron.rngState = currentTrack.rngState.Branch();
+      // Reuse the RNG state of the dying track.
+      positron.rngState = currentTrack.rngState;
       positron.energy = posKinEnergy;
       positron.dir.Set(dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]);
 


### PR DESCRIPTION
#### Reuse RNG state of killed particles

When the primary is killed, we can reuse the state for a secondary instead of branching twice.

---

#### Move RNG branching to reduce thread divergence

Creating a branched RNG state is faster before threads start diverging for the discrete interactions.

---

(please don't squash, the performance development might be of interest in the future)