### PR TITLE
transport rays to the next boundary at every step in RaytraceBenchmark

### DIFF
--- a/examples/Raytracer_Benchmark/README.md
+++ b/examples/Raytracer_Benchmark/README.md
@@ -18,12 +18,9 @@ It currently works for only 2 gdml files: "trackML.gdml" (placed in the source t
 
 ## Ray transport
 
-Every ray has a parameter called generation. The initial container contains as many rays as pixels and empty containers are created for the reflected rays of higher generations​.
+The initial container contains as many rays as pixels. In addition, two containers of indices are used. Initially, the first container hold all the indices for initial rays.
 
-The current version of scheduling is: transport the ray to first boundary only, then generate reflected ray and increase generation, moving to next container. Then, the refracted ray is transported to the next boundary.
-
-The number of generations for the reflected rays is unknown, so 10 containers are created for secondary rays (the rays with generation greater than 10 will be added in the (generation % 10) container). After transporting all the rays from a container, the initial rays are selected and released. This step is repeated for all the containers. In order to be sure that all the secondary rays are transported, the program verifies if there are any secondary rays in the containers. If yes, reiterate over all the containers and transport the rays.
-
+The current version of scheduling is: get the ray using the index from the first container of indices, then transport the ray only to the next boundary. If it's still alive, add the index in the second container of indices. After all the rays were transported to the next boundary, swap the pointers of the first and second containers of indices and clear the second container. Finally, add the indices of the reflected rays in the first container of indices. Repeat this at every step. The loop is finished when the number of elements in use from the first container of indices is equal to 0.
 
 ## How to use:
 

--- a/examples/Raytracer_Benchmark/RaytraceBenchmark.hpp
+++ b/examples/Raytracer_Benchmark/RaytraceBenchmark.hpp
@@ -6,9 +6,8 @@
 
 #include <CopCore/Global.h>
 #include <AdePT/ArgParser.h>
-#include <AdePT/BlockData.h>
-#include <AdePT/LoopNavigator.h>
 #include <AdePT/SparseVector.h>
+#include <AdePT/BVHNavigator.h>
 
 #include <VecGeom/base/Global.h>
 #include <VecGeom/base/Vector3D.h>
@@ -23,6 +22,13 @@
 #ifdef VECGEOM_GDML
 #include <VecGeom/gdml/Frontend.h>
 #endif
+
+unsigned int size_used_cuda(Vector_t *sparse_vector); 
+unsigned int size_used_cuda(Vector_t_int *sparse_vector); 
+    
+void clear_sparse_vector_cuda(Vector_t_int *vector);
+
+void add_indices_cuda(Vector_t_int *sparse_vector, unsigned *sel_vector_d, unsigned *nselected_hd);
 
 void print_vector_cuda(RaytracerData_t *rtdata, int no_generations);
 
@@ -40,25 +46,35 @@ void InitRTdata(RaytracerData_t *rtdata, const MyMediumProp *volume_container, i
                 std::vector<vecgeom::cxx::LogicalVolume *> logicalvolumes)
 {
   Vector_t *x;
+  Vector_t_int *sparse_int_copy, *sparse_int;
 
   if (backend == copcore::BackendType::CUDA) {
     initiliazeCudaWorld((RaytracerData_t *)rtdata, volume_container, logicalvolumes);
     COPCORE_CUDA_CHECK(cudaMalloc(&x, no_generations * sizeof(Vector_t)));
 
+    COPCORE_CUDA_CHECK(cudaMalloc(&sparse_int_copy, no_generations * sizeof(Vector_t_int))); 
+    COPCORE_CUDA_CHECK(cudaMalloc(&sparse_int, no_generations * sizeof(Vector_t_int)));
+
   } else {
     vecgeom::NavStateIndex vpstate;
-    LoopNavigator::LocatePointIn(rtdata->fWorld, rtdata->fStart, vpstate, true);
+    BVHNavigator::LocatePointIn(rtdata->fWorld, rtdata->fStart, vpstate, true);
     rtdata->fVPstate = vpstate;
 
     // COPCORE_CUDA_CHECK(cudaMallocManaged(&x, no_generations * sizeof(Vector_t)));
-    x = (Vector_t *)malloc(no_generations * sizeof(Vector_t));
+    x = (Vector_t *)malloc(no_generations * sizeof(Vector_t));  
+    sparse_int_copy = (Vector_t_int *)malloc(no_generations * sizeof(Vector_t_int)); 
+    sparse_int          = (Vector_t_int *)malloc(no_generations * sizeof(Vector_t_int));
   }
 
   for (int i = 0; i < no_generations; ++i) {
     Vector_t::MakeInstanceAt(&x[i]);
+    Vector_t_int::MakeInstanceAt(&sparse_int_copy[i]);
+    Vector_t_int::MakeInstanceAt(&sparse_int[i]);
   }
 
   rtdata->sparse_rays = x;
+  rtdata->sparse_int_copy  = sparse_int_copy; 
+  rtdata->sparse_int = sparse_int;
 }
 
 // Print information about containers
@@ -73,6 +89,50 @@ void print(RaytracerData_t *rtdata, int no_generations)
   }
 }
 
