### PR TITLE
Decorrelate branched RNG state

### DIFF
--- a/base/inc/CopCore/include/CopCore/Ranluxpp.h
+++ b/base/inc/CopCore/include/CopCore/Ranluxpp.h
@@ -173,6 +173,7 @@ public:
     // Copy and modify the new RNG state.
     RanluxppDouble newRNG(*this);
     newRNG.XORstate(oldState);
+    newRNG.Advance();
     return newRNG;
   }
 };


### PR DESCRIPTION
It appears I never validated the final version of commit 02f73620f6 ("Branch RNG state when generating secondaries") after dropping the call to `Advance()` for the branched RNG state with the other commits to optimize RNG usage from PR #117 (commits 127b7be676 ("Reuse RNG state of killed particles") and 08e4301a98 ("Move RNG branching to reduce thread divergence")). Testing current master reveals errors in comparison to Geant4 in the order of multiple per mill. Restore the call to `Advance()` for better decorrelation of the branched RNG.