### PR TITLE
Example11, same as Example9, but using BVH class from VecGeom on GPU

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,6 +12,7 @@ add_subdirectory(Example6)
 add_subdirectory(Example8)
 add_subdirectory(Example9)
 add_subdirectory(Example10)
+add_subdirectory(Example11)
 add_subdirectory(TestEm3)
 add_subdirectory(ECS)
 

--- a/examples/Example11/CMakeLists.txt
+++ b/examples/Example11/CMakeLists.txt
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2021 CERN
+# SPDX-License-Identifier: Apache-2.0
+
+if(NOT TARGET G4HepEm::g4HepEm)
+  message(STATUS "Disabling example11 (needs G4HepEm)")
+  return()
+endif()
+
+add_executable(example11 example11.cpp example11.cu electrons.cu gammas.cu)
+target_link_libraries(example11 PRIVATE AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml ${Geant4_LIBRARIES} G4HepEm::g4HepEmData G4HepEm::g4HepEmInit G4HepEm::g4HepEmRun)
+set_target_properties(example11 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
+
+add_test(NAME example11 COMMAND example11 -gdml_name "${TESTING_GDML}")

--- a/examples/Example11/README.md
+++ b/examples/Example11/README.md
@@ -1,0 +1,50 @@
+<!--
+SPDX-FileCopyrightText: 2021 CERN
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+## Example 11
+
+Demonstrator of particle transportation on GPUs, with:
+
+ * geometry via VecGeom and a magnetic field with constant Bz,
+ * physics processes for e-/e+ and gammas using G4HepEm.
+ * accelerated navigation using newly added BVH class in VecGeom
+
+Electrons, positrons, and gammas are stored in separate containers in device memory.
+Free positions in the storage are handed out with monotonic slot numbers, slots are not reused.
+Active tracks are passed via three queues per particle type (see `struct ParticleQueues`).
+Results are reproducible using one RANLUX++ state per track.
+
+### Kernels
+
+This example uses one stream per particle type to launch kernels asynchronously.
+They are synchronized via a forth stream using CUDA events.
+
+#### `TransportElectrons<bool IsElectron>`
+
+1. Determine physics step limit.
+2. Call magnetic field to get geometry step length.
+3. Apply continuous effects; kill track if stopped.
+4. If the particle reaches a boundary, perform relocation.
+5. If not, and if there is a discrete process:
+ 1. Sample the final state.
+ 2. Update the primary and produce secondaries.
+
+#### `TransportGammas`
+
+1. Determine the physics step limit.
+2. Query VecGeom to get geometry step length (no magnetic field for neutral particles!).
+3. If the particle reaches a boundary, perform relocation.
+4. If not, and if there is a discrete process:
+ 1. Sample the final state.
+ 2. Update the primary and produce secondaries.
+
+#### `FinishIteration`
+
+Clear the queues and return the tracks in flight.
+This kernel runs after all secondary particles were produced.
+
+#### `InitPrimaries` and `InitParticleQueues`
+
+Used to initialize multiple primary particles with separate seeds.

--- a/examples/Example11/electrons.cu
+++ b/examples/Example11/electrons.cu
@@ -1,0 +1,254 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include "example11.cuh"
+
+#include <fieldPropagatorConstBz.h>
+
+#include <CopCore/PhysicalConstants.h>
+#include <AdePT/BVHNavigator.h>
+
+#include <G4HepEmElectronManager.hh>
+#include <G4HepEmElectronTrack.hh>
+#include <G4HepEmElectronInteractionBrem.hh>
+#include <G4HepEmElectronInteractionIoni.hh>
+#include <G4HepEmPositronInteractionAnnihilation.hh>
+// Pull in implementation.
+#include <G4HepEmRunUtils.icc>
+#include <G4HepEmInteractionUtils.icc>
+#include <G4HepEmElectronManager.icc>
+#include <G4HepEmElectronInteractionBrem.icc>
+#include <G4HepEmElectronInteractionIoni.icc>
+#include <G4HepEmPositronInteractionAnnihilation.icc>
+
+// Compute the physics and geometry step limit, transport the electrons while
+// applying the continuous effects and maybe a discrete process that could
+// generate secondaries.
+template <bool IsElectron>
+static __device__ __forceinline__ void TransportElectrons(Track *electrons, const adept::MParray *active,
+                                                          Secondaries &secondaries, adept::MParray *activeQueue,
+                                                          GlobalScoring *scoring)
+{
+  constexpr int Charge  = IsElectron ? -1 : 1;
+  constexpr double Mass = copcore::units::kElectronMassC2;
+  fieldPropagatorConstBz fieldPropagatorBz(BzFieldValue);
+
+  int activeSize = active->size();
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
+    const int slot      = (*active)[i];
+    Track &currentTrack = electrons[slot];
+
+    // Init a track with the needed data to call into G4HepEm.
+    G4HepEmElectronTrack elTrack;
+    G4HepEmTrack *theTrack = elTrack.GetTrack();
+    theTrack->SetEKin(currentTrack.energy);
+    // For now, just assume a single material.
+    int theMCIndex = 1;
+    theTrack->SetMCIndex(theMCIndex);
+    theTrack->SetCharge(Charge);
+
+    // Sample the `number-of-interaction-left` and put it into the track.
+    for (int ip = 0; ip < 3; ++ip) {
+      double numIALeft = currentTrack.numIALeft[ip];
+      if (numIALeft <= 0) {
+        numIALeft                  = -std::log(currentTrack.Uniform());
+        currentTrack.numIALeft[ip] = numIALeft;
+      }
+      theTrack->SetNumIALeft(numIALeft, ip);
+    }
+
+    // Call G4HepEm to compute the physics step limit.
+    G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack);
+
+    // Get result into variables.
+    double geometricalStepLengthFromPhysics = theTrack->GetGStepLength();
+    // The phyiscal step length is the amount that the particle experiences
+    // which might be longer than the geometrical step length due to MSC. As
+    // long as we call PerformContinuous in the same kernel we don't need to
+    // care, but we need to make this available when splitting the operations.
+    // double physicalStepLength = elTrack.GetPStepLength();
+    int winnerProcessIndex = theTrack->GetWinnerProcessIndex();
+    // Leave the range and MFP inside the G4HepEmTrack. If we split kernels, we
+    // also need to carry them over!
+
+    // Check if there's a volume boundary in between.
+    double geometryStepLength = fieldPropagatorBz.ComputeStepAndPropagatedState</*Relocate=*/false, BVHNavigator>(
+        currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
+        currentTrack.currentState, currentTrack.nextState);
+
+    if (currentTrack.nextState.IsOnBoundary()) {
+      theTrack->SetGStepLength(geometryStepLength);
+      theTrack->SetOnBoundary(true);
+    }
+
+    // Apply continuous effects.
+    bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack);
+    // Collect the changes.
+    currentTrack.energy = theTrack->GetEKin();
+    atomicAdd(&scoring->energyDeposit, theTrack->GetEnergyDeposit());
+
+    // Save the `number-of-interaction-left` in our track.
+    for (int ip = 0; ip < 3; ++ip) {
+      double numIALeft           = theTrack->GetNumIALeft(ip);
+      currentTrack.numIALeft[ip] = numIALeft;
+    }
+
+    if (stopped) {
+      if (!IsElectron) {
+        // Annihilate the stopped positron into two gammas heading to opposite
+        // directions (isotropic).
+        Track &gamma1 = secondaries.gammas.NextTrack();
+        Track &gamma2 = secondaries.gammas.NextTrack();
+        atomicAdd(&scoring->secondaries, 2);
+
+        const double cost = 2 * currentTrack.Uniform() - 1;
+        const double sint = sqrt(1 - cost * cost);
+        const double phi  = k2Pi * currentTrack.Uniform();
+        double sinPhi, cosPhi;
+        sincos(phi, &sinPhi, &cosPhi);
+
+        gamma1.InitAsSecondary(/*parent=*/currentTrack);
+        gamma1.rngState = currentTrack.rngState.Branch();
+        gamma1.energy = copcore::units::kElectronMassC2;
+        gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
+
+        gamma2.InitAsSecondary(/*parent=*/currentTrack);
+        // Reuse the RNG state of the dying track.
+        gamma2.rngState = currentTrack.rngState;
+        gamma2.energy = copcore::units::kElectronMassC2;
+        gamma2.dir    = -gamma1.dir;
+      }
+      // Particles are killed by not enqueuing them into the new activeQueue.
+      continue;
+    }
+
+    if (currentTrack.nextState.IsOnBoundary()) {
+      // For now, just count that we hit something.
+      atomicAdd(&scoring->hits, 1);
+
+      // Kill the particle if it left the world.
+      if (currentTrack.nextState.Top() != nullptr) {
+        activeQueue->push_back(slot);
+
+        // Move to the next boundary.
+	BVHNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, currentTrack.nextState);
+        currentTrack.SwapStates();
+      }
+      continue;
+    } else if (winnerProcessIndex < 0) {
+      // No discrete process, move on.
+      activeQueue->push_back(slot);
+      continue;
+    }
+
+    // Reset number of interaction left for the winner discrete process.
+    // (Will be resampled in the next iteration.)
+    currentTrack.numIALeft[winnerProcessIndex] = -1.0;
+
+    // Check if a delta interaction happens instead of the real discrete process.
+    if (G4HepEmElectronManager::CheckDelta(&g4HepEmData, theTrack, currentTrack.Uniform())) {
+      // A delta interaction happened, move on.
+      activeQueue->push_back(slot);
+      continue;
+    }
+
+    // Perform the discrete interaction.
+    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    // We will need one branched RNG state, prepare while threads are synchronized.
+    RanluxppDouble newRNG(currentTrack.rngState.Branch());
+
+    const double energy   = currentTrack.energy;
+    const double theElCut = g4HepEmData.fTheMatCutData->fMatCutData[theMCIndex].fSecElProdCutE;
+
+    switch (winnerProcessIndex) {
+    case 0: {
+      // Invoke ionization (for e-/e+):
+      double deltaEkin = (IsElectron) ? G4HepEmElectronInteractionIoni::SampleETransferMoller(theElCut, energy, &rnge)
+                                      : G4HepEmElectronInteractionIoni::SampleETransferBhabha(theElCut, energy, &rnge);
+
+      double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+      double dirSecondary[3];
+      G4HepEmElectronInteractionIoni::SampleDirections(energy, deltaEkin, dirSecondary, dirPrimary, &rnge);
+
+      Track &secondary = secondaries.electrons.NextTrack();
+      atomicAdd(&scoring->secondaries, 1);
+
+      secondary.InitAsSecondary(/*parent=*/currentTrack);
+      secondary.rngState = newRNG;
+      secondary.energy = deltaEkin;
+      secondary.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
+
+      currentTrack.energy = energy - deltaEkin;
+      currentTrack.dir.Set(dirPrimary[0], dirPrimary[1], dirPrimary[2]);
+      // The current track continues to live.
+      activeQueue->push_back(slot);
+      break;
+    }
+    case 1: {
+      // Invoke model for Bremsstrahlung: either SB- or Rel-Brem.
+      double logEnergy = std::log(energy);
+      double deltaEkin = energy < g4HepEmPars.fElectronBremModelLim
+                             ? G4HepEmElectronInteractionBrem::SampleETransferSB(&g4HepEmData, energy, logEnergy,
+                                                                                 theMCIndex, &rnge, IsElectron)
+                             : G4HepEmElectronInteractionBrem::SampleETransferRB(&g4HepEmData, energy, logEnergy,
+                                                                                 theMCIndex, &rnge, IsElectron);
+
+      double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+      double dirSecondary[3];
+      G4HepEmElectronInteractionBrem::SampleDirections(energy, deltaEkin, dirSecondary, dirPrimary, &rnge);
+
+      Track &gamma = secondaries.gammas.NextTrack();
+      atomicAdd(&scoring->secondaries, 1);
+
+      gamma.InitAsSecondary(/*parent=*/currentTrack);
+      gamma.rngState = newRNG;
+      gamma.energy = deltaEkin;
+      gamma.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
+
+      currentTrack.energy = energy - deltaEkin;
+      currentTrack.dir.Set(dirPrimary[0], dirPrimary[1], dirPrimary[2]);
+      // The current track continues to live.
+      activeQueue->push_back(slot);
+      break;
+    }
+    case 2: {
+      // Invoke annihilation (in-flight) for e+
+      double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+      double theGamma1Ekin, theGamma2Ekin;
+      double theGamma1Dir[3], theGamma2Dir[3];
+      G4HepEmPositronInteractionAnnihilation::SampleEnergyAndDirectionsInFlight(
+          energy, dirPrimary, &theGamma1Ekin, theGamma1Dir, &theGamma2Ekin, theGamma2Dir, &rnge);
+
+      Track &gamma1 = secondaries.gammas.NextTrack();
+      Track &gamma2 = secondaries.gammas.NextTrack();
+      atomicAdd(&scoring->secondaries, 2);
+
+      gamma1.InitAsSecondary(/*parent=*/currentTrack);
+      gamma1.rngState = newRNG;
+      gamma1.energy = theGamma1Ekin;
+      gamma1.dir.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
+
+      gamma2.InitAsSecondary(/*parent=*/currentTrack);
+      // Reuse the RNG state of the dying track.
+      gamma2.rngState = currentTrack.rngState;
+      gamma2.energy = theGamma2Ekin;
+      gamma2.dir.Set(theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]);
+
+      // The current track is killed by not enqueuing into the next activeQueue.
+      break;
+    }
+    }
+  }
+}
+
+// Instantiate kernels for electrons and positrons.
+__global__ void TransportElectrons(Track *electrons, const adept::MParray *active, Secondaries secondaries,
+                                   adept::MParray *activeQueue, GlobalScoring *scoring)
+{
+  TransportElectrons</*IsElectron*/ true>(electrons, active, secondaries, activeQueue, scoring);
+}
+__global__ void TransportPositrons(Track *positrons, const adept::MParray *active, Secondaries secondaries,
+                                   adept::MParray *activeQueue, GlobalScoring *scoring)
+{
+  TransportElectrons</*IsElectron*/ false>(positrons, active, secondaries, activeQueue, scoring);
+}

