### PR TITLE
Example10, reduce number of iterations

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,6 +11,7 @@ add_subdirectory(Example5)
 add_subdirectory(Example6)
 add_subdirectory(Example8)
 add_subdirectory(Example9)
+add_subdirectory(Example10)
 add_subdirectory(TestEm3)
 add_subdirectory(ECS)
 

--- a/examples/Example10/CMakeLists.txt
+++ b/examples/Example10/CMakeLists.txt
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2021 CERN
+# SPDX-License-Identifier: Apache-2.0
+
+if(NOT TARGET G4HepEm::g4HepEm)
+  message(STATUS "Disabling example10 (needs G4HepEm)")
+  return()
+endif()
+
+add_executable(example10  example10.cpp example10.cu electrons.cu gammas.cu relocation.cu)
+target_link_libraries(example10 PRIVATE AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml ${Geant4_LIBRARIES} G4HepEm::g4HepEmData G4HepEm::g4HepEmInit G4HepEm::g4HepEmRun)
+set_target_properties(example10 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
+
+add_test(NAME example10 COMMAND example10 -gdml_name "${TESTING_GDML}")

--- a/examples/Example10/README.md
+++ b/examples/Example10/README.md
@@ -1,0 +1,60 @@
+<!--
+SPDX-FileCopyrightText: 2021 CERN
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+## Example 10
+
+Demonstrator of particle transportation on GPUs, with:
+
+ * geometry via VecGeom and a magnetic field with constant Bz,
+ * physics processes for e-/e+ and gammas using G4HepEm.
+
+Electrons, positrons, and gammas are stored in separate containers in device memory.
+Free positions in the storage are handed out with monotonic slot numbers, slots are not reused.
+Active tracks are passed via three queues per particle type (see `struct ParticleQueues`).
+Results are reproducible using one RANLUX++ state per track.
+
+### Kernels
+
+This example uses one stream per particle type to launch kernels asynchronously.
+They are synchronized via a forth stream using CUDA events.
+
+#### `TransportElectrons<bool IsElectron>`
+
+1. Determine physics step limit.
+2. Call magnetic field to get geometry step length.
+3. Apply continuous effects; kill track if stopped.
+4. If the particle reaches a boundary, enqueue for relocation.
+5. If not, and if there is a discrete process:
+   1. Sample the final state.
+   2. Update the primary and produce secondaries.
+
+#### `TransportGammas`
+
+1. Determine the physics step limit.
+2. Query VecGeom to get geometry step length (no magnetic field for neutral particles!).
+3. If the particle reaches a boundary, enqueue for relocation.
+4. If not, and if there is a discrete process:
+   1. Sample the final state.
+   2. Update the primary and produce secondaries.
+
+#### `RelocateToNextVolume`
+
+If the particle reached a boundary, update the state by pushing to the next volume.
+This kernel is a parallel implementation of `LoopNavigator::RelocateToNextVolume` and uses one warp (32 threads) per particle.
+
+1. One thread removes all volumes from the state that were left, eventually arriving at one volume that contains the pushed point.
+2. All threads are used to check the daughter volumes in parallel. This step is repeated as long as one thread finds a volume to descend into.
+3. Finally, one thread leaves all assembly volumes.
+
+Note: This kernel is called three times, once for each particle type (with separate containers) in the respective stream.
+
+#### `FinishIteration`
+
+Clear the queues and return the tracks in flight.
+This kernel runs after all secondary particles were produced.
+
+#### `InitPrimaries` and `InitParticleQueues`
+
+Used to initialize multiple primary particles with separate seeds.

--- a/examples/Example10/README.md
+++ b/examples/Example10/README.md
@@ -15,6 +15,27 @@ Free positions in the storage are handed out with monotonic slot numbers, slots 
 Active tracks are passed via three queues per particle type (see `struct ParticleQueues`).
 Results are reproducible using one RANLUX++ state per track.
 
+Compared to the previous Example 9, this one reduces the number of iterations with two ideas:
+1. On the device, each transportation kernel can make several steps
+   (up to a configurable limit, currently 4) as long as the particle
+   stays alive and inside the volume. At volume boundary, relocation
+   still happens in a separate kernel.
+2. The host submits multiple kernels (currently 4 per particle type)
+   into the appropriate streams and only synchronizes once at the end.
+   Proper ordering on the device is ensured via events, extending the
+   previous approach. The code uses an upper bound on the number of
+   particles to determine the launch configuration.
+
+In total, this reduces the number of iterations for trackML from 214
+with Example 9 to 29 using this example with identical results (energy
+deposition, number of secondaries, number of hit volume boundaries).
+However, best performance for this setup is obtained with only one
+step per kernel and submitting one kernel per iteration - in other
+words, exactly what Example 9 does.
+
+TL;DR: This example is currently meant as a proof-of-concept and for
+playing with the parameters (number of steps and submitted kernels).
+
 ### Kernels
 
 This example uses one stream per particle type to launch kernels asynchronously.

--- a/examples/Example10/electrons.cu
+++ b/examples/Example10/electrons.cu
@@ -26,7 +26,8 @@
 template <bool IsElectron>
 static __device__ __forceinline__ void TransportElectrons(Track *electrons, const adept::MParray *active,
                                                           Secondaries &secondaries, adept::MParray *activeQueue,
-                                                          adept::MParray *relocateQueue, GlobalScoring *scoring)
+                                                          adept::MParray *relocateQueue, GlobalScoring *scoring,
+                                                          int maxSteps)
 {
   constexpr int Charge  = IsElectron ? -1 : 1;
   constexpr double Mass = copcore::units::kElectronMassC2;
@@ -46,208 +47,227 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     theTrack->SetMCIndex(theMCIndex);
     theTrack->SetCharge(Charge);
 
-    // Sample the `number-of-interaction-left` and put it into the track.
-    for (int ip = 0; ip < 3; ++ip) {
-      double numIALeft = currentTrack.numIALeft[ip];
-      if (numIALeft <= 0) {
-        numIALeft                  = -std::log(currentTrack.Uniform());
+    bool alive = true;
+    for (int s = 0; alive && s < maxSteps; s++) {
+
+      // Sample the `number-of-interaction-left` and put it into the track.
+      for (int ip = 0; ip < 3; ++ip) {
+        double numIALeft = currentTrack.numIALeft[ip];
+        if (numIALeft <= 0) {
+          numIALeft                  = -std::log(currentTrack.Uniform());
+          currentTrack.numIALeft[ip] = numIALeft;
+        }
+        theTrack->SetNumIALeft(numIALeft, ip);
+      }
+
+      // Call G4HepEm to compute the physics step limit.
+      G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack);
+
+      // Get result into variables.
+      double geometricalStepLengthFromPhysics = theTrack->GetGStepLength();
+      // The phyiscal step length is the amount that the particle experiences
+      // which might be longer than the geometrical step length due to MSC. As
+      // long as we call PerformContinuous in the same kernel we don't need to
+      // care, but we need to make this available when splitting the operations.
+      // double physicalStepLength = elTrack.GetPStepLength();
+      int winnerProcessIndex = theTrack->GetWinnerProcessIndex();
+      // Leave the range and MFP inside the G4HepEmTrack. If we split kernels, we
+      // also need to carry them over!
+
+      // Check if there's a volume boundary in between.
+      double geometryStepLength = fieldPropagatorBz.ComputeStepAndPropagatedState</*Relocate=*/false>(
+          currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
+          currentTrack.currentState, currentTrack.nextState);
+
+      if (currentTrack.nextState.IsOnBoundary()) {
+        theTrack->SetGStepLength(geometryStepLength);
+        theTrack->SetOnBoundary(true);
+      }
+
+      // Apply continuous effects.
+      bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack);
+      // Collect the changes.
+      currentTrack.energy = theTrack->GetEKin();
+      atomicAdd(&scoring->energyDeposit, theTrack->GetEnergyDeposit());
+
+      // Save the `number-of-interaction-left` in our track.
+      for (int ip = 0; ip < 3; ++ip) {
+        double numIALeft           = theTrack->GetNumIALeft(ip);
         currentTrack.numIALeft[ip] = numIALeft;
       }
-      theTrack->SetNumIALeft(numIALeft, ip);
-    }
 
-    // Call G4HepEm to compute the physics step limit.
-    G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack);
+      if (stopped) {
+        if (!IsElectron) {
+          // Annihilate the stopped positron into two gammas heading to opposite
+          // directions (isotropic).
+          Track &gamma1 = secondaries.gammas.NextTrack();
+          Track &gamma2 = secondaries.gammas.NextTrack();
+          atomicAdd(&scoring->secondaries, 2);
 
-    // Get result into variables.
-    double geometricalStepLengthFromPhysics = theTrack->GetGStepLength();
-    // The phyiscal step length is the amount that the particle experiences
-    // which might be longer than the geometrical step length due to MSC. As
-    // long as we call PerformContinuous in the same kernel we don't need to
-    // care, but we need to make this available when splitting the operations.
-    // double physicalStepLength = elTrack.GetPStepLength();
-    int winnerProcessIndex = theTrack->GetWinnerProcessIndex();
-    // Leave the range and MFP inside the G4HepEmTrack. If we split kernels, we
-    // also need to carry them over!
+          const double cost = 2 * currentTrack.Uniform() - 1;
+          const double sint = sqrt(1 - cost * cost);
+          const double phi  = k2Pi * currentTrack.Uniform();
+          double sinPhi, cosPhi;
+          sincos(phi, &sinPhi, &cosPhi);
 
-    // Check if there's a volume boundary in between.
-    double geometryStepLength = fieldPropagatorBz.ComputeStepAndPropagatedState</*Relocate=*/false>(
-        currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
-        currentTrack.currentState, currentTrack.nextState);
+          gamma1.InitAsSecondary(/*parent=*/currentTrack);
+          gamma1.rngState = currentTrack.rngState.Branch();
+          gamma1.energy   = copcore::units::kElectronMassC2;
+          gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
 
-    if (currentTrack.nextState.IsOnBoundary()) {
-      theTrack->SetGStepLength(geometryStepLength);
-      theTrack->SetOnBoundary(true);
-    }
+          gamma2.InitAsSecondary(/*parent=*/currentTrack);
+          // Reuse the RNG state of the dying track.
+          gamma2.rngState = currentTrack.rngState;
+          gamma2.energy   = copcore::units::kElectronMassC2;
+          gamma2.dir      = -gamma1.dir;
+        }
+        alive = false;
+        break;
+      }
 
