### PR TITLE
Optimize RNG workflow with MSC

### DIFF
--- a/base/inc/CopCore/include/CopCore/Ranluxpp.h
+++ b/base/inc/CopCore/include/CopCore/Ranluxpp.h
@@ -49,6 +49,9 @@ protected:
     }
   }
 
+public:
+  RanluxppEngineImpl() = default;
+
   /// Produce next block of random bits
   __host__ __device__ void Advance()
   {
@@ -58,9 +61,6 @@ protected:
     to_ranlux(lcg, fState, fCarry);
     fPosition = 0;
   }
-
-public:
-  RanluxppEngineImpl() = default;
 
   /// Return the next random bits, generate a new block if necessary
   __host__ __device__ uint64_t NextRandomBits()
@@ -159,8 +159,9 @@ public:
   __host__ __device__ uint64_t IntRndm() { return this->NextRandomBits(); }
 
   /// Branch a new RNG state, also advancing the current one.
-  __host__ __device__
-  RanluxppDouble Branch()
+  /// The caller must Advance() the branched RNG state to decorrelate the
+  /// produced numbers.
+  __host__ __device__ RanluxppDouble BranchNoAdvance()
   {
     // Save the current state, will be used to branch a new RNG.
     uint64_t oldState[9];
@@ -169,6 +170,13 @@ public:
     // Copy and modify the new RNG state.
     RanluxppDouble newRNG(*this);
     newRNG.XORstate(oldState);
+    return newRNG;
+  }
+
+  /// Branch a new RNG state, also advancing the current one.
+  __host__ __device__ RanluxppDouble Branch()
+  {
+    RanluxppDouble newRNG(BranchNoAdvance());
     newRNG.Advance();
     return newRNG;
   }

--- a/examples/Example13/electrons.cu
+++ b/examples/Example13/electrons.cu
@@ -62,6 +62,11 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     mscData->fIsFirstStep        = currentTrack.initialRange < 0;
     mscData->fInitialRange       = currentTrack.initialRange;
 
+    // Prepare a branched RNG state while threads are synchronized. Even if not
+    // used, this provides a fresh round of random numbers and reduces thread
+    // divergence because the RNG state doesn't need to be advanced later.
+    RanluxppDouble newRNG(currentTrack.rngState.BranchNoAdvance());
+
     // Compute safety, needed for MSC step limit.
     double safety = 0;
     if (!currentTrack.navState.IsOnBoundary()) {
@@ -193,7 +198,8 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
         sincos(phi, &sinPhi, &cosPhi);
 
         gamma1.InitAsSecondary(/*parent=*/currentTrack);
-        gamma1.rngState = currentTrack.rngState.Branch();
+        newRNG.Advance();
+        gamma1.rngState = newRNG;
         gamma1.energy   = copcore::units::kElectronMassC2;
         gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
 
@@ -237,9 +243,12 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       continue;
     }
 
-    // Perform the discrete interaction.
-    // We will need one branched RNG state, prepare while threads are synchronized.
-    RanluxppDouble newRNG(currentTrack.rngState.Branch());
+    // Perform the discrete interaction, make sure the branched RNG state is
+    // ready to be used.
+    newRNG.Advance();
+    // Also advance the current RNG state to provide a fresh round of random
+    // numbers after MSC used up a fair share for sampling the displacement.
+    currentTrack.rngState.Advance();
 
     const double energy   = currentTrack.energy;
     const double theElCut = g4HepEmData.fTheMatCutData->fMatCutData[theMCIndex].fSecElProdCutE;

--- a/examples/Example13/example13.cu
+++ b/examples/Example13/example13.cu
@@ -112,7 +112,7 @@ __global__ void InitPrimaries(ParticleGenerator generator, int startEvent, int n
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < numEvents; i += blockDim.x * gridDim.x) {
     Track &track = generator.NextTrack();
 
-    track.rngState.SetSeed(314159265 * (startEvent + i));
+    track.rngState.SetSeed(startEvent + i);
     track.energy       = energy;
     track.numIALeft[0] = -1.0;
     track.numIALeft[1] = -1.0;

--- a/examples/TestEm3/TestEm3.cu
+++ b/examples/TestEm3/TestEm3.cu
@@ -137,7 +137,7 @@ __global__ void InitPrimaries(ParticleGenerator generator, int startEvent, int n
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < numEvents; i += blockDim.x * gridDim.x) {
     Track &track = generator.NextTrack();
 
-    track.rngState.SetSeed(314159265 * (startEvent + i));
+    track.rngState.SetSeed(startEvent + i);
     track.energy       = energy;
     track.numIALeft[0] = -1.0;
     track.numIALeft[1] = -1.0;

--- a/examples/TestEm3MT/TestEm3.cu
+++ b/examples/TestEm3MT/TestEm3.cu
@@ -139,7 +139,7 @@ __global__ void InitPrimaries(ParticleGenerator generator, int startEvent, int n
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < numEvents; i += blockDim.x * gridDim.x) {
     Track &track = generator.NextTrack();
 
-    track.rngState.SetSeed(314159265 * (startEvent + i));
+    track.rngState.SetSeed(startEvent + i);
     track.energy       = energy;
     track.numIALeft[0] = -1.0;
     track.numIALeft[1] = -1.0;

--- a/examples/TestEm3MT/electrons.cu
+++ b/examples/TestEm3MT/electrons.cu
@@ -55,6 +55,11 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     mscData->fIsFirstStep        = currentTrack.initialRange < 0;
     mscData->fInitialRange       = currentTrack.initialRange;
 
+    // Prepare a branched RNG state while threads are synchronized. Even if not
+    // used, this provides a fresh round of random numbers and reduces thread
+    // divergence because the RNG state doesn't need to be advanced later.
+    RanluxppDouble newRNG(currentTrack.rngState.BranchNoAdvance());
+
     // Compute safety, needed for MSC step limit.
     double safety = 0;
     if (!currentTrack.navState.IsOnBoundary()) {
@@ -185,7 +190,8 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
         sincos(phi, &sinPhi, &cosPhi);
 
         gamma1.InitAsSecondary(/*parent=*/currentTrack);
-        gamma1.rngState = currentTrack.rngState.Branch();
+        newRNG.Advance();
+        gamma1.rngState = newRNG;
         gamma1.energy   = copcore::units::kElectronMassC2;
         gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
 
@@ -229,9 +235,12 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       continue;
     }
 
-    // Perform the discrete interaction.
-    // We will need one branched RNG state, prepare while threads are synchronized.
-    RanluxppDouble newRNG(currentTrack.rngState.Branch());
+    // Perform the discrete interaction, make sure the branched RNG state is
+    // ready to be used.
+    newRNG.Advance();
+    // Also advance the current RNG state to provide a fresh round of random
+    // numbers after MSC used up a fair share for sampling the displacement.
+    currentTrack.rngState.Advance();
 
     const double energy   = currentTrack.energy;
     const double theElCut = g4HepEmData.fTheMatCutData->fMatCutData[theMCIndex].fSecElProdCutE;


### PR DESCRIPTION
Multiple Scattering uses quite some random numbers, even if there is no discrete interaction with final state sampling happening. This causes problems for the GPU performance because the RNG might need to advance the state when threads have already diverged. Moving the call to branch a new RNG state earlier and providing a fresh round of numbers shows a clear performance improvement of around 20% for TestEm3 and around 10% for Example13 with cms2018.