--- a/examples/Example11/example11.cpp
+++ b/examples/Example11/example11.cpp
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include "example11.h"
+
+#include <AdePT/ArgParser.h>
+#include <CopCore/SystemOfUnits.h>
+
+#include <G4NistManager.hh>
+#include <G4Material.hh>
+
+#include <G4Box.hh>
+#include <G4LogicalVolume.hh>
+#include <G4PVPlacement.hh>
+
+#include <G4ParticleTable.hh>
+#include <G4Electron.hh>
+#include <G4Positron.hh>
+#include <G4Gamma.hh>
+#include <G4Proton.hh>
+
+#include <G4ProductionCuts.hh>
+#include <G4Region.hh>
+#include <G4ProductionCutsTable.hh>
+
+#include <G4SystemOfUnits.hh>
+
+#include <VecGeom/base/Config.h>
+#include <VecGeom/management/BVHManager.h>
+#include <VecGeom/management/GeoManager.h>
+#ifdef VECGEOM_GDML
+#include <VecGeom/gdml/Frontend.h>
+#endif
+
+static void InitGeant4()
+{
+  // --- Create materials.
+  G4Material *galactic = G4NistManager::Instance()->FindOrBuildMaterial("G4_Galactic");
+  G4Material *silicon  = G4NistManager::Instance()->FindOrBuildMaterial("G4_Si");
+  //
+  // --- Define a world.
+  G4double worldDim         = 1 * m;
+  G4Box *worldBox           = new G4Box("world", worldDim, worldDim, worldDim);
+  G4LogicalVolume *worldLog = new G4LogicalVolume(worldBox, galactic, "world");
+  G4PVPlacement *world      = new G4PVPlacement(nullptr, {}, worldLog, "world", nullptr, false, 0);
+  // --- Define a box.
+  G4double boxDim             = 0.5 * m;
+  G4double boxPos             = 0.5 * boxDim;
+  G4Box *siliconBox           = new G4Box("silicon", boxDim, boxDim, boxDim);
+  G4LogicalVolume *siliconLog = new G4LogicalVolume(siliconBox, silicon, "silicon");
+  new G4PVPlacement(nullptr, {boxPos, boxPos, boxPos}, siliconLog, "silicon", worldLog, false, 0);
+  //
+  // --- Create particles that have secondary production threshold.
+  G4Gamma::Gamma();
+  G4Electron::Electron();
+  G4Positron::Positron();
+  G4Proton::Proton();
+  G4ParticleTable *partTable = G4ParticleTable::GetParticleTable();
+  partTable->SetReadiness();
+  //
+  // --- Create production - cuts object and set the secondary production threshold.
+  G4ProductionCuts *productionCuts = new G4ProductionCuts();
+  constexpr G4double ProductionCut = 1 * mm;
+  productionCuts->SetProductionCut(ProductionCut);
+  //
+  // --- Register a region for the world.
+  G4Region *reg = new G4Region("default");
+  reg->AddRootLogicalVolume(worldLog);
+  reg->UsedInMassGeometry(true);
+  reg->SetProductionCuts(productionCuts);
+  //
+  // --- Update the couple tables.
+  G4ProductionCutsTable *theCoupleTable = G4ProductionCutsTable::GetProductionCutsTable();
+  theCoupleTable->UpdateCoupleTable(world);
+}
+
+void InitBVH()
+{
+  vecgeom::cxx::BVHManager::Init();
+  vecgeom::cxx::BVHManager::DeviceInit();
+}
+
+int main(int argc, char *argv[])
+{
+#ifndef VECGEOM_GDML
+  std::cout << "### VecGeom must be compiled with GDML support to run this.\n";
+  return 1;
+#endif
+#ifndef VECGEOM_USE_NAVINDEX
+  std::cout << "### VecGeom must be compiled with USE_NAVINDEX support to run this.\n";
+  return 2;
+#endif
+
+  OPTION_STRING(gdml_name, "trackML.gdml");
+  OPTION_INT(cache_depth, 0); // 0 = full depth
+  OPTION_INT(particles, 1);
+  OPTION_DOUBLE(energy, 100); // entered in GeV
+  energy *= copcore::units::GeV;
+
+  InitGeant4();
+
+#ifdef VECGEOM_GDML
+  vecgeom::GeoManager::Instance().SetTransformationCacheDepth(cache_depth);
+  // The vecgeom millimeter unit is the last parameter of vgdml::Frontend::Load
+  bool load = vgdml::Frontend::Load(gdml_name.c_str(), false, copcore::units::mm);
+  if (!load) return 3;
+#endif
+
+  const vecgeom::VPlacedVolume *world = vecgeom::GeoManager::Instance().GetWorld();
+  if (!world) return 4;
+
+  example11(world, particles, energy);
+}