-    // Apply continuous effects.
-    bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack);
-    // Collect the changes.
-    currentTrack.energy = theTrack->GetEKin();
-    atomicAdd(&scoring->energyDeposit, theTrack->GetEnergyDeposit());
+      if (currentTrack.nextState.IsOnBoundary()) {
+        // For now, just count that we hit something.
+        atomicAdd(&scoring->hits, 1);
 
-    // Save the `number-of-interaction-left` in our track.
-    for (int ip = 0; ip < 3; ++ip) {
-      double numIALeft           = theTrack->GetNumIALeft(ip);
-      currentTrack.numIALeft[ip] = numIALeft;
-    }
+        // Kill the particle if it left the world.
+        if (currentTrack.nextState.Top() != nullptr) {
+          alive = true;
+          relocateQueue->push_back(slot);
 
-    if (stopped) {
-      if (!IsElectron) {
-        // Annihilate the stopped positron into two gammas heading to opposite
-        // directions (isotropic).
+          // Move to the next boundary.
+          currentTrack.SwapStates();
+        } else {
+          alive = false;
+        }
+
+        // Cannot continue for now: either the particles left the world, or we
+        // need to relocate it to the next volume.
+        break;
+      } else if (winnerProcessIndex < 0) {
+        // No discrete process, move on.
+        continue;
+      }
+
+      // Reset number of interaction left for the winner discrete process.
+      // (Will be resampled in the next iteration.)
+      currentTrack.numIALeft[winnerProcessIndex] = -1.0;
+
+      // Check if a delta interaction happens instead of the real discrete process.
+      if (G4HepEmElectronManager::CheckDelta(&g4HepEmData, theTrack, currentTrack.Uniform())) {
+        // A delta interaction happened, move on.
+        continue;
+      }
+
+      // Perform the discrete interaction.
+      RanluxppDoubleEngine rnge(&currentTrack.rngState);
+      // We will need one branched RNG state, prepare while threads are synchronized.
+      RanluxppDouble newRNG(currentTrack.rngState.Branch());
+
+      const double energy   = currentTrack.energy;
+      const double theElCut = g4HepEmData.fTheMatCutData->fMatCutData[theMCIndex].fSecElProdCutE;
+
+      switch (winnerProcessIndex) {
+      case 0: {
+        // Invoke ionization (for e-/e+):
+        double deltaEkin = (IsElectron)
+                               ? G4HepEmElectronInteractionIoni::SampleETransferMoller(theElCut, energy, &rnge)
+                               : G4HepEmElectronInteractionIoni::SampleETransferBhabha(theElCut, energy, &rnge);
+
+        double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+        double dirSecondary[3];
+        G4HepEmElectronInteractionIoni::SampleDirections(energy, deltaEkin, dirSecondary, dirPrimary, &rnge);
+
+        Track &secondary = secondaries.electrons.NextTrack();
+        atomicAdd(&scoring->secondaries, 1);
+
+        secondary.InitAsSecondary(/*parent=*/currentTrack);
+        secondary.rngState = newRNG;
+        secondary.energy   = deltaEkin;
+        secondary.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
+
+        currentTrack.energy = energy - deltaEkin;
+        theTrack->SetEKin(currentTrack.energy);
+        currentTrack.dir.Set(dirPrimary[0], dirPrimary[1], dirPrimary[2]);
+        // The current track continues to live.
+        alive = true;
+        break;
+      }
+      case 1: {
+        // Invoke model for Bremsstrahlung: either SB- or Rel-Brem.
+        double logEnergy = std::log(energy);
+        double deltaEkin = energy < g4HepEmPars.fElectronBremModelLim
+                               ? G4HepEmElectronInteractionBrem::SampleETransferSB(&g4HepEmData, energy, logEnergy,
+                                                                                   theMCIndex, &rnge, IsElectron)
+                               : G4HepEmElectronInteractionBrem::SampleETransferRB(&g4HepEmData, energy, logEnergy,
+                                                                                   theMCIndex, &rnge, IsElectron);
+
+        double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+        double dirSecondary[3];
+        G4HepEmElectronInteractionBrem::SampleDirections(energy, deltaEkin, dirSecondary, dirPrimary, &rnge);
+
+        Track &gamma = secondaries.gammas.NextTrack();
+        atomicAdd(&scoring->secondaries, 1);
+
+        gamma.InitAsSecondary(/*parent=*/currentTrack);
+        gamma.rngState = newRNG;
+        gamma.energy   = deltaEkin;
+        gamma.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
+
+        currentTrack.energy = energy - deltaEkin;
+        theTrack->SetEKin(currentTrack.energy);
+        currentTrack.dir.Set(dirPrimary[0], dirPrimary[1], dirPrimary[2]);
+        // The current track continues to live.
+        alive = true;
+        break;
+      }
+      case 2: {
+        // Invoke annihilation (in-flight) for e+
+        double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+        double theGamma1Ekin, theGamma2Ekin;
+        double theGamma1Dir[3], theGamma2Dir[3];
+        G4HepEmPositronInteractionAnnihilation::SampleEnergyAndDirectionsInFlight(
+            energy, dirPrimary, &theGamma1Ekin, theGamma1Dir, &theGamma2Ekin, theGamma2Dir, &rnge);
+
         Track &gamma1 = secondaries.gammas.NextTrack();
         Track &gamma2 = secondaries.gammas.NextTrack();
         atomicAdd(&scoring->secondaries, 2);
 
-        const double cost = 2 * currentTrack.Uniform() - 1;
-        const double sint = sqrt(1 - cost * cost);
-        const double phi  = k2Pi * currentTrack.Uniform();
-        double sinPhi, cosPhi;
-        sincos(phi, &sinPhi, &cosPhi);
-
         gamma1.InitAsSecondary(/*parent=*/currentTrack);
-        gamma1.rngState = currentTrack.rngState.Branch();
-        gamma1.energy   = copcore::units::kElectronMassC2;
-        gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
+        gamma1.rngState = newRNG;
+        gamma1.energy   = theGamma1Ekin;
+        gamma1.dir.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
 
         gamma2.InitAsSecondary(/*parent=*/currentTrack);
         // Reuse the RNG state of the dying track.
         gamma2.rngState = currentTrack.rngState;
-        gamma2.energy   = copcore::units::kElectronMassC2;
-        gamma2.dir      = -gamma1.dir;
+        gamma2.energy   = theGamma2Ekin;
+        gamma2.dir.Set(theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]);
+
+        // The current track is killed.
+        alive = false;
+        break;
       }
-      // Particles are killed by not enqueuing them into the new activeQueue.
-      continue;
-    }
-
-    if (currentTrack.nextState.IsOnBoundary()) {
-      // For now, just count that we hit something.
-      atomicAdd(&scoring->hits, 1);
-
-      // Kill the particle if it left the world.
-      if (currentTrack.nextState.Top() != nullptr) {
-        activeQueue->push_back(slot);
-        relocateQueue->push_back(slot);
-
-        // Move to the next boundary.
-        currentTrack.SwapStates();
       }
-      continue;
-    } else if (winnerProcessIndex < 0) {
-      // No discrete process, move on.
+    }
+
+    if (alive) {
       activeQueue->push_back(slot);
-      continue;
-    }
-
-    // Reset number of interaction left for the winner discrete process.
-    // (Will be resampled in the next iteration.)
-    currentTrack.numIALeft[winnerProcessIndex] = -1.0;
-
-    // Check if a delta interaction happens instead of the real discrete process.
-    if (G4HepEmElectronManager::CheckDelta(&g4HepEmData, theTrack, currentTrack.Uniform())) {
-      // A delta interaction happened, move on.
-      activeQueue->push_back(slot);
-      continue;
-    }
-
-    // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
-    // We will need one branched RNG state, prepare while threads are synchronized.
-    RanluxppDouble newRNG(currentTrack.rngState.Branch());
-
-    const double energy   = currentTrack.energy;
-    const double theElCut = g4HepEmData.fTheMatCutData->fMatCutData[theMCIndex].fSecElProdCutE;
-
-    switch (winnerProcessIndex) {
-    case 0: {
-      // Invoke ionization (for e-/e+):
-      double deltaEkin = (IsElectron) ? G4HepEmElectronInteractionIoni::SampleETransferMoller(theElCut, energy, &rnge)
-                                      : G4HepEmElectronInteractionIoni::SampleETransferBhabha(theElCut, energy, &rnge);
-
-      double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
-      double dirSecondary[3];
-      G4HepEmElectronInteractionIoni::SampleDirections(energy, deltaEkin, dirSecondary, dirPrimary, &rnge);
-
-      Track &secondary = secondaries.electrons.NextTrack();
-      atomicAdd(&scoring->secondaries, 1);
-
-      secondary.InitAsSecondary(/*parent=*/currentTrack);
-      secondary.rngState = newRNG;
-      secondary.energy   = deltaEkin;
-      secondary.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
-
-      currentTrack.energy = energy - deltaEkin;
-      currentTrack.dir.Set(dirPrimary[0], dirPrimary[1], dirPrimary[2]);
-      // The current track continues to live.
-      activeQueue->push_back(slot);
-      break;
-    }
-    case 1: {
-      // Invoke model for Bremsstrahlung: either SB- or Rel-Brem.
-      double logEnergy = std::log(energy);
-      double deltaEkin = energy < g4HepEmPars.fElectronBremModelLim
-                             ? G4HepEmElectronInteractionBrem::SampleETransferSB(&g4HepEmData, energy, logEnergy,
-                                                                                 theMCIndex, &rnge, IsElectron)
-                             : G4HepEmElectronInteractionBrem::SampleETransferRB(&g4HepEmData, energy, logEnergy,
-                                                                                 theMCIndex, &rnge, IsElectron);
-
-      double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
-      double dirSecondary[3];
-      G4HepEmElectronInteractionBrem::SampleDirections(energy, deltaEkin, dirSecondary, dirPrimary, &rnge);
-
-      Track &gamma = secondaries.gammas.NextTrack();
-      atomicAdd(&scoring->secondaries, 1);
-
-      gamma.InitAsSecondary(/*parent=*/currentTrack);
-      gamma.rngState = newRNG;
-      gamma.energy   = deltaEkin;
-      gamma.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
-
-      currentTrack.energy = energy - deltaEkin;
-      currentTrack.dir.Set(dirPrimary[0], dirPrimary[1], dirPrimary[2]);
-      // The current track continues to live.
-      activeQueue->push_back(slot);
-      break;
-    }
-    case 2: {
-      // Invoke annihilation (in-flight) for e+
-      double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
-      double theGamma1Ekin, theGamma2Ekin;
-      double theGamma1Dir[3], theGamma2Dir[3];
-      G4HepEmPositronInteractionAnnihilation::SampleEnergyAndDirectionsInFlight(
-          energy, dirPrimary, &theGamma1Ekin, theGamma1Dir, &theGamma2Ekin, theGamma2Dir, &rnge);
-
-      Track &gamma1 = secondaries.gammas.NextTrack();
-      Track &gamma2 = secondaries.gammas.NextTrack();
-      atomicAdd(&scoring->secondaries, 2);
-
-      gamma1.InitAsSecondary(/*parent=*/currentTrack);
-      gamma1.rngState = newRNG;
-      gamma1.energy   = theGamma1Ekin;
-      gamma1.dir.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
-
-      gamma2.InitAsSecondary(/*parent=*/currentTrack);
-      // Reuse the RNG state of the dying track.
-      gamma2.rngState = currentTrack.rngState;
-      gamma2.energy   = theGamma2Ekin;
-      gamma2.dir.Set(theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]);
-
-      // The current track is killed by not enqueuing into the next activeQueue.
-      break;
-    }
     }
   }
 }
 
 // Instantiate kernels for electrons and positrons.
 __global__ void TransportElectrons(Track *electrons, const adept::MParray *active, Secondaries secondaries,
-                                   adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring)
+                                   adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring,
+                                   int maxSteps)
 {
-  TransportElectrons</*IsElectron*/ true>(electrons, active, secondaries, activeQueue, relocateQueue, scoring);
+  TransportElectrons</*IsElectron*/ true>(electrons, active, secondaries, activeQueue, relocateQueue, scoring,
+                                          maxSteps);
 }
 __global__ void TransportPositrons(Track *positrons, const adept::MParray *active, Secondaries secondaries,
-                                   adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring)
+                                   adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring,
+                                   int maxSteps)
 {
-  TransportElectrons</*IsElectron*/ false>(positrons, active, secondaries, activeQueue, relocateQueue, scoring);
+  TransportElectrons</*IsElectron*/ false>(positrons, active, secondaries, activeQueue, relocateQueue, scoring,
+                                           maxSteps);
 }

