### PR TITLE
Example12 featuring TestEm3-like transport in arbitrary geometry imported from GDML.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,10 @@ find_package(VecGeom ${VecGeom_VERSION} REQUIRED)
 message(STATUS "Using VecGeom version ${VecGeom_VERSION}")
 # make sure we import VecGeom architecture flags - is this needed?
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${VECGEOM_CXX_FLAGS}")
+# Make sure VecGeom::vgdml is enabled
+if(NOT TARGET VecGeom::vgdml)
+  message(FATAL_ERROR "AdePT requires VecGeom compiled with GDML support")
+endif()
 
 # Find Geant4, optional for now
 find_package(Geant4 QUIET)
@@ -80,7 +84,9 @@ add_subdirectory(external)
 
 if(BUILD_TESTING)
   set(TESTING_GDML "${PROJECT_BINARY_DIR}/trackML.gdml")
+  set(CMS2018_GDML "${PROJECT_BINARY_DIR}/cms2018.gdml")
   file(DOWNLOAD https://gitlab.cern.ch/VecGeom/VecGeom/raw/master/persistency/gdml/gdmls/trackML.gdml "${TESTING_GDML}")
+  file(DOWNLOAD https://gitlab.cern.ch/VecGeom/VecGeom/raw/master/persistency/gdml/gdmls/cms2018.gdml "${CMS2018_GDML}")
 endif()
 
 # Builds...

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,7 +14,7 @@ add_subdirectory(Example8)
 add_subdirectory(Example9)
 add_subdirectory(Example10)
 add_subdirectory(Example11)
+add_subdirectory(Example12)
 add_subdirectory(TestEm3)
 add_subdirectory(TestEm3MT)
 add_subdirectory(ECS)
-

--- a/examples/Example12/CMakeLists.txt
+++ b/examples/Example12/CMakeLists.txt
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2021 CERN
+# SPDX-License-Identifier: Apache-2.0
+
+if(NOT TARGET G4HepEm::g4HepEm)
+  message(STATUS "Disabling example12 (needs G4HepEm)")
+  return()
+endif()
+
+if(Geant4_FOUND)
+  if(NOT Geant4_gdml_FOUND)
+    message(STATUS "Disabling example12 (needs Geant4 with GDML support)")
+    return()
+  endif()
+else()
+  message(STATUS "Disabling example12 (needs Geant4)")
+  return()
+endif()
+
+# example12 is the AdePT demo example using material cuts as defined in the input gdml file
+add_executable(example12
+  example12.cpp
+  example12.cu
+  electrons.cu
+  gammas.cu)
+target_link_libraries(example12 
+  PRIVATE
+    AdePT
+    CopCore::CopCore
+    VecGeom::vecgeom
+    VecGeom::vecgeomcuda_static
+    VecGeom::vgdml
+    ${Geant4_LIBRARIES}
+    G4HepEm::g4HepEmData
+    G4HepEm::g4HepEmInit
+    G4HepEm::g4HepEmRun
+    CUDA::cudart)
+
+set_target_properties(example12 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
+
+# Tests
+add_test(NAME example12
+  COMMAND $<TARGET_FILE:example12> -gdml_file ${CMAKE_BINARY_DIR}/cms2018.gdml)

--- a/examples/Example12/README.md
+++ b/examples/Example12/README.md
@@ -1,0 +1,53 @@
+<!--
+SPDX-FileCopyrightText: 2021 CERN
+SPDX-License-Identifier: CC-BY-4.0
+-->
+# Example12 example
+Example demonstrating particle transportation on GPUs in arbitrary geometry read from a GDML file, with the same GPU workflow as Example 11.
+
+ * arbitrary geometry via gdml file (tested with cms2018.gdml from VecGeom persistency/gdml/gdmls folder) and optionally a magnetic field with constant Bz,
+ * geometry read as Geant4 geometry, reading in regions and cuts, to initialize G4HepEm data
+ * geometry read then into VecGeom, and synchronized to GPU
+ * G4HepEm material-cuts couple indices mapped to VecGeom logical volume id's
+ * physics processes for e-/e+ and gammas using G4HepEm.
+ * scoring per placed volume, no sensitive detector feature
+
+Electrons, positrons, and gammas are stored in separate containers in device memory.
+Free positions in the storage are handed out with monotonic slot numbers, slots are not reused.
+Active tracks are passed via three queues per particle type (see `struct ParticleQueues`).
+Results are reproducible using one RANLUX++ state per track.
+
+Additionally, the kernels score energy deposit and the charged track length per volume.
+
+### Kernels
+
+This example uses one stream per particle type to launch kernels asynchronously.
+They are synchronized via a forth stream using CUDA events.
+
+#### `TransportElectrons<bool IsElectron>`
+
+1. Determine physics step limit.
+2. Call magnetic field to get geometry step length.
+3. Apply continuous effects; kill track if stopped.
+4. If the particle reaches a boundary, perform relocation.
+5. If not, and if there is a discrete process:
+ 1. Sample the final state.
+ 2. Update the primary and produce secondaries.
+
+#### `TransportGammas`
+
+1. Determine the physics step limit.
+2. Query VecGeom to get geometry step length (no magnetic field for neutral particles!).
+3. If the particle reaches a boundary, perform relocation.
+4. If not, and if there is a discrete process:
+ 1. Sample the final state.
+ 2. Update the primary and produce secondaries.
+
+#### `FinishIteration`
+
+Clear the queues and return the tracks in flight.
+This kernel runs after all secondary particles were produced.
+
+#### `InitPrimaries` and `InitParticleQueues`
+
+Used to initialize multiple primary particles with separate seeds.

--- a/examples/Example12/electrons.cu
+++ b/examples/Example12/electrons.cu
@@ -1,0 +1,279 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include "example12.cuh"
+
+#include <AdePT/BVHNavigator.h>
+#include <fieldPropagatorConstBz.h>
+
+#include <CopCore/PhysicalConstants.h>
+
+#include <G4HepEmElectronManager.hh>
+#include <G4HepEmElectronTrack.hh>
+#include <G4HepEmElectronInteractionBrem.hh>
+#include <G4HepEmElectronInteractionIoni.hh>
+#include <G4HepEmPositronInteractionAnnihilation.hh>
+// Pull in implementation.
+#include <G4HepEmRunUtils.icc>
+#include <G4HepEmInteractionUtils.icc>
+#include <G4HepEmElectronManager.icc>
+#include <G4HepEmElectronInteractionBrem.icc>
+#include <G4HepEmElectronInteractionIoni.icc>
+#include <G4HepEmPositronInteractionAnnihilation.icc>
+
+// Compute the physics and geometry step limit, transport the electrons while
+// applying the continuous effects and maybe a discrete process that could
+// generate secondaries.
+template <bool IsElectron>
+static __device__ __forceinline__ void TransportElectrons(Track *electrons, const adept::MParray *active,
+                                                          Secondaries &secondaries, adept::MParray *activeQueue,
+                                                          GlobalScoring *globalScoring,
+                                                          ScoringPerVolume *scoringPerVolume)
+{
+#ifdef VECGEOM_FLOAT_PRECISION
+  const Precision kPush = 10 * vecgeom::kTolerance;
+#else
+  const Precision kPush = 0.;
+#endif
+  constexpr int Charge  = IsElectron ? -1 : 1;
+  constexpr double Mass = copcore::units::kElectronMassC2;
+  fieldPropagatorConstBz fieldPropagatorBz(BzFieldValue);
+
+  int activeSize = active->size();
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
+    const int slot      = (*active)[i];
+    Track &currentTrack = electrons[slot];
+    auto volume         = currentTrack.navState.Top();
+    int volumeID        = volume->id();
+    // the MCC vector is indexed by the logical volume id
+    int lvolID     = volume->GetLogicalVolume()->id();
+    int theMCIndex = MCIndex[lvolID];
+
+    // Init a track with the needed data to call into G4HepEm.
+    G4HepEmElectronTrack elTrack;
+    G4HepEmTrack *theTrack = elTrack.GetTrack();
+    theTrack->SetEKin(currentTrack.energy);
+    theTrack->SetMCIndex(theMCIndex);
+    theTrack->SetCharge(Charge);
+
+    // Sample the `number-of-interaction-left` and put it into the track.
+    for (int ip = 0; ip < 3; ++ip) {
+      double numIALeft = currentTrack.numIALeft[ip];
+      if (numIALeft <= 0) {
+        numIALeft                  = -std::log(currentTrack.Uniform());
+        currentTrack.numIALeft[ip] = numIALeft;
+      }
+      theTrack->SetNumIALeft(numIALeft, ip);
+    }
+
+    // Call G4HepEm to compute the physics step limit.
+    G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack);
+
+    // Get result into variables.
+    double geometricalStepLengthFromPhysics = theTrack->GetGStepLength();
+    // The phyiscal step length is the amount that the particle experiences
+    // which might be longer than the geometrical step length due to MSC. As
+    // long as we call PerformContinuous in the same kernel we don't need to
+    // care, but we need to make this available when splitting the operations.
+    // double physicalStepLength = elTrack.GetPStepLength();
+    int winnerProcessIndex = theTrack->GetWinnerProcessIndex();
+    // Leave the range and MFP inside the G4HepEmTrack. If we split kernels, we
+    // also need to carry them over!
+
+    // Check if there's a volume boundary in between.
+    double geometryStepLength;
+    vecgeom::NavStateIndex nextState;
+    if (BzFieldValue != 0) {
+      geometryStepLength = fieldPropagatorBz.ComputeStepAndPropagatedState</*Relocate=*/false, BVHNavigator>(
+          currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
+          currentTrack.navState, nextState);
+    } else {
+      geometryStepLength =
+          BVHNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics,
+                                                 currentTrack.navState, nextState, kPush);
+      currentTrack.pos += geometryStepLength * currentTrack.dir;
+    }
+    atomicAdd(&globalScoring->chargedSteps, 1);
+    atomicAdd(&scoringPerVolume->chargedTrackLength[volumeID], geometryStepLength);
+
+    if (nextState.IsOnBoundary()) {
+      theTrack->SetGStepLength(geometryStepLength);
+      theTrack->SetOnBoundary(true);
+    }
+
+    // Apply continuous effects.
+    bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack);
+    // Collect the changes.
+    currentTrack.energy  = theTrack->GetEKin();
+    double energyDeposit = theTrack->GetEnergyDeposit();
+    atomicAdd(&globalScoring->energyDeposit, energyDeposit);
+    atomicAdd(&scoringPerVolume->energyDeposit[volumeID], energyDeposit);
+
+    // Save the `number-of-interaction-left` in our track.
+    for (int ip = 0; ip < 3; ++ip) {
+      double numIALeft           = theTrack->GetNumIALeft(ip);
+      currentTrack.numIALeft[ip] = numIALeft;
+    }
+
+    if (stopped) {
+      if (!IsElectron) {
+        // Annihilate the stopped positron into two gammas heading to opposite
+        // directions (isotropic).
+        Track &gamma1 = secondaries.gammas.NextTrack();
+        Track &gamma2 = secondaries.gammas.NextTrack();
+        atomicAdd(&globalScoring->numGammas, 2);
+
+        const double cost = 2 * currentTrack.Uniform() - 1;
+        const double sint = sqrt(1 - cost * cost);
+        const double phi  = k2Pi * currentTrack.Uniform();
+        double sinPhi, cosPhi;
+        sincos(phi, &sinPhi, &cosPhi);
+
+        gamma1.InitAsSecondary(/*parent=*/currentTrack);
+        gamma1.rngState = currentTrack.rngState.Branch();
+        gamma1.energy   = copcore::units::kElectronMassC2;
+        gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
+
+        gamma2.InitAsSecondary(/*parent=*/currentTrack);
+        // Reuse the RNG state of the dying track.
+        gamma2.rngState = currentTrack.rngState;
+        gamma2.energy   = copcore::units::kElectronMassC2;
+        gamma2.dir      = -gamma1.dir;
+      }
+      // Particles are killed by not enqueuing them into the new activeQueue.
+      continue;
+    }
+
+    if (nextState.IsOnBoundary()) {
+      // For now, just count that we hit something.
+      atomicAdd(&globalScoring->hits, 1);
+
+      // Kill the particle if it left the world.
+      if (nextState.Top() != nullptr) {
+        activeQueue->push_back(slot);
+        BVHNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, nextState);
+
+        // Move to the next boundary.
+        currentTrack.navState = nextState;
+      }
+      continue;
+    } else if (winnerProcessIndex < 0) {
+      // No discrete process, move on.
+      activeQueue->push_back(slot);
+      continue;
+    }
+
+    // Reset number of interaction left for the winner discrete process.
+    // (Will be resampled in the next iteration.)
+    currentTrack.numIALeft[winnerProcessIndex] = -1.0;
+
+    // Check if a delta interaction happens instead of the real discrete process.
+    if (G4HepEmElectronManager::CheckDelta(&g4HepEmData, theTrack, currentTrack.Uniform())) {
+      // A delta interaction happened, move on.
+      activeQueue->push_back(slot);
+      continue;
+    }
+
+    // Perform the discrete interaction.
+    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    // We will need one branched RNG state, prepare while threads are synchronized.
+    RanluxppDouble newRNG(currentTrack.rngState.Branch());
+
+    const double energy   = currentTrack.energy;
+    const double theElCut = g4HepEmData.fTheMatCutData->fMatCutData[theMCIndex].fSecElProdCutE;
+
+    switch (winnerProcessIndex) {
+    case 0: {
+      // Invoke ionization (for e-/e+):
+      double deltaEkin = (IsElectron) ? G4HepEmElectronInteractionIoni::SampleETransferMoller(theElCut, energy, &rnge)
+                                      : G4HepEmElectronInteractionIoni::SampleETransferBhabha(theElCut, energy, &rnge);
+
+      double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+      double dirSecondary[3];
+      G4HepEmElectronInteractionIoni::SampleDirections(energy, deltaEkin, dirSecondary, dirPrimary, &rnge);
+
+      Track &secondary = secondaries.electrons.NextTrack();
+      atomicAdd(&globalScoring->numElectrons, 1);
+
+      secondary.InitAsSecondary(/*parent=*/currentTrack);
+      secondary.rngState = newRNG;
+      secondary.energy   = deltaEkin;
+      secondary.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
+
+      currentTrack.energy = energy - deltaEkin;
+      currentTrack.dir.Set(dirPrimary[0], dirPrimary[1], dirPrimary[2]);
+      // The current track continues to live.
+      activeQueue->push_back(slot);
+      break;
+    }
+    case 1: {
+      // Invoke model for Bremsstrahlung: either SB- or Rel-Brem.
+      double logEnergy = std::log(energy);
+      double deltaEkin = energy < g4HepEmPars.fElectronBremModelLim
+                             ? G4HepEmElectronInteractionBrem::SampleETransferSB(&g4HepEmData, energy, logEnergy,
+                                                                                 theMCIndex, &rnge, IsElectron)
+                             : G4HepEmElectronInteractionBrem::SampleETransferRB(&g4HepEmData, energy, logEnergy,
+                                                                                 theMCIndex, &rnge, IsElectron);
+
+      double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+      double dirSecondary[3];
+      G4HepEmElectronInteractionBrem::SampleDirections(energy, deltaEkin, dirSecondary, dirPrimary, &rnge);
+
+      Track &gamma = secondaries.gammas.NextTrack();
+      atomicAdd(&globalScoring->numGammas, 1);
+
+      gamma.InitAsSecondary(/*parent=*/currentTrack);
+      gamma.rngState = newRNG;
+      gamma.energy   = deltaEkin;
+      gamma.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
+
+      currentTrack.energy = energy - deltaEkin;
+      currentTrack.dir.Set(dirPrimary[0], dirPrimary[1], dirPrimary[2]);
+      // The current track continues to live.
+      activeQueue->push_back(slot);
+      break;
+    }
+    case 2: {
+      // Invoke annihilation (in-flight) for e+
+      double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+      double theGamma1Ekin, theGamma2Ekin;
+      double theGamma1Dir[3], theGamma2Dir[3];
+      G4HepEmPositronInteractionAnnihilation::SampleEnergyAndDirectionsInFlight(
+          energy, dirPrimary, &theGamma1Ekin, theGamma1Dir, &theGamma2Ekin, theGamma2Dir, &rnge);
+
+      Track &gamma1 = secondaries.gammas.NextTrack();
+      Track &gamma2 = secondaries.gammas.NextTrack();
+      atomicAdd(&globalScoring->numGammas, 2);
+
+      gamma1.InitAsSecondary(/*parent=*/currentTrack);
+      gamma1.rngState = newRNG;
+      gamma1.energy   = theGamma1Ekin;
+      gamma1.dir.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
+
+      gamma2.InitAsSecondary(/*parent=*/currentTrack);
+      // Reuse the RNG state of the dying track.
+      gamma2.rngState = currentTrack.rngState;
+      gamma2.energy   = theGamma2Ekin;
+      gamma2.dir.Set(theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]);
+
+      // The current track is killed by not enqueuing into the next activeQueue.
+      break;
+    }
+    }
+  }
+}
+
+// Instantiate kernels for electrons and positrons.
+__global__ void TransportElectrons(Track *electrons, const adept::MParray *active, Secondaries secondaries,
+                                   adept::MParray *activeQueue, GlobalScoring *globalScoring,
+                                   ScoringPerVolume *scoringPerVolume)
+{
+  TransportElectrons</*IsElectron*/ true>(electrons, active, secondaries, activeQueue, globalScoring, scoringPerVolume);
+}
+__global__ void TransportPositrons(Track *positrons, const adept::MParray *active, Secondaries secondaries,
+                                   adept::MParray *activeQueue, GlobalScoring *globalScoring,
+                                   ScoringPerVolume *scoringPerVolume)
+{
+  TransportElectrons</*IsElectron*/ false>(positrons, active, secondaries, activeQueue, globalScoring,
+                                           scoringPerVolume);
+}