--- a/examples/Example11/example11.cu
+++ b/examples/Example11/example11.cu
@@ -1,0 +1,348 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include "example11.h"
+#include "example11.cuh"
+
+#include <AdePT/Atomic.h>
+#include <AdePT/BVHNavigator.h>
+#include <AdePT/MParray.h>
+
+#include <CopCore/Global.h>
+#include <CopCore/PhysicalConstants.h>
+#include <CopCore/Ranluxpp.h>
+
+#include <VecGeom/base/Config.h>
+#include <VecGeom/base/Stopwatch.h>
+#include <VecGeom/management/BVHManager.h>
+
+#include <G4HepEmData.hh>
+#include <G4HepEmElectronInit.hh>
+#include <G4HepEmGammaInit.hh>
+#include <G4HepEmMatCutData.hh>
+#include <G4HepEmMaterialInit.hh>
+#include <G4HepEmParameters.hh>
+#include <G4HepEmParametersInit.hh>
+
+#include <iostream>
+#include <iomanip>
+#include <stdio.h>
+
+__constant__ __device__ struct G4HepEmParameters g4HepEmPars;
+__constant__ __device__ struct G4HepEmData g4HepEmData;
+
+__constant__ __device__ int Zero = 0;
+
+struct G4HepEmState {
+  G4HepEmData data;
+  G4HepEmParameters parameters;
+};
+
+static G4HepEmState *InitG4HepEm()
+{
+  G4HepEmState *state = new G4HepEmState;
+  InitG4HepEmData(&state->data);
+  InitHepEmParameters(&state->parameters);
+
+  InitMaterialAndCoupleData(&state->data, &state->parameters);
+
+  InitElectronData(&state->data, &state->parameters, true);
+  InitElectronData(&state->data, &state->parameters, false);
+  InitGammaData(&state->data, &state->parameters);
+
+  G4HepEmMatCutData *cutData = state->data.fTheMatCutData;
+  std::cout << "fNumG4MatCuts = " << cutData->fNumG4MatCuts << ", fNumMatCutData = " << cutData->fNumMatCutData
+            << std::endl;
+
+  // Copy to GPU.
+  CopyG4HepEmDataToGPU(&state->data);
+  COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(g4HepEmPars, &state->parameters, sizeof(G4HepEmParameters)));
+
+  // Create G4HepEmData with the device pointers.
+  G4HepEmData dataOnDevice;
+  dataOnDevice.fTheMatCutData   = state->data.fTheMatCutData_gpu;
+  dataOnDevice.fTheMaterialData = state->data.fTheMaterialData_gpu;
+  dataOnDevice.fTheElementData  = state->data.fTheElementData_gpu;
+  dataOnDevice.fTheElectronData = state->data.fTheElectronData_gpu;
+  dataOnDevice.fThePositronData = state->data.fThePositronData_gpu;
+  dataOnDevice.fTheSBTableData  = state->data.fTheSBTableData_gpu;
+  dataOnDevice.fTheGammaData    = state->data.fTheGammaData_gpu;
+  // The other pointers should never be used.
+  dataOnDevice.fTheMatCutData_gpu   = nullptr;
+  dataOnDevice.fTheMaterialData_gpu = nullptr;
+  dataOnDevice.fTheElementData_gpu  = nullptr;
+  dataOnDevice.fTheElectronData_gpu = nullptr;
+  dataOnDevice.fThePositronData_gpu = nullptr;
+  dataOnDevice.fTheSBTableData_gpu  = nullptr;
+  dataOnDevice.fTheGammaData_gpu    = nullptr;
+
+  COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(g4HepEmData, &dataOnDevice, sizeof(G4HepEmData)));
+
+  return state;
+}
+
+static void FreeG4HepEm(G4HepEmState *state)
+{
+  FreeG4HepEmData(&state->data);
+  delete state;
+}
+
+// A bundle of queues per particle type:
+//  * Two for active particles, one for the current iteration and the second for the next.
+struct ParticleQueues {
+  adept::MParray *currentlyActive;
+  adept::MParray *nextActive;
+
+  void SwapActive() { std::swap(currentlyActive, nextActive); }
+};
+
+struct ParticleType {
+  Track *tracks;
+  SlotManager *slotManager;
+  ParticleQueues queues;
+  cudaStream_t stream;
+  cudaEvent_t event;
+
+  enum {
+    Electron = 0,
+    Positron = 1,
+    Gamma    = 2,
+
+    NumParticleTypes,
+  };
+};
+
+// A bundle of queues for the three particle types.
+struct AllParticleQueues {
+  ParticleQueues queues[ParticleType::NumParticleTypes];
+};
+
+// Kernel to initialize the set of queues per particle type.
+__global__ void InitParticleQueues(ParticleQueues queues, size_t Capacity)
+{
+  adept::MParray::MakeInstanceAt(Capacity, queues.currentlyActive);
+  adept::MParray::MakeInstanceAt(Capacity, queues.nextActive);
+}
+
+// Kernel function to initialize a set of primary particles.
+__global__ void InitPrimaries(ParticleGenerator generator, int particles, double energy,
+                              const vecgeom::VPlacedVolume *world)
+{
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < particles; i += blockDim.x * gridDim.x) {
+    Track &track = generator.NextTrack();
+
+    track.rngState.SetSeed(314159265 * (i + 1));
+    track.energy       = energy;
+    track.numIALeft[0] = -1.0;
+    track.numIALeft[1] = -1.0;
+    track.numIALeft[2] = -1.0;
+
+    track.pos = {0, 0, 0};
+    track.dir = {1.0, 0, 0};
+    BVHNavigator::LocatePointIn(world, track.pos, track.currentState, true);
+    // nextState is initialized as needed.
+  }
+}
+
+// A data structure to transfer statistics after each iteration.
+struct Stats {
+  GlobalScoring scoring;
+  int inFlight[ParticleType::NumParticleTypes];
+};
+
+// Finish iteration: clear queues and fill statistics.
+__global__ void FinishIteration(AllParticleQueues all, const GlobalScoring *scoring, Stats *stats)
+{
+  stats->scoring = *scoring;
+  for (int i = 0; i < ParticleType::NumParticleTypes; i++) {
+    all.queues[i].currentlyActive->clear();
+    stats->inFlight[i] = all.queues[i].nextActive->size();
+  }
+}
+
+void example11(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double energy)
+{
+  auto &cudaManager = vecgeom::cxx::CudaManager::Instance();
+  cudaManager.LoadGeometry(world);
+  cudaManager.Synchronize();
+
+  const vecgeom::cuda::VPlacedVolume *world_dev = cudaManager.world_gpu();
+
+  InitBVH();
+
+  G4HepEmState *state = InitG4HepEm();
+
+  // Capacity of the different containers aka the maximum number of particles.
+  constexpr int Capacity = 256 * 1024;
+
+  std::cout << "INFO: capacity of containers set to " << Capacity << std::endl;
+
+  // Allocate structures to manage tracks of an implicit type:
+  //  * memory to hold the actual Track elements,
+  //  * objects to manage slots inside the memory,
+  //  * queues of slots to remember active particle,
+  //  * a stream and an event for synchronization of kernels.
+  constexpr size_t TracksSize  = sizeof(Track) * Capacity;
+  constexpr size_t ManagerSize = sizeof(SlotManager);
+  const size_t QueueSize       = adept::MParray::SizeOfInstance(Capacity);
+
+  ParticleType particles[ParticleType::NumParticleTypes];
+  SlotManager slotManagerInit(Capacity);
+  for (int i = 0; i < ParticleType::NumParticleTypes; i++) {
+    COPCORE_CUDA_CHECK(cudaMalloc(&particles[i].tracks, TracksSize));
+
+    COPCORE_CUDA_CHECK(cudaMalloc(&particles[i].slotManager, ManagerSize));
+    COPCORE_CUDA_CHECK(cudaMemcpy(particles[i].slotManager, &slotManagerInit, ManagerSize, cudaMemcpyHostToDevice));
+
+    COPCORE_CUDA_CHECK(cudaMalloc(&particles[i].queues.currentlyActive, QueueSize));
+    COPCORE_CUDA_CHECK(cudaMalloc(&particles[i].queues.nextActive, QueueSize));
+    InitParticleQueues<<<1, 1>>>(particles[i].queues, Capacity);
+
+    COPCORE_CUDA_CHECK(cudaStreamCreate(&particles[i].stream));
+    COPCORE_CUDA_CHECK(cudaEventCreate(&particles[i].event));
+  }
+  COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
+
+  ParticleType &electrons = particles[ParticleType::Electron];
+  ParticleType &positrons = particles[ParticleType::Positron];
+  ParticleType &gammas    = particles[ParticleType::Gamma];
+
+  // Create a stream to synchronize kernels of all particle types.
+  cudaStream_t stream;
+  COPCORE_CUDA_CHECK(cudaStreamCreate(&stream));
+
+  // Allocate and initialize scoring and statistics.
+  GlobalScoring *scoring = nullptr;
+  COPCORE_CUDA_CHECK(cudaMalloc(&scoring, sizeof(GlobalScoring)));
+  COPCORE_CUDA_CHECK(cudaMemset(scoring, 0, sizeof(GlobalScoring)));
+
+  Stats *stats_dev = nullptr;
+  COPCORE_CUDA_CHECK(cudaMalloc(&stats_dev, sizeof(Stats)));
+  Stats *stats = nullptr;
+  COPCORE_CUDA_CHECK(cudaMallocHost(&stats, sizeof(Stats)));
+
+  // Initialize primary particles.
+  constexpr int InitThreads = 32;
+  int initBlocks            = (numParticles + InitThreads - 1) / InitThreads;
+  ParticleGenerator electronGenerator(electrons.tracks, electrons.slotManager, electrons.queues.currentlyActive);
+  InitPrimaries<<<initBlocks, InitThreads>>>(electronGenerator, numParticles, energy, world_dev);
+  COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
+
+  stats->inFlight[ParticleType::Electron] = numParticles;
+  stats->inFlight[ParticleType::Positron] = 0;
+  stats->inFlight[ParticleType::Gamma]    = 0;
+
+  std::cout << "INFO: running with field Bz = " << BzFieldValue / copcore::units::tesla << " T";
+  std::cout << std::endl;
+
+  constexpr int MaxBlocks        = 1024;
+  constexpr int TransportThreads = 32;
+  int transportBlocks;
+
+  vecgeom::Stopwatch timer;
+  timer.Start();
+
+  int inFlight;
+  int iterNo = 0;
+
+  do {
+    Secondaries secondaries = {
+        .electrons = {electrons.tracks, electrons.slotManager, electrons.queues.nextActive},
+        .positrons = {positrons.tracks, positrons.slotManager, positrons.queues.nextActive},
+        .gammas    = {gammas.tracks, gammas.slotManager, gammas.queues.nextActive},
+    };
+
+    // *** ELECTRONS ***
+    int numElectrons = stats->inFlight[ParticleType::Electron];
+    if (numElectrons > 0) {
+      transportBlocks = (numElectrons + TransportThreads - 1) / TransportThreads;
+      transportBlocks = std::min(transportBlocks, MaxBlocks);
+
+      TransportElectrons<<<transportBlocks, TransportThreads, 0, electrons.stream>>>(
+          electrons.tracks, electrons.queues.currentlyActive, secondaries, electrons.queues.nextActive, scoring);
+
+      COPCORE_CUDA_CHECK(cudaEventRecord(electrons.event, electrons.stream));
+      COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, electrons.event, 0));
+    }
+
+    // *** POSITRONS ***
+    int numPositrons = stats->inFlight[ParticleType::Positron];
+    if (numPositrons > 0) {
+      transportBlocks = (numPositrons + TransportThreads - 1) / TransportThreads;
+      transportBlocks = std::min(transportBlocks, MaxBlocks);
+
+      TransportPositrons<<<transportBlocks, TransportThreads, 0, positrons.stream>>>(
+          positrons.tracks, positrons.queues.currentlyActive, secondaries, positrons.queues.nextActive, scoring);
+
+      COPCORE_CUDA_CHECK(cudaEventRecord(positrons.event, positrons.stream));
+      COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, positrons.event, 0));
+    }
+
+    // *** GAMMAS ***
+    int numGammas = stats->inFlight[ParticleType::Gamma];
+    if (numGammas > 0) {
+      transportBlocks = (numGammas + TransportThreads - 1) / TransportThreads;
+      transportBlocks = std::min(transportBlocks, MaxBlocks);
+
+      TransportGammas<<<transportBlocks, TransportThreads, 0, gammas.stream>>>(
+          gammas.tracks, gammas.queues.currentlyActive, secondaries, gammas.queues.nextActive, scoring);
+
+      COPCORE_CUDA_CHECK(cudaEventRecord(gammas.event, gammas.stream));
+      COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, gammas.event, 0));
+    }
+
+    // *** END OF TRANSPORT ***
+
+    // The events ensure synchronization before finishing this iteration and
+    // copying the Stats back to the host.
+    AllParticleQueues queues = {{electrons.queues, positrons.queues, gammas.queues}};
+    FinishIteration<<<1, 1, 0, stream>>>(queues, scoring, stats_dev);
+    COPCORE_CUDA_CHECK(cudaMemcpyAsync(stats, stats_dev, sizeof(Stats), cudaMemcpyDeviceToHost, stream));
+
+    // Finally synchronize all kernels.
+    COPCORE_CUDA_CHECK(cudaStreamSynchronize(stream));
+
+    // Count the number of particles in flight.
+    inFlight = 0;
+    for (int i = 0; i < ParticleType::NumParticleTypes; i++) {
+      inFlight += stats->inFlight[i];
+    }
+
+    // Swap the queues for the next iteration.
+    electrons.queues.SwapActive();
+    positrons.queues.SwapActive();
+    gammas.queues.SwapActive();
+
+    std::cout << std::fixed << std::setprecision(4) << std::setfill(' ');
+    std::cout << "iter " << std::setw(4) << iterNo << " -- tracks in flight: " << std::setw(5) << inFlight
+              << " energy deposition: " << std::setw(10) << stats->scoring.energyDeposit / copcore::units::GeV
+              << " number of secondaries: " << std::setw(5) << stats->scoring.secondaries
+              << " number of hits: " << std::setw(4) << stats->scoring.hits;
+    std::cout << std::endl;
+
+    iterNo++;
+  } while (inFlight > 0 && iterNo < 1000);
+
+  auto time_cpu = timer.Stop();
+  std::cout << "Run time: " << time_cpu << "\n";
+
+  // Free resources.
+  COPCORE_CUDA_CHECK(cudaFree(scoring));
+  COPCORE_CUDA_CHECK(cudaFree(stats_dev));
+  COPCORE_CUDA_CHECK(cudaFreeHost(stats));
+
+  COPCORE_CUDA_CHECK(cudaStreamDestroy(stream));
+
+  for (int i = 0; i < ParticleType::NumParticleTypes; i++) {
+    COPCORE_CUDA_CHECK(cudaFree(particles[i].tracks));
+    COPCORE_CUDA_CHECK(cudaFree(particles[i].slotManager));
+
+    COPCORE_CUDA_CHECK(cudaFree(particles[i].queues.currentlyActive));
+    COPCORE_CUDA_CHECK(cudaFree(particles[i].queues.nextActive));
+
+    COPCORE_CUDA_CHECK(cudaStreamDestroy(particles[i].stream));
+    COPCORE_CUDA_CHECK(cudaEventDestroy(particles[i].event));
+  }
+
+  FreeG4HepEm(state);
+}