--- a/examples/Example10/electrons.cu
+++ b/examples/Example10/electrons.cu
@@ -1,0 +1,253 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include "example10.cuh"
+
+#include <fieldPropagatorConstBz.h>
+
+#include <CopCore/PhysicalConstants.h>
+
+#include <G4HepEmElectronManager.hh>
+#include <G4HepEmElectronTrack.hh>
+#include <G4HepEmElectronInteractionBrem.hh>
+#include <G4HepEmElectronInteractionIoni.hh>
+#include <G4HepEmPositronInteractionAnnihilation.hh>
+// Pull in implementation.
+#include <G4HepEmRunUtils.icc>
+#include <G4HepEmInteractionUtils.icc>
+#include <G4HepEmElectronManager.icc>
+#include <G4HepEmElectronInteractionBrem.icc>
+#include <G4HepEmElectronInteractionIoni.icc>
+#include <G4HepEmPositronInteractionAnnihilation.icc>
+
+// Compute the physics and geometry step limit, transport the electrons while
+// applying the continuous effects and maybe a discrete process that could
+// generate secondaries.
+template <bool IsElectron>
+static __device__ __forceinline__ void TransportElectrons(Track *electrons, const adept::MParray *active,
+                                                          Secondaries &secondaries, adept::MParray *activeQueue,
+                                                          adept::MParray *relocateQueue, GlobalScoring *scoring)
+{
+  constexpr int Charge  = IsElectron ? -1 : 1;
+  constexpr double Mass = copcore::units::kElectronMassC2;
+  fieldPropagatorConstBz fieldPropagatorBz(BzFieldValue);
+
+  int activeSize = active->size();
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
+    const int slot      = (*active)[i];
+    Track &currentTrack = electrons[slot];
+
+    // Init a track with the needed data to call into G4HepEm.
+    G4HepEmElectronTrack elTrack;
+    G4HepEmTrack *theTrack = elTrack.GetTrack();
+    theTrack->SetEKin(currentTrack.energy);
+    // For now, just assume a single material.
+    int theMCIndex = 1;
+    theTrack->SetMCIndex(theMCIndex);
+    theTrack->SetCharge(Charge);
+
+    // Sample the `number-of-interaction-left` and put it into the track.
+    for (int ip = 0; ip < 3; ++ip) {
+      double numIALeft = currentTrack.numIALeft[ip];
+      if (numIALeft <= 0) {
+        numIALeft                  = -std::log(currentTrack.Uniform());
+        currentTrack.numIALeft[ip] = numIALeft;
+      }
+      theTrack->SetNumIALeft(numIALeft, ip);
+    }
+
+    // Call G4HepEm to compute the physics step limit.
+    G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack);
+
+    // Get result into variables.
+    double geometricalStepLengthFromPhysics = theTrack->GetGStepLength();
+    // The phyiscal step length is the amount that the particle experiences
+    // which might be longer than the geometrical step length due to MSC. As
+    // long as we call PerformContinuous in the same kernel we don't need to
+    // care, but we need to make this available when splitting the operations.
+    // double physicalStepLength = elTrack.GetPStepLength();
+    int winnerProcessIndex = theTrack->GetWinnerProcessIndex();
+    // Leave the range and MFP inside the G4HepEmTrack. If we split kernels, we
+    // also need to carry them over!
+
+    // Check if there's a volume boundary in between.
+    double geometryStepLength = fieldPropagatorBz.ComputeStepAndPropagatedState</*Relocate=*/false>(
+        currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
+        currentTrack.currentState, currentTrack.nextState);
+
+    if (currentTrack.nextState.IsOnBoundary()) {
+      theTrack->SetGStepLength(geometryStepLength);
+      theTrack->SetOnBoundary(true);
+    }
+
+    // Apply continuous effects.
+    bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack);
+    // Collect the changes.
+    currentTrack.energy = theTrack->GetEKin();
+    atomicAdd(&scoring->energyDeposit, theTrack->GetEnergyDeposit());
+
+    // Save the `number-of-interaction-left` in our track.
+    for (int ip = 0; ip < 3; ++ip) {
+      double numIALeft           = theTrack->GetNumIALeft(ip);
+      currentTrack.numIALeft[ip] = numIALeft;
+    }
+
+    if (stopped) {
+      if (!IsElectron) {
+        // Annihilate the stopped positron into two gammas heading to opposite
+        // directions (isotropic).
+        Track &gamma1 = secondaries.gammas.NextTrack();
+        Track &gamma2 = secondaries.gammas.NextTrack();
+        atomicAdd(&scoring->secondaries, 2);
+
+        const double cost = 2 * currentTrack.Uniform() - 1;
+        const double sint = sqrt(1 - cost * cost);
+        const double phi  = k2Pi * currentTrack.Uniform();
+        double sinPhi, cosPhi;
+        sincos(phi, &sinPhi, &cosPhi);
+
+        gamma1.InitAsSecondary(/*parent=*/currentTrack);
+        gamma1.rngState = currentTrack.rngState.Branch();
+        gamma1.energy   = copcore::units::kElectronMassC2;
+        gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
+
+        gamma2.InitAsSecondary(/*parent=*/currentTrack);
+        // Reuse the RNG state of the dying track.
+        gamma2.rngState = currentTrack.rngState;
+        gamma2.energy   = copcore::units::kElectronMassC2;
+        gamma2.dir      = -gamma1.dir;
+      }
+      // Particles are killed by not enqueuing them into the new activeQueue.
+      continue;
+    }
+
+    if (currentTrack.nextState.IsOnBoundary()) {
+      // For now, just count that we hit something.
+      atomicAdd(&scoring->hits, 1);
+
+      // Kill the particle if it left the world.
+      if (currentTrack.nextState.Top() != nullptr) {
+        activeQueue->push_back(slot);
+        relocateQueue->push_back(slot);
+
+        // Move to the next boundary.
+        currentTrack.SwapStates();
+      }
+      continue;
+    } else if (winnerProcessIndex < 0) {
+      // No discrete process, move on.
+      activeQueue->push_back(slot);
+      continue;
+    }
+
+    // Reset number of interaction left for the winner discrete process.
+    // (Will be resampled in the next iteration.)
+    currentTrack.numIALeft[winnerProcessIndex] = -1.0;
+
+    // Check if a delta interaction happens instead of the real discrete process.
+    if (G4HepEmElectronManager::CheckDelta(&g4HepEmData, theTrack, currentTrack.Uniform())) {
+      // A delta interaction happened, move on.
+      activeQueue->push_back(slot);
+      continue;
+    }
+
+    // Perform the discrete interaction.
+    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    // We will need one branched RNG state, prepare while threads are synchronized.
+    RanluxppDouble newRNG(currentTrack.rngState.Branch());
+
+    const double energy   = currentTrack.energy;
+    const double theElCut = g4HepEmData.fTheMatCutData->fMatCutData[theMCIndex].fSecElProdCutE;
+
+    switch (winnerProcessIndex) {
+    case 0: {
+      // Invoke ionization (for e-/e+):
+      double deltaEkin = (IsElectron) ? G4HepEmElectronInteractionIoni::SampleETransferMoller(theElCut, energy, &rnge)
+                                      : G4HepEmElectronInteractionIoni::SampleETransferBhabha(theElCut, energy, &rnge);
+
+      double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+      double dirSecondary[3];
+      G4HepEmElectronInteractionIoni::SampleDirections(energy, deltaEkin, dirSecondary, dirPrimary, &rnge);
+
+      Track &secondary = secondaries.electrons.NextTrack();
+      atomicAdd(&scoring->secondaries, 1);
+
+      secondary.InitAsSecondary(/*parent=*/currentTrack);
+      secondary.rngState = newRNG;
+      secondary.energy   = deltaEkin;
+      secondary.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
+
+      currentTrack.energy = energy - deltaEkin;
+      currentTrack.dir.Set(dirPrimary[0], dirPrimary[1], dirPrimary[2]);
+      // The current track continues to live.
+      activeQueue->push_back(slot);
+      break;
+    }
+    case 1: {
+      // Invoke model for Bremsstrahlung: either SB- or Rel-Brem.
+      double logEnergy = std::log(energy);
+      double deltaEkin = energy < g4HepEmPars.fElectronBremModelLim
+                             ? G4HepEmElectronInteractionBrem::SampleETransferSB(&g4HepEmData, energy, logEnergy,
+                                                                                 theMCIndex, &rnge, IsElectron)
+                             : G4HepEmElectronInteractionBrem::SampleETransferRB(&g4HepEmData, energy, logEnergy,
+                                                                                 theMCIndex, &rnge, IsElectron);
+
+      double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+      double dirSecondary[3];
+      G4HepEmElectronInteractionBrem::SampleDirections(energy, deltaEkin, dirSecondary, dirPrimary, &rnge);
+
+      Track &gamma = secondaries.gammas.NextTrack();
+      atomicAdd(&scoring->secondaries, 1);
+
+      gamma.InitAsSecondary(/*parent=*/currentTrack);
+      gamma.rngState = newRNG;
+      gamma.energy   = deltaEkin;
+      gamma.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
+
+      currentTrack.energy = energy - deltaEkin;
+      currentTrack.dir.Set(dirPrimary[0], dirPrimary[1], dirPrimary[2]);
+      // The current track continues to live.
+      activeQueue->push_back(slot);
+      break;
+    }
+    case 2: {
+      // Invoke annihilation (in-flight) for e+
+      double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+      double theGamma1Ekin, theGamma2Ekin;
+      double theGamma1Dir[3], theGamma2Dir[3];
+      G4HepEmPositronInteractionAnnihilation::SampleEnergyAndDirectionsInFlight(
+          energy, dirPrimary, &theGamma1Ekin, theGamma1Dir, &theGamma2Ekin, theGamma2Dir, &rnge);
+
+      Track &gamma1 = secondaries.gammas.NextTrack();
+      Track &gamma2 = secondaries.gammas.NextTrack();
+      atomicAdd(&scoring->secondaries, 2);
+
+      gamma1.InitAsSecondary(/*parent=*/currentTrack);
+      gamma1.rngState = newRNG;
+      gamma1.energy   = theGamma1Ekin;
+      gamma1.dir.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
+
+      gamma2.InitAsSecondary(/*parent=*/currentTrack);
+      // Reuse the RNG state of the dying track.
+      gamma2.rngState = currentTrack.rngState;
+      gamma2.energy   = theGamma2Ekin;
+      gamma2.dir.Set(theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]);
+
+      // The current track is killed by not enqueuing into the next activeQueue.
+      break;
+    }
+    }
+  }
+}
+
+// Instantiate kernels for electrons and positrons.
+__global__ void TransportElectrons(Track *electrons, const adept::MParray *active, Secondaries secondaries,
+                                   adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring)
+{
+  TransportElectrons</*IsElectron*/ true>(electrons, active, secondaries, activeQueue, relocateQueue, scoring);
+}
+__global__ void TransportPositrons(Track *positrons, const adept::MParray *active, Secondaries secondaries,
+                                   adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring)
+{
+  TransportElectrons</*IsElectron*/ false>(positrons, active, secondaries, activeQueue, relocateQueue, scoring);
+}

