### PR TITLE
Update RANLUX++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,9 @@ add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:--device-
 # - For both, interleave the source in PTX to enhance the debugging experience.
 add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<OR:$<CONFIG:RelWithDebInfo>,$<CONFIG:Debug>>>:--source-in-ptx>")
 
+# Disable warnings from the CUDA frontend about unknown GCC pragmas - let the compiler decide what it likes.
+add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe;--diag_suppress=unrecognized_gcc_pragma>")
+
 # Add external dependencies before our own code to allow checking for the
 # targets and depend on them.
 add_subdirectory(external)

--- a/base/inc/CopCore/include/CopCore/ranluxpp/helpers.h
+++ b/base/inc/CopCore/include/CopCore/ranluxpp/helpers.h
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#ifndef COPCORE_RANLUXPP_HELPERS_H_
+#define COPCORE_RANLUXPP_HELPERS_H_
+
+#include <cstdint>
+
+/// Compute `a + b` and set `overflow` accordingly.
+__host__ __device__ static inline uint64_t add_overflow(uint64_t a, uint64_t b, unsigned &overflow)
+{
+  uint64_t add = a + b;
+  overflow     = (add < a);
+  return add;
+}
+
+/// Compute `a + b` and increment `carry` if there was an overflow
+__host__ __device__ static inline uint64_t add_carry(uint64_t a, uint64_t b, unsigned &carry)
+{
+  unsigned overflow;
+  uint64_t add = add_overflow(a, b, overflow);
+  // Do NOT branch on overflow to avoid jumping code, just add 0 if there was
+  // no overflow.
+  carry += overflow;
+  return add;
+}
+
+/// Compute `a - b` and set `overflow` accordingly
+__host__ __device__ static inline uint64_t sub_overflow(uint64_t a, uint64_t b, unsigned &overflow)
+{
+  uint64_t sub = a - b;
+  overflow     = (sub > a);
+  return sub;
+}
+
+/// Compute `a - b` and increment `carry` if there was an overflow
+__host__ __device__ static inline uint64_t sub_carry(uint64_t a, uint64_t b, unsigned &carry)
+{
+  unsigned overflow;
+  uint64_t sub = sub_overflow(a, b, overflow);
+  // Do NOT branch on overflow to avoid jumping code, just add 0 if there was
+  // no overflow.
+  carry += overflow;
+  return sub;
+}
+
+/// Update r = r - (t1 + t2) + (t3 + t2) * b ** 10
+///
+/// This function also yields cbar = floor(r / m) as its return value (int64_t
+/// because the value can be -1). With an initial value of r = t0, this can
+/// be used for computing the remainder after division by m (see the function
+/// mod_m in mulmod.h). The function to_ranlux passes r = 0 and uses only the
+/// return value to obtain the decimal expansion after divison by m.
+__host__ __device__ static inline int64_t compute_r(const uint64_t *upper, uint64_t *r)
+{
+  // Subtract t1 (24 * 24 = 576 bits)
+  unsigned carry = 0;
+  for (int i = 0; i < 9; i++) {
+    uint64_t r_i = r[i];
+    r_i          = sub_overflow(r_i, carry, carry);
+
+    uint64_t t1_i = upper[i];
+    r_i           = sub_carry(r_i, t1_i, carry);
+    r[i]          = r_i;
+  }
+  int64_t c = -((int64_t)carry);
+
+  // Subtract t2 (only 240 bits, so need to extend)
+  carry = 0;
+  for (int i = 0; i < 9; i++) {
+    uint64_t r_i = r[i];
+    r_i          = sub_overflow(r_i, carry, carry);
+
+    uint64_t t2_bits = 0;
+    if (i < 4) {
+      t2_bits += upper[i + 5] >> 16;
+      if (i < 3) {
+        t2_bits += upper[i + 6] << 48;
+      }
+    }
+    r_i  = sub_carry(r_i, t2_bits, carry);
+    r[i] = r_i;
+  }
+  c -= carry;
+
+  // r += (t3 + t2) * 2 ** 240
+  carry = 0;
+  {
+    uint64_t r_3 = r[3];
+    // 16 upper bits
+    uint64_t t2_bits = (upper[5] >> 16) << 48;
+    uint64_t t3_bits = (upper[0] << 48);
+
+    r_3 = add_carry(r_3, t2_bits, carry);
+    r_3 = add_carry(r_3, t3_bits, carry);
+
+    r[3] = r_3;
+  }
+  for (int i = 0; i < 3; i++) {
+    uint64_t r_i = r[i + 4];
+    r_i          = add_overflow(r_i, carry, carry);
+
+    uint64_t t2_bits = (upper[5 + i] >> 32) + (upper[6 + i] << 32);
+    uint64_t t3_bits = (upper[i] >> 16) + (upper[1 + i] << 48);
+
+    r_i = add_carry(r_i, t2_bits, carry);
+    r_i = add_carry(r_i, t3_bits, carry);
+
+    r[i + 4] = r_i;
+  }
+  {
+    uint64_t r_7 = r[7];
+    r_7          = add_overflow(r_7, carry, carry);
+
+    uint64_t t2_bits = (upper[8] >> 32);
+    uint64_t t3_bits = (upper[3] >> 16) + (upper[4] << 48);
+
+    r_7 = add_carry(r_7, t2_bits, carry);
+    r_7 = add_carry(r_7, t3_bits, carry);
+
+    r[7] = r_7;
+  }
+  {
+    uint64_t r_8 = r[8];
+    r_8          = add_overflow(r_8, carry, carry);
+
+    uint64_t t3_bits = (upper[4] >> 16) + (upper[5] << 48);
+
+    r_8 = add_carry(r_8, t3_bits, carry);
+
+    r[8] = r_8;
+  }
+  c += carry;
+
+  // c = floor(r / 2 ** 576) has been computed along the way via the carry
+  // flags. Now if c = 0 and the value currently stored in r is greater or
+  // equal to m, we need cbar = 1 and subtract m, otherwise cbar = c. The
+  // value currently in r is greater or equal to m, if and only if one of
+  // the last 240 bits is set and the upper bits are all set.
+  bool greater_m = r[0] | r[1] | r[2] | (r[3] & 0x0000ffffffffffff);
+  greater_m &= (r[3] >> 48) == 0xffff;
+  for (int i = 4; i < 9; i++) {
+    greater_m &= (r[i] == UINT64_MAX);
+  }
+  return c + (c == 0 && greater_m);
+}
+
+#endif