--- a/examples/Example11/example11.cuh
+++ b/examples/Example11/example11.cuh
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef EXAMPLE9_CUH
+#define EXAMPLE9_CUH
+
+#include <AdePT/MParray.h>
+#include <CopCore/SystemOfUnits.h>
+#include <CopCore/Ranluxpp.h>
+
+#include <G4HepEmData.hh>
+#include <G4HepEmParameters.hh>
+#include <G4HepEmRandomEngine.hh>
+
+#include <VecGeom/base/Vector3D.h>
+#include <VecGeom/navigation/NavStateIndex.h>
+
+
+// A data structure to represent a particle track. The particle type is implicit
+// by the queue and not stored in memory.
+struct Track {
+  RanluxppDouble rngState;
+  double energy;
+  double numIALeft[3];
+
+  vecgeom::Vector3D<double> pos;
+  vecgeom::Vector3D<double> dir;
+  vecgeom::NavStateIndex currentState;
+  vecgeom::NavStateIndex nextState;
+
+  __host__ __device__ double Uniform() { return rngState.Rndm(); }
+
+  __host__ __device__ void SwapStates()
+  {
+    auto state         = this->currentState;
+    this->currentState = this->nextState;
+    this->nextState    = state;
+  }
+
+  __host__ __device__ void InitAsSecondary(const Track &parent)
+  {
+    // The caller is responsible to branch a new RNG state and to set the energy.
+    this->numIALeft[0] = -1.0;
+    this->numIALeft[1] = -1.0;
+    this->numIALeft[2] = -1.0;
+
+    // A secondary inherits the position of its parent; the caller is responsible
+    // to update the directions.
+    this->pos           = parent.pos;
+    this->currentState = parent.currentState;
+    this->nextState    = parent.nextState;
+  }
+};
+
+// Defined in example11.cu
+extern __constant__ __device__ int Zero;
+
+class RanluxppDoubleEngine : public G4HepEmRandomEngine {
+  // Wrapper functions to call into RanluxppDouble.
+  static __host__ __device__ __attribute__((noinline))
+  double FlatWrapper(void *object)
+  {
+    return ((RanluxppDouble *)object)->Rndm();
+  }
+  static __host__ __device__ __attribute__((noinline))
+  void FlatArrayWrapper(void *object, const int size, double *vect)
+  {
+    for (int i = 0; i < size; i++) {
+      vect[i] = ((RanluxppDouble *)object)->Rndm();
+    }
+  }
+
+public:
+  __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
+      : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
+  {
+#ifdef __CUDA_ARCH__
+    // This is a hack: The compiler cannot see that we're going to call the
+    // functions through their pointers, so it underestimates the number of
+    // required registers. By including calls to the (non-inlinable) functions
+    // we force the compiler to account for the register usage, even if this
+    // particular set of calls are not executed at runtime.
+    if (Zero) {
+      FlatWrapper(engine);
+      FlatArrayWrapper(engine, 0, nullptr);
+    }
+#endif
+  }
+};
+
+
+// A data structure for some global scoring. The accessors must make sure to use
+// atomic operations if needed.
+struct GlobalScoring {
+  int hits;
+  int secondaries;
+  double energyDeposit;
+};
+
+// A data structure to manage slots in the track storage.
+class SlotManager {
+  adept::Atomic_t<int> fNextSlot;
+  const int fMaxSlot;
+
+public:
+  __host__ __device__ SlotManager(int maxSlot) : fMaxSlot(maxSlot) { fNextSlot = 0; }
+
+  __host__ __device__ int NextSlot()
+  {
+    int next = fNextSlot.fetch_add(1);
+    if (next >= fMaxSlot) return -1;
+    return next;
+  }
+};
+
+// A bundle of pointers to generate particles of an implicit type.
+class ParticleGenerator {
+  Track *fTracks;
+  SlotManager *fSlotManager;
+  adept::MParray *fActiveQueue;
+
+public:
+  __host__ __device__ ParticleGenerator(Track *tracks, SlotManager *slotManager, adept::MParray *activeQueue)
+    : fTracks(tracks), fSlotManager(slotManager), fActiveQueue(activeQueue) {}
+
+  __host__ __device__ Track &NextTrack()
+  {
+    int slot = fSlotManager->NextSlot();
+    if (slot == -1) {
+      COPCORE_EXCEPTION("No slot available in ParticleGenerator::NextTrack");
+    }
+    fActiveQueue->push_back(slot);
+    return fTracks[slot];
+  }
+};
+
+// A bundle of generators for the three particle types.
+struct Secondaries {
+  ParticleGenerator electrons;
+  ParticleGenerator positrons;
+  ParticleGenerator gammas;
+};
+
+
+__global__ void TransportElectrons(
+    Track *electrons, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
+    GlobalScoring *scoring);
+__global__ void TransportPositrons(
+    Track *positrons, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
+    GlobalScoring *scoring);
+
+__global__ void TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries,
+                                adept::MParray *activeQueue, GlobalScoring *scoring);
+
+// Constant data structures from G4HepEm accessed by the kernels.
+// (defined in example11.cu)
+extern __constant__ __device__ struct G4HepEmParameters g4HepEmPars;
+extern __constant__ __device__ struct G4HepEmData g4HepEmData;
+
+constexpr float BzFieldValue = 0.1 * copcore::units::tesla;
+
+#endif