--- a/examples/Example12/example12.cpp
+++ b/examples/Example12/example12.cpp
@@ -1,0 +1,259 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include "example12.h"
+
+#include <globals.hh>
+#include <G4SystemOfUnits.hh>
+#include <G4GDMLParser.hh>
+#include <G4MaterialCutsCouple.hh>
+#include <G4ProductionCutsTable.hh>
+#include <G4RegionStore.hh>
+
+#include <G4Gamma.hh>
+#include <G4Electron.hh>
+#include <G4Positron.hh>
+#include <G4Proton.hh>
+#include <G4ParticleTable.hh>
+
+#include <G4HepEmData.hh>
+#include <G4HepEmState.hh>
+#include <G4HepEmStateInit.hh>
+#include <G4HepEmParameters.hh>
+#include <G4HepEmMatCutData.hh>
+
+#include <VecGeom/base/Stopwatch.h>
+#include <VecGeom/management/GeoManager.h>
+#include <VecGeom/management/BVHManager.h>
+#include <VecGeom/gdml/Frontend.h>
+#include <VecGeom/management/CudaManager.h>
+
+#include <CopCore/SystemOfUnits.h>
+#include <AdePT/ArgParser.h>
+
+const G4VPhysicalVolume *InitGeant4(const std::string &gdml_file)
+{
+  // Read the geometry, regions and cuts from the GDML file
+  std::cout << "reading " << gdml_file << " transiently on CPU for Geant4 ...\n";
+  G4GDMLParser parser;
+  parser.Read(gdml_file, false); // turn off schema checker
+  G4VPhysicalVolume *world = parser.GetWorldVolume();
+
+  if (world == nullptr) {
+    std::cerr << "example12: World volume not set properly check your setup selection criteria or GDML input!\n";
+    return world;
+  }
+
+  // - PHYSICS
+  // --- Create particles that have secondary production threshold.
+  G4Gamma::Gamma();
+  G4Electron::Electron();
+  G4Positron::Positron();
+  G4Proton::Proton();
+  G4ParticleTable *partTable = G4ParticleTable::GetParticleTable();
+  partTable->SetReadiness();
+
+  // - REGIONS
+  if (world->GetLogicalVolume()->GetRegion() == nullptr) {
+    // Add default region if none available
+    auto defaultRegion = new G4Region("DefaultRegionForTheWorld"); // deleted by store
+    defaultRegion->AddRootLogicalVolume(world->GetLogicalVolume());
+    defaultRegion->SetProductionCuts(G4ProductionCutsTable::GetProductionCutsTable()->GetDefaultProductionCuts());
+  }
+  for (auto region : *G4RegionStore::GetInstance())
+    region->UsedInMassGeometry(true); // make sure all regions are marked as used
+
+  // - UPDATE COUPLES
+  std::cout << "updating material-cut couples based on " << G4RegionStore::GetInstance()->size() << " regions ...\n";
+  G4ProductionCutsTable *theCoupleTable = G4ProductionCutsTable::GetProductionCutsTable();
+  theCoupleTable->UpdateCoupleTable(world);
+  return world;
+}
+
+const vecgeom::cxx::VPlacedVolume *InitVecGeom(const std::string &gdml_file, int cache_depth)
+{
+  // Import the gdml file into VecGeom
+  vecgeom::GeoManager::Instance().SetTransformationCacheDepth(cache_depth);
+  vgdml::Parser vgdmlParser;
+  auto middleWare = vgdmlParser.Load(gdml_file.c_str(), false, copcore::units::mm);
+  if (middleWare == nullptr) {
+    std::cerr << "Failed to read geometry from GDML file '" << gdml_file << "'" << std::endl;
+    return nullptr;
+  }
+
+  const vecgeom::VPlacedVolume *world = vecgeom::GeoManager::Instance().GetWorld();
+  if (world == nullptr) {
+    std::cerr << "GeoManager world volume is nullptr" << std::endl;
+    return nullptr;
+  }
+  return world;
+}
+
+int *CreateMCCindex(const G4VPhysicalVolume *g4world, const vecgeom::VPlacedVolume *world,
+                    const G4HepEmState &hepEmState)
+{
+  const int *g4tohepmcindex = hepEmState.fData->fTheMatCutData->fG4MCIndexToHepEmMCIndex;
+
+  // - FIND vecgeom::LogicalVolume corresponding to each and every G4LogicalVolume
+  int nphysical = 0;
+
+  int nvolumes   = vecgeom::GeoManager::Instance().GetRegisteredVolumesCount();
+  int *mcc_index = new int[nvolumes];
+  memset(mcc_index, 0, nvolumes * sizeof(int));
+
+  // recursive geometry visitor lambda matching one by one Geant4 and VecGeom logical volumes
+  // (we need to make sure we set the right MCC index to the right volume)
+  typedef std::function<void(G4LogicalVolume const *, vecgeom::LogicalVolume const *)> func_t;
+  func_t visitAndSetMCindex = [&](G4LogicalVolume const *g4vol, vecgeom::LogicalVolume const *vol) {
+    int nd         = g4vol->GetNoDaughters();
+    auto daughters = vol->GetDaughters();
+    if (nd != daughters.size()) throw std::runtime_error("Mismatch in number of daughters");
+    // Check the couples
+    if (g4vol->GetMaterialCutsCouple() == nullptr)
+      throw std::runtime_error("G4LogicalVolume " + std::string(g4vol->GetName()) +
+                               std::string(" has no material-cuts couple"));
+    int g4mcindex    = g4vol->GetMaterialCutsCouple()->GetIndex();
+    int hepemmcindex = g4tohepmcindex[g4mcindex];
+    // Check consistency with G4HepEm data
+    if (hepEmState.fData->fTheMatCutData->fMatCutData[hepemmcindex].fG4MatCutIndex != g4mcindex)
+      throw std::runtime_error("Mismatch between Geant4 mcindex and corresponding G4HepEm index");
+    if (vol->id() >= nvolumes) throw std::runtime_error("Volume id larger than number of volumes");
+
+    // All OK, now fill the index in the array
+    mcc_index[vol->id()] = hepemmcindex;
+    nphysical++;
+
+    // Now do the daughters
+    for (int id = 0; id < nd; ++id) {
+      auto g4pvol = g4vol->GetDaughter(id);
+      auto pvol   = daughters[id];
+      // VecGeom does not strip pointers from logical volume names
+      if (std::string(pvol->GetLogicalVolume()->GetName()).rfind(g4pvol->GetLogicalVolume()->GetName(), 0) != 0)
+        throw std::runtime_error("Volume names " + std::string(pvol->GetLogicalVolume()->GetName()) + " and " +
+                                 std::string(g4pvol->GetLogicalVolume()->GetName()) + " mismatch");
+      visitAndSetMCindex(g4pvol->GetLogicalVolume(), pvol->GetLogicalVolume());
+    }
+  };
+
+  visitAndSetMCindex(g4world->GetLogicalVolume(), world->GetLogicalVolume());
+  std::cout << "Visited " << nphysical << " matching physical volumes\n";
+  return mcc_index;
+}
+
+void FreeG4HepEm(G4HepEmState *state)
+{
+  FreeG4HepEmData(state->fData);
+}
+
+void InitBVH()
+{
+  vecgeom::cxx::BVHManager::Init();
+  vecgeom::cxx::BVHManager::DeviceInit();
+}
+
+void PrintScoringPerVolume(const vecgeom::VPlacedVolume *placed, const ScoringPerVolume *scoring, int level = 0)
+{
+  for (auto *daughter : placed->GetDaughters()) {
+    std::cout << std::setw(level * 2) << "";
+    auto id = daughter->id();
+    std::cout << " ID " << id << " Charged-TrakL " << scoring->chargedTrackLength[id] / copcore::units::mm
+              << " mm; Energy-Dep " << scoring->energyDeposit[id] / copcore::units::MeV << " MeV" << std::endl;
+    PrintScoringPerVolume(daughter, scoring, level + 1);
+  }
+}
+
+int main(int argc, char *argv[])
+{
+  // Only outputs are the data file(s)
+  // Separate for now, but will want to unify
+  OPTION_STRING(gdml_file, "cms2018.gdml");
+  OPTION_INT(cache_depth, 0); // 0 = full depth
+  OPTION_INT(particles, 100);
+  OPTION_DOUBLE(energy, 10); // entered in GeV
+  energy *= copcore::units::GeV;
+  OPTION_INT(batch, -1);
+
+  vecgeom::Stopwatch timer;
+  timer.Start();
+
+  // Initialize Geant4
+  auto g4world = InitGeant4(gdml_file);
+  if (!g4world) return 3;
+
+  // Initialize VecGeom
+  std::cout << "reading " << gdml_file << " transiently on CPU for VecGeom ...\n";
+  auto world = InitVecGeom(gdml_file, cache_depth);
+  if (!world) return 3;
+
+  // Construct and initialize the G4HepEmState data/tables
+  std::cout << "initializing G4HepEm state ...\n";
+  G4HepEmState hepEmState;
+  InitG4HepEmState(&hepEmState);
+
+  // Initialize G4HepEm material-cut couple array indexed by VecGeom volume id.
+  // (In future we should connect the index directly to the VecGeom logical volume)
+  std::cout << "initializing material-cut couple indices ...\n";
+  int *MCCindex = nullptr;
+
+  try {
+    MCCindex = CreateMCCindex(g4world, world, hepEmState);
+  } catch (const std::runtime_error &ex) {
+    std::cerr << "*** CreateMCCindex: " << ex.what() << "\n";
+    return 1;
+  }
+
+  // Load and synchronize the geometry on the GPU
+  std::cout << "synchronizing VecGeom geometry to GPU ...\n";
+  auto &cudaManager = vecgeom::cxx::CudaManager::Instance();
+  cudaManager.LoadGeometry(world);
+  cudaManager.Synchronize();
+  InitBVH();
+
+  auto time_cpu = timer.Stop();
+  std::cout << "Initialization took: " << time_cpu << " sec\n";
+
+  int NumVolumes = vecgeom::GeoManager::Instance().GetRegisteredVolumesCount();
+  int NumPlaced  = vecgeom::GeoManager::Instance().GetPlacedVolumesCount();
+
+  // Scoring is done per placed volume (for now...)
+  double *chargedTrackLength = new double[NumPlaced];
+  double *energyDeposit      = new double[NumPlaced];
+  ScoringPerVolume scoringPerVolume;
+  scoringPerVolume.chargedTrackLength = chargedTrackLength;
+  scoringPerVolume.energyDeposit      = energyDeposit;
+  GlobalScoring globalScoring;
+
+  example12(particles, energy, batch, MCCindex, &scoringPerVolume, &globalScoring, NumVolumes, NumPlaced, &hepEmState);
+
+  std::cout << std::endl;
+  std::cout << std::endl;
+  double meanEnergyDeposit = globalScoring.energyDeposit / particles;
+  std::cout << "Mean energy deposit          " << (meanEnergyDeposit / copcore::units::GeV) << " GeV\n"
+            << "Mean number of gamma         " << ((double)globalScoring.numGammas / particles) << "\n"
+            << "Mean number of e-            " << ((double)globalScoring.numElectrons / particles) << "\n"
+            << "Mean number of e+            " << ((double)globalScoring.numPositrons / particles) << "\n"
+            << "Mean number of charged steps " << ((double)globalScoring.chargedSteps / particles) << "\n"
+            << "Mean number of neutral steps " << ((double)globalScoring.neutralSteps / particles) << "\n"
+            << "Mean number of hits          " << ((double)globalScoring.hits / particles) << "\n";
+  std::cout << std::endl;
+
+  // Average charged track length and energy deposit per particle.
+  for (int i = 0; i < NumPlaced; i++) {
+    chargedTrackLength[i] /= particles;
+    energyDeposit[i] /= particles;
+  }
+
+  std::cout << std::scientific;
+#ifdef VERBOSE
+  std::cout << std::endl;
+  const int id = world->id();
+  std::cout << "World (ID " << world->id() << ") Charged-TrakL " << chargedTrackLength[id] / copcore::units::mm
+            << " Energy-Dep " << energyDeposit[id] / copcore::units::MeV << " MeV" << std::endl;
+  PrintScoringPerVolume(world, &scoringPerVolume);
+#endif
+  FreeG4HepEm(&hepEmState);
+  delete[] MCCindex;
+  delete[] chargedTrackLength;
+  delete[] energyDeposit;
+  return 0;
+}