--- a/examples/Example10/example10.cpp
+++ b/examples/Example10/example10.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include "example10.h"
+
+#include <AdePT/ArgParser.h>
+#include <CopCore/SystemOfUnits.h>
+
+#include <G4NistManager.hh>
+#include <G4Material.hh>
+
+#include <G4Box.hh>
+#include <G4LogicalVolume.hh>
+#include <G4PVPlacement.hh>
+
+#include <G4ParticleTable.hh>
+#include <G4Electron.hh>
+#include <G4Positron.hh>
+#include <G4Gamma.hh>
+#include <G4Proton.hh>
+
+#include <G4ProductionCuts.hh>
+#include <G4Region.hh>
+#include <G4ProductionCutsTable.hh>
+
+#include <G4SystemOfUnits.hh>
+
+#include <VecGeom/base/Config.h>
+#include <VecGeom/management/GeoManager.h>
+#ifdef VECGEOM_GDML
+#include <VecGeom/gdml/Frontend.h>
+#endif
+
+static void InitGeant4()
+{
+  // --- Create materials.
+  G4Material *galactic = G4NistManager::Instance()->FindOrBuildMaterial("G4_Galactic");
+  G4Material *silicon  = G4NistManager::Instance()->FindOrBuildMaterial("G4_Si");
+  //
+  // --- Define a world.
+  G4double worldDim         = 1 * m;
+  G4Box *worldBox           = new G4Box("world", worldDim, worldDim, worldDim);
+  G4LogicalVolume *worldLog = new G4LogicalVolume(worldBox, galactic, "world");
+  G4PVPlacement *world      = new G4PVPlacement(nullptr, {}, worldLog, "world", nullptr, false, 0);
+  // --- Define a box.
+  G4double boxDim             = 0.5 * m;
+  G4double boxPos             = 0.5 * boxDim;
+  G4Box *siliconBox           = new G4Box("silicon", boxDim, boxDim, boxDim);
+  G4LogicalVolume *siliconLog = new G4LogicalVolume(siliconBox, silicon, "silicon");
+  new G4PVPlacement(nullptr, {boxPos, boxPos, boxPos}, siliconLog, "silicon", worldLog, false, 0);
+  //
+  // --- Create particles that have secondary production threshold.
+  G4Gamma::Gamma();
+  G4Electron::Electron();
+  G4Positron::Positron();
+  G4Proton::Proton();
+  G4ParticleTable *partTable = G4ParticleTable::GetParticleTable();
+  partTable->SetReadiness();
+  //
+  // --- Create production - cuts object and set the secondary production threshold.
+  G4ProductionCuts *productionCuts = new G4ProductionCuts();
+  constexpr G4double ProductionCut = 1 * mm;
+  productionCuts->SetProductionCut(ProductionCut);
+  //
+  // --- Register a region for the world.
+  G4Region *reg = new G4Region("default");
+  reg->AddRootLogicalVolume(worldLog);
+  reg->UsedInMassGeometry(true);
+  reg->SetProductionCuts(productionCuts);
+  //
+  // --- Update the couple tables.
+  G4ProductionCutsTable *theCoupleTable = G4ProductionCutsTable::GetProductionCutsTable();
+  theCoupleTable->UpdateCoupleTable(world);
+}
+
+int main(int argc, char *argv[])
+{
+#ifndef VECGEOM_GDML
+  std::cout << "### VecGeom must be compiled with GDML support to run this.\n";
+  return 1;
+#endif
+#ifndef VECGEOM_USE_NAVINDEX
+  std::cout << "### VecGeom must be compiled with USE_NAVINDEX support to run this.\n";
+  return 2;
+#endif
+
+  OPTION_STRING(gdml_name, "trackML.gdml");
+  OPTION_INT(cache_depth, 0); // 0 = full depth
+  OPTION_INT(particles, 1);
+  OPTION_DOUBLE(energy, 100); // entered in GeV
+  energy *= copcore::units::GeV;
+
+  InitGeant4();
+
+#ifdef VECGEOM_GDML
+  vecgeom::GeoManager::Instance().SetTransformationCacheDepth(cache_depth);
+  // The vecgeom millimeter unit is the last parameter of vgdml::Frontend::Load
+  bool load = vgdml::Frontend::Load(gdml_name.c_str(), false, copcore::units::mm);
+  if (!load) return 3;
+#endif
+
+  const vecgeom::VPlacedVolume *world = vecgeom::GeoManager::Instance().GetWorld();
+  if (!world) return 4;
+
+  example10(world, particles, energy);
+}