--- a/examples/Example11/example11.h
+++ b/examples/Example11/example11.h
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef EXAMPLE9_H
+#define EXAMPLE9_H
+
+#include <VecGeom/base/Config.h>
+#ifdef VECGEOM_ENABLE_CUDA
+#include <VecGeom/management/CudaManager.h> // forward declares vecgeom::cxx::VPlacedVolume
+#endif
+
+// Interface between C++ and CUDA.
+void InitBVH();
+void example11(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double energy);
+
+#endif

--- a/examples/Example11/gammas.cu
+++ b/examples/Example11/gammas.cu
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include "example11.cuh"
+
+#include <AdePT/BVHNavigator.h>
+#include <CopCore/PhysicalConstants.h>
+
+#include <G4HepEmGammaManager.hh>
+#include <G4HepEmTrack.hh>
+#include <G4HepEmGammaInteractionCompton.hh>
+#include <G4HepEmGammaInteractionConversion.hh>
+// Pull in implementation.
+#include <G4HepEmGammaManager.icc>
+#include <G4HepEmGammaInteractionCompton.icc>
+#include <G4HepEmGammaInteractionConversion.icc>
+
+constexpr double kPush = 1.e-8 * copcore::units::cm;
+
+__global__ void TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries,
+                                adept::MParray *activeQueue, GlobalScoring *scoring)
+{
+  int activeSize = active->size();
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
+    const int slot      = (*active)[i];
+    Track &currentTrack = gammas[slot];
+
+    // Init a track with the needed data to call into G4HepEm.
+    G4HepEmTrack emTrack;
+    emTrack.SetEKin(currentTrack.energy);
+    // For now, just assume a single material.
+    int theMCIndex = 1;
+    emTrack.SetMCIndex(theMCIndex);
+
+    // Sample the `number-of-interaction-left` and put it into the track.
+    for (int ip = 0; ip < 3; ++ip) {
+      double numIALeft = currentTrack.numIALeft[ip];
+      if (numIALeft <= 0) {
+        numIALeft                  = -std::log(currentTrack.Uniform());
+        currentTrack.numIALeft[ip] = numIALeft;
+      }
+      emTrack.SetNumIALeft(numIALeft, ip);
+    }
+
+    // Call G4HepEm to compute the physics step limit.
+    G4HepEmGammaManager::HowFar(&g4HepEmData, &g4HepEmPars, &emTrack);
+
+    // Get result into variables.
+    double geometricalStepLengthFromPhysics = emTrack.GetGStepLength();
+    int winnerProcessIndex = emTrack.GetWinnerProcessIndex();
+    // Leave the range and MFP inside the G4HepEmTrack. If we split kernels, we
+    // also need to carry them over!
+
+    // Check if there's a volume boundary in between.
+    double geometryStepLength =
+        BVHNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics,
+                                                currentTrack.currentState, currentTrack.nextState);
+    currentTrack.pos += (geometryStepLength + kPush) * currentTrack.dir;
+
+    if (currentTrack.nextState.IsOnBoundary()) {
+      emTrack.SetGStepLength(geometryStepLength);
+      emTrack.SetOnBoundary(true);
+    }
+
+    G4HepEmGammaManager::UpdateNumIALeft(&emTrack);
+
+    // Save the `number-of-interaction-left` in our track.
+    for (int ip = 0; ip < 3; ++ip) {
+      double numIALeft           = emTrack.GetNumIALeft(ip);
+      currentTrack.numIALeft[ip] = numIALeft;
+    }
+
+    if (currentTrack.nextState.IsOnBoundary()) {
+      // For now, just count that we hit something.
+      atomicAdd(&scoring->hits, 1);
+
+      // Kill the particle if it left the world.
+      if (currentTrack.nextState.Top() != nullptr) {
+        activeQueue->push_back(slot);
+
+        // Move to the next boundary.
+	BVHNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, currentTrack.nextState);
+        currentTrack.SwapStates();
+      }
+      continue;
+    } else if (winnerProcessIndex < 0) {
+      // No discrete process, move on.
+      activeQueue->push_back(slot);
+      continue;
+    }
+
+    // Reset number of interaction left for the winner discrete process.
+    // (Will be resampled in the next iteration.)
+    currentTrack.numIALeft[winnerProcessIndex] = -1.0;
+
+    // Perform the discrete interaction.
+    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    // We might need one branched RNG state, prepare while threads are synchronized.
+    RanluxppDouble newRNG(currentTrack.rngState.Branch());
+
+    const double energy   = currentTrack.energy;
+
+    switch (winnerProcessIndex) {
+    case 0: {
+      // Invoke gamma conversion to e-/e+ pairs, if the energy is above the threshold.
+      if (energy < 2 * copcore::units::kElectronMassC2) {
+        activeQueue->push_back(slot);
+        continue;
+      }
+
+      double logEnergy = std::log(energy);
+      double elKinEnergy, posKinEnergy;
+      G4HepEmGammaInteractionConversion::SampleKinEnergies(&g4HepEmData, energy, logEnergy, theMCIndex, elKinEnergy,
+                                                           posKinEnergy, &rnge);
+
+      double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+      double dirSecondaryEl[3], dirSecondaryPos[3];
+      G4HepEmGammaInteractionConversion::SampleDirections(dirPrimary, dirSecondaryEl, dirSecondaryPos, elKinEnergy,
+                                                          posKinEnergy, &rnge);
+
+      Track &electron = secondaries.electrons.NextTrack();
+      Track &positron = secondaries.positrons.NextTrack();
+      atomicAdd(&scoring->secondaries, 2);
+
+      electron.InitAsSecondary(/*parent=*/currentTrack);
+      electron.rngState = newRNG;
+      electron.energy = elKinEnergy;
+      electron.dir.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
+
+      positron.InitAsSecondary(/*parent=*/currentTrack);
+      // Reuse the RNG state of the dying track.
+      positron.rngState = currentTrack.rngState;
+      positron.energy = posKinEnergy;
+      positron.dir.Set(dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]);
+
+      // The current track is killed by not enqueuing into the next activeQueue.
+      break;
+    }
+    case 1: {
+      // Invoke Compton scattering of gamma.
+      constexpr double LowEnergyThreshold = 100 * copcore::units::eV;
+      if (energy < LowEnergyThreshold) {
+        activeQueue->push_back(slot);
+        continue;
+      }
+      const double origDirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+      double dirPrimary[3];
+      const double newEnergyGamma =
+          G4HepEmGammaInteractionCompton::SamplePhotonEnergyAndDirection(energy, dirPrimary, origDirPrimary, &rnge);
+      vecgeom::Vector3D<double> newDirGamma(dirPrimary[0], dirPrimary[1], dirPrimary[2]);
+
+      const double energyEl = energy - newEnergyGamma;
+      if (energyEl > LowEnergyThreshold) {
+        // Create a secondary electron and sample/compute directions.
+        Track &electron = secondaries.electrons.NextTrack();
+        atomicAdd(&scoring->secondaries, 1);
+
+        electron.InitAsSecondary(/*parent=*/currentTrack);
+        electron.rngState = newRNG;
+        electron.energy = energyEl;
+        electron.dir = energy * currentTrack.dir - newEnergyGamma * newDirGamma;
+        electron.dir.Normalize();
+      } else {
+        atomicAdd(&scoring->energyDeposit, energyEl);
+      }
+
+      // Check the new gamma energy and deposit if below threshold.
+      if (newEnergyGamma > LowEnergyThreshold) {
+        currentTrack.energy = newEnergyGamma;
+        currentTrack.dir = newDirGamma;
+
+        // The current track continues to live.
+        activeQueue->push_back(slot);
+      } else {
+        atomicAdd(&scoring->energyDeposit, newEnergyGamma);
+        // The current track is killed by not enqueuing into the next activeQueue.
+      }
+      break;
+    }
+    case 2: {
+      // Invoke photoelectric process: right now only absorb the gamma.
+      atomicAdd(&scoring->energyDeposit, energy);
+      // The current track is killed by not enqueuing into the next activeQueue.
+      break;
+    }
+    }
+  }
+}

