### PR TITLE
Remove broken is_on_device macro and its use in SparseVector.

### DIFF
--- a/base/inc/AdePT/SparseVector.h
+++ b/base/inc/AdePT/SparseVector.h
@@ -718,15 +718,23 @@ protected:
   }
 
 public:
-  __host__ static SparseVector *MakeInstanceAt(void *addr = nullptr)
+
+  template <copcore::BackendType backend>
+  __host__ static SparseVector *MakeInstanceAt(void *addr)
   {
-    if (!addr) return new SparseVector(N);
-    bool devicePtr = copcore::is_device_pointer(addr);
-    if (devicePtr) return SparseVector::ConstructOnDevice(addr);
-    return new (addr) SparseVector(N);
+    switch (backend) {
+      case copcore::BackendType::CUDA:
+        return SparseVector::ConstructOnDevice(addr);
+      case copcore::BackendType::CPU:
+        if (!addr)
+          return new SparseVector(N);
+        return new (addr) SparseVector(N);
+    }
+    return nullptr;
   }
 
 }; // End class SparseVector
+
 } // End namespace adept
 
 #endif // ADEPT_SPARSEVECTOR_H_

--- a/base/inc/CopCore/include/CopCore/Global.h
+++ b/base/inc/CopCore/include/CopCore/Global.h
@@ -53,19 +53,6 @@ static inline void error_check(cudaError_t err, const char *file, int line)
   } while (0)
 #endif
 
-/** @brief Check if pointer id device-resident */
-#ifndef COPCORE_CUDA_COMPILER
-static inline bool is_device_pointer(void *ptr) { return false; }
-#else
-static inline bool is_device_pointer(void *ptr)
-{
-  cudaPointerAttributes attr;
-  cudaError_t err = cudaPointerGetAttributes(&attr, ptr);
-  COPCORE_CUDA_CHECK(err);
-  return (attr.type == cudaMemoryTypeDevice);
-}
-#endif
-
 /** @brief Get number of SMs on the current device */
 #ifndef COPCORE_CUDA_COMPILER
 static inline int get_num_SMs() { return 0; }

--- a/test/test_sparsevector.cu
+++ b/test/test_sparsevector.cu
@@ -112,8 +112,8 @@ int main(void)
   COPCORE_CUDA_CHECK(cudaMallocManaged(&nselected, 2 * sizeof(int)));
 
   // static allocator for convenience
-  Vector_t::MakeInstanceAt(vect1_ptr_d);
-  Vector_t::MakeInstanceAt(vect2_ptr_d);
+  Vector_t::MakeInstanceAt<copcore::BackendType::CUDA>(vect1_ptr_d);
+  Vector_t::MakeInstanceAt<copcore::BackendType::CUDA>(vect2_ptr_d);
 
   reset_selection<<<1, 1>>>(nselected_hd);
 

--- a/test/test_sparsevector_cpu.cpp
+++ b/test/test_sparsevector_cpu.cpp
@@ -107,8 +107,8 @@ int main(void)
   int nshared[2] = {0}, nused[2] = {0}, nselected[2] = {0};
 
   // static allocator for convenience
-  vect1_ptr_d = Vector_t::MakeInstanceAt(nullptr);
-  vect2_ptr_d = Vector_t::MakeInstanceAt(nullptr);
+  vect1_ptr_d = Vector_t::MakeInstanceAt<copcore::BackendType::CPU>(nullptr);
+  vect2_ptr_d = Vector_t::MakeInstanceAt<copcore::BackendType::CPU>(nullptr);
 
   // Construct and distribute tracks concurrently
   timer.Start();


### PR DESCRIPTION
This removes the use of the is_on_device macro that confused the compiler producing undetermined behavior.