--- a/examples/Example10/example10.cu
+++ b/examples/Example10/example10.cu
@@ -1,0 +1,373 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include "example10.h"
+#include "example10.cuh"
+
+#include <AdePT/Atomic.h>
+#include <AdePT/LoopNavigator.h>
+#include <AdePT/MParray.h>
+
+#include <CopCore/Global.h>
+#include <CopCore/PhysicalConstants.h>
+#include <CopCore/Ranluxpp.h>
+
+#include <VecGeom/base/Config.h>
+#include <VecGeom/base/Stopwatch.h>
+#ifdef VECGEOM_ENABLE_CUDA
+#include <VecGeom/backend/cuda/Interface.h>
+#endif
+
+#include <G4HepEmData.hh>
+#include <G4HepEmElectronInit.hh>
+#include <G4HepEmGammaInit.hh>
+#include <G4HepEmMatCutData.hh>
+#include <G4HepEmMaterialInit.hh>
+#include <G4HepEmParameters.hh>
+#include <G4HepEmParametersInit.hh>
+
+#include <iostream>
+#include <iomanip>
+#include <stdio.h>
+
+__constant__ __device__ struct G4HepEmParameters g4HepEmPars;
+__constant__ __device__ struct G4HepEmData g4HepEmData;
+
+__constant__ __device__ int Zero = 0;
+
+struct G4HepEmState {
+  G4HepEmData data;
+  G4HepEmParameters parameters;
+};
+
+static G4HepEmState *InitG4HepEm()
+{
+  G4HepEmState *state = new G4HepEmState;
+  InitG4HepEmData(&state->data);
+  InitHepEmParameters(&state->parameters);
+
+  InitMaterialAndCoupleData(&state->data, &state->parameters);
+
+  InitElectronData(&state->data, &state->parameters, true);
+  InitElectronData(&state->data, &state->parameters, false);
+  InitGammaData(&state->data, &state->parameters);
+
+  G4HepEmMatCutData *cutData = state->data.fTheMatCutData;
+  std::cout << "fNumG4MatCuts = " << cutData->fNumG4MatCuts << ", fNumMatCutData = " << cutData->fNumMatCutData
+            << std::endl;
+
+  // Copy to GPU.
+  CopyG4HepEmDataToGPU(&state->data);
+  COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(g4HepEmPars, &state->parameters, sizeof(G4HepEmParameters)));
+
+  // Create G4HepEmData with the device pointers.
+  G4HepEmData dataOnDevice;
+  dataOnDevice.fTheMatCutData   = state->data.fTheMatCutData_gpu;
+  dataOnDevice.fTheMaterialData = state->data.fTheMaterialData_gpu;
+  dataOnDevice.fTheElementData  = state->data.fTheElementData_gpu;
+  dataOnDevice.fTheElectronData = state->data.fTheElectronData_gpu;
+  dataOnDevice.fThePositronData = state->data.fThePositronData_gpu;
+  dataOnDevice.fTheSBTableData  = state->data.fTheSBTableData_gpu;
+  dataOnDevice.fTheGammaData    = state->data.fTheGammaData_gpu;
+  // The other pointers should never be used.
+  dataOnDevice.fTheMatCutData_gpu   = nullptr;
+  dataOnDevice.fTheMaterialData_gpu = nullptr;
+  dataOnDevice.fTheElementData_gpu  = nullptr;
+  dataOnDevice.fTheElectronData_gpu = nullptr;
+  dataOnDevice.fThePositronData_gpu = nullptr;
+  dataOnDevice.fTheSBTableData_gpu  = nullptr;
+  dataOnDevice.fTheGammaData_gpu    = nullptr;
+
+  COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(g4HepEmData, &dataOnDevice, sizeof(G4HepEmData)));
+
+  return state;
+}
+
+static void FreeG4HepEm(G4HepEmState *state)
+{
+  FreeG4HepEmData(&state->data);
+  delete state;
+}
+
+// A bundle of queues per particle type:
+//  * Two for active particles, one for the current iteration and the second for the next.
+//  * One for all particles that need to be relocated to the next volume.
+struct ParticleQueues {
+  adept::MParray *currentlyActive;
+  adept::MParray *nextActive;
+  adept::MParray *relocate;
+
+  void SwapActive() { std::swap(currentlyActive, nextActive); }
+};
+
+struct ParticleType {
+  Track *tracks;
+  SlotManager *slotManager;
+  ParticleQueues queues;
+  cudaStream_t stream;
+  cudaEvent_t event;
+
+  enum {
+    Electron = 0,
+    Positron = 1,
+    Gamma    = 2,
+
+    NumParticleTypes,
+  };
+};
+
+// A bundle of queues for the three particle types.
+struct AllParticleQueues {
+  ParticleQueues queues[ParticleType::NumParticleTypes];
+};
+
+// Kernel to initialize the set of queues per particle type.
+__global__ void InitParticleQueues(ParticleQueues queues, size_t Capacity)
+{
+  adept::MParray::MakeInstanceAt(Capacity, queues.currentlyActive);
+  adept::MParray::MakeInstanceAt(Capacity, queues.nextActive);
+  adept::MParray::MakeInstanceAt(Capacity, queues.relocate);
+}
+
+// Kernel function to initialize a set of primary particles.
+__global__ void InitPrimaries(ParticleGenerator generator, int particles, double energy,
+                              const vecgeom::VPlacedVolume *world)
+{
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < particles; i += blockDim.x * gridDim.x) {
+    Track &track = generator.NextTrack();
+
+    track.rngState.SetSeed(314159265 * (i + 1));
+    track.energy       = energy;
+    track.numIALeft[0] = -1.0;
+    track.numIALeft[1] = -1.0;
+    track.numIALeft[2] = -1.0;
+
+    track.pos = {0, 0, 0};
+    track.dir = {1.0, 0, 0};
+    LoopNavigator::LocatePointIn(world, track.pos, track.currentState, true);
+    // nextState is initialized as needed.
+  }
+}
+
+// A data structure to transfer statistics after each iteration.
+struct Stats {
+  GlobalScoring scoring;
+  int inFlight[ParticleType::NumParticleTypes];
+};
+
+// Finish iteration: clear queues and fill statistics.
+__global__ void FinishIteration(AllParticleQueues all, const GlobalScoring *scoring, Stats *stats)
+{
+  stats->scoring = *scoring;
+  for (int i = 0; i < ParticleType::NumParticleTypes; i++) {
+    all.queues[i].currentlyActive->clear();
+    stats->inFlight[i] = all.queues[i].nextActive->size();
+    all.queues[i].relocate->clear();
+  }
+}
+
+void example10(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double energy)
+{
+  auto &cudaManager = vecgeom::cxx::CudaManager::Instance();
+  cudaManager.LoadGeometry(world);
+  cudaManager.Synchronize();
+
+  const vecgeom::cuda::VPlacedVolume *world_dev = cudaManager.world_gpu();
+
+  G4HepEmState *state = InitG4HepEm();
+
+  // Capacity of the different containers aka the maximum number of particles.
+  constexpr int Capacity = 256 * 1024;
+
+  std::cout << "INFO: capacity of containers set to " << Capacity << std::endl;
+
+  // Allocate structures to manage tracks of an implicit type:
+  //  * memory to hold the actual Track elements,
+  //  * objects to manage slots inside the memory,
+  //  * queues of slots to remember active particle and those needing relocation,
+  //  * a stream and an event for synchronization of kernels.
+  constexpr size_t TracksSize  = sizeof(Track) * Capacity;
+  constexpr size_t ManagerSize = sizeof(SlotManager);
+  const size_t QueueSize       = adept::MParray::SizeOfInstance(Capacity);
+
+  ParticleType particles[ParticleType::NumParticleTypes];
+  SlotManager slotManagerInit(Capacity);
+  for (int i = 0; i < ParticleType::NumParticleTypes; i++) {
+    COPCORE_CUDA_CHECK(cudaMalloc(&particles[i].tracks, TracksSize));
+
+    COPCORE_CUDA_CHECK(cudaMalloc(&particles[i].slotManager, ManagerSize));
+    COPCORE_CUDA_CHECK(cudaMemcpy(particles[i].slotManager, &slotManagerInit, ManagerSize, cudaMemcpyHostToDevice));
+
+    COPCORE_CUDA_CHECK(cudaMalloc(&particles[i].queues.currentlyActive, QueueSize));
+    COPCORE_CUDA_CHECK(cudaMalloc(&particles[i].queues.nextActive, QueueSize));
+    COPCORE_CUDA_CHECK(cudaMalloc(&particles[i].queues.relocate, QueueSize));
+    InitParticleQueues<<<1, 1>>>(particles[i].queues, Capacity);
+
+    COPCORE_CUDA_CHECK(cudaStreamCreate(&particles[i].stream));
+    COPCORE_CUDA_CHECK(cudaEventCreate(&particles[i].event));
+  }
+  COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
+
+  ParticleType &electrons = particles[ParticleType::Electron];
+  ParticleType &positrons = particles[ParticleType::Positron];
+  ParticleType &gammas    = particles[ParticleType::Gamma];
+
+  // Create a stream to synchronize kernels of all particle types.
+  cudaStream_t stream;
+  COPCORE_CUDA_CHECK(cudaStreamCreate(&stream));
+
+  // Allocate and initialize scoring and statistics.
+  GlobalScoring *scoring = nullptr;
+  COPCORE_CUDA_CHECK(cudaMalloc(&scoring, sizeof(GlobalScoring)));
+  COPCORE_CUDA_CHECK(cudaMemset(scoring, 0, sizeof(GlobalScoring)));
+
+  Stats *stats_dev = nullptr;
+  COPCORE_CUDA_CHECK(cudaMalloc(&stats_dev, sizeof(Stats)));
+  Stats *stats = nullptr;
+  COPCORE_CUDA_CHECK(cudaMallocHost(&stats, sizeof(Stats)));
+
+  // Initialize primary particles.
+  constexpr int InitThreads = 32;
+  int initBlocks            = (numParticles + InitThreads - 1) / InitThreads;
+  ParticleGenerator electronGenerator(electrons.tracks, electrons.slotManager, electrons.queues.currentlyActive);
+  InitPrimaries<<<initBlocks, InitThreads>>>(electronGenerator, numParticles, energy, world_dev);
+  COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
+
+  stats->inFlight[ParticleType::Electron] = numParticles;
+  stats->inFlight[ParticleType::Positron] = 0;
+  stats->inFlight[ParticleType::Gamma]    = 0;
+
+  std::cout << "INFO: running with field Bz = " << BzFieldValue / copcore::units::tesla << " T";
+  std::cout << std::endl;
+
+  constexpr int MaxBlocks        = 1024;
+  constexpr int TransportThreads = 32;
+  constexpr int RelocateThreads  = 32;
+  int transportBlocks, relocateBlocks;
+
+  vecgeom::Stopwatch timer;
+  timer.Start();
+
+  int inFlight;
+  int iterNo = 0;
+
+  do {
+    Secondaries secondaries = {
+        .electrons = {electrons.tracks, electrons.slotManager, electrons.queues.nextActive},
+        .positrons = {positrons.tracks, positrons.slotManager, positrons.queues.nextActive},
+        .gammas    = {gammas.tracks, gammas.slotManager, gammas.queues.nextActive},
+    };
+
+    // *** ELECTRONS ***
+    int numElectrons = stats->inFlight[ParticleType::Electron];
+    if (numElectrons > 0) {
+      transportBlocks = (numElectrons + TransportThreads - 1) / TransportThreads;
+      transportBlocks = std::min(transportBlocks, MaxBlocks);
+
+      relocateBlocks = std::min(numElectrons, MaxBlocks);
+
+      TransportElectrons<<<transportBlocks, TransportThreads, 0, electrons.stream>>>(
+          electrons.tracks, electrons.queues.currentlyActive, secondaries, electrons.queues.nextActive,
+          electrons.queues.relocate, scoring);
+
+      RelocateToNextVolume<<<relocateBlocks, RelocateThreads, 0, electrons.stream>>>(electrons.tracks,
+                                                                                     electrons.queues.relocate);
+
+      COPCORE_CUDA_CHECK(cudaEventRecord(electrons.event, electrons.stream));
+      COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, electrons.event, 0));
+    }
+
+    // *** POSITRONS ***
+    int numPositrons = stats->inFlight[ParticleType::Positron];
+    if (numPositrons > 0) {
+      transportBlocks = (numPositrons + TransportThreads - 1) / TransportThreads;
+      transportBlocks = std::min(transportBlocks, MaxBlocks);
+
+      relocateBlocks = std::min(numPositrons, MaxBlocks);
+
+      TransportPositrons<<<transportBlocks, TransportThreads, 0, positrons.stream>>>(
+          positrons.tracks, positrons.queues.currentlyActive, secondaries, positrons.queues.nextActive,
+          positrons.queues.relocate, scoring);
+
+      RelocateToNextVolume<<<relocateBlocks, RelocateThreads, 0, positrons.stream>>>(positrons.tracks,
+                                                                                     positrons.queues.relocate);
+
+      COPCORE_CUDA_CHECK(cudaEventRecord(positrons.event, positrons.stream));
+      COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, positrons.event, 0));
+    }
+
+    // *** GAMMAS ***
+    int numGammas = stats->inFlight[ParticleType::Gamma];
+    if (numGammas > 0) {
+      transportBlocks = (numGammas + TransportThreads - 1) / TransportThreads;
+      transportBlocks = std::min(transportBlocks, MaxBlocks);
+
+      relocateBlocks = std::min(numGammas, MaxBlocks);
+
+      TransportGammas<<<transportBlocks, TransportThreads, 0, gammas.stream>>>(
+          gammas.tracks, gammas.queues.currentlyActive, secondaries, gammas.queues.nextActive, gammas.queues.relocate,
+          scoring);
+
+      RelocateToNextVolume<<<relocateBlocks, RelocateThreads, 0, gammas.stream>>>(gammas.tracks,
+                                                                                  gammas.queues.relocate);
+
+      COPCORE_CUDA_CHECK(cudaEventRecord(gammas.event, gammas.stream));
+      COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, gammas.event, 0));
+    }
+
+    // *** END OF TRANSPORT ***
+
+    // The events ensure synchronization before finishing this iteration and
+    // copying the Stats back to the host.
+    AllParticleQueues queues = {{electrons.queues, positrons.queues, gammas.queues}};
+    FinishIteration<<<1, 1, 0, stream>>>(queues, scoring, stats_dev);
+    COPCORE_CUDA_CHECK(cudaMemcpyAsync(stats, stats_dev, sizeof(Stats), cudaMemcpyDeviceToHost, stream));
+
+    // Finally synchronize all kernels.
+    COPCORE_CUDA_CHECK(cudaStreamSynchronize(stream));
+
+    // Count the number of particles in flight.
+    inFlight = 0;
+    for (int i = 0; i < ParticleType::NumParticleTypes; i++) {
+      inFlight += stats->inFlight[i];
+    }
+
+    // Swap the queues for the next iteration.
+    electrons.queues.SwapActive();
+    positrons.queues.SwapActive();
+    gammas.queues.SwapActive();
+
+    std::cout << std::fixed << std::setprecision(4) << std::setfill(' ');
+    std::cout << "iter " << std::setw(4) << iterNo << " -- tracks in flight: " << std::setw(5) << inFlight
+              << " energy deposition: " << std::setw(10) << stats->scoring.energyDeposit / copcore::units::GeV
+              << " number of secondaries: " << std::setw(5) << stats->scoring.secondaries
+              << " number of hits: " << std::setw(4) << stats->scoring.hits;
+    std::cout << std::endl;
+
+    iterNo++;
+  } while (inFlight > 0 && iterNo < 1000);
+
+  auto time_cpu = timer.Stop();
+  std::cout << "Run time: " << time_cpu << "\n";
+
+  // Free resources.
+  COPCORE_CUDA_CHECK(cudaFree(scoring));
+  COPCORE_CUDA_CHECK(cudaFree(stats_dev));
+  COPCORE_CUDA_CHECK(cudaFreeHost(stats));
+
+  COPCORE_CUDA_CHECK(cudaStreamDestroy(stream));
+
+  for (int i = 0; i < ParticleType::NumParticleTypes; i++) {
+    COPCORE_CUDA_CHECK(cudaFree(particles[i].tracks));
+    COPCORE_CUDA_CHECK(cudaFree(particles[i].slotManager));
+
+    COPCORE_CUDA_CHECK(cudaFree(particles[i].queues.currentlyActive));
+    COPCORE_CUDA_CHECK(cudaFree(particles[i].queues.nextActive));
+    COPCORE_CUDA_CHECK(cudaFree(particles[i].queues.relocate));
+
+    COPCORE_CUDA_CHECK(cudaStreamDestroy(particles[i].stream));
+    COPCORE_CUDA_CHECK(cudaEventDestroy(particles[i].event));
+  }
+
+  FreeG4HepEm(state);
+}