--- a/base/inc/CopCore/include/CopCore/ranluxpp/mulmod.h
+++ b/base/inc/CopCore/include/CopCore/ranluxpp/mulmod.h
@@ -18,7 +18,7 @@ __host__ __device__ static void multiply9x9(const uint64_t *in1, const uint64_t 
   uint64_t next      = 0;
   unsigned nextCarry = 0;
 
-#if defined(__clang__) || defined(__INTEL_COMPILER) || defined(__CUDACC__)
+#if defined(__clang__) || defined(__INTEL_COMPILER) || defined(__CUDA_ARCH__)
 #pragma unroll
 #elif defined(__GNUC__) && __GNUC__ >= 8
 // This pragma was introduced in GCC version 8.
@@ -31,7 +31,7 @@ __host__ __device__ static void multiply9x9(const uint64_t *in1, const uint64_t 
     next      = 0;
     nextCarry = 0;
 
-#if defined(__clang__) || defined(__INTEL_COMPILER) || defined(__CUDACC__)
+#if defined(__clang__) || defined(__INTEL_COMPILER) || defined(__CUDA_ARCH__)
 #pragma unroll
 #elif defined(__GNUC__) && __GNUC__ >= 8
 // This pragma was introduced in GCC version 8.

--- a/base/inc/CopCore/include/CopCore/ranluxpp/mulmod.h
+++ b/base/inc/CopCore/include/CopCore/ranluxpp/mulmod.h
@@ -1,59 +1,19 @@
 // SPDX-FileCopyrightText: 2020 CERN
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#ifndef COPCORE_RANLUXPP_MULMOD_H_
+#define COPCORE_RANLUXPP_MULMOD_H_
+
+#include "helpers.h"
+
 #include <cstdint>
-
-#include "CopCore/Global.h"
-
-/// Compute `a + b` and set `overflow` accordingly.
-__host__ __device__
-static inline uint64_t add_overflow(uint64_t a, uint64_t b, unsigned &overflow)
-{
-  uint64_t add = a + b;
-  overflow     = (add < a);
-  return add;
-}
-
-/// Compute `a + b` and increment `carry` if there was an overflow
-__host__ __device__
-static inline uint64_t add_carry(uint64_t a, uint64_t b, unsigned &carry)
-{
-  unsigned overflow;
-  uint64_t add = add_overflow(a, b, overflow);
-  // Do NOT branch on overflow to avoid jumping code, just add 0 if there was
-  // no overflow.
-  carry += overflow;
-  return add;
-}
-
-/// Compute `a - b` and set `overflow` accordingly
-__host__ __device__
-static inline uint64_t sub_overflow(uint64_t a, uint64_t b, unsigned &overflow)
-{
-  uint64_t sub = a - b;
-  overflow     = (sub > a);
-  return sub;
-}
-
-/// Compute `a - b` and increment `carry` if there was an overflow
-__host__ __device__
-static inline uint64_t sub_carry(uint64_t a, uint64_t b, unsigned &carry)
-{
-  unsigned overflow;
-  uint64_t sub = sub_overflow(a, b, overflow);
-  // Do NOT branch on overflow to avoid jumping code, just add 0 if there was
-  // no overflow.
-  carry += overflow;
-  return sub;
-}
 
 /// Multiply two 576 bit numbers, stored as 9 numbers of 64 bits each
 ///
 /// \param[in] in1 first factor as 9 numbers of 64 bits each
 /// \param[in] in2 second factor as 9 numbers of 64 bits each
 /// \param[out] out result with 18 numbers of 64 bits each
-__host__ __device__
-static inline void multiply9x9(const uint64_t *in1, const uint64_t *in2, uint64_t *out)
+__host__ __device__ static void multiply9x9(const uint64_t *in1, const uint64_t *in2, uint64_t *out)
 {
   uint64_t next      = 0;
   unsigned nextCarry = 0;
@@ -165,94 +125,18 @@ static inline void multiply9x9(const uint64_t *in1, const uint64_t *in2, uint64_
 ///
 /// \f$ m = 2^{576} - 2^{240} + 1 \f$
 ///
-/// Note that this function does *not* return the smallest value congruent to
-/// the modulus, it only guarantees a value smaller than \f$ 2^{576} \$!
-__host__ __device__
-static inline void mod_m(const uint64_t *mul, uint64_t *out)
+/// The result in out is guaranteed to be smaller than the modulus.
+__host__ __device__ static void mod_m(const uint64_t *mul, uint64_t *out)
 {
-  uint64_t r[9] = {0};
-
-  // r = t0 - t1 (24 * 24 = 576 bits)
-  unsigned carry = 0;
+  uint64_t r[9];
+  // Assign r = t0
   for (int i = 0; i < 9; i++) {
-    uint64_t t0_i = mul[i];
-    uint64_t r_i  = sub_overflow(t0_i, carry, carry);
-
-    uint64_t t1_i = mul[i + 9];
-    r_i           = sub_carry(r_i, t1_i, carry);
-    r[i]          = r_i;
+    r[i] = mul[i];
   }
-  int64_t c = -((int64_t)carry);
 
-  // r -= t2 (only 240 bits, so need to extend)
-  carry = 0;
-  for (int i = 0; i < 9; i++) {
-    uint64_t r_i = r[i];
-    r_i          = sub_overflow(r_i, carry, carry);
+  int64_t c = compute_r(mul + 9, r);
 
-    uint64_t t2_bits = 0;
-    if (i < 4) {
-      t2_bits += mul[i + 14] >> 16;
-      if (i < 3) {
-        t2_bits += mul[i + 15] << 48;
-      }
-    }
-    r_i  = sub_carry(r_i, t2_bits, carry);
-    r[i] = r_i;
-  }
-  c -= carry;
-
-  // r += (t3 + t2) * 2 ** 240
-  carry = 0;
-  {
-    uint64_t r_3 = r[3];
-    // 16 upper bits
-    uint64_t t2_bits = (mul[14] >> 16) << 48;
-    uint64_t t3_bits = (mul[9] << 48);
-
-    r_3 = add_carry(r_3, t2_bits, carry);
-    r_3 = add_carry(r_3, t3_bits, carry);
-
-    r[3] = r_3;
-  }
-  for (int i = 0; i < 3; i++) {
-    uint64_t r_i = r[i + 4];
-    r_i          = add_overflow(r_i, carry, carry);
-
-    uint64_t t2_bits = (mul[14 + i] >> 32) + (mul[15 + i] << 32);
-    uint64_t t3_bits = (mul[9 + i] >> 16) + (mul[10 + i] << 48);
-
-    r_i = add_carry(r_i, t2_bits, carry);
-    r_i = add_carry(r_i, t3_bits, carry);
-
-    r[i + 4] = r_i;
-  }
-  {
-    uint64_t r_7 = r[7];
-    r_7          = add_overflow(r_7, carry, carry);
-
-    uint64_t t2_bits = (mul[17] >> 32);
-    uint64_t t3_bits = (mul[12] >> 16) + (mul[13] << 48);
-
-    r_7 = add_carry(r_7, t2_bits, carry);
-    r_7 = add_carry(r_7, t3_bits, carry);
-
-    r[7] = r_7;
-  }
-  {
-    uint64_t r_8 = r[8];
-    r_8          = add_overflow(r_8, carry, carry);
-
-    uint64_t t3_bits = (mul[13] >> 16) + (mul[14] << 48);
-
-    r_8 = add_carry(r_8, t3_bits, carry);
-
-    r[8] = r_8;
-  }
-  c += carry;
-
-  // c = floor(r / 2 ** 576) has been computed along the way via the carry
-  // flags. Now to update r = r - c * m, it suffices to know c * (-2 ** 240 + 1)
+  // To update r = r - c * m, it suffices to know c * (-2 ** 240 + 1)
   // because the 2 ** 576 will cancel out. Also note that c may be zero, but
   // the operation is still performed to avoid branching.
 
@@ -279,7 +163,7 @@ static inline void mod_m(const uint64_t *mul, uint64_t *out)
   // (The assembly implementation shifts by 63, which gives the same result.)
   int64_t t1 = t2 >> 48;
 
-  carry = 0;
+  unsigned carry = 0;
   {
     uint64_t r_0 = r[0];
 
@@ -313,8 +197,9 @@ static inline void mod_m(const uint64_t *mul, uint64_t *out)
 ///
 /// \param[in] in1 first factor with 9 numbers of 64 bits each
 /// \param[inout] inout second factor and also the output of the same size
-__host__ __device__
-static inline void mulmod(const uint64_t *in1, uint64_t *inout)
+///
+/// The result in inout is guaranteed to be smaller than the modulus.
+__host__ __device__ static void mulmod(const uint64_t *in1, uint64_t *inout)
 {
   uint64_t mul[2 * 9] = {0};
   multiply9x9(in1, inout, mul);
@@ -328,8 +213,7 @@ static inline void mulmod(const uint64_t *in1, uint64_t *inout)
 /// \param[in] n exponent
 ///
 /// The arguments base and res may point to the same location.
-__host__ __device__
-static inline void powermod(const uint64_t *base, uint64_t *res, uint64_t n)
+__host__ __device__ static void powermod(const uint64_t *base, uint64_t *res, uint64_t n)
 {
   uint64_t fac[9] = {0};
   fac[0]          = base[0];
@@ -351,3 +235,5 @@ static inline void powermod(const uint64_t *base, uint64_t *res, uint64_t n)
     mod_m(mul, fac);
   }
 }
+
+#endif

--- a/base/inc/CopCore/include/CopCore/ranluxpp/ranlux_lcg.h
+++ b/base/inc/CopCore/include/CopCore/ranluxpp/ranlux_lcg.h
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#ifndef COPCORE_RANLUXPP_RANLUX_LCG_H_
+#define COPCORE_RANLUXPP_RANLUX_LCG_H_
+
+#include "helpers.h"
+
+#include <cstdint>
+
+/// Convert RANLUX numbers to an LCG state
+///
+/// \param[in] ranlux the RANLUX numbers as 576 bits
+/// \param[out] lcg the 576 bits of the LCG state, smaller than m
+/// \param[in] c the carry bit of the RANLUX state
+///
+/// \f$ m = 2^{576} - 2^{240} + 1 \f$
+__host__ __device__ static void to_lcg(const uint64_t *ranlux, unsigned c, uint64_t *lcg)
+{
+  unsigned carry = 0;
+  // Subtract the final 240 bits.
+  for (int i = 0; i < 9; i++) {
+    uint64_t ranlux_i = ranlux[i];
+    uint64_t lcg_i    = sub_overflow(ranlux_i, carry, carry);
+
+    uint64_t bits = 0;
+    if (i < 4) {
+      bits += ranlux[i + 5] >> 16;
+      if (i < 3) {
+        bits += ranlux[i + 6] << 48;
+      }
+    }
+    lcg_i  = sub_carry(lcg_i, bits, carry);
+    lcg[i] = lcg_i;
+  }
+
+  // Add and propagate the carry bit.
+  for (int i = 0; i < 9; i++) {
+    lcg[i] = add_overflow(lcg[i], c, c);
+  }
+}
+
+/// Convert an LCG state to RANLUX numbers
+///
+/// \param[in] lcg the 576 bits of the LCG state, must be smaller than m
+/// \param[out] ranlux the RANLUX numbers as 576 bits
+/// \param[out] c the carry bit of the RANLUX state
+///
+/// \f$ m = 2^{576} - 2^{240} + 1 \f$
+__host__ __device__ static void to_ranlux(const uint64_t *lcg, uint64_t *ranlux, unsigned &c_out)
+{
+  uint64_t r[9] = {0};
+  int64_t c     = compute_r(lcg, r);
+
+  // ranlux = t1 + t2 + c
+  unsigned carry = 0;
+  for (int i = 0; i < 9; i++) {
+    uint64_t in_i  = lcg[i];
+    uint64_t tmp_i = add_overflow(in_i, carry, carry);
+
+    uint64_t bits = 0;
+    if (i < 4) {
+      bits += lcg[i + 5] >> 16;
+      if (i < 3) {
+        bits += lcg[i + 6] << 48;
+      }
+    }
+    tmp_i     = add_carry(tmp_i, bits, carry);
+    ranlux[i] = tmp_i;
+  }
+
+  // If c = -1, we need to add it to all components.
+  int64_t c1 = c >> 1;
+  ranlux[0]  = add_overflow(ranlux[0], c, carry);
+  for (int i = 1; i < 9; i++) {
+    uint64_t ranlux_i = ranlux[i];
+    ranlux_i          = add_overflow(ranlux_i, carry, carry);
+    ranlux_i          = add_carry(ranlux_i, c1, carry);
+  }
+
+  c_out = carry;
+}
+
+#endif


### PR DESCRIPTION
Avoid a bias in the generated numbers by always converting the LCG state back to RANLUX numbers, and fix a compiler warning in RANLUX++ reported by ECS demo.