+// Add elements from sel_vector in sparse_vector
+template <copcore::BackendType backend> 
+void add_indices(Vector_t_int *sparse_vector, unsigned *sel_vector, unsigned *nselected_hd)  
+{ 
+  if (backend == copcore::BackendType::CUDA) {  
+    add_indices_cuda(sparse_vector, sel_vector, nselected_hd); 
+  } else {  
+    add_indices_cpp(sparse_vector, sel_vector, nselected_hd);
+  } 
+} 
+    
+// Return number of elements in use
+template <copcore::BackendType backend> 
+unsigned int size_used(Vector_t *sparse_vector) 
+{ 
+  if (backend == copcore::BackendType::CUDA) {  
+    return size_used_cuda(sparse_vector); 
+  } else {  
+  return (unsigned int) sparse_vector->size_used(); 
+  } 
+} 
+    
+// Return number of elements in use
+template <copcore::BackendType backend> 
+unsigned int size_used(Vector_t_int *sparse_vector) 
+{ 
+  if (backend == copcore::BackendType::CUDA) {  
+    return size_used_cuda(sparse_vector); 
+  } else {  
+    return (unsigned int) sparse_vector->size_used(); 
+  } 
+}
+
+// Clear sparse vector
+template <copcore::BackendType backend> 
+void clear_sparse_vector(Vector_t_int *vector) {  
+  if (backend == copcore::BackendType::CUDA) {  
+    clear_sparse_vector_cuda(vector);  
+  }   
+  else {  
+    vector->clear();
+  } 
+}  
+
 // Check if there are rays in containers
 template <copcore::BackendType backend>
 bool check_used(RaytracerData_t *rtdata, int no_generations)
@@ -80,7 +140,7 @@ bool check_used(RaytracerData_t *rtdata, int no_generations)
   if (backend == copcore::BackendType::CUDA) {
     return check_used_cuda(rtdata, no_generations);
   } else {
-    return check_used_cpp(*rtdata, no_generations);
+    return (rtdata->sparse_int->size() > 0);
   }
 }
 