--- a/examples/Example10/example10.cuh
+++ b/examples/Example10/example10.cuh
@@ -147,13 +147,13 @@ __global__ void RelocateToNextVolume(Track *allTracks, const adept::MParray *rel
 
 __global__ void TransportElectrons(
     Track *electrons, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
-    adept::MParray *relocateQueue, GlobalScoring *scoring);
+    adept::MParray *relocateQueue, GlobalScoring *scoring, int maxSteps);
 __global__ void TransportPositrons(
     Track *positrons, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
-    adept::MParray *relocateQueue, GlobalScoring *scoring);
+    adept::MParray *relocateQueue, GlobalScoring *scoring, int maxSteps);
 
 __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries,
-                                adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring);
+                                adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring, int maxSteps);
 
 // Constant data structures from G4HepEm accessed by the kernels.
 // (defined in example10.cu)

--- a/examples/Example10/example10.cuh
+++ b/examples/Example10/example10.cuh
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef EXAMPLE10_CUH
+#define EXAMPLE10_CUH
+
+#include <AdePT/MParray.h>
+#include <CopCore/SystemOfUnits.h>
+#include <CopCore/Ranluxpp.h>
+
+#include <G4HepEmData.hh>
+#include <G4HepEmParameters.hh>
+#include <G4HepEmRandomEngine.hh>
+
+#include <VecGeom/base/Vector3D.h>
+#include <VecGeom/navigation/NavStateIndex.h>
+
+
+// A data structure to represent a particle track. The particle type is implicit
+// by the queue and not stored in memory.
+struct Track {
+  RanluxppDouble rngState;
+  double energy;
+  double numIALeft[3];
+
+  vecgeom::Vector3D<double> pos;
+  vecgeom::Vector3D<double> dir;
+  vecgeom::NavStateIndex currentState;
+  vecgeom::NavStateIndex nextState;
+
+  __host__ __device__ double Uniform() { return rngState.Rndm(); }
+
+  __host__ __device__ void SwapStates()
+  {
+    auto state         = this->currentState;
+    this->currentState = this->nextState;
+    this->nextState    = state;
+  }
+
+  __host__ __device__ void InitAsSecondary(const Track &parent)
+  {
+    // The caller is responsible to branch a new RNG state and to set the energy.
+    this->numIALeft[0] = -1.0;
+    this->numIALeft[1] = -1.0;
+    this->numIALeft[2] = -1.0;
+
+    // A secondary inherits the position of its parent; the caller is responsible
+    // to update the directions.
+    this->pos           = parent.pos;
+    this->currentState = parent.currentState;
+    this->nextState    = parent.nextState;
+  }
+};
+
+// Defined in example10.cu
+extern __constant__ __device__ int Zero;
+
+class RanluxppDoubleEngine : public G4HepEmRandomEngine {
+  // Wrapper functions to call into RanluxppDouble.
+  static __host__ __device__ __attribute__((noinline))
+  double FlatWrapper(void *object)
+  {
+    return ((RanluxppDouble *)object)->Rndm();
+  }
+  static __host__ __device__ __attribute__((noinline))
+  void FlatArrayWrapper(void *object, const int size, double *vect)
+  {
+    for (int i = 0; i < size; i++) {
+      vect[i] = ((RanluxppDouble *)object)->Rndm();
+    }
+  }
+
+public:
+  __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
+      : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
+  {
+#ifdef __CUDA_ARCH__
+    // This is a hack: The compiler cannot see that we're going to call the
+    // functions through their pointers, so it underestimates the number of
+    // required registers. By including calls to the (non-inlinable) functions
+    // we force the compiler to account for the register usage, even if this
+    // particular set of calls are not executed at runtime.
+    if (Zero) {
+      FlatWrapper(engine);
+      FlatArrayWrapper(engine, 0, nullptr);
+    }
+#endif
+  }
+};
+
+
+// A data structure for some global scoring. The accessors must make sure to use
+// atomic operations if needed.
+struct GlobalScoring {
+  int hits;
+  int secondaries;
+  double energyDeposit;
+};
+
+// A data structure to manage slots in the track storage.
+class SlotManager {
+  adept::Atomic_t<int> fNextSlot;
+  const int fMaxSlot;
+
+public:
+  __host__ __device__ SlotManager(int maxSlot) : fMaxSlot(maxSlot) { fNextSlot = 0; }
+
+  __host__ __device__ int NextSlot()
+  {
+    int next = fNextSlot.fetch_add(1);
+    if (next >= fMaxSlot) return -1;
+    return next;
+  }
+};
+
+// A bundle of pointers to generate particles of an implicit type.
+class ParticleGenerator {
+  Track *fTracks;
+  SlotManager *fSlotManager;
+  adept::MParray *fActiveQueue;
+
+public:
+  __host__ __device__ ParticleGenerator(Track *tracks, SlotManager *slotManager, adept::MParray *activeQueue)
+    : fTracks(tracks), fSlotManager(slotManager), fActiveQueue(activeQueue) {}
+
+  __host__ __device__ Track &NextTrack()
+  {
+    int slot = fSlotManager->NextSlot();
+    if (slot == -1) {
+      COPCORE_EXCEPTION("No slot available in ParticleGenerator::NextTrack");
+    }
+    fActiveQueue->push_back(slot);
+    return fTracks[slot];
+  }
+};
+
+// A bundle of generators for the three particle types.
+struct Secondaries {
+  ParticleGenerator electrons;
+  ParticleGenerator positrons;
+  ParticleGenerator gammas;
+};
+
+
+// Kernels in different TUs.
+__global__ void RelocateToNextVolume(Track *allTracks, const adept::MParray *relocateQueue);
+
+__global__ void TransportElectrons(
+    Track *electrons, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
+    adept::MParray *relocateQueue, GlobalScoring *scoring);
+__global__ void TransportPositrons(
+    Track *positrons, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
+    adept::MParray *relocateQueue, GlobalScoring *scoring);
+
+__global__ void TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries,
+                                adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring);
+
+// Constant data structures from G4HepEm accessed by the kernels.
+// (defined in example10.cu)
+extern __constant__ __device__ struct G4HepEmParameters g4HepEmPars;
+extern __constant__ __device__ struct G4HepEmData g4HepEmData;
+
+constexpr float BzFieldValue = 0.1 * copcore::units::tesla;
+
+#endif

--- a/examples/Example10/example10.h
+++ b/examples/Example10/example10.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef EXAMPLE10_H
+#define EXAMPLE10_H
+
+#include <VecGeom/base/Config.h>
+#ifdef VECGEOM_ENABLE_CUDA
+#include <VecGeom/management/CudaManager.h> // forward declares vecgeom::cxx::VPlacedVolume
+#endif
+
+// Interface between C++ and CUDA.
+void example10(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double energy);
+
+#endif

--- a/examples/Example10/gammas.cu
+++ b/examples/Example10/gammas.cu
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include "example10.cuh"
+
+#include <AdePT/LoopNavigator.h>
+#include <CopCore/PhysicalConstants.h>
+
+#include <G4HepEmGammaManager.hh>
+#include <G4HepEmTrack.hh>
+#include <G4HepEmGammaInteractionCompton.hh>
+#include <G4HepEmGammaInteractionConversion.hh>
+// Pull in implementation.
+#include <G4HepEmGammaManager.icc>
+#include <G4HepEmGammaInteractionCompton.icc>
+#include <G4HepEmGammaInteractionConversion.icc>
+
+constexpr double kPush = 1.e-8 * copcore::units::cm;
+
+__global__ void TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries,
+                                adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring)
+{
+  int activeSize = active->size();
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
+    const int slot      = (*active)[i];
+    Track &currentTrack = gammas[slot];
+
+    // Init a track with the needed data to call into G4HepEm.
+    G4HepEmTrack emTrack;
+    emTrack.SetEKin(currentTrack.energy);
+    // For now, just assume a single material.
+    int theMCIndex = 1;
+    emTrack.SetMCIndex(theMCIndex);
+
+    // Sample the `number-of-interaction-left` and put it into the track.
+    for (int ip = 0; ip < 3; ++ip) {
+      double numIALeft = currentTrack.numIALeft[ip];
+      if (numIALeft <= 0) {
+        numIALeft                  = -std::log(currentTrack.Uniform());
+        currentTrack.numIALeft[ip] = numIALeft;
+      }
+      emTrack.SetNumIALeft(numIALeft, ip);
+    }
+
+    // Call G4HepEm to compute the physics step limit.
+    G4HepEmGammaManager::HowFar(&g4HepEmData, &g4HepEmPars, &emTrack);
+
+    // Get result into variables.
+    double geometricalStepLengthFromPhysics = emTrack.GetGStepLength();
+    int winnerProcessIndex                  = emTrack.GetWinnerProcessIndex();
+    // Leave the range and MFP inside the G4HepEmTrack. If we split kernels, we
+    // also need to carry them over!
+
+    // Check if there's a volume boundary in between.
+    double geometryStepLength =
+        LoopNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics,
+                                                currentTrack.currentState, currentTrack.nextState);
+    currentTrack.pos += (geometryStepLength + kPush) * currentTrack.dir;
+
+    if (currentTrack.nextState.IsOnBoundary()) {
+      emTrack.SetGStepLength(geometryStepLength);
+      emTrack.SetOnBoundary(true);
+    }
+
+    G4HepEmGammaManager::UpdateNumIALeft(&emTrack);
+
+    // Save the `number-of-interaction-left` in our track.
+    for (int ip = 0; ip < 3; ++ip) {
+      double numIALeft           = emTrack.GetNumIALeft(ip);
+      currentTrack.numIALeft[ip] = numIALeft;
+    }
+
+    if (currentTrack.nextState.IsOnBoundary()) {
+      // For now, just count that we hit something.
+      atomicAdd(&scoring->hits, 1);
+
+      // Kill the particle if it left the world.
+      if (currentTrack.nextState.Top() != nullptr) {
+        activeQueue->push_back(slot);
+        relocateQueue->push_back(slot);
+
+        // Move to the next boundary.
+        currentTrack.SwapStates();
+      }
+      continue;
+    } else if (winnerProcessIndex < 0) {
+      // No discrete process, move on.
+      activeQueue->push_back(slot);
+      continue;
+    }
+
+    // Reset number of interaction left for the winner discrete process.
+    // (Will be resampled in the next iteration.)
+    currentTrack.numIALeft[winnerProcessIndex] = -1.0;
+
+    // Perform the discrete interaction.
+    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    // We might need one branched RNG state, prepare while threads are synchronized.
+    RanluxppDouble newRNG(currentTrack.rngState.Branch());
+
+    const double energy = currentTrack.energy;
+
+    switch (winnerProcessIndex) {
+    case 0: {
+      // Invoke gamma conversion to e-/e+ pairs, if the energy is above the threshold.
+      if (energy < 2 * copcore::units::kElectronMassC2) {
+        activeQueue->push_back(slot);
+        continue;
+      }
+
+      double logEnergy = std::log(energy);
+      double elKinEnergy, posKinEnergy;
+      G4HepEmGammaInteractionConversion::SampleKinEnergies(&g4HepEmData, energy, logEnergy, theMCIndex, elKinEnergy,
+                                                           posKinEnergy, &rnge);
+
+      double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+      double dirSecondaryEl[3], dirSecondaryPos[3];
+      G4HepEmGammaInteractionConversion::SampleDirections(dirPrimary, dirSecondaryEl, dirSecondaryPos, elKinEnergy,
+                                                          posKinEnergy, &rnge);
+
+      Track &electron = secondaries.electrons.NextTrack();
+      Track &positron = secondaries.positrons.NextTrack();
+      atomicAdd(&scoring->secondaries, 2);
+
+      electron.InitAsSecondary(/*parent=*/currentTrack);
+      electron.rngState = newRNG;
+      electron.energy   = elKinEnergy;
+      electron.dir.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
+
+      positron.InitAsSecondary(/*parent=*/currentTrack);
+      // Reuse the RNG state of the dying track.
+      positron.rngState = currentTrack.rngState;
+      positron.energy   = posKinEnergy;
+      positron.dir.Set(dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]);
+
+      // The current track is killed by not enqueuing into the next activeQueue.
+      break;
+    }
+    case 1: {
+      // Invoke Compton scattering of gamma.
+      constexpr double LowEnergyThreshold = 100 * copcore::units::eV;
+      if (energy < LowEnergyThreshold) {
+        activeQueue->push_back(slot);
+        continue;
+      }
+      const double origDirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+      double dirPrimary[3];
+      const double newEnergyGamma =
+          G4HepEmGammaInteractionCompton::SamplePhotonEnergyAndDirection(energy, dirPrimary, origDirPrimary, &rnge);
+      vecgeom::Vector3D<double> newDirGamma(dirPrimary[0], dirPrimary[1], dirPrimary[2]);
+
+      const double energyEl = energy - newEnergyGamma;
+      if (energyEl > LowEnergyThreshold) {
+        // Create a secondary electron and sample/compute directions.
+        Track &electron = secondaries.electrons.NextTrack();
+        atomicAdd(&scoring->secondaries, 1);
+
+        electron.InitAsSecondary(/*parent=*/currentTrack);
+        electron.rngState = newRNG;
+        electron.energy   = energyEl;
+        electron.dir      = energy * currentTrack.dir - newEnergyGamma * newDirGamma;
+        electron.dir.Normalize();
+      } else {
+        atomicAdd(&scoring->energyDeposit, energyEl);
+      }
+
+      // Check the new gamma energy and deposit if below threshold.
+      if (newEnergyGamma > LowEnergyThreshold) {
+        currentTrack.energy = newEnergyGamma;
+        currentTrack.dir    = newDirGamma;
+
+        // The current track continues to live.
+        activeQueue->push_back(slot);
+      } else {
+        atomicAdd(&scoring->energyDeposit, newEnergyGamma);
+        // The current track is killed by not enqueuing into the next activeQueue.
+      }
+      break;
+    }
+    case 2: {
+      // Invoke photoelectric process: right now only absorb the gamma.
+      atomicAdd(&scoring->energyDeposit, energy);
+      // The current track is killed by not enqueuing into the next activeQueue.
+      break;
+    }
+    }
+  }
+}

