### PR TITLE
Add option to distribute particles over eta,phi in example13.

### DIFF
--- a/examples/Example13/example13.cpp
+++ b/examples/Example13/example13.cpp
@@ -189,6 +189,7 @@ int main(int argc, char *argv[])
   OPTION_DOUBLE(energy, 10); // entered in GeV
   energy *= copcore::units::GeV;
   OPTION_INT(batch, -1);
+  OPTION_BOOL(rotatingParticleGun, false);
 
   vecgeom::Stopwatch timer;
   timer.Start();
@@ -240,7 +241,8 @@ int main(int argc, char *argv[])
   scoringPerVolume.energyDeposit      = energyDeposit;
   GlobalScoring globalScoring;
 
-  example13(particles, energy, batch, MCCindex, &scoringPerVolume, &globalScoring, NumVolumes, NumPlaced, &hepEmState);
+  example13(particles, energy, batch, MCCindex, &scoringPerVolume, &globalScoring, NumVolumes, NumPlaced, &hepEmState,
+            rotatingParticleGun);
 
   std::cout << std::endl;
   std::cout << std::endl;

--- a/examples/Example13/example13.h
+++ b/examples/Example13/example13.h
@@ -27,6 +27,6 @@ struct ScoringPerVolume {
 
 // Interface between C++ and CUDA.
 void example13(int numParticles, double energy, int batch, const int *MCCindex, ScoringPerVolume *scoringPerVolume,
-               GlobalScoring *globalScoring, int numVolumes, int numPlaced, G4HepEmState *state);
+               GlobalScoring *globalScoring, int numVolumes, int numPlaced, G4HepEmState *state, bool rotatingParticleGun);
 
 #endif


### PR DESCRIPTION
Implement a simple rotating particle gun that generates flat
distributions in eta and phi between -5 and 5.
This option is off by default.