### PR TITLE
Optional NVTX annotations for example11 and 13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,14 @@ target_include_directories(AdePT
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_link_libraries(AdePT INTERFACE CopCore::CopCore)
 
+# Optional library to activate NVTX annotations for profiling:
+set(NVTX OFF CACHE BOOL "Add NVTX instrumentation for profiling (only for annotated examples)")
+add_library(NVTX INTERFACE)
+if(NVTX)
+  target_link_libraries(NVTX INTERFACE nvToolsExt)
+  target_compile_definitions(NVTX INTERFACE -DUSE_NVTX)
+endif()
+
 add_subdirectory(tracking)
 add_subdirectory(test)
 add_subdirectory(examples)

--- a/examples/Example11/CMakeLists.txt
+++ b/examples/Example11/CMakeLists.txt
@@ -9,5 +9,6 @@ endif()
 add_executable(example11 example11.cpp example11.cu electrons.cu gammas.cu)
 target_link_libraries(example11 PRIVATE AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml ${Geant4_LIBRARIES} G4HepEm::g4HepEmData G4HepEm::g4HepEmInit G4HepEm::g4HepEmRun)
 set_target_properties(example11 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
+target_link_libraries(example11 PRIVATE NVTX)
 
 add_test(NAME example11 COMMAND example11 -gdml_name "${TESTING_GDML}")

--- a/examples/Example13/CMakeLists.txt
+++ b/examples/Example13/CMakeLists.txt
@@ -37,6 +37,9 @@ target_link_libraries(example13
 
 set_target_properties(example13 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
+# NVTX
+target_link_libraries(example13 PRIVATE NVTX)
+
 # Tests
 add_test(NAME example13
   COMMAND $<TARGET_FILE:example13> -gdml_file ${CMAKE_BINARY_DIR}/cms2018.gdml)

--- a/examples/Example13/example13.cu
+++ b/examples/Example13/example13.cu
@@ -7,6 +7,7 @@
 #include <AdePT/Atomic.h>
 #include <AdePT/BVHNavigator.h>
 #include <AdePT/MParray.h>
+#include <AdePT/NVTX.h>
 
 #include <CopCore/Global.h>
 #include <CopCore/PhysicalConstants.h>
@@ -161,8 +162,10 @@ void example13(int numParticles, double energy, int batch, const int *MCIndex_ho
                ScoringPerVolume *scoringPerVolume_host, GlobalScoring *globalScoring_host, int numVolumes,
                int numPlaced, G4HepEmState *state, bool rotatingParticleGun)
 {
+  NVTXTracer tracer("InitG4HepEM");
   InitG4HepEmGPU(state);
 
+  tracer.setTag("InitParticles/malloc/copy");
   // Transfer MC indices.
   int *MCIndex_dev = nullptr;
   COPCORE_CUDA_CHECK(cudaMalloc(&MCIndex_dev, sizeof(int) * numVolumes));
@@ -252,6 +255,7 @@ void example13(int numParticles, double energy, int batch, const int *MCIndex_ho
 
   vecgeom::Stopwatch timer;
   timer.Start();
+  tracer.setTag("sim");
 
   std::cout << std::endl << "Simulating particles ";
   const bool detailed = (numParticles / batch) < 50;
@@ -291,6 +295,10 @@ void example13(int numParticles, double energy, int batch, const int *MCIndex_ho
     int inFlight;
     int loopingNo         = 0;
     int previousElectrons = -1, previousPositrons = -1;
+#ifdef USE_NVTX
+    int maxInFlight = chunk, localMinInFlight = chunk;
+    NVTXTracer occupTracer("Occup trace");
+#endif
 
     do {
       Secondaries secondaries = {
@@ -357,6 +365,18 @@ void example13(int numParticles, double energy, int batch, const int *MCIndex_ho
       for (int i = 0; i < ParticleType::NumParticleTypes; i++) {
         inFlight += stats->inFlight[i];
       }
+
+#ifdef USE_NVTX
+      if (inFlight < maxInFlight * 0.8) {
+        occupTracer.setTag(("Occup do from " +  std::to_string(maxInFlight)).c_str());
+        localMinInFlight = maxInFlight;
+      }
+      if (inFlight > localMinInFlight * 1.1) {
+        occupTracer.setTag(("Occup up from " +  std::to_string(localMinInFlight)).c_str());
+      }
+      maxInFlight = std::max(inFlight, maxInFlight);
+      localMinInFlight = std::min(inFlight, localMinInFlight);
+#endif
 
       // Swap the queues for the next iteration.
       electrons.queues.SwapActive();

--- a/examples/Example9/CMakeLists.txt
+++ b/examples/Example9/CMakeLists.txt
@@ -9,5 +9,6 @@ endif()
 add_executable(example9 example9.cpp example9.cu electrons.cu gammas.cu relocation.cu)
 target_link_libraries(example9 PRIVATE AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml ${Geant4_LIBRARIES} G4HepEm::g4HepEmData G4HepEm::g4HepEmInit G4HepEm::g4HepEmRun)
 set_target_properties(example9 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
+target_link_libraries(example9 PRIVATE NVTX)
 
 add_test(NAME example9 COMMAND example9 -gdml_name "${TESTING_GDML}")


### PR DESCRIPTION
This adds NVTX annotations for example 11 and 13, e.g.
![image](https://user-images.githubusercontent.com/16205615/142642944-783effca-768d-4fa1-9e56-e53710b08cba.png)

They only have an effect, though, if the executable is linked against NVTX, e.g. by doing:
```bash
cmake -DNVTX=On ...
```