--- a/examples/Example12/example12.cu
+++ b/examples/Example12/example12.cu
@@ -1,0 +1,440 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include "example12.h"
+#include "example12.cuh"
+
+#include <AdePT/Atomic.h>
+#include <AdePT/BVHNavigator.h>
+#include <AdePT/MParray.h>
+
+#include <CopCore/Global.h>
+#include <CopCore/PhysicalConstants.h>
+#include <CopCore/Ranluxpp.h>
+
+#include <VecGeom/base/Config.h>
+#include <VecGeom/base/Stopwatch.h>
+#include <VecGeom/management/GeoManager.h>
+#ifdef VECGEOM_ENABLE_CUDA
+#include <VecGeom/backend/cuda/Interface.h>
+#endif
+
+#include <G4HepEmState.hh>
+#include <G4HepEmData.hh>
+#include <G4HepEmElectronInit.hh>
+#include <G4HepEmGammaInit.hh>
+#include <G4HepEmMatCutData.hh>
+#include <G4HepEmMaterialInit.hh>
+#include <G4HepEmParameters.hh>
+#include <G4HepEmParametersInit.hh>
+
+#include <iostream>
+#include <iomanip>
+#include <stdio.h>
+
+__constant__ __device__ struct G4HepEmParameters g4HepEmPars;
+__constant__ __device__ struct G4HepEmData g4HepEmData;
+
+__constant__ __device__ int *MCIndex = nullptr;
+
+__constant__ __device__ int Zero = 0;
+
+void InitG4HepEmGPU(G4HepEmState *state)
+{
+  // Copy to GPU.
+  CopyG4HepEmDataToGPU(state->fData);
+  COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(g4HepEmPars, state->fParameters, sizeof(G4HepEmParameters)));
+
+  // Create G4HepEmData with the device pointers.
+  G4HepEmData dataOnDevice;
+  dataOnDevice.fTheMatCutData   = state->fData->fTheMatCutData_gpu;
+  dataOnDevice.fTheMaterialData = state->fData->fTheMaterialData_gpu;
+  dataOnDevice.fTheElementData  = state->fData->fTheElementData_gpu;
+  dataOnDevice.fTheElectronData = state->fData->fTheElectronData_gpu;
+  dataOnDevice.fThePositronData = state->fData->fThePositronData_gpu;
+  dataOnDevice.fTheSBTableData  = state->fData->fTheSBTableData_gpu;
+  dataOnDevice.fTheGammaData    = state->fData->fTheGammaData_gpu;
+  // The other pointers should never be used.
+  dataOnDevice.fTheMatCutData_gpu   = nullptr;
+  dataOnDevice.fTheMaterialData_gpu = nullptr;
+  dataOnDevice.fTheElementData_gpu  = nullptr;
+  dataOnDevice.fTheElectronData_gpu = nullptr;
+  dataOnDevice.fThePositronData_gpu = nullptr;
+  dataOnDevice.fTheSBTableData_gpu  = nullptr;
+  dataOnDevice.fTheGammaData_gpu    = nullptr;
+
+  COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(g4HepEmData, &dataOnDevice, sizeof(G4HepEmData)));
+}
+
+// A bundle of queues per particle type:
+//  * Two for active particles, one for the current iteration and the second for the next.
+struct ParticleQueues {
+  adept::MParray *currentlyActive;
+  adept::MParray *nextActive;
+
+  void SwapActive() { std::swap(currentlyActive, nextActive); }
+};
+
+struct ParticleType {
+  Track *tracks;
+  SlotManager *slotManager;
+  ParticleQueues queues;
+  cudaStream_t stream;
+  cudaEvent_t event;
+
+  enum {
+    Electron = 0,
+    Positron = 1,
+    Gamma    = 2,
+
+    NumParticleTypes,
+  };
+};
+
+// A bundle of queues for the three particle types.
+struct AllParticleQueues {
+  ParticleQueues queues[ParticleType::NumParticleTypes];
+};
+
+// Kernel to initialize the set of queues per particle type.
+__global__ void InitParticleQueues(ParticleQueues queues, size_t Capacity)
+{
+  adept::MParray::MakeInstanceAt(Capacity, queues.currentlyActive);
+  adept::MParray::MakeInstanceAt(Capacity, queues.nextActive);
+}
+
+// Kernel function to initialize a set of primary particles.
+__global__ void InitPrimaries(ParticleGenerator generator, int startEvent, int numEvents, double energy,
+                              const vecgeom::VPlacedVolume *world, GlobalScoring *globalScoring)
+{
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < numEvents; i += blockDim.x * gridDim.x) {
+    Track &track = generator.NextTrack();
+
+    track.rngState.SetSeed(314159265 * (startEvent + i));
+    track.energy       = energy;
+    track.numIALeft[0] = -1.0;
+    track.numIALeft[1] = -1.0;
+    track.numIALeft[2] = -1.0;
+
+    track.pos = {0, 0, 0};
+    track.dir = {1.0, 0, 0};
+    track.navState.Clear();
+    BVHNavigator::LocatePointIn(world, track.pos, track.navState, true);
+
+    atomicAdd(&globalScoring->numElectrons, 1);
+  }
+}
+
+// A data structure to transfer statistics after each iteration.
+struct Stats {
+  int inFlight[ParticleType::NumParticleTypes];
+};
+
+// Finish iteration: clear queues and fill statistics.
+__global__ void FinishIteration(AllParticleQueues all, Stats *stats)
+{
+  for (int i = 0; i < ParticleType::NumParticleTypes; i++) {
+    all.queues[i].currentlyActive->clear();
+    stats->inFlight[i] = all.queues[i].nextActive->size();
+  }
+}
+
+// Deposit energy of particles still in flight.
+__global__ void DepositEnergy(Track *allTracks, const adept::MParray *queue, GlobalScoring *globalScoring,
+                              ScoringPerVolume *scoringPerVolume)
+{
+  int queueSize = queue->size();
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < queueSize; i += blockDim.x * gridDim.x) {
+    const int slot      = (*queue)[i];
+    Track &currentTrack = allTracks[slot];
+    auto volume         = currentTrack.navState.Top();
+    if (volume == nullptr) {
+      // The particle left the world, why wasn't it killed before?!
+      continue;
+    }
+    int volumeID = volume->id();
+
+    double energy = currentTrack.energy;
+    atomicAdd(&globalScoring->energyDeposit, energy);
+    atomicAdd(&scoringPerVolume->energyDeposit[volumeID], energy);
+  }
+}
+
+__global__ void ClearQueue(adept::MParray *queue)
+{
+  queue->clear();
+}
+
+void example12(int numParticles, double energy, int batch, const int *MCIndex_host,
+               ScoringPerVolume *scoringPerVolume_host, GlobalScoring *globalScoring_host, int numVolumes,
+               int numPlaced, G4HepEmState *state)
+{
+  InitG4HepEmGPU(state);
+
+  // Transfer MC indices.
+  int *MCIndex_dev = nullptr;
+  COPCORE_CUDA_CHECK(cudaMalloc(&MCIndex_dev, sizeof(int) * numVolumes));
+  COPCORE_CUDA_CHECK(cudaMemcpy(MCIndex_dev, MCIndex_host, sizeof(int) * numVolumes, cudaMemcpyHostToDevice));
+  COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(MCIndex, &MCIndex_dev, sizeof(int *)));
+
+  // Capacity of the different containers aka the maximum number of particles.
+  constexpr int Capacity = 256 * 1024;
+
+  std::cout << "INFO: capacity of containers set to " << Capacity << std::endl;
+  if (batch == -1) {
+    // Rule of thumb: at most 1000 particles of one type per GeV primary.
+    batch = Capacity / ((int)energy / copcore::units::GeV) / 1000;
+  } else if (batch < 1) {
+    batch = 1;
+  }
+  std::cout << "INFO: batching " << batch << " particles for transport on the GPU" << std::endl;
+  if (BzFieldValue != 0) {
+    std::cout << "INFO: running with field Bz = " << BzFieldValue / copcore::units::tesla << " T" << std::endl;
+  } else {
+    std::cout << "INFO: running with magnetic field OFF" << std::endl;
+  }
+
+  // Allocate structures to manage tracks of an implicit type:
+  //  * memory to hold the actual Track elements,
+  //  * objects to manage slots inside the memory,
+  //  * queues of slots to remember active particle and those needing relocation,
+  //  * a stream and an event for synchronization of kernels.
+  constexpr size_t TracksSize  = sizeof(Track) * Capacity;
+  constexpr size_t ManagerSize = sizeof(SlotManager);
+  const size_t QueueSize       = adept::MParray::SizeOfInstance(Capacity);
+
+  ParticleType particles[ParticleType::NumParticleTypes];
+  for (int i = 0; i < ParticleType::NumParticleTypes; i++) {
+    COPCORE_CUDA_CHECK(cudaMalloc(&particles[i].tracks, TracksSize));
+
+    COPCORE_CUDA_CHECK(cudaMalloc(&particles[i].slotManager, ManagerSize));
+
+    COPCORE_CUDA_CHECK(cudaMalloc(&particles[i].queues.currentlyActive, QueueSize));
+    COPCORE_CUDA_CHECK(cudaMalloc(&particles[i].queues.nextActive, QueueSize));
+    InitParticleQueues<<<1, 1>>>(particles[i].queues, Capacity);
+
+    COPCORE_CUDA_CHECK(cudaStreamCreate(&particles[i].stream));
+    COPCORE_CUDA_CHECK(cudaEventCreate(&particles[i].event));
+  }
+  COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
+
+  ParticleType &electrons = particles[ParticleType::Electron];
+  ParticleType &positrons = particles[ParticleType::Positron];
+  ParticleType &gammas    = particles[ParticleType::Gamma];
+
+  // Create a stream to synchronize kernels of all particle types.
+  cudaStream_t stream;
+  COPCORE_CUDA_CHECK(cudaStreamCreate(&stream));
+
+  // Allocate memory to score charged track length and energy deposit per volume.
+  double *chargedTrackLength = nullptr;
+  COPCORE_CUDA_CHECK(cudaMalloc(&chargedTrackLength, sizeof(double) * numPlaced));
+  COPCORE_CUDA_CHECK(cudaMemset(chargedTrackLength, 0, sizeof(double) * numPlaced));
+  double *energyDeposit = nullptr;
+  COPCORE_CUDA_CHECK(cudaMalloc(&energyDeposit, sizeof(double) * numPlaced));
+  COPCORE_CUDA_CHECK(cudaMemset(energyDeposit, 0, sizeof(double) * numPlaced));
+
+  // Allocate and initialize scoring and statistics.
+  GlobalScoring *globalScoring = nullptr;
+  COPCORE_CUDA_CHECK(cudaMalloc(&globalScoring, sizeof(GlobalScoring)));
+  COPCORE_CUDA_CHECK(cudaMemset(globalScoring, 0, sizeof(GlobalScoring)));
+
+  ScoringPerVolume *scoringPerVolume = nullptr;
+  ScoringPerVolume scoringPerVolume_devPtrs;
+  scoringPerVolume_devPtrs.chargedTrackLength = chargedTrackLength;
+  scoringPerVolume_devPtrs.energyDeposit      = energyDeposit;
+  COPCORE_CUDA_CHECK(cudaMalloc(&scoringPerVolume, sizeof(ScoringPerVolume)));
+  COPCORE_CUDA_CHECK(
+      cudaMemcpy(scoringPerVolume, &scoringPerVolume_devPtrs, sizeof(ScoringPerVolume), cudaMemcpyHostToDevice));
+
+  Stats *stats_dev = nullptr;
+  COPCORE_CUDA_CHECK(cudaMalloc(&stats_dev, sizeof(Stats)));
+  Stats *stats = nullptr;
+  COPCORE_CUDA_CHECK(cudaMallocHost(&stats, sizeof(Stats)));
+
+  // Allocate memory to hold a "vanilla" SlotManager to initialize for each batch.
+  SlotManager slotManagerInit(Capacity);
+  SlotManager *slotManagerInit_dev = nullptr;
+  COPCORE_CUDA_CHECK(cudaMalloc(&slotManagerInit_dev, sizeof(SlotManager)));
+  COPCORE_CUDA_CHECK(cudaMemcpy(slotManagerInit_dev, &slotManagerInit, sizeof(SlotManager), cudaMemcpyHostToDevice));
+
+  vecgeom::Stopwatch timer;
+  timer.Start();
+
+  std::cout << std::endl << "Simulating particle ";
+  for (int startEvent = 1; startEvent <= numParticles; startEvent += batch) {
+    std::cout << startEvent << " ... " << std::flush;
+    int left  = numParticles - startEvent + 1;
+    int chunk = std::min(left, batch);
+
+    for (int i = 0; i < ParticleType::NumParticleTypes; i++) {
+      COPCORE_CUDA_CHECK(cudaMemcpyAsync(particles[i].slotManager, slotManagerInit_dev, ManagerSize,
+                                         cudaMemcpyDeviceToDevice, stream));
+    }
+
+    // Initialize primary particles.
+    constexpr int InitThreads = 32;
+    int initBlocks            = (chunk + InitThreads - 1) / InitThreads;
+    ParticleGenerator electronGenerator(electrons.tracks, electrons.slotManager, electrons.queues.currentlyActive);
+    auto world_dev = vecgeom::cxx::CudaManager::Instance().world_gpu();
+    InitPrimaries<<<initBlocks, InitThreads, 0, stream>>>(electronGenerator, startEvent, chunk, energy, world_dev,
+                                                          globalScoring);
+    COPCORE_CUDA_CHECK(cudaStreamSynchronize(stream));
+
+    stats->inFlight[ParticleType::Electron] = chunk;
+    stats->inFlight[ParticleType::Positron] = 0;
+    stats->inFlight[ParticleType::Gamma]    = 0;
+
+    constexpr int MaxBlocks        = 1024;
+    constexpr int TransportThreads = 32;
+    int transportBlocks;
+
+    int inFlight;
+    int loopingNo         = 0;
+    int previousElectrons = -1, previousPositrons = -1;
+
+    do {
+      Secondaries secondaries = {
+          .electrons = {electrons.tracks, electrons.slotManager, electrons.queues.nextActive},
+          .positrons = {positrons.tracks, positrons.slotManager, positrons.queues.nextActive},
+          .gammas    = {gammas.tracks, gammas.slotManager, gammas.queues.nextActive},
+      };
+
+      // *** ELECTRONS ***
+      int numElectrons = stats->inFlight[ParticleType::Electron];
+      if (numElectrons > 0) {
+        transportBlocks = (numElectrons + TransportThreads - 1) / TransportThreads;
+        transportBlocks = std::min(transportBlocks, MaxBlocks);
+
+        TransportElectrons<<<transportBlocks, TransportThreads, 0, electrons.stream>>>(
+            electrons.tracks, electrons.queues.currentlyActive, secondaries, electrons.queues.nextActive, globalScoring,
+            scoringPerVolume);
+
+        COPCORE_CUDA_CHECK(cudaEventRecord(electrons.event, electrons.stream));
+        COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, electrons.event, 0));
+      }
+
+      // *** POSITRONS ***
+      int numPositrons = stats->inFlight[ParticleType::Positron];
+      if (numPositrons > 0) {
+        transportBlocks = (numPositrons + TransportThreads - 1) / TransportThreads;
+        transportBlocks = std::min(transportBlocks, MaxBlocks);
+
+        TransportPositrons<<<transportBlocks, TransportThreads, 0, positrons.stream>>>(
+            positrons.tracks, positrons.queues.currentlyActive, secondaries, positrons.queues.nextActive, globalScoring,
+            scoringPerVolume);
+
+        COPCORE_CUDA_CHECK(cudaEventRecord(positrons.event, positrons.stream));
+        COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, positrons.event, 0));
+      }
+
+      // *** GAMMAS ***
+      int numGammas = stats->inFlight[ParticleType::Gamma];
+      if (numGammas > 0) {
+        transportBlocks = (numGammas + TransportThreads - 1) / TransportThreads;
+        transportBlocks = std::min(transportBlocks, MaxBlocks);
+
+        TransportGammas<<<transportBlocks, TransportThreads, 0, gammas.stream>>>(
+            gammas.tracks, gammas.queues.currentlyActive, secondaries, gammas.queues.nextActive, globalScoring,
+            scoringPerVolume);
+
+        COPCORE_CUDA_CHECK(cudaEventRecord(gammas.event, gammas.stream));
+        COPCORE_CUDA_CHECK(cudaStreamWaitEvent(stream, gammas.event, 0));
+      }
+
+      // *** END OF TRANSPORT ***
+
+      // The events ensure synchronization before finishing this iteration and
+      // copying the Stats back to the host.
+      AllParticleQueues queues = {{electrons.queues, positrons.queues, gammas.queues}};
+      FinishIteration<<<1, 1, 0, stream>>>(queues, stats_dev);
+      COPCORE_CUDA_CHECK(cudaMemcpyAsync(stats, stats_dev, sizeof(Stats), cudaMemcpyDeviceToHost, stream));
+
+      // Finally synchronize all kernels.
+      COPCORE_CUDA_CHECK(cudaStreamSynchronize(stream));
+
+      // Count the number of particles in flight.
+      inFlight = 0;
+      for (int i = 0; i < ParticleType::NumParticleTypes; i++) {
+        inFlight += stats->inFlight[i];
+      }
+
+      // Swap the queues for the next iteration.
+      electrons.queues.SwapActive();
+      positrons.queues.SwapActive();
+      gammas.queues.SwapActive();
+
+      // Check if only charged particles are left that are looping.
+      numElectrons = stats->inFlight[ParticleType::Electron];
+      numPositrons = stats->inFlight[ParticleType::Positron];
+      numGammas    = stats->inFlight[ParticleType::Gamma];
+      if (numElectrons == previousElectrons && numPositrons == previousPositrons && numGammas == 0) {
+        loopingNo++;
+      } else {
+        previousElectrons = numElectrons;
+        previousPositrons = numPositrons;
+        loopingNo         = 0;
+      }
+
+    } while (inFlight > 0 && loopingNo < 20);
+
+    if (inFlight > 0) {
+      std::cout << std::endl;
+      std::cout << "WARN: Depositing energy of " << inFlight << " particles still in flight!" << std::endl;
+      constexpr int DepositThreads = 32;
+
+      for (int i = 0; i < ParticleType::NumParticleTypes; i++) {
+        ParticleType &pType   = particles[i];
+        int inFlightParticles = stats->inFlight[i];
+        if (inFlightParticles == 0) {
+          continue;
+        }
+
+        int depositBlocks = (inFlightParticles + DepositThreads - 1) / DepositThreads;
+        depositBlocks     = std::min(depositBlocks, MaxBlocks);
+        DepositEnergy<<<depositBlocks, DepositThreads, 0, stream>>>(pType.tracks, pType.queues.currentlyActive,
+                                                                    globalScoring, scoringPerVolume);
+        ClearQueue<<<1, 1, 0, stream>>>(pType.queues.currentlyActive);
+      }
+      COPCORE_CUDA_CHECK(cudaStreamSynchronize(stream));
+      std::cout << " ... ";
+    }
+  }
+  std::cout << "done!" << std::endl;
+
+  auto time = timer.Stop();
+  std::cout << "Run time: " << time << "\n";
+
+  // Transfer back scoring.
+  COPCORE_CUDA_CHECK(cudaMemcpy(globalScoring_host, globalScoring, sizeof(GlobalScoring), cudaMemcpyDeviceToHost));
+
+  // Transfer back the scoring per volume (charged track length and energy deposit).
+  COPCORE_CUDA_CHECK(cudaMemcpy(scoringPerVolume_host->chargedTrackLength, scoringPerVolume_devPtrs.chargedTrackLength,
+                                sizeof(double) * numPlaced, cudaMemcpyDeviceToHost));
+  COPCORE_CUDA_CHECK(cudaMemcpy(scoringPerVolume_host->energyDeposit, scoringPerVolume_devPtrs.energyDeposit,
+                                sizeof(double) * numPlaced, cudaMemcpyDeviceToHost));
+
+  // Free resources.
+  COPCORE_CUDA_CHECK(cudaFree(MCIndex_dev));
+  COPCORE_CUDA_CHECK(cudaFree(chargedTrackLength));
+  COPCORE_CUDA_CHECK(cudaFree(energyDeposit));
+
+  COPCORE_CUDA_CHECK(cudaFree(globalScoring));
+  COPCORE_CUDA_CHECK(cudaFree(scoringPerVolume));
+  COPCORE_CUDA_CHECK(cudaFree(stats_dev));
+  COPCORE_CUDA_CHECK(cudaFreeHost(stats));
+  COPCORE_CUDA_CHECK(cudaFree(slotManagerInit_dev));
+
+  COPCORE_CUDA_CHECK(cudaStreamDestroy(stream));
+
+  for (int i = 0; i < ParticleType::NumParticleTypes; i++) {
+    COPCORE_CUDA_CHECK(cudaFree(particles[i].tracks));
+    COPCORE_CUDA_CHECK(cudaFree(particles[i].slotManager));
+
+    COPCORE_CUDA_CHECK(cudaFree(particles[i].queues.currentlyActive));
+    COPCORE_CUDA_CHECK(cudaFree(particles[i].queues.nextActive));
+
+    COPCORE_CUDA_CHECK(cudaStreamDestroy(particles[i].stream));
+    COPCORE_CUDA_CHECK(cudaEventDestroy(particles[i].event));
+  }
+}