--- a/magneticfield/inc/fieldPropagatorConstBz.h
+++ b/magneticfield/inc/fieldPropagatorConstBz.h
@@ -23,7 +23,7 @@ public:
   __host__ __device__ void stepInField(double kinE, double mass, int charge, double step,
                                        vecgeom::Vector3D<double> &position, vecgeom::Vector3D<double> &direction);
 
-  template <bool Relocate = true>
+  template <bool Relocate = true, class Navigator = LoopNavigator>
   __host__ __device__ double ComputeStepAndPropagatedState(double kinE, double mass, int charge, double physicsStep,
                                                            vecgeom::Vector3D<double> &position,
                                                            vecgeom::Vector3D<double> &direction,
@@ -62,7 +62,7 @@ __host__ __device__ void fieldPropagatorConstBz::stepInField(double kinE, double
 
 // Determine the step along curved trajectory for charged particles in a field.
 //  ( Same name as as navigator method. )
-template <bool Relocate>
+template <bool Relocate, class Navigator>
 __host__ __device__ double fieldPropagatorConstBz::ComputeStepAndPropagatedState(
     double kinE, double mass, int charge, double physicsStep, vecgeom::Vector3D<double> &position,
     vecgeom::Vector3D<double> &direction, vecgeom::NavStateIndex const &current_state,
@@ -93,9 +93,9 @@ __host__ __device__ double fieldPropagatorConstBz::ComputeStepAndPropagatedState
 
   if (charge == 0) {
     if (Relocate) {
-      stepDone = LoopNavigator::ComputeStepAndPropagatedState(position, direction, remains, current_state, next_state);
+      stepDone = Navigator::ComputeStepAndPropagatedState(position, direction, remains, current_state, next_state);
     } else {
-      stepDone = LoopNavigator::ComputeStepAndNextVolume(position, direction, remains, current_state, next_state);
+      stepDone = Navigator::ComputeStepAndNextVolume(position, direction, remains, current_state, next_state);
     }
     position += (stepDone + kPushField) * direction;
   } else {
@@ -122,9 +122,9 @@ __host__ __device__ double fieldPropagatorConstBz::ComputeStepAndPropagatedState
 
       double move;
       if (Relocate) {
-        move = LoopNavigator::ComputeStepAndPropagatedState(position, chordDir, chordLen, current_state, next_state);
+        move = Navigator::ComputeStepAndPropagatedState(position, chordDir, chordLen, current_state, next_state);
       } else {
-        move = LoopNavigator::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state);
+        move = Navigator::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state);
       }
 
       fullChord = (move == chordLen);


### PR DESCRIPTION
In this new example, the relocation queue is removed, and a call to `BVHNavigator::LocateToNextVolume()` is made within the transportation kernels instead. Please validate on your side as well. I seem to at least get the same results as Example9, just slightly faster (0.73s vs 0.90s before):

```sh
epsftws build $ BuildProducts/bin/example9 -gdml_name trackML.gdml > example9.log
epsftws build $ BuildProducts/bin/example11 -gdml_name trackML.gdml > example11.log
epsftws build $ diff example9.log example11.log 
236c236
< Run time: 0.9069
---
> Run time: 0.7363
```

*Update*: After swapping the `LoopNavigator` with `BVHNavigator` in the field propagator, the results are still the same, but the speedup is a lot larger:

```
epsftws build $ BuildProducts/bin/example9  -gdml_name trackML.gdml > 9.log
epsftws build $ BuildProducts/bin/example11 -gdml_name trackML.gdml > 11.log
epsftws build $ diff -u 9.log 11.log 
--- 9.log	2021-06-09 10:20:47.993541052 +0200
+++ 11.log	2021-06-09 10:20:55.923546775 +0200
@@ -233,4 +233,4 @@
 iter  212 -- tracks in flight:     1 energy deposition:    88.4433 number of secondaries: 62973 number of hits: 67728
 iter  213 -- tracks in flight:     2 energy deposition:    88.4433 number of secondaries: 62974 number of hits: 67728
 iter  214 -- tracks in flight:     0 energy deposition:    88.4437 number of secondaries: 62974 number of hits: 67728
-Run time: 0.9383
+Run time: 0.0510
epsftws build $ bc -l <<< "0.9383 / 0.0510"
18.39803921568627450980
```

That's about 18.4x speedup overall, and for the CMS geometry it's more or less 1.96x (0.5901 for example9, vs 0.3014 for example11).