--- a/examples/Example10/gammas.cu
+++ b/examples/Example10/gammas.cu
@@ -18,7 +18,8 @@
 constexpr double kPush = 1.e-8 * copcore::units::cm;
 
 __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries,
-                                adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring)
+                                adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring,
+                                int maxSteps)
 {
   int activeSize = active->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
@@ -32,157 +33,170 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     int theMCIndex = 1;
     emTrack.SetMCIndex(theMCIndex);
 
-    // Sample the `number-of-interaction-left` and put it into the track.
-    for (int ip = 0; ip < 3; ++ip) {
-      double numIALeft = currentTrack.numIALeft[ip];
-      if (numIALeft <= 0) {
-        numIALeft                  = -std::log(currentTrack.Uniform());
+    bool alive = true;
+    for (int s = 0; alive && s < maxSteps; s++) {
+
+      // Sample the `number-of-interaction-left` and put it into the track.
+      for (int ip = 0; ip < 3; ++ip) {
+        double numIALeft = currentTrack.numIALeft[ip];
+        if (numIALeft <= 0) {
+          numIALeft                  = -std::log(currentTrack.Uniform());
+          currentTrack.numIALeft[ip] = numIALeft;
+        }
+        emTrack.SetNumIALeft(numIALeft, ip);
+      }
+
+      // Call G4HepEm to compute the physics step limit.
+      G4HepEmGammaManager::HowFar(&g4HepEmData, &g4HepEmPars, &emTrack);
+
+      // Get result into variables.
+      double geometricalStepLengthFromPhysics = emTrack.GetGStepLength();
+      int winnerProcessIndex                  = emTrack.GetWinnerProcessIndex();
+      // Leave the range and MFP inside the G4HepEmTrack. If we split kernels, we
+      // also need to carry them over!
+
+      // Check if there's a volume boundary in between.
+      double geometryStepLength =
+          LoopNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics,
+                                                  currentTrack.currentState, currentTrack.nextState);
+      currentTrack.pos += (geometryStepLength + kPush) * currentTrack.dir;
+
+      if (currentTrack.nextState.IsOnBoundary()) {
+        emTrack.SetGStepLength(geometryStepLength);
+        emTrack.SetOnBoundary(true);
+      }
+
+      G4HepEmGammaManager::UpdateNumIALeft(&emTrack);
+
+      // Save the `number-of-interaction-left` in our track.
+      for (int ip = 0; ip < 3; ++ip) {
+        double numIALeft           = emTrack.GetNumIALeft(ip);
         currentTrack.numIALeft[ip] = numIALeft;
       }
-      emTrack.SetNumIALeft(numIALeft, ip);
-    }
 
-    // Call G4HepEm to compute the physics step limit.
-    G4HepEmGammaManager::HowFar(&g4HepEmData, &g4HepEmPars, &emTrack);
+      if (currentTrack.nextState.IsOnBoundary()) {
+        // For now, just count that we hit something.
+        atomicAdd(&scoring->hits, 1);
 
-    // Get result into variables.
-    double geometricalStepLengthFromPhysics = emTrack.GetGStepLength();
-    int winnerProcessIndex                  = emTrack.GetWinnerProcessIndex();
-    // Leave the range and MFP inside the G4HepEmTrack. If we split kernels, we
-    // also need to carry them over!
+        // Kill the particle if it left the world.
+        if (currentTrack.nextState.Top() != nullptr) {
+          alive = true;
+          relocateQueue->push_back(slot);
 
-    // Check if there's a volume boundary in between.
-    double geometryStepLength =
-        LoopNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics,
-                                                currentTrack.currentState, currentTrack.nextState);
-    currentTrack.pos += (geometryStepLength + kPush) * currentTrack.dir;
+          // Move to the next boundary.
+          currentTrack.SwapStates();
+        } else {
+          alive = false;
+        }
 
-    if (currentTrack.nextState.IsOnBoundary()) {
-      emTrack.SetGStepLength(geometryStepLength);
-      emTrack.SetOnBoundary(true);
-    }
-
-    G4HepEmGammaManager::UpdateNumIALeft(&emTrack);
-
-    // Save the `number-of-interaction-left` in our track.
-    for (int ip = 0; ip < 3; ++ip) {
-      double numIALeft           = emTrack.GetNumIALeft(ip);
-      currentTrack.numIALeft[ip] = numIALeft;
-    }
-
-    if (currentTrack.nextState.IsOnBoundary()) {
-      // For now, just count that we hit something.
-      atomicAdd(&scoring->hits, 1);
-
-      // Kill the particle if it left the world.
-      if (currentTrack.nextState.Top() != nullptr) {
-        activeQueue->push_back(slot);
-        relocateQueue->push_back(slot);
-
-        // Move to the next boundary.
-        currentTrack.SwapStates();
-      }
-      continue;
-    } else if (winnerProcessIndex < 0) {
-      // No discrete process, move on.
-      activeQueue->push_back(slot);
-      continue;
-    }
-
-    // Reset number of interaction left for the winner discrete process.
-    // (Will be resampled in the next iteration.)
-    currentTrack.numIALeft[winnerProcessIndex] = -1.0;
-
-    // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
-    // We might need one branched RNG state, prepare while threads are synchronized.
-    RanluxppDouble newRNG(currentTrack.rngState.Branch());
-
-    const double energy = currentTrack.energy;
-
-    switch (winnerProcessIndex) {
-    case 0: {
-      // Invoke gamma conversion to e-/e+ pairs, if the energy is above the threshold.
-      if (energy < 2 * copcore::units::kElectronMassC2) {
-        activeQueue->push_back(slot);
+        // Cannot continue for now: either the particles left the world, or we
+        // need to relocate it to the next volume.
+        break;
+      } else if (winnerProcessIndex < 0) {
+        // No discrete process, move on.
         continue;
       }
 
-      double logEnergy = std::log(energy);
-      double elKinEnergy, posKinEnergy;
-      G4HepEmGammaInteractionConversion::SampleKinEnergies(&g4HepEmData, energy, logEnergy, theMCIndex, elKinEnergy,
-                                                           posKinEnergy, &rnge);
+      // Reset number of interaction left for the winner discrete process.
+      // (Will be resampled in the next iteration.)
+      currentTrack.numIALeft[winnerProcessIndex] = -1.0;
 
-      double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
-      double dirSecondaryEl[3], dirSecondaryPos[3];
-      G4HepEmGammaInteractionConversion::SampleDirections(dirPrimary, dirSecondaryEl, dirSecondaryPos, elKinEnergy,
-                                                          posKinEnergy, &rnge);
+      // Perform the discrete interaction.
+      RanluxppDoubleEngine rnge(&currentTrack.rngState);
+      // We might need one branched RNG state, prepare while threads are synchronized.
+      RanluxppDouble newRNG(currentTrack.rngState.Branch());
 
-      Track &electron = secondaries.electrons.NextTrack();
-      Track &positron = secondaries.positrons.NextTrack();
-      atomicAdd(&scoring->secondaries, 2);
+      const double energy = currentTrack.energy;
 
-      electron.InitAsSecondary(/*parent=*/currentTrack);
-      electron.rngState = newRNG;
-      electron.energy   = elKinEnergy;
-      electron.dir.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
+      switch (winnerProcessIndex) {
+      case 0: {
+        // Invoke gamma conversion to e-/e+ pairs, if the energy is above the threshold.
+        if (energy < 2 * copcore::units::kElectronMassC2) {
+          alive = true;
+          continue;
+        }
 
-      positron.InitAsSecondary(/*parent=*/currentTrack);
-      // Reuse the RNG state of the dying track.
-      positron.rngState = currentTrack.rngState;
-      positron.energy   = posKinEnergy;
-      positron.dir.Set(dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]);
+        double logEnergy = std::log(energy);
+        double elKinEnergy, posKinEnergy;
+        G4HepEmGammaInteractionConversion::SampleKinEnergies(&g4HepEmData, energy, logEnergy, theMCIndex, elKinEnergy,
+                                                             posKinEnergy, &rnge);
 
-      // The current track is killed by not enqueuing into the next activeQueue.
-      break;
-    }
-    case 1: {
-      // Invoke Compton scattering of gamma.
-      constexpr double LowEnergyThreshold = 100 * copcore::units::eV;
-      if (energy < LowEnergyThreshold) {
-        activeQueue->push_back(slot);
-        continue;
-      }
-      const double origDirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
-      double dirPrimary[3];
-      const double newEnergyGamma =
-          G4HepEmGammaInteractionCompton::SamplePhotonEnergyAndDirection(energy, dirPrimary, origDirPrimary, &rnge);
-      vecgeom::Vector3D<double> newDirGamma(dirPrimary[0], dirPrimary[1], dirPrimary[2]);
+        double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+        double dirSecondaryEl[3], dirSecondaryPos[3];
+        G4HepEmGammaInteractionConversion::SampleDirections(dirPrimary, dirSecondaryEl, dirSecondaryPos, elKinEnergy,
+                                                            posKinEnergy, &rnge);
 
-      const double energyEl = energy - newEnergyGamma;
-      if (energyEl > LowEnergyThreshold) {
-        // Create a secondary electron and sample/compute directions.
         Track &electron = secondaries.electrons.NextTrack();
-        atomicAdd(&scoring->secondaries, 1);
+        Track &positron = secondaries.positrons.NextTrack();
+        atomicAdd(&scoring->secondaries, 2);
 
         electron.InitAsSecondary(/*parent=*/currentTrack);
         electron.rngState = newRNG;
-        electron.energy   = energyEl;
-        electron.dir      = energy * currentTrack.dir - newEnergyGamma * newDirGamma;
-        electron.dir.Normalize();
-      } else {
-        atomicAdd(&scoring->energyDeposit, energyEl);
-      }
+        electron.energy   = elKinEnergy;
+        electron.dir.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
 
-      // Check the new gamma energy and deposit if below threshold.
-      if (newEnergyGamma > LowEnergyThreshold) {
-        currentTrack.energy = newEnergyGamma;
-        currentTrack.dir    = newDirGamma;
+        positron.InitAsSecondary(/*parent=*/currentTrack);
+        // Reuse the RNG state of the dying track.
+        positron.rngState = currentTrack.rngState;
+        positron.energy   = posKinEnergy;
+        positron.dir.Set(dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]);
 
-        // The current track continues to live.
-        activeQueue->push_back(slot);
-      } else {
-        atomicAdd(&scoring->energyDeposit, newEnergyGamma);
-        // The current track is killed by not enqueuing into the next activeQueue.
+        alive = false;
+        break;
       }
-      break;
+      case 1: {
+        // Invoke Compton scattering of gamma.
+        constexpr double LowEnergyThreshold = 100 * copcore::units::eV;
+        if (energy < LowEnergyThreshold) {
+          alive = true;
+          continue;
+        }
+        const double origDirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+        double dirPrimary[3];
+        const double newEnergyGamma =
+            G4HepEmGammaInteractionCompton::SamplePhotonEnergyAndDirection(energy, dirPrimary, origDirPrimary, &rnge);
+        vecgeom::Vector3D<double> newDirGamma(dirPrimary[0], dirPrimary[1], dirPrimary[2]);
+
+        const double energyEl = energy - newEnergyGamma;
+        if (energyEl > LowEnergyThreshold) {
+          // Create a secondary electron and sample/compute directions.
+          Track &electron = secondaries.electrons.NextTrack();
+          atomicAdd(&scoring->secondaries, 1);
+
+          electron.InitAsSecondary(/*parent=*/currentTrack);
+          electron.rngState = newRNG;
+          electron.energy   = energyEl;
+          electron.dir      = energy * currentTrack.dir - newEnergyGamma * newDirGamma;
+          electron.dir.Normalize();
+        } else {
+          atomicAdd(&scoring->energyDeposit, energyEl);
+        }
+
+        // Check the new gamma energy and deposit if below threshold.
+        if (newEnergyGamma > LowEnergyThreshold) {
+          currentTrack.energy = newEnergyGamma;
+          emTrack.SetEKin(currentTrack.energy);
+          currentTrack.dir = newDirGamma;
+
+          // The current track continues to live.
+          alive = true;
+        } else {
+          alive = false;
+          atomicAdd(&scoring->energyDeposit, newEnergyGamma);
+        }
+        break;
+      }
+      case 2: {
+        // Invoke photoelectric process: right now only absorb the gamma.
+        atomicAdd(&scoring->energyDeposit, energy);
+        alive = false;
+        break;
+      }
+      }
     }
-    case 2: {
-      // Invoke photoelectric process: right now only absorb the gamma.
-      atomicAdd(&scoring->energyDeposit, energy);
-      // The current track is killed by not enqueuing into the next activeQueue.
-      break;
-    }
+
+    if (alive) {
+      activeQueue->push_back(slot);
     }
   }
 }

