### PR TITLE
Changed field propagator interface to account for error and modified examples to use this.

### DIFF
--- a/examples/Example10/electrons.cu
+++ b/examples/Example10/electrons.cu
@@ -77,9 +77,17 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       // also need to carry them over!
 
       // Check if there's a volume boundary in between.
+      bool propagated = true;
       double geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume(
           currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
-          currentTrack.currentState, currentTrack.nextState);
+          currentTrack.currentState, currentTrack.nextState, propagated);
+
+      if (!propagated) {
+        // error condition from field propagator. Just kill the track here and account for it explicitly.
+        atomicAdd(&scoring->killedInPropagation, 1);
+        // Particles are killed by not enqueuing them into the new activeQueue.
+        continue;
+      }
 
       if (currentTrack.nextState.IsOnBoundary()) {
         theTrack->SetGStepLength(geometryStepLength);

--- a/examples/Example10/example10.cu
+++ b/examples/Example10/example10.cu
@@ -369,6 +369,8 @@ void example10(const vecgeom::cxx::VPlacedVolume *world, int numParticles, doubl
               << " energy deposition: " << std::setw(10) << stats->scoring.energyDeposit / copcore::units::GeV
               << " number of secondaries: " << std::setw(5) << stats->scoring.secondaries
               << " number of hits: " << std::setw(4) << stats->scoring.hits;
+    if (stats->scoring.killedInPropagation)
+      std::cout << " killed in propagation: " << std::setw(4) << stats->scoring.killedInPropagation;
     std::cout << std::endl;
 
     iterNo++;

--- a/examples/Example10/example10.cuh
+++ b/examples/Example10/example10.cuh
@@ -95,6 +95,7 @@ public:
 struct GlobalScoring {
   int hits;
   int secondaries;
+  int killedInPropagation;
   double energyDeposit;
 };
 

--- a/examples/Example11/electrons.cu
+++ b/examples/Example11/electrons.cu
@@ -75,9 +75,17 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
 
     // Check if there's a volume boundary in between.
     vecgeom::NavStateIndex nextState;
+    bool propagated = true;
     double geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume<BVHNavigator>(
         currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
-        currentTrack.navState, nextState);
+        currentTrack.navState, nextState, propagated);
+
+    if (!propagated) {
+        // error condition from field propagator. Just kill the track here and account for it explicitly.
+        atomicAdd(&scoring->killedInPropagation, 1);
+        // Particles are killed by not enqueuing them into the new activeQueue.
+        continue;
+    }
 
     if (nextState.IsOnBoundary()) {
       theTrack->SetGStepLength(geometryStepLength);

--- a/examples/Example11/example11.cu
+++ b/examples/Example11/example11.cu
@@ -318,6 +318,8 @@ void example11(const vecgeom::cxx::VPlacedVolume *world, int numParticles, doubl
               << " energy deposition: " << std::setw(10) << stats->scoring.energyDeposit / copcore::units::GeV
               << " number of secondaries: " << std::setw(5) << stats->scoring.secondaries
               << " number of hits: " << std::setw(4) << stats->scoring.hits;
+    if (stats->scoring.killedInPropagation)
+      std::cout << " killed in propagation: " << std::setw(4) << stats->scoring.killedInPropagation;
     std::cout << std::endl;
 
     // Check if only charged particles are left that are looping.

--- a/examples/Example11/example11.cuh
+++ b/examples/Example11/example11.cuh
@@ -86,6 +86,7 @@ public:
 struct GlobalScoring {
   int hits;
   int secondaries;
+  int killedInPropagation;
   double energyDeposit;
 };
 

--- a/examples/Example12/electrons.cu
+++ b/examples/Example12/electrons.cu
@@ -83,18 +83,27 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     // also need to carry them over!
 
     // Check if there's a volume boundary in between.
+    bool propagated = true;
     double geometryStepLength;
     vecgeom::NavStateIndex nextState;
     if (BzFieldValue != 0) {
       geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume<BVHNavigator>(
           currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
-          currentTrack.navState, nextState);
+          currentTrack.navState, nextState, propagated);
     } else {
       geometryStepLength =
           BVHNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics,
                                                  currentTrack.navState, nextState, kPush);
       currentTrack.pos += geometryStepLength * currentTrack.dir;
     }
+
+    if (!propagated) {
+      // error condition from field propagator. Just kill the track here and account for it explicitly.
+      atomicAdd(&globalScoring->killedInPropagation, 1);
+      // Particles are killed by not enqueuing them into the new activeQueue.
+      continue;
+    }
+
     atomicAdd(&globalScoring->chargedSteps, 1);
     atomicAdd(&scoringPerVolume->chargedTrackLength[volumeID], geometryStepLength);
 

--- a/examples/Example12/example12.cpp
+++ b/examples/Example12/example12.cpp
@@ -235,6 +235,8 @@ int main(int argc, char *argv[])
             << "Mean number of charged steps " << ((double)globalScoring.chargedSteps / particles) << "\n"
             << "Mean number of neutral steps " << ((double)globalScoring.neutralSteps / particles) << "\n"
             << "Mean number of hits          " << ((double)globalScoring.hits / particles) << "\n";
+  if (globalScoring.killedInPropagation)
+    std::cout << "Killed in propagation:       " << globalScoring.killedInPropagation << "\n";
   std::cout << std::endl;
 
   // Average charged track length and energy deposit per particle.

--- a/examples/Example12/example12.h
+++ b/examples/Example12/example12.h
@@ -17,6 +17,7 @@ struct GlobalScoring {
   unsigned long long numGammas;
   unsigned long long numElectrons;
   unsigned long long numPositrons;
+  unsigned long long killedInPropagation;
 };
 
 struct ScoringPerVolume {

--- a/examples/Example13/example13.cpp
+++ b/examples/Example13/example13.cpp
@@ -242,6 +242,8 @@ int main(int argc, char *argv[])
             << "Mean number of charged steps " << ((double)globalScoring.chargedSteps / particles) << "\n"
             << "Mean number of neutral steps " << ((double)globalScoring.neutralSteps / particles) << "\n"
             << "Mean number of hits          " << ((double)globalScoring.hits / particles) << "\n";
+  if (globalScoring.killedInPropagation)
+    std::cout << "Killed in propagation:       " << globalScoring.killedInPropagation << "\n";
   std::cout << std::endl;
 
   // Average charged track length and energy deposit per particle.

--- a/examples/Example13/example13.h
+++ b/examples/Example13/example13.h
@@ -17,6 +17,7 @@ struct GlobalScoring {
   unsigned long long numGammas;
   unsigned long long numElectrons;
   unsigned long long numPositrons;
+  unsigned long long killedInPropagation;
 };
 
 struct ScoringPerVolume {

--- a/examples/Example7/TestEm3.h
+++ b/examples/Example7/TestEm3.h
@@ -22,6 +22,7 @@ struct GlobalScoring {
   unsigned long long numGammas;
   unsigned long long numElectrons;
   unsigned long long numPositrons;
+  unsigned long long killedInPropagation;
 };
 
 struct ScoringPerVolume {

--- a/examples/Example9/example9.cu
+++ b/examples/Example9/example9.cu
@@ -363,6 +363,8 @@ void example9(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double
               << " energy deposition: " << std::setw(10) << stats->scoring.energyDeposit / copcore::units::GeV
               << " number of secondaries: " << std::setw(5) << stats->scoring.secondaries
               << " number of hits: " << std::setw(4) << stats->scoring.hits;
+    if (stats->scoring.killedInPropagation)
+      std::cout << " killed in propagation: " << std::setw(4) << stats->scoring.killedInPropagation;
     std::cout << std::endl;
 
     // Check if only charged particles are left that are looping.

--- a/examples/Example9/example9.cuh
+++ b/examples/Example9/example9.cuh
@@ -86,6 +86,7 @@ public:
 struct GlobalScoring {
   int hits;
   int secondaries;
+  int killedInPropagation;
   double energyDeposit;
 };
 

--- a/examples/TestEm3/TestEm3.cpp
+++ b/examples/TestEm3/TestEm3.cpp
@@ -237,6 +237,8 @@ int main(int argc, char *argv[])
             << "Mean number of charged steps " << ((double)globalScoring.chargedSteps / particles) << "\n"
             << "Mean number of neutral steps " << ((double)globalScoring.neutralSteps / particles) << "\n"
             << "Mean number of hits          " << ((double)globalScoring.hits / particles) << "\n";
+  if (globalScoring.killedInPropagation)
+    std::cout << "Killed in propagation:       " << globalScoring.killedInPropagation << "\n";
   std::cout << std::endl;
 
   // Average charged track length and energy deposit per particle.

--- a/examples/TestEm3/TestEm3.h
+++ b/examples/TestEm3/TestEm3.h
@@ -20,6 +20,7 @@ struct GlobalScoring {
   unsigned long long numGammas;
   unsigned long long numElectrons;
   unsigned long long numPositrons;
+  unsigned long long killedInPropagation;
 };
 
 struct ScoringPerVolume {

--- a/examples/TestEm3/electrons.cu
+++ b/examples/TestEm3/electrons.cu
@@ -97,16 +97,24 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     // also need to carry them over!
 
     // Check if there's a volume boundary in between.
+    bool propagated = true;
     double geometryStepLength;
     vecgeom::NavStateIndex nextState;
     if (BzFieldValue != 0) {
       geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume<BVHNavigator>(
           currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
-          currentTrack.navState, nextState);
+          currentTrack.navState, nextState, propagated);
     } else {
       geometryStepLength = BVHNavigator::ComputeStepAndNextVolume(
           currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics, currentTrack.navState, nextState);
       currentTrack.pos += geometryStepLength * currentTrack.dir;
+    }
+
+    if (!propagated) {
+      // error condition from field propagator. Just kill the track here and account for it explicitly.
+      atomicAdd(&globalScoring->killedInPropagation, 1);
+      // Particles are killed by not enqueuing them into the new activeQueue.
+      continue;
     }
 
     // Set boundary state in navState so the next step and secondaries get the

--- a/examples/TestEm3MT/TestEm3.cpp
+++ b/examples/TestEm3MT/TestEm3.cpp
@@ -238,6 +238,8 @@ int main(int argc, char *argv[])
             << "Mean number of charged steps " << ((double)globalScoring.chargedSteps / particles) << "\n"
             << "Mean number of neutral steps " << ((double)globalScoring.neutralSteps / particles) << "\n"
             << "Mean number of hits          " << ((double)globalScoring.hits / particles) << "\n";
+  if (globalScoring.killedInPropagation)
+    std::cout << "Killed in propagation:       " << globalScoring.killedInPropagation << "\n";
   std::cout << std::endl;
 
   // Average charged track length and energy deposit per particle.

--- a/examples/TestEm3MT/TestEm3.h
+++ b/examples/TestEm3MT/TestEm3.h
@@ -20,6 +20,7 @@ struct GlobalScoring {
   unsigned long long numGammas;
   unsigned long long numElectrons;
   unsigned long long numPositrons;
+  unsigned long long killedInPropagation;
 };
 
 struct ScoringPerVolume {

--- a/examples/TestEm3MT/electrons.cu
+++ b/examples/TestEm3MT/electrons.cu
@@ -97,16 +97,24 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     // also need to carry them over!
 
     // Check if there's a volume boundary in between.
+    bool propagated = true;
     double geometryStepLength;
     vecgeom::NavStateIndex nextState;
     if (BzFieldValue != 0) {
       geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume<BVHNavigator>(
           currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
-          currentTrack.navState, nextState);
+          currentTrack.navState, nextState, propagated);
     } else {
       geometryStepLength = BVHNavigator::ComputeStepAndNextVolume(
           currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics, currentTrack.navState, nextState);
       currentTrack.pos += geometryStepLength * currentTrack.dir;
+    }
+
+    if (!propagated) {
+      // error condition from field propagator. Just kill the track here and account for it explicitly.
+      atomicAdd(&globalScoring->killedInPropagation, 1);
+      // Particles are killed by not enqueuing them into the new activeQueue.
+      continue;
     }
 
     // Set boundary state in navState so the next step and secondaries get the


### PR DESCRIPTION
This addresses a bug in the field propagator, currently hard-limited to 10 iterations. An interface change was needed to:
- allow the user define the cutoff in number of iterations, if not used set to 100
- return the propagation success flag, set to false if the cutoff is being hit, giving the responsibility to the caller to kill the track (likely a slow electron)
- require the user to call with a safety value computed at the starting point. However, if the value is not computed, the method will accept 0.0, with the meaning (not using it). This feature will be preserved in the further optimizations

The safety value is not used in this PR, but allows further optimizations based on safety without changing the interface.

After this change, the output for the examples doing propagation in field is numerically identical (checked for example9 to 12 and TestEM3). This addresses the discussion opened on #148 