### PR TITLE
Store only one NavStateIndex

### DIFF
--- a/examples/Example11/example11.cu
+++ b/examples/Example11/example11.cu
@@ -139,8 +139,7 @@ __global__ void InitPrimaries(ParticleGenerator generator, int particles, double
 
     track.pos = {0, 0, 0};
     track.dir = {1.0, 0, 0};
-    BVHNavigator::LocatePointIn(world, track.pos, track.currentState, true);
-    // nextState is initialized as needed.
+    BVHNavigator::LocatePointIn(world, track.pos, track.navState, true);
   }
 }
 

--- a/examples/Example11/example11.cuh
+++ b/examples/Example11/example11.cuh
@@ -25,17 +25,9 @@ struct Track {
 
   vecgeom::Vector3D<double> pos;
   vecgeom::Vector3D<double> dir;
-  vecgeom::NavStateIndex currentState;
-  vecgeom::NavStateIndex nextState;
+  vecgeom::NavStateIndex navState;
 
   __host__ __device__ double Uniform() { return rngState.Rndm(); }
-
-  __host__ __device__ void SwapStates()
-  {
-    auto state         = this->currentState;
-    this->currentState = this->nextState;
-    this->nextState    = state;
-  }
 
   __host__ __device__ void InitAsSecondary(const Track &parent)
   {
@@ -46,9 +38,8 @@ struct Track {
 
     // A secondary inherits the position of its parent; the caller is responsible
     // to update the directions.
-    this->pos           = parent.pos;
-    this->currentState = parent.currentState;
-    this->nextState    = parent.nextState;
+    this->pos      = parent.pos;
+    this->navState = parent.navState;
   }
 };
 

--- a/examples/Example11/gammas.cu
+++ b/examples/Example11/gammas.cu
@@ -50,12 +50,12 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     // also need to carry them over!
 
     // Check if there's a volume boundary in between.
-    double geometryStepLength =
-        BVHNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics,
-                                                currentTrack.currentState, currentTrack.nextState);
+    vecgeom::NavStateIndex nextState;
+    double geometryStepLength = BVHNavigator::ComputeStepAndNextVolume(
+        currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics, currentTrack.navState, nextState);
     currentTrack.pos += geometryStepLength * currentTrack.dir;
 
-    if (currentTrack.nextState.IsOnBoundary()) {
+    if (nextState.IsOnBoundary()) {
       emTrack.SetGStepLength(geometryStepLength);
       emTrack.SetOnBoundary(true);
     }
@@ -68,17 +68,17 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
       currentTrack.numIALeft[ip] = numIALeft;
     }
 
-    if (currentTrack.nextState.IsOnBoundary()) {
+    if (nextState.IsOnBoundary()) {
       // For now, just count that we hit something.
       atomicAdd(&scoring->hits, 1);
 
       // Kill the particle if it left the world.
-      if (currentTrack.nextState.Top() != nullptr) {
+      if (nextState.Top() != nullptr) {
         activeQueue->push_back(slot);
 
         // Move to the next boundary.
-	BVHNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, currentTrack.nextState);
-        currentTrack.SwapStates();
+        BVHNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, nextState);
+        currentTrack.navState = nextState;
       }
       continue;
     } else if (winnerProcessIndex < 0) {

--- a/examples/Example9/electrons.cu
+++ b/examples/Example9/electrons.cu
@@ -71,11 +71,12 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     // also need to carry them over!
 
     // Check if there's a volume boundary in between.
+    vecgeom::NavStateIndex nextState;
     double geometryStepLength = fieldPropagatorBz.ComputeStepAndPropagatedState</*Relocate=*/false>(
         currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
-        currentTrack.currentState, currentTrack.nextState);
+        currentTrack.navState, nextState);
 
-    if (currentTrack.nextState.IsOnBoundary()) {
+    if (nextState.IsOnBoundary()) {
       theTrack->SetGStepLength(geometryStepLength);
       theTrack->SetOnBoundary(true);
     }
@@ -121,17 +122,17 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       continue;
     }
 