--- a/examples/Example10/relocation.cu
+++ b/examples/Example10/relocation.cu
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include "example10.cuh"
+
+#include <AdePT/MParray.h>
+
+#include <VecGeom/base/Vector3D.h>
+#include <VecGeom/navigation/NavStateIndex.h>
+#include <VecGeom/volumes/PlacedVolume.h>
+
+__device__ __forceinline__ vecgeom::VPlacedVolume const *ShuffleVolume(unsigned mask, vecgeom::VPlacedVolume const *ptr,
+                                                                       int src)
+{
+  // __shfl_sync only accepts integer and floating point values, so we have to
+  // cast into a type of approriate length...
+  auto val = reinterpret_cast<unsigned long long>(ptr);
+  val      = __shfl_sync(mask, val, src);
+  return reinterpret_cast<vecgeom::VPlacedVolume const *>(val);
+}
+
+// A parallel version of LoopNavigator::RelocateToNextVolume. This function
+// uses the parallelism of a warp to check daughters in parallel.
+__global__ void RelocateToNextVolume(Track *allTracks, const adept::MParray *relocateQueue)
+{
+  // Determine which threads are active in the current warp.
+  unsigned mask     = __activemask();
+  int threadsInWrap = __popc(mask);
+  // Count warps per block, including incomplete ones.
+  int warpsPerBlock = (blockDim.x + warpSize - 1) / warpSize;
+  // Find this thread's warp and lane.
+  int warp = threadIdx.x / warpSize;
+  int lane = threadIdx.x % warpSize;
+
+  int queueSize = relocateQueue->size();
+  // Note the loop setup: All threads in a block relocate one particle.
+  // For comparison, here's the usual grid-strided loop header:
+  //   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < queueSize; i += blockDim.x * gridDim.x)
+  for (int i = blockIdx.x * warpsPerBlock + warp; i < queueSize; i += warpsPerBlock * gridDim.x) {
+    const int slot      = (*relocateQueue)[i];
+    Track &currentTrack = allTracks[slot];
+
+    vecgeom::NavStateIndex &state = currentTrack.currentState;
+
+    vecgeom::VPlacedVolume const *currentVolume;
+    vecgeom::Precision localCoordinates[3];
+
+    // The first lane removes all volumes from the state that were left, and
+    // stores it in the variable currentVolume. During the process, it also
+    // transforms the point to local coordinates, eventually stored in the
+    // variable localCoordinates.
+    if (lane == 0) {
+      // Push the point inside the next volume.
+      vecgeom::Vector3D<vecgeom::Precision> pushed = currentTrack.pos + 1.E-6 * currentTrack.dir;
+
+      // Calculate local point from global point.
+      vecgeom::Transformation3D m;
+      state.TopMatrix(m);
+      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(pushed);
+
+      currentVolume = state.Top();
+
+      // Remove all volumes that were left.
+      while (currentVolume && (currentVolume->IsAssembly() || !currentVolume->UnplacedContains(localPoint))) {
+        state.Pop();
+        localPoint    = currentVolume->GetTransformation()->InverseTransform(localPoint);
+        currentVolume = state.Top();
+      }
+
+      // Store the transformed coordinates, to be broadcasted to the other
+      // active threads in this warp.
+      localCoordinates[0] = localPoint.x();
+      localCoordinates[1] = localPoint.y();
+      localCoordinates[2] = localPoint.z();
+    }
+
+    // Broadcast the values.
+    currentVolume = ShuffleVolume(mask, currentVolume, 0);
+    for (int dim = 0; dim < 3; dim++) {
+      localCoordinates[dim] = __shfl_sync(mask, localCoordinates[dim], 0);
+    }
+
+    if (currentVolume) {
+      unsigned hasNextVolume;
+      do {
+
+        vecgeom::Vector3D<vecgeom::Precision> localPoint(localCoordinates[0], localCoordinates[1], localCoordinates[2]);
+
+        const auto &daughters = currentVolume->GetDaughters();
+        auto daughtersSize    = daughters.size();
+        vecgeom::Vector3D<vecgeom::Precision> transformedPoint;
+        vecgeom::VPlacedVolume const *nextVolume = nullptr;
+        // The active threads in the wrap check all daughters in parallel.
+        for (int d = lane; d < daughtersSize; d += threadsInWrap) {
+          const auto *daughter = daughters[d];
+          if (daughter->Contains(localPoint, transformedPoint)) {
+            nextVolume = daughter;
+            break;
+          }
+        }
+
+        // All active threads in the warp synchronize and vote which of them
+        // found a daughter that is entered. The result has the Nth bit set if
+        // the Nth lane has a nextVolume != nullptr.
+        hasNextVolume = __ballot_sync(mask, nextVolume != nullptr);
+        if (hasNextVolume != 0) {
+          // Determine which volume to use if there are multiple: Just pick the
+          // first one, corresponding to the position of the first set bit.
+          int firstThread = __ffs(hasNextVolume) - 1;
+          if (lane == firstThread) {
+            localCoordinates[0] = transformedPoint.x();
+            localCoordinates[1] = transformedPoint.y();
+            localCoordinates[2] = transformedPoint.z();
+
+            currentVolume = nextVolume;
+            state.Push(currentVolume);
+          }
+
+          // Broadcast the values.
+          currentVolume = ShuffleVolume(mask, currentVolume, firstThread);
+          for (int dim = 0; dim < 3; dim++) {
+            localCoordinates[dim] = __shfl_sync(mask, localCoordinates[dim], firstThread);
+          }
+        }
+        // If hasNextVolume is zero, there is no point in synchronizing since
+        // this will exit the loop.
+      } while (hasNextVolume != 0);
+    }
+
+    // Finally the first lane again leaves all assembly volumes.
+    if (lane == 0) {
+      if (state.Top() != nullptr) {
+        while (state.Top()->IsAssembly()) {
+          state.Pop();
+        }
+        assert(!state.Top()->GetLogicalVolume()->GetUnplacedVolume()->IsAssembly());
+      }
+    }
+  }
+}


### PR DESCRIPTION
There are two levels:
1. On the device, each transportation kernel can make several steps (up to a configurable limit, currently 4) as long as the particle stays alive and inside the volume. At volume boundary, relocation still happens in a separate kernel.
2. The host submits multiple kernels (currently 4 per particle type) into the appropriate streams and only synchronizes once at the end. Proper ordering on the device is ensured via events, extending the previous approach. The code uses an upper bound on the number of particles to determine the launch configuration.

In total, this reduces the number of iterations for `trackML` from 214 with `example9` to 29 using the code from the new example with identical results (energy deposition, number of secondaries, number of hit volume boundaries). However, best performance for this setup is obtained with only one step per kernel and submitting one kernel per iteration - in other words, exactly what example9 does.

TL;DR: This example is currently meant as a proof-of-concept and for playing with the parameters (number of steps and submitted kernels).