### PR TITLE
Use fewer threads when not enough particles

### DIFF
--- a/examples/TestEm3/TestEm3.cu
+++ b/examples/TestEm3/TestEm3.cu
@@ -308,9 +308,10 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
     stats->inFlight[ParticleType::Positron] = 0;
     stats->inFlight[ParticleType::Gamma]    = 0;
 
-    constexpr int MaxBlocks        = 1024;
-    constexpr int TransportThreads = 32;
-    int transportBlocks;
+    constexpr int MaxBlocks              = 1024;
+    constexpr int MinParticlesForThreads = 32;
+    constexpr int TransportThreads       = 32;
+    int transportThreads, transportBlocks;
 
     int inFlight;
     int loopingNo = 0;
@@ -326,10 +327,11 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
       // *** ELECTRONS ***
       int numElectrons = stats->inFlight[ParticleType::Electron];
       if (numElectrons > 0) {
-        transportBlocks = (numElectrons + TransportThreads - 1) / TransportThreads;
-        transportBlocks = std::min(transportBlocks, MaxBlocks);
+        transportThreads = std::min(std::max(1, numElectrons / MinParticlesForThreads), TransportThreads);
+        transportBlocks  = (numElectrons + transportThreads - 1) / transportThreads;
+        transportBlocks  = std::min(transportBlocks, MaxBlocks);
 
-        TransportElectrons<<<transportBlocks, TransportThreads, 0, electrons.stream>>>(
+        TransportElectrons<<<transportBlocks, transportThreads, 0, electrons.stream>>>(
             electrons.tracks, electrons.queues.currentlyActive, secondaries, electrons.queues.nextActive, globalScoring,
             scoringPerVolume);
 
@@ -340,10 +342,11 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
       // *** POSITRONS ***
       int numPositrons = stats->inFlight[ParticleType::Positron];
       if (numPositrons > 0) {
-        transportBlocks = (numPositrons + TransportThreads - 1) / TransportThreads;
-        transportBlocks = std::min(transportBlocks, MaxBlocks);
+        transportThreads = std::min(std::max(1, numPositrons / MinParticlesForThreads), TransportThreads);
+        transportBlocks  = (numPositrons + transportThreads - 1) / transportThreads;
+        transportBlocks  = std::min(transportBlocks, MaxBlocks);
 
-        TransportPositrons<<<transportBlocks, TransportThreads, 0, positrons.stream>>>(
+        TransportPositrons<<<transportBlocks, transportThreads, 0, positrons.stream>>>(
             positrons.tracks, positrons.queues.currentlyActive, secondaries, positrons.queues.nextActive, globalScoring,
             scoringPerVolume);
 
@@ -354,10 +357,11 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
       // *** GAMMAS ***
       int numGammas = stats->inFlight[ParticleType::Gamma];
       if (numGammas > 0) {
-        transportBlocks = (numGammas + TransportThreads - 1) / TransportThreads;
-        transportBlocks = std::min(transportBlocks, MaxBlocks);
+        transportThreads = std::min(std::max(1, numGammas / MinParticlesForThreads), TransportThreads);
+        transportBlocks  = (numGammas + transportThreads - 1) / transportThreads;
+        transportBlocks  = std::min(transportBlocks, MaxBlocks);
 
-        TransportGammas<<<transportBlocks, TransportThreads, 0, gammas.stream>>>(
+        TransportGammas<<<transportBlocks, transportThreads, 0, gammas.stream>>>(
             gammas.tracks, gammas.queues.currentlyActive, secondaries, gammas.queues.nextActive, globalScoring,
             scoringPerVolume);
 

--- a/examples/TestEm3MT/TestEm3.cu
+++ b/examples/TestEm3MT/TestEm3.cu
@@ -292,9 +292,10 @@ static void Worker(ThreadData *data)
     stats->inFlight[ParticleType::Positron] = 0;
     stats->inFlight[ParticleType::Gamma]    = 0;
 
-    constexpr int MaxBlocks        = 1024;
-    constexpr int TransportThreads = 32;
-    int transportBlocks;
+    constexpr int MaxBlocks              = 1024;
+    constexpr int MinParticlesForThreads = 32;
+    constexpr int TransportThreads       = 32;
+    int transportThreads, transportBlocks;
 
     int inFlight;
     int loopingNo         = 0;
@@ -310,10 +311,11 @@ static void Worker(ThreadData *data)
       // *** ELECTRONS ***
       int numElectrons = stats->inFlight[ParticleType::Electron];
       if (numElectrons > 0) {
-        transportBlocks = (numElectrons + TransportThreads - 1) / TransportThreads;
-        transportBlocks = std::min(transportBlocks, MaxBlocks);
+        transportThreads = std::min(std::max(1, numElectrons / MinParticlesForThreads), TransportThreads);
+        transportBlocks  = (numElectrons + transportThreads - 1) / transportThreads;
+        transportBlocks  = std::min(transportBlocks, MaxBlocks);
 
-        TransportElectrons<<<transportBlocks, TransportThreads, 0, electrons.stream>>>(
+        TransportElectrons<<<transportBlocks, transportThreads, 0, electrons.stream>>>(
             electrons.tracks, electrons.queues.currentlyActive, secondaries, electrons.queues.nextActive, globalScoring,
             scoringPerVolume);
 
@@ -324,10 +326,11 @@ static void Worker(ThreadData *data)
       // *** POSITRONS ***
       int numPositrons = stats->inFlight[ParticleType::Positron];
       if (numPositrons > 0) {
-        transportBlocks = (numPositrons + TransportThreads - 1) / TransportThreads;
-        transportBlocks = std::min(transportBlocks, MaxBlocks);
+        transportThreads = std::min(std::max(1, numPositrons / MinParticlesForThreads), TransportThreads);
+        transportBlocks  = (numPositrons + transportThreads - 1) / transportThreads;
+        transportBlocks  = std::min(transportBlocks, MaxBlocks);
 
-        TransportPositrons<<<transportBlocks, TransportThreads, 0, positrons.stream>>>(
+        TransportPositrons<<<transportBlocks, transportThreads, 0, positrons.stream>>>(
             positrons.tracks, positrons.queues.currentlyActive, secondaries, positrons.queues.nextActive, globalScoring,
             scoringPerVolume);
 
@@ -338,10 +341,11 @@ static void Worker(ThreadData *data)
       // *** GAMMAS ***
       int numGammas = stats->inFlight[ParticleType::Gamma];
       if (numGammas > 0) {
-        transportBlocks = (numGammas + TransportThreads - 1) / TransportThreads;
-        transportBlocks = std::min(transportBlocks, MaxBlocks);
+        transportThreads = std::min(std::max(1, numGammas / MinParticlesForThreads), TransportThreads);
+        transportBlocks  = (numGammas + transportThreads - 1) / transportThreads;
+        transportBlocks  = std::min(transportBlocks, MaxBlocks);
 
-        TransportGammas<<<transportBlocks, TransportThreads, 0, gammas.stream>>>(
+        TransportGammas<<<transportBlocks, transportThreads, 0, gammas.stream>>>(
             gammas.tracks, gammas.queues.currentlyActive, secondaries, gammas.queues.nextActive, globalScoring,
             scoringPerVolume);
 


### PR DESCRIPTION
*Note*: not necessarily a good idea since it wastes resources that other host threads might fill with their work, but makes `example13` 40% and `TestEm3` 5% faster in the current setup. This should not be merged until we can test with more than one thread on the CPU, once we have integration with Geant4.

Credits to @amadio for making me (re)think about using less threads, but the approach implemented here is beneficial overall since it only applies the strategy if there are few particles.