### PR TITLE
example10: Fix estimate of nextMaxElectrons

### DIFF
--- a/examples/Example10/example10.cu
+++ b/examples/Example10/example10.cu
@@ -343,7 +343,7 @@ void example10(const vecgeom::cxx::VPlacedVolume *world, int numParticles, doubl
       gammas.queues.SwapActive();
 
       // Estimate the maximum number of secondaries that could occur in the next iteration.
-      int nextMaxElectrons = maxElectrons + /*ioni*/ maxElectrons + /*conversion*/ maxGammas + /*Compton*/ maxGammas;
+      int nextMaxElectrons = maxElectrons + /*ioni*/ maxElectrons + /*ioni*/ maxPositrons + /*conversion/Compton/photoelectric*/ maxGammas;
       int nextMaxPositrons = maxPositrons + /*conversion*/ maxGammas;
       int nextMaxGammas    = maxGammas + /*brems*/ maxElectrons + /*annihilation*/ 2 * maxPositrons;
 


### PR DESCRIPTION
Gammas can do at most one of conversion, Compton scattering, or photoelectric effect and only produce at most one new electron. Also include electrons ionized by positrons (even if they are few).