--- a/examples/Example12/example12.cuh
+++ b/examples/Example12/example12.cuh
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef EXAMPLE12_CUH
+#define EXAMPLE12_CUH
+
+#include "example12.h"
+
+#include <AdePT/MParray.h>
+#include <CopCore/SystemOfUnits.h>
+#include <CopCore/Ranluxpp.h>
+
+#include <G4HepEmData.hh>
+#include <G4HepEmParameters.hh>
+#include <G4HepEmRandomEngine.hh>
+
+#include <VecGeom/base/Vector3D.h>
+#include <VecGeom/navigation/NavStateIndex.h>
+
+// A data structure to represent a particle track. The particle type is implicit
+// by the queue and not stored in memory.
+struct Track {
+  using Precision = vecgeom::Precision;
+  RanluxppDouble rngState;
+  double energy;
+  double numIALeft[3];
+
+  vecgeom::Vector3D<Precision> pos;
+  vecgeom::Vector3D<Precision> dir;
+  vecgeom::NavStateIndex navState;
+
+  __host__ __device__ double Uniform() { return rngState.Rndm(); }
+
+  __host__ __device__ void InitAsSecondary(const Track &parent)
+  {
+    // The caller is responsible to branch a new RNG state and to set the energy.
+    this->numIALeft[0] = -1.0;
+    this->numIALeft[1] = -1.0;
+    this->numIALeft[2] = -1.0;
+
+    // A secondary inherits the position of its parent; the caller is responsible
+    // to update the directions.
+    this->pos      = parent.pos;
+    this->navState = parent.navState;
+  }
+};
+
+// Defined in example12.cu
+extern __constant__ __device__ int Zero;
+
+class RanluxppDoubleEngine : public G4HepEmRandomEngine {
+  // Wrapper functions to call into RanluxppDouble.
+  static __host__ __device__ __attribute__((noinline)) double FlatWrapper(void *object)
+  {
+    return ((RanluxppDouble *)object)->Rndm();
+  }
+  static __host__ __device__ __attribute__((noinline)) void FlatArrayWrapper(void *object, const int size, double *vect)
+  {
+    for (int i = 0; i < size; i++) {
+      vect[i] = ((RanluxppDouble *)object)->Rndm();
+    }
+  }
+
+public:
+  __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
+      : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
+  {
+#ifdef __CUDA_ARCH__
+    // This is a hack: The compiler cannot see that we're going to call the
+    // functions through their pointers, so it underestimates the number of
+    // required registers. By including calls to the (non-inlinable) functions
+    // we force the compiler to account for the register usage, even if this
+    // particular set of calls are not executed at runtime.
+    if (Zero) {
+      FlatWrapper(engine);
+      FlatArrayWrapper(engine, 0, nullptr);
+    }
+#endif
+  }
+};
+
+// A data structure to manage slots in the track storage.
+class SlotManager {
+  adept::Atomic_t<int> fNextSlot;
+  const int fMaxSlot;
+
+public:
+  __host__ __device__ SlotManager(int maxSlot) : fMaxSlot(maxSlot) { fNextSlot = 0; }
+
+  __host__ __device__ int NextSlot()
+  {
+    int next = fNextSlot.fetch_add(1);
+    if (next >= fMaxSlot) return -1;
+    return next;
+  }
+};
+
+// A bundle of pointers to generate particles of an implicit type.
+class ParticleGenerator {
+  Track *fTracks;
+  SlotManager *fSlotManager;
+  adept::MParray *fActiveQueue;
+
+public:
+  __host__ __device__ ParticleGenerator(Track *tracks, SlotManager *slotManager, adept::MParray *activeQueue)
+      : fTracks(tracks), fSlotManager(slotManager), fActiveQueue(activeQueue)
+  {
+  }
+
+  __host__ __device__ Track &NextTrack()
+  {
+    int slot = fSlotManager->NextSlot();
+    if (slot == -1) {
+      COPCORE_EXCEPTION("No slot available in ParticleGenerator::NextTrack");
+    }
+    fActiveQueue->push_back(slot);
+    return fTracks[slot];
+  }
+};
+
+// A bundle of generators for the three particle types.
+struct Secondaries {
+  ParticleGenerator electrons;
+  ParticleGenerator positrons;
+  ParticleGenerator gammas;
+};
+
+// Kernels in different TUs.
+__global__ void TransportElectrons(Track *electrons, const adept::MParray *active, Secondaries secondaries,
+                                   adept::MParray *activeQueue, GlobalScoring *globalScoring,
+                                   ScoringPerVolume *scoringPerVolume);
+__global__ void TransportPositrons(Track *positrons, const adept::MParray *active, Secondaries secondaries,
+                                   adept::MParray *activeQueue, GlobalScoring *globalScoring,
+                                   ScoringPerVolume *scoringPerVolume);
+
+__global__ void TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries,
+                                adept::MParray *activeQueue, GlobalScoring *globalScoring,
+                                ScoringPerVolume *scoringPerVolume);
+
+// Constant data structures from G4HepEm accessed by the kernels.
+// (defined in TestEm3.cu)
+extern __constant__ __device__ struct G4HepEmParameters g4HepEmPars;
+extern __constant__ __device__ struct G4HepEmData g4HepEmData;
+
+extern __constant__ __device__ int *MCIndex;
+
+// constexpr float BzFieldValue = 0.1 * copcore::units::tesla;
+constexpr double BzFieldValue = 0;
+
+#endif

