### PR TITLE
Navigator fixes

### DIFF
--- a/base/inc/AdePT/BVHNavigator.h
+++ b/base/inc/AdePT/BVHNavigator.h
@@ -29,7 +29,8 @@ public:
 
   __host__ __device__ static VPlacedVolumePtr_t LocatePointIn(vecgeom::VPlacedVolume const *vol,
                                                               vecgeom::Vector3D<vecgeom::Precision> const &point,
-                                                              vecgeom::NavStateIndex &path, bool top)
+                                                              vecgeom::NavStateIndex &path, bool top,
+                                                              vecgeom::VPlacedVolume const *exclude = nullptr)
   {
     if (top) {
       assert(vol != nullptr);
@@ -44,10 +45,13 @@ public:
     for (auto v = vol; v->GetDaughters().size() > 0;) {
       auto bvh = vecgeom::BVHManager::GetBVH(v->GetLogicalVolume()->id());
 
-      if (!bvh->LevelLocate(currentpoint, v, daughterlocalpoint)) break;
+      if (!bvh->LevelLocate(exclude, currentpoint, v, daughterlocalpoint)) break;
 
       currentpoint = daughterlocalpoint;
       path.Push(v);
+      // Only exclude the placed volume once since we could enter it again via a
+      // different volume history.
+      exclude = nullptr;
     }
 
     return path.Top();
@@ -230,10 +234,10 @@ public:
   // Computes a step from the globalpoint (which must be in the current volume)
   // into globaldir, taking step_limit into account. If a volume is hit, the
   // function calls out_state.SetBoundaryState(true) and
-  //  - removes the current volume from out_state if the it is left, or
+  //  - removes all volumes from out_state if the current volume is left, or
   //  - adds the hit daughter volume to out_state if one is hit.
   // However the function does _NOT_ relocate the state to the next volume,
-  // such as leaving or entering multiple volumes that share a boundary.
+  // that is entering multiple volumes that share a boundary.
   __host__ __device__ static double ComputeStepAndNextVolume(vecgeom::Vector3D<vecgeom::Precision> const &globalpoint,
                                                              vecgeom::Vector3D<vecgeom::Precision> const &globaldir,
                                                              vecgeom::Precision step_limit,
@@ -258,7 +262,18 @@ public:
 
     if (out_state.IsOnBoundary()) {
       if (!hitcandidate) {
-        out_state.Pop();
+        vecgeom::VPlacedVolume const *currentmother       = out_state.Top();
+        vecgeom::Vector3D<vecgeom::Precision> transformed = localpoint;
+        // Push the point inside the next volume.
+        static constexpr double kPush = 10. * vecgeom::kTolerance;
+        transformed += (step + kPush) * localdir;
+
+        do {
+          out_state.SetLastExited();
+          out_state.Pop();
+          transformed   = currentmother->GetTransformation()->InverseTransform(transformed);
+          currentmother = out_state.Top();
+        } while (currentmother && (currentmother->IsAssembly() || !currentmother->UnplacedContains(transformed)));
       } else {
         out_state.Push(hitcandidate);
       }
@@ -287,9 +302,8 @@ public:
     return step;
   }
 
-  // Relocate a state that was returned from ComputeStepAndNextVolume: It first
-  // removes all volumes from the state that were left, and then recursively
-  // locates the pushed point in the containing volume.
+  // Relocate a state that was returned from ComputeStepAndNextVolume: It
+  // recursively locates the pushed point in the containing volume.
   __host__ __device__ static void RelocateToNextVolume(vecgeom::Vector3D<vecgeom::Precision> &globalpoint,
                                                        vecgeom::Vector3D<vecgeom::Precision> const &globaldir,
                                                        vecgeom::NavStateIndex &state)
@@ -305,12 +319,8 @@ public:
 
     VPlacedVolumePtr_t pvol = state.Top();
 
-    if (!pvol->UnplacedContains(localpoint)) {
-      RelocatePoint(localpoint, state);
-    } else {
-      state.Pop();
-      LocatePointIn(pvol, localpoint, state, false);
-    }
+    state.Pop();
+    LocatePointIn(pvol, localpoint, state, false, state.GetLastExited());
 
     if (state.Top() != nullptr) {
       while (state.Top()->IsAssembly()) {

--- a/examples/Example10/electrons.cu
+++ b/examples/Example10/electrons.cu
@@ -77,7 +77,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       // also need to carry them over!
 
       // Check if there's a volume boundary in between.
-      double geometryStepLength = fieldPropagatorBz.ComputeStepAndPropagatedState</*Relocate=*/false>(
+      double geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume(
           currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
           currentTrack.currentState, currentTrack.nextState);
 

--- a/examples/Example10/relocation.cu
+++ b/examples/Example10/relocation.cu
@@ -61,13 +61,6 @@ __global__ void RelocateToNextVolume(Track *allTracks, const adept::MParray *rel
 
       currentVolume = state.Top();
 
-      // Remove all volumes that were left.
-      while (currentVolume && (currentVolume->IsAssembly() || !currentVolume->UnplacedContains(localPoint))) {
-        state.Pop();
-        localPoint    = currentVolume->GetTransformation()->InverseTransform(localPoint);
-        currentVolume = state.Top();
-      }
-
       // Store the transformed coordinates, to be broadcasted to the other
       // active threads in this warp.
       localCoordinates[0] = localPoint.x();

--- a/examples/Example11/electrons.cu
+++ b/examples/Example11/electrons.cu
@@ -75,7 +75,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
 
     // Check if there's a volume boundary in between.
     vecgeom::NavStateIndex nextState;
-    double geometryStepLength = fieldPropagatorBz.ComputeStepAndPropagatedState</*Relocate=*/false, BVHNavigator>(
+    double geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume<BVHNavigator>(
         currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
         currentTrack.navState, nextState);
 

--- a/examples/Example11/example11.cu
+++ b/examples/Example11/example11.cu
@@ -333,7 +333,7 @@ void example11(const vecgeom::cxx::VPlacedVolume *world, int numParticles, doubl
     }
 
     iterNo++;
-  } while (inFlight > 0 && loopingNo < 20);
+  } while (inFlight > 0 && loopingNo < 200);
 
   auto time_cpu = timer.Stop();
   std::cout << "Run time: " << time_cpu << "\n";

--- a/examples/Example12/electrons.cu
+++ b/examples/Example12/electrons.cu
@@ -86,7 +86,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     double geometryStepLength;
     vecgeom::NavStateIndex nextState;
     if (BzFieldValue != 0) {
-      geometryStepLength = fieldPropagatorBz.ComputeStepAndPropagatedState</*Relocate=*/false, BVHNavigator>(
+      geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume<BVHNavigator>(
           currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
           currentTrack.navState, nextState);
     } else {

--- a/examples/Example12/example12.cu
+++ b/examples/Example12/example12.cu
@@ -362,7 +362,7 @@ void example12(int numParticles, double energy, int batch, const int *MCIndex_ho
         loopingNo         = 0;
       }
 
-    } while (inFlight > 0 && loopingNo < 20);
+    } while (inFlight > 0 && loopingNo < 200);
 
     if (inFlight > 0) {
       for (int i = 0; i < ParticleType::NumParticleTypes; i++) {

--- a/examples/Example13/electrons.cu
+++ b/examples/Example13/electrons.cu
@@ -107,7 +107,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     double geometryStepLength;
     vecgeom::NavStateIndex nextState;
     if (BzFieldValue != 0) {
-      geometryStepLength = fieldPropagatorBz.ComputeStepAndPropagatedState</*Relocate=*/false, BVHNavigator>(
+      geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume<BVHNavigator>(
           currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
           currentTrack.navState, nextState);
     } else {

--- a/examples/Example13/example13.cu
+++ b/examples/Example13/example13.cu
@@ -365,7 +365,7 @@ void example13(int numParticles, double energy, int batch, const int *MCIndex_ho
         loopingNo         = 0;
       }
 
-    } while (inFlight > 0 && loopingNo < 20);
+    } while (inFlight > 0 && loopingNo < 200);
 
     if (inFlight > 0) {
       for (int i = 0; i < ParticleType::NumParticleTypes; i++) {

--- a/examples/Example6/example6.cu
+++ b/examples/Example6/example6.cu
@@ -296,13 +296,6 @@ __global__ void RelocateToNextVolume(adept::BlockData<track> *allTracks, adept::
 
       currentVolume = state.Top();
 
-      // Remove all volumes that were left.
-      while (currentVolume && (currentVolume->IsAssembly() || !currentVolume->UnplacedContains(localPoint))) {
-        state.Pop();
-        localPoint    = currentVolume->GetTransformation()->InverseTransform(localPoint);
-        currentVolume = state.Top();
-      }
-
       // Store the transformed coordinates, to be broadcasted to the other
       // active threads in this warp.
       localCoordinates[0] = localPoint.x();

--- a/examples/Example6/example6.cu
+++ b/examples/Example6/example6.cu
@@ -179,7 +179,7 @@ __global__ void PerformStep(adept::BlockData<track> *allTracks, adept::MParray *
     // also need to carry them over!
 
     // Check if there's a volume boundary in between.
-    double geometryStepLength = fieldPropagatorBz.ComputeStepAndPropagatedState</*Relocate=*/false>(
+    double geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume(
         currentTrack.energy, currentTrack.mass(), currentTrack.charge(), geometricalStepLengthFromPhysics,
         currentTrack.pos, currentTrack.dir, currentTrack.current_state, currentTrack.next_state);
     currentTrack.total_length += geometryStepLength;

--- a/examples/Example7/electrons.cu
+++ b/examples/Example7/electrons.cu
@@ -83,7 +83,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     // Check if there's a volume boundary in between.
     double geometryStepLength;
     if (BzFieldValue != 0) {
-      geometryStepLength = fieldPropagatorBz.ComputeStepAndPropagatedState</*Relocate=*/false>(
+      geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume(
           currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
           currentTrack.currentState, currentTrack.nextState);
     } else {

--- a/examples/Example7/relocation.cu
+++ b/examples/Example7/relocation.cu
@@ -61,13 +61,6 @@ __global__ void RelocateToNextVolume(Track *allTracks, const adept::MParray *rel
 
       currentVolume = state.Top();
 
-      // Remove all volumes that were left.
-      while (currentVolume && (currentVolume->IsAssembly() || !currentVolume->UnplacedContains(localPoint))) {
-        state.Pop();
-        localPoint    = currentVolume->GetTransformation()->InverseTransform(localPoint);
-        currentVolume = state.Top();
-      }
-
       // Store the transformed coordinates, to be broadcasted to the other
       // active threads in this warp.
       localCoordinates[0] = localPoint.x();

--- a/examples/Example8/example8.cu
+++ b/examples/Example8/example8.cu
@@ -283,7 +283,7 @@ __global__ void PerformStep(Track *allTracks, SlotManager *manager, const adept:
     // also need to carry them over!
 
     // Check if there's a volume boundary in between.
-    double geometryStepLength = fieldPropagatorBz.ComputeStepAndPropagatedState</*Relocate=*/false>(
+    double geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume(
         currentTrack.energy, currentTrack.mass(), currentTrack.charge(), geometricalStepLengthFromPhysics,
         currentTrack.pos, currentTrack.dir, currentTrack.current_state, currentTrack.next_state);
 

--- a/examples/Example8/example8.cu
+++ b/examples/Example8/example8.cu
@@ -490,13 +490,6 @@ __global__ void RelocateToNextVolume(Track *allTracks, const adept::MParray *rel
 
       currentVolume = state.Top();
 
-      // Remove all volumes that were left.
-      while (currentVolume && (currentVolume->IsAssembly() || !currentVolume->UnplacedContains(localPoint))) {
-        state.Pop();
-        localPoint    = currentVolume->GetTransformation()->InverseTransform(localPoint);
-        currentVolume = state.Top();
-      }
-
       // Store the transformed coordinates, to be broadcasted to the other
       // active threads in this warp.
       localCoordinates[0] = localPoint.x();

--- a/examples/Example9/electrons.cu
+++ b/examples/Example9/electrons.cu
@@ -74,7 +74,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
 
     // Check if there's a volume boundary in between.
     vecgeom::NavStateIndex nextState;
-    double geometryStepLength = fieldPropagatorBz.ComputeStepAndPropagatedState</*Relocate=*/false>(
+    double geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume(
         currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
         currentTrack.navState, nextState);
 

--- a/examples/Example9/example9.cu
+++ b/examples/Example9/example9.cu
@@ -378,7 +378,7 @@ void example9(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double
     }
 
     iterNo++;
-  } while (inFlight > 0 && loopingNo < 20);
+  } while (inFlight > 0 && loopingNo < 200);
 
   auto time_cpu = timer.Stop();
   std::cout << "Run time: " << time_cpu << "\n";

--- a/examples/Example9/relocation.cu
+++ b/examples/Example9/relocation.cu
@@ -61,13 +61,6 @@ __global__ void RelocateToNextVolume(Track *allTracks, const adept::MParray *rel
 
       currentVolume = state.Top();
 
-      // Remove all volumes that were left.
-      while (currentVolume && (currentVolume->IsAssembly() || !currentVolume->UnplacedContains(localPoint))) {
-        state.Pop();
-        localPoint    = currentVolume->GetTransformation()->InverseTransform(localPoint);
-        currentVolume = state.Top();
-      }
-
       // Store the transformed coordinates, to be broadcasted to the other
       // active threads in this warp.
       localCoordinates[0] = localPoint.x();

--- a/examples/TestEm3/TestEm3.cu
+++ b/examples/TestEm3/TestEm3.cu
@@ -397,7 +397,7 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
         loopingNo = 0;
       }
 
-    } while (inFlight > 0 && loopingNo < 20);
+    } while (inFlight > 0 && loopingNo < 200);
 
     if (inFlight > 0) {
       for (int i = 0; i < ParticleType::NumParticleTypes; i++) {

--- a/examples/TestEm3/electrons.cu
+++ b/examples/TestEm3/electrons.cu
@@ -100,7 +100,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     double geometryStepLength;
     vecgeom::NavStateIndex nextState;
     if (BzFieldValue != 0) {
-      geometryStepLength = fieldPropagatorBz.ComputeStepAndPropagatedState</*Relocate=*/false, BVHNavigator>(
+      geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume<BVHNavigator>(
           currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
           currentTrack.navState, nextState);
     } else {

--- a/examples/TestEm3MT/TestEm3.cu
+++ b/examples/TestEm3MT/TestEm3.cu
@@ -383,7 +383,7 @@ static void Worker(ThreadData *data)
         loopingNo         = 0;
       }
 
-    } while (inFlight > 0 && loopingNo < 20);
+    } while (inFlight > 0 && loopingNo < 200);
 
     if (inFlight > 0) {
       for (int i = 0; i < ParticleType::NumParticleTypes; i++) {

--- a/examples/TestEm3MT/electrons.cu
+++ b/examples/TestEm3MT/electrons.cu
@@ -100,7 +100,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     double geometryStepLength;
     vecgeom::NavStateIndex nextState;
     if (BzFieldValue != 0) {
-      geometryStepLength = fieldPropagatorBz.ComputeStepAndPropagatedState</*Relocate=*/false, BVHNavigator>(
+      geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume<BVHNavigator>(
           currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
           currentTrack.navState, nextState);
     } else {


### PR DESCRIPTION
First, improve robustness of the navigators by making sure that hit volumes are really entered or left. This protects against cases where the pushed point is not yet on the right side of a boundary. Then relax the looping detection to fix #147. Of course, this has an influence on performance for simple geometries like `TestEm3`, but the numbers indicate that even there the looping detection was too aggressive in some cases (even though full comparison with Geant4 is currently not possible due to #145).