@@ -139,23 +199,22 @@ int runSimulation(const MyMediumProp *volume_container, const vecgeom::cxx::VPla
   constexpr int VectorSize = 1 << 22;
   const int no_pixels      = rtdata->fSize_py * rtdata->fSize_px;
 
-  using RayBlock     = adept::BlockData<Ray_t>;
-  using RayAllocator = copcore::VariableSizeObjAllocator<RayBlock, backend>;
   using Launcher_t   = copcore::Launcher<backend>;
   using StreamStruct = copcore::StreamType<backend>;
   using Stream_t     = typename StreamStruct::value_type;
   using Vector_t     = adept::SparseVector<Ray_t, VectorSize>; // 1<<16 is the default vector size if parameter omitted
   using VectorInterface = adept::SparseVectorInterface<Ray_t>;
+  using Vector_t_int    = adept::SparseVector<int, VectorSize>; 
+  using VectorInterface_int = adept::SparseVectorInterface<int>;
 
   int no_generations = 1;
-  if (rtdata->fReflection) no_generations = 10;
+  // if (rtdata->fReflection) no_generations = 10;
   int rays_per_pixel = 10; // maximum number of rays per pixel
 
   InitRTdata<backend>(rtdata, volume_container, no_generations, logicalvolumes);
 
   rtdata->Print();
 
-  // rtdata->sparse_rays = array_ptr;
   COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
 
   bool on_gpu = backend == copcore::BackendType::CUDA;
@@ -164,7 +223,15 @@ int runSimulation(const MyMediumProp *volume_container, const vecgeom::cxx::VPla
   // Boilerplate to get the pointers to the device functions to be used
   COPCORE_CALLABLE_DECLARE(generateRaysFunc, generateRays);
   COPCORE_CALLABLE_DECLARE(renderkernelFunc, renderKernels);
-  COPCORE_CALLABLE_DECLARE(printFunc, print_vector);
+  COPCORE_CALLABLE_DECLARE(sortColorFunc, sortColor); 
+    
+  unsigned *sel_vector_d; 
+  COPCORE_CUDA_CHECK(cudaMallocManaged(&sel_vector_d, VectorSize * sizeof(unsigned)));  
+  COPCORE_CUDA_CHECK(cudaDeviceSynchronize());  
+    
+  unsigned *nselected_hd; 
+  COPCORE_CUDA_CHECK(cudaMallocManaged(&nselected_hd, sizeof(unsigned))); 
+  COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
 
   // Create a stream to work with.
   Stream_t stream;
@@ -188,40 +255,49 @@ int runSimulation(const MyMediumProp *volume_container, const vecgeom::cxx::VPla
   vecgeom::Stopwatch timer;
   timer.Start();
 
-  unsigned *sel_vector_d;
-  COPCORE_CUDA_CHECK(cudaMallocManaged(&sel_vector_d, VectorSize * sizeof(unsigned)));
-  COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
-
-  unsigned *nselected_hd;
-  COPCORE_CUDA_CHECK(cudaMallocManaged(&nselected_hd, sizeof(unsigned)));
-  COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
-
   // Add initial rays in container
   generate.Run(generateRaysFunc, no_pixels, {0, 0}, *rtdata);
   COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
+
+  int step = 0; 
+  int size = 0;
 
   if (backend == copcore::BackendType::CUDA && use_tiles) {
     RenderTiledImage((RaytracerData_t *)rtdata, output_buffer, 0, block_size);
   } else {
     Launcher_t renderKernel(stream);
-    while (check_used<backend>(rtdata, no_generations)) {
-      for (int i = 0; i < no_generations; ++i) {
-        renderKernel.Run(renderkernelFunc, VectorSize, {0, 0}, *rtdata, i, rays_per_pixel, color);
+    while (check_used<backend>(rtdata, no_generations)) {  
+
+      size = size_used<backend>(rtdata->sparse_int);
+
+      renderKernel.Run(renderkernelFunc, size, {0, 0}, *rtdata, step, rays_per_pixel, color);
+      COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
+
+      std::swap(rtdata->sparse_int, rtdata->sparse_int_copy);  // swap the pointers
+
+      clear_sparse_vector<backend>(rtdata->sparse_int_copy);
+      COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
+
+      if (rtdata->fReflection) {
+
+        // Get indices of reflected rays
+        auto select_func2 = [] __device__(int i, const VectorInterface *arr) { return ((*arr)[i].reflection == true); };
+        VectorInterface::select(&(rtdata->sparse_rays[0]), select_func2, sel_vector_d, nselected_hd);
         COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
 
-        auto select_func = [] __device__(int i, const VectorInterface *arr) { return ((*arr)[i].fDone == true); };
-        VectorInterface::select(&(rtdata->sparse_rays[i]), select_func, sel_vector_d, nselected_hd);
-        COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
-
-        VectorInterface::release_selected(&(rtdata->sparse_rays[i]), sel_vector_d, nselected_hd);
-        COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
-
-        VectorInterface::select_used(&(rtdata->sparse_rays[i]), sel_vector_d, nselected_hd);
-        COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
+        if (*nselected_hd > 0)
+          add_indices<backend>(rtdata->sparse_int, sel_vector_d, nselected_hd);
       }
-      // printf("-----------------------------------------\n");
+      
+      COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
+
+      step++;
     }
   }
+
+  // Sort colors (for every index)  
+  generate.Run(sortColorFunc, no_pixels, {0, 0}, rays_per_pixel, color);  
+  COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
 
   for (int i = 0; i < no_pixels; i++) {
     int pixel_index                = 4 * i;

--- a/examples/Raytracer_Benchmark/kernels.h
+++ b/examples/Raytracer_Benchmark/kernels.h
@@ -12,27 +12,52 @@ inline namespace COPCORE_IMPL {
 
 constexpr int VectorSize = 1 << 22;
 using Vector_t           = adept::SparseVector<Ray_t, VectorSize>;
+using Vector_t_int    = adept::SparseVector<int, VectorSize>;
+using VectorInterface_int = adept::SparseVectorInterface<int>;
 
-// Add color in the vector of color (ascending order)
+// Add color in the vector of color
 __host__ __device__ void add_color(int index, int rays_per_pixel, adept::Atomic_t<unsigned int> *color,
                                    unsigned int pixel_color)
+  {
+    for (int i = index; i < index + rays_per_pixel; ++i) {
+      unsigned int x = color[i].load();
+      if (x == 0)
+        if (color[i].compare_exchange_strong(x, pixel_color))
+          return;
+    }
+  }
+
+// Sort colors (basic implementation)
+__host__ __device__ void sortColor(int id, int rays_per_pixel, adept::Atomic_t<unsigned int> *color)
 {
+  int index = id*rays_per_pixel;
+  
   for (int i = index; i < index + rays_per_pixel; ++i) {
     if (color[i].load() == 0) {
-      color[i].store(pixel_color);
       return;
-    } else if (pixel_color < color[i].load()) {
-      unsigned int x = color[i].load();
-      color[i].store(pixel_color);
-      pixel_color = x;
+    }
+    for (int j = i+1; j < index + rays_per_pixel; ++j)
+    {
+  
+      if (color[j].load() == 0) {
+        break;
+      }
+      else if (color[i].load() > color[j].load() && color[j].load() > 0) {
+        unsigned int x = color[i].load();
+        color[i].store(color[j].load());
+        color[j].store(x);
+      }
     }
   }
 }
+  
+COPCORE_CALLABLE_FUNC(sortColor)  
 
 // Add initial rays in SparseVector
 __host__ __device__ void generateRays(int id, const RaytracerData_t &rtdata)
 {
   Ray_t *ray      = rtdata.sparse_rays[0].next_free();
+  rtdata.sparse_int->next_free(id);
   ray->index      = id;
   ray->generation = 0;
   ray->intensity.store(1.);
@@ -45,15 +70,20 @@ COPCORE_CALLABLE_FUNC(generateRays)
 __host__ __device__ void renderKernels(int id, const RaytracerData_t &rtdata, int generation, int rays_per_pixel,
                                        adept::Atomic_t<unsigned int> *color)
 {
-  // Propagate all rays and write out the image on the backend
-  if (!(rtdata.sparse_rays)[generation].is_used(id)) return;
 
-  Ray_t &ray = rtdata.sparse_rays[generation][id];
+  int index = rtdata.sparse_int[0][id];
 
+  Ray_t &ray = rtdata.sparse_rays[0][index];
+  
   auto pixel_color = Raytracer::RaytraceOne(rtdata, ray, generation);
-  if (pixel_color.fColor == 0) return;
 
-  add_color(rays_per_pixel * ray.index, rays_per_pixel, color, pixel_color.fColor);
+  // if ray is still alive, add the index in the container
+  if (!ray.fDone)
+    rtdata.sparse_int_copy->next_free(rtdata.sparse_int[0][id]);
+
+  // if ray is not alive, add the color in container
+  else if (pixel_color.fColor != 0)
+    add_color(rays_per_pixel * ray.index, rays_per_pixel, color, pixel_color.fColor);
 }
 
 COPCORE_CALLABLE_FUNC(renderKernels)
@@ -66,19 +96,19 @@ __host__ __device__ void print_vector(Vector_t *vect)
          100. * vect->get_sparsity());
 }
 
-COPCORE_CALLABLE_FUNC(print_vector)
-
-// Check if there are rays in containers
-__host__ bool check_used_cpp(const RaytracerData_t &rtdata, int no_generations)
+// Print information about containers
+__host__ __device__ void print_vector(Vector_t_int *vect)
 {
+  printf("=== vect: fNshared=%lu/%lu fNused=%lu fNbooked=%lu - shared=%.1f%% sparsity=%.1f%%\n", vect->size(),
+         vect->capacity(), vect->size_used(), vect->size_booked(), 100. * vect->get_shared_fraction(),
+         100. * vect->get_sparsity());
+}
 
-  auto rays_containers = rtdata.sparse_rays;
-
-  for (int i = 0; i < no_generations; ++i) {
-    if (rays_containers[i].size_used() > 0) return true;
-  }
-
-  return false;
+// Add elements from sel_vector_d in container sparse_vector
+__host__ void add_indices_cpp(Vector_t_int *sparse_vector, unsigned *sel_vector_d, unsigned *nselected_hd)
+{
+  for (int j = 0; j < *nselected_hd; ++j)
+    sparse_vector->next_free(sel_vector_d[j]);
 }
 
 } // End namespace COPCORE_IMPL


### PR DESCRIPTION
The rays are transported only to the next boundary at every step. Two containers of indices are used. The rays used at every step are taken based on the indices from the first container. The second one stores temporary the indices of the alive rays. Before moving to the next step, the first and second containers are swapped and the second container is cleared.
Every ray has a new parameter, called ```reflection```. The new generated reflected rays have this parameter set (only for the current step). ```reflection``` is used for getting the indices of reflected rays.