--- a/examples/Example12/example12.h
+++ b/examples/Example12/example12.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef EXAMPLE12_H
+#define EXAMPLE12_H
+
+struct G4HepEmState;
+
+// Data structures for scoring. The accessors must make sure to use atomic operations if needed.
+struct GlobalScoring {
+  double energyDeposit;
+  // Not int to avoid overflows for more than 100,000 events; unsigned long long
+  // is the only other data type available for atomicAdd().
+  unsigned long long chargedSteps;
+  unsigned long long neutralSteps;
+  unsigned long long hits;
+  unsigned long long numGammas;
+  unsigned long long numElectrons;
+  unsigned long long numPositrons;
+};
+
+struct ScoringPerVolume {
+  double *energyDeposit;
+  double *chargedTrackLength;
+};
+
+// Interface between C++ and CUDA.
+void example12(int numParticles, double energy, int batch, const int *MCCindex, ScoringPerVolume *scoringPerVolume,
+               GlobalScoring *globalScoring, int numVolumes, int numPlaced, G4HepEmState *state);
+
+#endif

--- a/examples/Example12/gammas.cu
+++ b/examples/Example12/gammas.cu
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: 2021 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include "example12.cuh"
+
+#include <AdePT/BVHNavigator.h>
+
+#include <CopCore/PhysicalConstants.h>
+
+#include <G4HepEmGammaManager.hh>
+#include <G4HepEmTrack.hh>
+#include <G4HepEmGammaInteractionCompton.hh>
+#include <G4HepEmGammaInteractionConversion.hh>
+// Pull in implementation.
+#include <G4HepEmGammaManager.icc>
+#include <G4HepEmGammaInteractionCompton.icc>
+#include <G4HepEmGammaInteractionConversion.icc>
+
+__global__ void TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries,
+                                adept::MParray *activeQueue, GlobalScoring *globalScoring,
+                                ScoringPerVolume *scoringPerVolume)
+{
+#ifdef VECGEOM_FLOAT_PRECISION
+  const Precision kPush = 10 * vecgeom::kTolerance;
+#else
+  const Precision kPush = 0.;
+#endif
+  int activeSize = active->size();
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
+    const int slot      = (*active)[i];
+    Track &currentTrack = gammas[slot];
+    auto volume         = currentTrack.navState.Top();
+    int volumeID        = volume->id();
+    // the MCC vector is indexed by the logical volume id
+    int lvolID     = volume->GetLogicalVolume()->id();
+    int theMCIndex = MCIndex[lvolID];
+
+    // Init a track with the needed data to call into G4HepEm.
+    G4HepEmTrack emTrack;
+    emTrack.SetEKin(currentTrack.energy);
+    emTrack.SetMCIndex(theMCIndex);
+
+    // Sample the `number-of-interaction-left` and put it into the track.
+    for (int ip = 0; ip < 3; ++ip) {
+      double numIALeft = currentTrack.numIALeft[ip];
+      if (numIALeft <= 0) {
+        numIALeft                  = -std::log(currentTrack.Uniform());
+        currentTrack.numIALeft[ip] = numIALeft;
+      }
+      emTrack.SetNumIALeft(numIALeft, ip);
+    }
+
+    // Call G4HepEm to compute the physics step limit.
+    G4HepEmGammaManager::HowFar(&g4HepEmData, &g4HepEmPars, &emTrack);
+
+    // Get result into variables.
+    double geometricalStepLengthFromPhysics = emTrack.GetGStepLength();
+    int winnerProcessIndex                  = emTrack.GetWinnerProcessIndex();
+    // Leave the range and MFP inside the G4HepEmTrack. If we split kernels, we
+    // also need to carry them over!
+
+    // Check if there's a volume boundary in between.
+    vecgeom::NavStateIndex nextState;
+    double geometryStepLength = BVHNavigator::ComputeStepAndNextVolume(
+        currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics, currentTrack.navState, nextState, kPush);
+    currentTrack.pos += geometryStepLength * currentTrack.dir;
+    atomicAdd(&globalScoring->neutralSteps, 1);
+
+    if (nextState.IsOnBoundary()) {
+      emTrack.SetGStepLength(geometryStepLength);
+      emTrack.SetOnBoundary(true);
+    }
+
+    G4HepEmGammaManager::UpdateNumIALeft(&emTrack);
+
+    // Save the `number-of-interaction-left` in our track.
+    for (int ip = 0; ip < 3; ++ip) {
+      double numIALeft           = emTrack.GetNumIALeft(ip);
+      currentTrack.numIALeft[ip] = numIALeft;
+    }
+
+    if (nextState.IsOnBoundary()) {
+      // For now, just count that we hit something.
+      atomicAdd(&globalScoring->hits, 1);
+
+      // Kill the particle if it left the world.
+      if (nextState.Top() != nullptr) {
+        activeQueue->push_back(slot);
+        BVHNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, nextState);
+
+        // Move to the next boundary.
+        currentTrack.navState = nextState;
+      }
+      continue;
+    } else if (winnerProcessIndex < 0) {
+      // No discrete process, move on.
+      activeQueue->push_back(slot);
+      continue;
+    }
+
+    // Reset number of interaction left for the winner discrete process.
+    // (Will be resampled in the next iteration.)
+    currentTrack.numIALeft[winnerProcessIndex] = -1.0;
+
+    // Perform the discrete interaction.
+    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    // We might need one branched RNG state, prepare while threads are synchronized.
+    RanluxppDouble newRNG(currentTrack.rngState.Branch());
+
+    const double energy = currentTrack.energy;
+
+    switch (winnerProcessIndex) {
+    case 0: {
+      // Invoke gamma conversion to e-/e+ pairs, if the energy is above the threshold.
+      if (energy < 2 * copcore::units::kElectronMassC2) {
+        activeQueue->push_back(slot);
+        continue;
+      }
+
+      double logEnergy = std::log(energy);
+      double elKinEnergy, posKinEnergy;
+      G4HepEmGammaInteractionConversion::SampleKinEnergies(&g4HepEmData, energy, logEnergy, theMCIndex, elKinEnergy,
+                                                           posKinEnergy, &rnge);
+
+      double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+      double dirSecondaryEl[3], dirSecondaryPos[3];
+      G4HepEmGammaInteractionConversion::SampleDirections(dirPrimary, dirSecondaryEl, dirSecondaryPos, elKinEnergy,
+                                                          posKinEnergy, &rnge);
+
+      Track &electron = secondaries.electrons.NextTrack();
+      Track &positron = secondaries.positrons.NextTrack();
+      atomicAdd(&globalScoring->numElectrons, 1);
+      atomicAdd(&globalScoring->numPositrons, 1);
+
+      electron.InitAsSecondary(/*parent=*/currentTrack);
+      electron.rngState = newRNG;
+      electron.energy   = elKinEnergy;
+      electron.dir.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
+
+      positron.InitAsSecondary(/*parent=*/currentTrack);
+      // Reuse the RNG state of the dying track.
+      positron.rngState = currentTrack.rngState;
+      positron.energy   = posKinEnergy;
+      positron.dir.Set(dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]);
+
+      // The current track is killed by not enqueuing into the next activeQueue.
+      break;
+    }
+    case 1: {
+      // Invoke Compton scattering of gamma.
+      constexpr double LowEnergyThreshold = 100 * copcore::units::eV;
+      if (energy < LowEnergyThreshold) {
+        activeQueue->push_back(slot);
+        continue;
+      }
+      const double origDirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
+      double dirPrimary[3];
+      const double newEnergyGamma =
+          G4HepEmGammaInteractionCompton::SamplePhotonEnergyAndDirection(energy, dirPrimary, origDirPrimary, &rnge);
+      vecgeom::Vector3D<double> newDirGamma(dirPrimary[0], dirPrimary[1], dirPrimary[2]);
+
+      const double energyEl = energy - newEnergyGamma;
+      if (energyEl > LowEnergyThreshold) {
+        // Create a secondary electron and sample/compute directions.
+        Track &electron = secondaries.electrons.NextTrack();
+        atomicAdd(&globalScoring->numElectrons, 1);
+
+        electron.InitAsSecondary(/*parent=*/currentTrack);
+        electron.rngState = newRNG;
+        electron.energy   = energyEl;
+        electron.dir      = energy * currentTrack.dir - newEnergyGamma * newDirGamma;
+        electron.dir.Normalize();
+      } else {
+        atomicAdd(&globalScoring->energyDeposit, energyEl);
+        atomicAdd(&scoringPerVolume->energyDeposit[volumeID], energyEl);
+      }
+
+      // Check the new gamma energy and deposit if below threshold.
+      if (newEnergyGamma > LowEnergyThreshold) {
+        currentTrack.energy = newEnergyGamma;
+        currentTrack.dir    = newDirGamma;
+
+        // The current track continues to live.
+        activeQueue->push_back(slot);
+      } else {
+        atomicAdd(&globalScoring->energyDeposit, newEnergyGamma);
+        atomicAdd(&scoringPerVolume->energyDeposit[volumeID], newEnergyGamma);
+        // The current track is killed by not enqueuing into the next activeQueue.
+      }
+      break;
+    }
+    case 2: {
+      // Invoke photoelectric process: right now only absorb the gamma.
+      atomicAdd(&globalScoring->energyDeposit, energy);
+      atomicAdd(&scoringPerVolume->energyDeposit[volumeID], energy);
+      // The current track is killed by not enqueuing into the next activeQueue.
+      break;
+    }
+    }
+  }
+}


### PR DESCRIPTION
The example implements TestEm3-like workflow, but the geometry can be taken from an arbitrary GDML file. 
* The geometry is first read by the Geant4 parser and the G4HepEm state is initialized based on this
* The geometry is then imported via vecgeom::vgdml and the geometry hierarchy is visited in parallel with the Geant4 one to match G4LogicalVolume<->vecgeom::LogicalVolume and build the LUT (logical volume index) -> (G4HepEm material-cut couple index)
* GPU data is initialized and showering/scoring is done as in TestEm3
* Scoring is done per placed volume, no sensitivity selection

I tested this with cms2018.gdml, it works and gives reasonable (at first glance) results (the energy deposit per primary equal to the primary energy) when shooting electrons of 10 GeV perpendicular to the beam axis.