### PR TITLE
Detect charged particles that are looping

### DIFF
--- a/examples/Example11/example11.cu
+++ b/examples/Example11/example11.cu
@@ -243,7 +243,8 @@ void example11(const vecgeom::cxx::VPlacedVolume *world, int numParticles, doubl
   timer.Start();
 
   int inFlight;
-  int iterNo = 0;
+  int iterNo = 0, loopingNo = 0;
+  int previousElectrons = -1, previousPositrons = -1;
 
   do {
     Secondaries secondaries = {
@@ -320,8 +321,20 @@ void example11(const vecgeom::cxx::VPlacedVolume *world, int numParticles, doubl
               << " number of hits: " << std::setw(4) << stats->scoring.hits;
     std::cout << std::endl;
 
+    // Check if only charged particles are left that are looping.
+    numElectrons = stats->inFlight[ParticleType::Electron];
+    numPositrons = stats->inFlight[ParticleType::Positron];
+    numGammas = stats->inFlight[ParticleType::Gamma];
+    if (numElectrons == previousElectrons && numPositrons == previousPositrons && numGammas == 0) {
+      loopingNo++;
+    } else {
+      previousElectrons = numElectrons;
+      previousPositrons = numPositrons;
+      loopingNo = 0;
+    }
+
     iterNo++;
-  } while (inFlight > 0 && iterNo < 1000);
+  } while (inFlight > 0 && loopingNo < 20);
 
   auto time_cpu = timer.Stop();
   std::cout << "Run time: " << time_cpu << "\n";

--- a/examples/Example9/example9.cu
+++ b/examples/Example9/example9.cu
@@ -249,7 +249,8 @@ void example9(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double
   timer.Start();
 
   int inFlight;
-  int iterNo = 0;
+  int iterNo = 0, loopingNo = 0;
+  int previousElectrons = -1, previousPositrons = -1;
 
   do {
     Secondaries secondaries = {
@@ -344,8 +345,20 @@ void example9(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double
               << " number of hits: " << std::setw(4) << stats->scoring.hits;
     std::cout << std::endl;
 
+    // Check if only charged particles are left that are looping.
+    numElectrons = stats->inFlight[ParticleType::Electron];
+    numPositrons = stats->inFlight[ParticleType::Positron];
+    numGammas = stats->inFlight[ParticleType::Gamma];
+    if (numElectrons == previousElectrons && numPositrons == previousPositrons && numGammas == 0) {
+      loopingNo++;
+    } else {
+      previousElectrons = numElectrons;
+      previousPositrons = numPositrons;
+      loopingNo = 0;
+    }
+
     iterNo++;
-  } while (inFlight > 0 && iterNo < 1000);
+  } while (inFlight > 0 && loopingNo < 20);
 
   auto time_cpu = timer.Stop();
   std::cout << "Run time: " << time_cpu << "\n";

--- a/examples/TestEm3/TestEm3.cu
+++ b/examples/TestEm3/TestEm3.cu
@@ -317,7 +317,8 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
     int transportBlocks;
 
     int inFlight;
-    int iterNo = 0;
+    int loopingNo = 0;
+    int previousElectrons = -1, previousPositrons = -1;
 
     do {
       Secondaries secondaries = {
@@ -390,8 +391,19 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
       positrons.queues.SwapActive();
       gammas.queues.SwapActive();
 
-      iterNo++;
-    } while (inFlight > 0 && iterNo < 1000);
+      // Check if only charged particles are left that are looping.
+      numElectrons = stats->inFlight[ParticleType::Electron];
+      numPositrons = stats->inFlight[ParticleType::Positron];
+      numGammas = stats->inFlight[ParticleType::Gamma];
+      if (numElectrons == previousElectrons && numPositrons == previousPositrons && numGammas == 0) {
+        loopingNo++;
+      } else {
+        previousElectrons = numElectrons;
+        previousPositrons = numPositrons;
+        loopingNo = 0;
+      }
+
+    } while (inFlight > 0 && loopingNo < 20);
 
     if (inFlight > 0) {
       std::cout << std::endl;


### PR DESCRIPTION
This improves performance by up to a factor of 2x if a significant fraction of the runtime is spent on waiting for these particles, until eventually running into the previous limit of 1000 iterations.

---

For testing with `cms2018.gdml`, be sure to have a VecGeom with https://gitlab.cern.ch/VecGeom/VecGeom/-/merge_requests/831 to avoid stuck particles due to `DistanceToOut` and `Contains` disagreeing for some polyhedra...