-    if (currentTrack.nextState.IsOnBoundary()) {
+    if (nextState.IsOnBoundary()) {
       // For now, just count that we hit something.
       atomicAdd(&scoring->hits, 1);
 
       // Kill the particle if it left the world.
-      if (currentTrack.nextState.Top() != nullptr) {
+      if (nextState.Top() != nullptr) {
         activeQueue->push_back(slot);
         relocateQueue->push_back(slot);
 
         // Move to the next boundary.
-        currentTrack.SwapStates();
+        currentTrack.navState = nextState;
       }
       continue;
     } else if (winnerProcessIndex < 0) {

--- a/examples/Example9/example9.cu
+++ b/examples/Example9/example9.cu
@@ -144,8 +144,7 @@ __global__ void InitPrimaries(ParticleGenerator generator, int particles, double
 
     track.pos = {0, 0, 0};
     track.dir = {1.0, 0, 0};
-    LoopNavigator::LocatePointIn(world, track.pos, track.currentState, true);
-    // nextState is initialized as needed.
+    LoopNavigator::LocatePointIn(world, track.pos, track.navState, true);
   }
 }
 

--- a/examples/Example9/example9.cuh
+++ b/examples/Example9/example9.cuh
@@ -25,17 +25,9 @@ struct Track {
 
   vecgeom::Vector3D<double> pos;
   vecgeom::Vector3D<double> dir;
-  vecgeom::NavStateIndex currentState;
-  vecgeom::NavStateIndex nextState;
+  vecgeom::NavStateIndex navState;
 
   __host__ __device__ double Uniform() { return rngState.Rndm(); }
-
-  __host__ __device__ void SwapStates()
-  {
-    auto state         = this->currentState;
-    this->currentState = this->nextState;
-    this->nextState    = state;
-  }
 
   __host__ __device__ void InitAsSecondary(const Track &parent)
   {
@@ -46,9 +38,8 @@ struct Track {
 
     // A secondary inherits the position of its parent; the caller is responsible
     // to update the directions.
-    this->pos           = parent.pos;
-    this->currentState = parent.currentState;
-    this->nextState    = parent.nextState;
+    this->pos      = parent.pos;
+    this->navState = parent.navState;
   }
 };
 

--- a/examples/Example9/relocation.cu
+++ b/examples/Example9/relocation.cu
@@ -40,7 +40,7 @@ __global__ void RelocateToNextVolume(Track *allTracks, const adept::MParray *rel
     const int slot      = (*relocateQueue)[i];
     Track &currentTrack = allTracks[slot];
 
-    vecgeom::NavStateIndex &state = currentTrack.currentState;
+    vecgeom::NavStateIndex &state = currentTrack.navState;
 
     vecgeom::VPlacedVolume const *currentVolume;
     vecgeom::Precision localCoordinates[3];

--- a/examples/TestEm3/TestEm3.cu
+++ b/examples/TestEm3/TestEm3.cu
@@ -143,9 +143,8 @@ __global__ void InitPrimaries(ParticleGenerator generator, int startEvent, int n
 
     track.pos = {startX, 0, 0};
     track.dir = {1.0, 0, 0};
-    track.currentState.Clear();
-    BVHNavigator::LocatePointIn(world, track.pos, track.currentState, true);
-    // nextState is initialized as needed.
+    track.navState.Clear();
+    BVHNavigator::LocatePointIn(world, track.pos, track.navState, true);
 
     atomicAdd(&globalScoring->numElectrons, 1);
   }
@@ -173,7 +172,7 @@ __global__ void DepositEnergy(Track *allTracks, const adept::MParray *queue, Glo
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < queueSize; i += blockDim.x * gridDim.x) {
     const int slot      = (*queue)[i];
     Track &currentTrack = allTracks[slot];
-    auto volume         = currentTrack.currentState.Top();
+    auto volume         = currentTrack.navState.Top();
     if (volume == nullptr) {
       // The particle left the world, why wasn't it killed before?!
       continue;

--- a/examples/TestEm3/TestEm3.cuh
+++ b/examples/TestEm3/TestEm3.cuh
@@ -27,17 +27,9 @@ struct Track {
 
   vecgeom::Vector3D<double> pos;
   vecgeom::Vector3D<double> dir;
-  vecgeom::NavStateIndex currentState;
-  vecgeom::NavStateIndex nextState;
+  vecgeom::NavStateIndex navState;
 
   __host__ __device__ double Uniform() { return rngState.Rndm(); }
-
-  __host__ __device__ void SwapStates()
-  {
-    auto state         = this->currentState;
-    this->currentState = this->nextState;
-    this->nextState    = state;
-  }
 
   __host__ __device__ void InitAsSecondary(const Track &parent)
   {
@@ -48,9 +40,8 @@ struct Track {
 
     // A secondary inherits the position of its parent; the caller is responsible
     // to update the directions.
-    this->pos           = parent.pos;
-    this->currentState = parent.currentState;
-    this->nextState    = parent.nextState;
+    this->pos      = parent.pos;
+    this->navState = parent.navState;
   }
 };
 

--- a/examples/TestEm3MT/TestEm3.cu
+++ b/examples/TestEm3MT/TestEm3.cu
@@ -145,9 +145,8 @@ __global__ void InitPrimaries(ParticleGenerator generator, int startEvent, int n
 
     track.pos = {startX, 0, 0};
     track.dir = {1.0, 0, 0};
-    track.currentState.Clear();
-    BVHNavigator::LocatePointIn(world, track.pos, track.currentState, true);
-    // nextState is initialized as needed.
+    track.navState.Clear();
+    BVHNavigator::LocatePointIn(world, track.pos, track.navState, true);
 
     atomicAdd(&globalScoring->numElectrons, 1);
   }
@@ -175,7 +174,7 @@ __global__ void DepositEnergy(Track *allTracks, const adept::MParray *queue, Glo
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < queueSize; i += blockDim.x * gridDim.x) {
     const int slot      = (*queue)[i];
     Track &currentTrack = allTracks[slot];
-    auto volume         = currentTrack.currentState.Top();
+    auto volume         = currentTrack.navState.Top();
     if (volume == nullptr) {
       // The particle left the world, why wasn't it killed before?!
       continue;

--- a/examples/TestEm3MT/TestEm3.cuh
+++ b/examples/TestEm3MT/TestEm3.cuh
@@ -26,17 +26,9 @@ struct Track {
 
   vecgeom::Vector3D<double> pos;
   vecgeom::Vector3D<double> dir;
-  vecgeom::NavStateIndex currentState;
-  vecgeom::NavStateIndex nextState;
+  vecgeom::NavStateIndex navState;
 
   __host__ __device__ double Uniform() { return rngState.Rndm(); }
-
-  __host__ __device__ void SwapStates()
-  {
-    auto state         = this->currentState;
-    this->currentState = this->nextState;
-    this->nextState    = state;
-  }
 
   __host__ __device__ void InitAsSecondary(const Track &parent)
   {
@@ -47,9 +39,8 @@ struct Track {
 
     // A secondary inherits the position of its parent; the caller is responsible
     // to update the directions.
-    this->pos          = parent.pos;
-    this->currentState = parent.currentState;
-    this->nextState    = parent.nextState;
+    this->pos      = parent.pos;
+    this->navState = parent.navState;
   }
 };
 


### PR DESCRIPTION
This saves 8 bytes per track and a bunch of global memory accesses. Ideally, we would only save the `NavIndex_t` but there is no API to directly retrieve the member `fNavInd` (`GetNavIndex` expects a level and both getting and using that requires walking the hierarchy).