### PR TITLE
Only push when relocating a track

### DIFF
--- a/base/inc/AdePT/BVHNavigator.h
+++ b/base/inc/AdePT/BVHNavigator.h
@@ -211,17 +211,18 @@ public:
   // Relocate a state that was returned from ComputeStepAndNextVolume: It first
   // removes all volumes from the state that were left, and then recursively
   // locates the pushed point in the containing volume.
-  __host__ __device__ static void RelocateToNextVolume(vecgeom::Vector3D<vecgeom::Precision> const &globalpoint,
+  __host__ __device__ static void RelocateToNextVolume(vecgeom::Vector3D<vecgeom::Precision> &globalpoint,
                                                        vecgeom::Vector3D<vecgeom::Precision> const &globaldir,
                                                        vecgeom::NavStateIndex &state)
   {
     // Push the point inside the next volume.
-    vecgeom::Vector3D<vecgeom::Precision> pushed = globalpoint + 1.E-6 * globaldir;
+    static constexpr double kPush = 1.e-8;
+    globalpoint += kPush * globaldir;
 
     // Calculate local point from global point.
     vecgeom::Transformation3D m;
     state.TopMatrix(m);
-    vecgeom::Vector3D<vecgeom::Precision> localpoint = m.Transform(pushed);
+    vecgeom::Vector3D<vecgeom::Precision> localpoint = m.Transform(globalpoint);
 
     VPlacedVolumePtr_t pvol = state.Top();
 

--- a/base/inc/AdePT/LoopNavigator.h
+++ b/base/inc/AdePT/LoopNavigator.h
@@ -215,17 +215,18 @@ public:
   // Relocate a state that was returned from ComputeStepAndNextVolume: It first
   // removes all volumes from the state that were left, and then recursively
   // locates the pushed point in the containing volume.
-  __host__ __device__ static void RelocateToNextVolume(vecgeom::Vector3D<vecgeom::Precision> const &globalpoint,
+  __host__ __device__ static void RelocateToNextVolume(vecgeom::Vector3D<vecgeom::Precision> &globalpoint,
                                                        vecgeom::Vector3D<vecgeom::Precision> const &globaldir,
                                                        vecgeom::NavStateIndex &state)
   {
     // Push the point inside the next volume.
-    vecgeom::Vector3D<vecgeom::Precision> pushed = globalpoint + 1.E-6 * globaldir;
+    static constexpr double kPush = 1.e-8;
+    globalpoint += kPush * globaldir;
 
     // Calculate local point from global point.
     vecgeom::Transformation3D m;
     state.TopMatrix(m);
-    vecgeom::Vector3D<vecgeom::Precision> localpoint = m.Transform(pushed);
+    vecgeom::Vector3D<vecgeom::Precision> localpoint = m.Transform(globalpoint);
 
     VPlacedVolumePtr_t pvol = state.Top();
 

--- a/base/inc/AdePT/LoopNavigator.h
+++ b/base/inc/AdePT/LoopNavigator.h
@@ -100,10 +100,9 @@ private:
     for (auto *daughter : pvol->GetDaughters()) {
       double ddistance = daughter->DistanceToIn(localpoint, localdir, step);
 
-      // if distance is negative; we are inside that daughter and should relocate
-      // unless distance is minus infinity
-      const bool valid = (ddistance < step && !vecgeom::IsInf(ddistance)) &&
-                         !((ddistance <= 0.) && in_state.GetLastExited() == daughter);
+      // If ddistance is negative, we are already inside that daughter. The most
+      // likely case is that we just left it and should should not enter again.
+      const bool valid = (ddistance >= 0 && ddistance < step && !vecgeom::IsInf(ddistance));
       hitcandidate = valid ? daughter : hitcandidate;
       step         = valid ? ddistance : step;
     }
@@ -128,10 +127,6 @@ private:
 
     // Otherwise it is a geometry step and we push the point to the boundary.
     out_state.SetBoundaryState(true);
-
-    if (step < 0.) {
-      step = 0.;
-    }
 
     return step;
   }

--- a/examples/Example10/gammas.cu
+++ b/examples/Example10/gammas.cu
@@ -15,8 +15,6 @@
 #include <G4HepEmGammaInteractionCompton.icc>
 #include <G4HepEmGammaInteractionConversion.icc>
 
-constexpr double kPush = 1.e-8 * copcore::units::cm;
-
 __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries,
                                 adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring,
                                 int maxSteps)
@@ -59,7 +57,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
       double geometryStepLength =
           LoopNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics,
                                                   currentTrack.currentState, currentTrack.nextState);
-      currentTrack.pos += (geometryStepLength + kPush) * currentTrack.dir;
+      currentTrack.pos += geometryStepLength * currentTrack.dir;
 
       if (currentTrack.nextState.IsOnBoundary()) {
         emTrack.SetGStepLength(geometryStepLength);

--- a/examples/Example10/relocation.cu
+++ b/examples/Example10/relocation.cu
@@ -51,12 +51,13 @@ __global__ void RelocateToNextVolume(Track *allTracks, const adept::MParray *rel
     // variable localCoordinates.
     if (lane == 0) {
       // Push the point inside the next volume.
-      vecgeom::Vector3D<vecgeom::Precision> pushed = currentTrack.pos + 1.E-6 * currentTrack.dir;
+      static constexpr double kPush = 1.e-8;
+      currentTrack.pos += kPush * currentTrack.dir;
 
       // Calculate local point from global point.
       vecgeom::Transformation3D m;
       state.TopMatrix(m);
-      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(pushed);
+      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(currentTrack.pos);
 
       currentVolume = state.Top();
 

--- a/examples/Example11/gammas.cu
+++ b/examples/Example11/gammas.cu
@@ -15,8 +15,6 @@
 #include <G4HepEmGammaInteractionCompton.icc>
 #include <G4HepEmGammaInteractionConversion.icc>
 
-constexpr double kPush = 1.e-8 * copcore::units::cm;
-
 __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries,
                                 adept::MParray *activeQueue, GlobalScoring *scoring)
 {
@@ -55,7 +53,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     double geometryStepLength =
         BVHNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics,
                                                 currentTrack.currentState, currentTrack.nextState);
-    currentTrack.pos += (geometryStepLength + kPush) * currentTrack.dir;
+    currentTrack.pos += geometryStepLength * currentTrack.dir;
 
     if (currentTrack.nextState.IsOnBoundary()) {
       emTrack.SetGStepLength(geometryStepLength);

--- a/examples/Example6/example6.cu
+++ b/examples/Example6/example6.cu
@@ -284,12 +284,13 @@ __global__ void RelocateToNextVolume(adept::BlockData<track> *allTracks, adept::
     // variable localCoordinates.
     if (lane == 0) {
       // Push the point inside the next volume.
-      vecgeom::Vector3D<vecgeom::Precision> pushed = currentTrack.pos + 1.E-6 * currentTrack.dir;
+      static constexpr double kPush = 1.e-8;
+      currentTrack.pos += kPush * currentTrack.dir;
 
       // Calculate local point from global point.
       vecgeom::Transformation3D m;
       state.TopMatrix(m);
-      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(pushed);
+      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(currentTrack.pos);
 
       currentVolume = state.Top();
 

--- a/examples/Example7/TestEm3.cuh
+++ b/examples/Example7/TestEm3.cuh
@@ -159,6 +159,5 @@ extern __constant__ __device__ int *MCIndex;
 
 // constexpr float BzFieldValue = 0.1 * copcore::units::tesla;
 constexpr double BzFieldValue = 0;
-constexpr double kPush = 1.e-8 * copcore::units::cm;
 
 #endif

--- a/examples/Example7/electrons.cu
+++ b/examples/Example7/electrons.cu
@@ -83,7 +83,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       geometryStepLength =
           LoopNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics,
                                                   currentTrack.currentState, currentTrack.nextState);
-      currentTrack.pos += (geometryStepLength + kPush) * currentTrack.dir;
+      currentTrack.pos += geometryStepLength * currentTrack.dir;
     }
     atomicAdd(&globalScoring->chargedSteps, 1);
     atomicAdd(&scoringPerVolume->chargedTrackLength[volumeID], geometryStepLength);

--- a/examples/Example7/gammas.cu
+++ b/examples/Example7/gammas.cu
@@ -56,7 +56,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     double geometryStepLength =
         LoopNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics,
                                                 currentTrack.currentState, currentTrack.nextState);
-    currentTrack.pos += (geometryStepLength + kPush) * currentTrack.dir;
+    currentTrack.pos += geometryStepLength * currentTrack.dir;
     atomicAdd(&globalScoring->neutralSteps, 1);
 
     if (currentTrack.nextState.IsOnBoundary()) {

--- a/examples/Example7/relocation.cu
+++ b/examples/Example7/relocation.cu
@@ -51,12 +51,13 @@ __global__ void RelocateToNextVolume(Track *allTracks, const adept::MParray *rel
     // variable localCoordinates.
     if (lane == 0) {
       // Push the point inside the next volume.
-      vecgeom::Vector3D<vecgeom::Precision> pushed = currentTrack.pos + 1.E-6 * currentTrack.dir;
+      static constexpr double kPush = 1.e-8;
+      currentTrack.pos += kPush * currentTrack.dir;
 
       // Calculate local point from global point.
       vecgeom::Transformation3D m;
       state.TopMatrix(m);
-      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(pushed);
+      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(currentTrack.pos);
 
       currentVolume = state.Top();
 

--- a/examples/Example8/example8.cu
+++ b/examples/Example8/example8.cu
@@ -477,12 +477,13 @@ __global__ void RelocateToNextVolume(Track *allTracks, const adept::MParray *rel
     // variable localCoordinates.
     if (lane == 0) {
       // Push the point inside the next volume.
-      vecgeom::Vector3D<vecgeom::Precision> pushed = currentTrack.pos + 1.E-6 * currentTrack.dir;
+      static constexpr double kPush = 1.e-8;
+      currentTrack.pos += kPush * currentTrack.dir;
 
       // Calculate local point from global point.
       vecgeom::Transformation3D m;
       state.TopMatrix(m);
-      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(pushed);
+      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(currentTrack.pos);
 
       currentVolume = state.Top();
 

--- a/examples/Example9/gammas.cu
+++ b/examples/Example9/gammas.cu
@@ -15,8 +15,6 @@
 #include <G4HepEmGammaInteractionCompton.icc>
 #include <G4HepEmGammaInteractionConversion.icc>
 
-constexpr double kPush = 1.e-8 * copcore::units::cm;
-
 __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries,
                                 adept::MParray *activeQueue, adept::MParray *relocateQueue, GlobalScoring *scoring)
 {
@@ -55,7 +53,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     double geometryStepLength =
         LoopNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics,
                                                 currentTrack.currentState, currentTrack.nextState);
-    currentTrack.pos += (geometryStepLength + kPush) * currentTrack.dir;
+    currentTrack.pos += geometryStepLength * currentTrack.dir;
 
     if (currentTrack.nextState.IsOnBoundary()) {
       emTrack.SetGStepLength(geometryStepLength);

--- a/examples/Example9/relocation.cu
+++ b/examples/Example9/relocation.cu
@@ -51,12 +51,13 @@ __global__ void RelocateToNextVolume(Track *allTracks, const adept::MParray *rel
     // variable localCoordinates.
     if (lane == 0) {
       // Push the point inside the next volume.
-      vecgeom::Vector3D<vecgeom::Precision> pushed = currentTrack.pos + 1.E-6 * currentTrack.dir;
+      static constexpr double kPush = 1.e-8;
+      currentTrack.pos += kPush * currentTrack.dir;
 
       // Calculate local point from global point.
       vecgeom::Transformation3D m;
       state.TopMatrix(m);
-      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(pushed);
+      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(currentTrack.pos);
 
       currentVolume = state.Top();
 

--- a/examples/TestEm3/TestEm3.cuh
+++ b/examples/TestEm3/TestEm3.cuh
@@ -157,6 +157,5 @@ extern __constant__ __device__ int *MCIndex;
 
 // constexpr float BzFieldValue = 0.1 * copcore::units::tesla;
 constexpr double BzFieldValue = 0;
-constexpr double kPush = 1.e-8 * copcore::units::cm;
 
 #endif

--- a/examples/TestEm3/electrons.cu
+++ b/examples/TestEm3/electrons.cu
@@ -83,7 +83,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       geometryStepLength =
           BVHNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics,
                                                  currentTrack.currentState, currentTrack.nextState);
-      currentTrack.pos += (geometryStepLength + kPush) * currentTrack.dir;
+      currentTrack.pos += geometryStepLength * currentTrack.dir;
     }
     atomicAdd(&globalScoring->chargedSteps, 1);
     atomicAdd(&scoringPerVolume->chargedTrackLength[volumeID], geometryStepLength);

--- a/examples/TestEm3/gammas.cu
+++ b/examples/TestEm3/gammas.cu
@@ -56,7 +56,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     double geometryStepLength =
         BVHNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics,
                                                currentTrack.currentState, currentTrack.nextState);
-    currentTrack.pos += (geometryStepLength + kPush) * currentTrack.dir;
+    currentTrack.pos += geometryStepLength * currentTrack.dir;
     atomicAdd(&globalScoring->neutralSteps, 1);
 
     if (currentTrack.nextState.IsOnBoundary()) {

--- a/magneticfield/inc/fieldPropagatorConstBz.h
+++ b/magneticfield/inc/fieldPropagatorConstBz.h
@@ -34,8 +34,6 @@ private:
   float BzValue;
 };
 
-constexpr double kPushField = 1.e-8 * copcore::units::cm;
-
 // -----------------------------------------------------------------------------
 
 __host__ __device__ void fieldPropagatorConstBz::stepInField(double kinE, double mass, int charge, double step,
@@ -97,7 +95,7 @@ __host__ __device__ double fieldPropagatorConstBz::ComputeStepAndPropagatedState
     } else {
       stepDone = Navigator::ComputeStepAndNextVolume(position, direction, remains, current_state, next_state);
     }
-    position += (stepDone + kPushField) * direction;
+    position += stepDone * direction;
   } else {
     bool fullChord = false;
 


### PR DESCRIPTION
The previous code pushed on every step which introduces systematic errors. Instead only push when reaching a boundary, also removing the problematic case that a slightly pushed point is relocated and the track itself is stuck at one position.

Also correct the handling of negative values from `DistanceToIn` in `LoopNavigator`.

---

I tested all examples with the `cms2018` geometry and I think the pushing when at boundary resolves all stuck particles. For validation, I ran with 1 million electrons on TestEm3 and didn't see much of a difference, presumably because the geometry is very simple.