### PR TITLE
Fixes for TestEm3

### DIFF
--- a/examples/TestEm3/TestEm3.cu
+++ b/examples/TestEm3/TestEm3.cu
@@ -308,7 +308,7 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
                                                globalScoring);
     COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
 
-    stats->inFlight[ParticleType::Electron] = numParticles;
+    stats->inFlight[ParticleType::Electron] = chunk;
     stats->inFlight[ParticleType::Positron] = 0;
     stats->inFlight[ParticleType::Gamma]    = 0;
 


### PR DESCRIPTION
 * Correct initial number of electrons
 * Avoid legacy default stream during simulation

These changes only have a very minor effect in the current setup, but are critical when using multiple threads.