### PR TITLE
Push only temporarily on boundary crossing

### DIFF
--- a/base/inc/AdePT/BVHNavigator.h
+++ b/base/inc/AdePT/BVHNavigator.h
@@ -27,6 +27,8 @@ class BVHNavigator {
 public:
   using VPlacedVolumePtr_t = vecgeom::VPlacedVolume const *;
 
+  static constexpr vecgeom::Precision kBoundaryPush = 10 * vecgeom::kTolerance;
+
   __host__ __device__ static VPlacedVolumePtr_t LocatePointIn(vecgeom::VPlacedVolume const *vol,
                                                               vecgeom::Vector3D<vecgeom::Precision> const &point,
                                                               vecgeom::NavStateIndex &path, bool top,
@@ -191,7 +193,6 @@ public:
       vecgeom::Precision step_limit, vecgeom::NavStateIndex const &in_state, vecgeom::NavStateIndex &out_state,
       vecgeom::Precision push = 0.)
   {
-    constexpr vecgeom::Precision kPush = 10. * vecgeom::kTolerance;
     // calculate local point/dir from global point/dir
     vecgeom::Vector3D<vecgeom::Precision> localpoint;
     vecgeom::Vector3D<vecgeom::Precision> localdir;
@@ -209,7 +210,7 @@ public:
 
     if (out_state.IsOnBoundary()) {
       // Relocate the point after the step to refine out_state.
-      localpoint += (step + kPush) * localdir;
+      localpoint += (step + kBoundaryPush) * localdir;
 
       if (!hitcandidate) {
         // We didn't hit a daughter but instead we're exiting the current volume.
@@ -265,8 +266,7 @@ public:
         vecgeom::VPlacedVolume const *currentmother       = out_state.Top();
         vecgeom::Vector3D<vecgeom::Precision> transformed = localpoint;
         // Push the point inside the next volume.
-        static constexpr double kPush = 10. * vecgeom::kTolerance;
-        transformed += (step + kPush) * localdir;
+        transformed += (step + kBoundaryPush) * localdir;
 
         do {
           out_state.SetLastExited();
@@ -309,8 +309,7 @@ public:
                                                        vecgeom::NavStateIndex &state)
   {
     // Push the point inside the next volume.
-    static constexpr double kPush = 10. * vecgeom::kTolerance;
-    globalpoint += kPush * globaldir;
+    globalpoint += kBoundaryPush * globaldir;
 
     // Calculate local point from global point.
     vecgeom::Transformation3D m;

--- a/base/inc/AdePT/BVHNavigator.h
+++ b/base/inc/AdePT/BVHNavigator.h
@@ -193,6 +193,11 @@ public:
       vecgeom::Precision step_limit, vecgeom::NavStateIndex const &in_state, vecgeom::NavStateIndex &out_state,
       vecgeom::Precision push = 0.)
   {
+    // If we are on the boundary, push a bit more.
+    if (in_state.IsOnBoundary()) {
+      push += kBoundaryPush;
+    }
+
     // calculate local point/dir from global point/dir
     vecgeom::Vector3D<vecgeom::Precision> localpoint;
     vecgeom::Vector3D<vecgeom::Precision> localdir;
@@ -246,6 +251,11 @@ public:
                                                              vecgeom::NavStateIndex &out_state,
                                                              vecgeom::Precision push = 0.)
   {
+    // If we are on the boundary, push a bit more.
+    if (in_state.IsOnBoundary()) {
+      push += kBoundaryPush;
+    }
+
     // calculate local point/dir from global point/dir
     vecgeom::Vector3D<vecgeom::Precision> localpoint;
     vecgeom::Vector3D<vecgeom::Precision> localdir;
@@ -304,17 +314,17 @@ public:
 
   // Relocate a state that was returned from ComputeStepAndNextVolume: It
   // recursively locates the pushed point in the containing volume.
-  __host__ __device__ static void RelocateToNextVolume(vecgeom::Vector3D<vecgeom::Precision> &globalpoint,
+  __host__ __device__ static void RelocateToNextVolume(vecgeom::Vector3D<vecgeom::Precision> const &globalpoint,
                                                        vecgeom::Vector3D<vecgeom::Precision> const &globaldir,
                                                        vecgeom::NavStateIndex &state)
   {
     // Push the point inside the next volume.
-    globalpoint += kBoundaryPush * globaldir;
+    vecgeom::Vector3D<vecgeom::Precision> pushed = globalpoint + kBoundaryPush * globaldir;
 
     // Calculate local point from global point.
     vecgeom::Transformation3D m;
     state.TopMatrix(m);
-    vecgeom::Vector3D<vecgeom::Precision> localpoint = m.Transform(globalpoint);
+    vecgeom::Vector3D<vecgeom::Precision> localpoint = m.Transform(pushed);
 
     VPlacedVolumePtr_t pvol = state.Top();
 

--- a/base/inc/AdePT/BVHNavigator.h
+++ b/base/inc/AdePT/BVHNavigator.h
@@ -197,6 +197,14 @@ public:
     if (in_state.IsOnBoundary()) {
       push += kBoundaryPush;
     }
+    if (step_limit < push) {
+      // Go as far as the step limit says, assuming there is no boundary.
+      // TODO: Does this make sense?
+      in_state.CopyTo(&out_state);
+      out_state.SetBoundaryState(false);
+      return step_limit;
+    }
+    step_limit -= push;
 
     // calculate local point/dir from global point/dir
     vecgeom::Vector3D<vecgeom::Precision> localpoint;
@@ -211,7 +219,7 @@ public:
 
     VPlacedVolumePtr_t hitcandidate = nullptr;
     vecgeom::Precision step = ComputeStepAndHit(localpoint, localdir, step_limit, in_state, out_state, hitcandidate);
-    if (step < step_limit) step += push;
+    step += push;
 
     if (out_state.IsOnBoundary()) {
       // Relocate the point after the step to refine out_state.
@@ -255,6 +263,14 @@ public:
     if (in_state.IsOnBoundary()) {
       push += kBoundaryPush;
     }
+    if (step_limit < push) {
+      // Go as far as the step limit says, assuming there is no boundary.
+      // TODO: Does this make sense?
+      in_state.CopyTo(&out_state);
+      out_state.SetBoundaryState(false);
+      return step_limit;
+    }
+    step_limit -= push;
 
     // calculate local point/dir from global point/dir
     vecgeom::Vector3D<vecgeom::Precision> localpoint;
@@ -269,7 +285,7 @@ public:
 
     VPlacedVolumePtr_t hitcandidate = nullptr;
     vecgeom::Precision step = ComputeStepAndHit(localpoint, localdir, step_limit, in_state, out_state, hitcandidate);
-    if (step < step_limit) step += push;
+    step += push;
 
     if (out_state.IsOnBoundary()) {
       if (!hitcandidate) {

--- a/base/inc/AdePT/LoopNavigator.h
+++ b/base/inc/AdePT/LoopNavigator.h
@@ -26,6 +26,8 @@ class LoopNavigator {
 public:
   using VPlacedVolumePtr_t = vecgeom::VPlacedVolume const *;
 
+  static constexpr vecgeom::Precision kBoundaryPush = 10 * vecgeom::kTolerance;
+
   __host__ __device__
   static VPlacedVolumePtr_t LocatePointIn(vecgeom::VPlacedVolume const *vol,
                                           vecgeom::Vector3D<vecgeom::Precision> const &point,
@@ -167,7 +169,6 @@ public:
       vecgeom::Vector3D<vecgeom::Precision> const &globalpoint, vecgeom::Vector3D<vecgeom::Precision> const &globaldir,
       vecgeom::Precision step_limit, vecgeom::NavStateIndex const &in_state, vecgeom::NavStateIndex &out_state, vecgeom::Precision push = 0.)
   {
-    constexpr vecgeom::Precision kPush = 10. * vecgeom::kTolerance;
     // calculate local point/dir from global point/dir
     vecgeom::Vector3D<vecgeom::Precision> localpoint;
     vecgeom::Vector3D<vecgeom::Precision> localdir;
@@ -185,7 +186,7 @@ public:
 
     if (out_state.IsOnBoundary()) {
       // Relocate the point after the step to refine out_state.
-      localpoint += (step + kPush) * localdir;
+      localpoint += (step + kBoundaryPush) * localdir;
 
       if (!hitcandidate) {
         // We didn't hit a daughter but instead we're exiting the current volume.
@@ -241,8 +242,7 @@ public:
         vecgeom::VPlacedVolume const *currentmother       = out_state.Top();
         vecgeom::Vector3D<vecgeom::Precision> transformed = localpoint;
         // Push the point inside the next volume.
-        static constexpr double kPush = 10. * vecgeom::kTolerance;
-        transformed += (step + kPush) * localdir;
+        transformed += (step + kBoundaryPush) * localdir;
         do {
           out_state.SetLastExited();
           out_state.Pop();
@@ -264,8 +264,7 @@ public:
                                                        vecgeom::NavStateIndex &state)
   {
     // Push the point inside the next volume.
-    static constexpr double kPush = 10. * vecgeom::kTolerance;
-    globalpoint += kPush * globaldir;
+    globalpoint += kBoundaryPush * globaldir;
 
     // Calculate local point from global point.
     vecgeom::Transformation3D m;

--- a/base/inc/AdePT/LoopNavigator.h
+++ b/base/inc/AdePT/LoopNavigator.h
@@ -173,6 +173,14 @@ public:
     if (in_state.IsOnBoundary()) {
       push += kBoundaryPush;
     }
+    if (step_limit < push) {
+      // Go as far as the step limit says, assuming there is no boundary.
+      // TODO: Does this make sense?
+      in_state.CopyTo(&out_state);
+      out_state.SetBoundaryState(false);
+      return step_limit;
+    }
+    step_limit -= push;
 
     // calculate local point/dir from global point/dir
     vecgeom::Vector3D<vecgeom::Precision> localpoint;
@@ -187,7 +195,7 @@ public:
 
     VPlacedVolumePtr_t hitcandidate = nullptr;
     vecgeom::Precision step = ComputeStepAndHit(localpoint, localdir, step_limit, in_state, out_state, hitcandidate);
-    if (step < step_limit) step += push;
+    step += push;
 
     if (out_state.IsOnBoundary()) {
       // Relocate the point after the step to refine out_state.
@@ -231,6 +239,14 @@ public:
     if (in_state.IsOnBoundary()) {
       push += kBoundaryPush;
     }
+    if (step_limit < push) {
+      // Go as far as the step limit says, assuming there is no boundary.
+      // TODO: Does this make sense?
+      in_state.CopyTo(&out_state);
+      out_state.SetBoundaryState(false);
+      return step_limit;
+    }
+    step_limit -= push;
 
     // calculate local point/dir from global point/dir
     vecgeom::Vector3D<vecgeom::Precision> localpoint;
@@ -245,7 +261,7 @@ public:
 
     VPlacedVolumePtr_t hitcandidate = nullptr;
     vecgeom::Precision step = ComputeStepAndHit(localpoint, localdir, step_limit, in_state, out_state, hitcandidate);
-    if (step < step_limit) step += push;
+    step += push;
 
     if (out_state.IsOnBoundary()) {
       if (!hitcandidate) {

--- a/base/inc/AdePT/LoopNavigator.h
+++ b/base/inc/AdePT/LoopNavigator.h
@@ -169,6 +169,11 @@ public:
       vecgeom::Vector3D<vecgeom::Precision> const &globalpoint, vecgeom::Vector3D<vecgeom::Precision> const &globaldir,
       vecgeom::Precision step_limit, vecgeom::NavStateIndex const &in_state, vecgeom::NavStateIndex &out_state, vecgeom::Precision push = 0.)
   {
+    // If we are on the boundary, push a bit more.
+    if (in_state.IsOnBoundary()) {
+      push += kBoundaryPush;
+    }
+
     // calculate local point/dir from global point/dir
     vecgeom::Vector3D<vecgeom::Precision> localpoint;
     vecgeom::Vector3D<vecgeom::Precision> localdir;
@@ -222,6 +227,11 @@ public:
                                                              vecgeom::NavStateIndex &out_state,
                                                              vecgeom::Precision push = 0.)
   {
+    // If we are on the boundary, push a bit more.
+    if (in_state.IsOnBoundary()) {
+      push += kBoundaryPush;
+    }
+
     // calculate local point/dir from global point/dir
     vecgeom::Vector3D<vecgeom::Precision> localpoint;
     vecgeom::Vector3D<vecgeom::Precision> localdir;
@@ -259,17 +269,17 @@ public:
 
   // Relocate a state that was returned from ComputeStepAndNextVolume: It
   // recursively locates the pushed point in the containing volume.
-  __host__ __device__ static void RelocateToNextVolume(vecgeom::Vector3D<vecgeom::Precision> &globalpoint,
+  __host__ __device__ static void RelocateToNextVolume(vecgeom::Vector3D<vecgeom::Precision> const &globalpoint,
                                                        vecgeom::Vector3D<vecgeom::Precision> const &globaldir,
                                                        vecgeom::NavStateIndex &state)
   {
     // Push the point inside the next volume.
-    globalpoint += kBoundaryPush * globaldir;
+    vecgeom::Vector3D<vecgeom::Precision> pushed = globalpoint + kBoundaryPush * globaldir;
 
     // Calculate local point from global point.
     vecgeom::Transformation3D m;
     state.TopMatrix(m);
-    vecgeom::Vector3D<vecgeom::Precision> localpoint = m.Transform(globalpoint);
+    vecgeom::Vector3D<vecgeom::Precision> localpoint = m.Transform(pushed);
 
     VPlacedVolumePtr_t pvol = state.Top();
 

--- a/examples/Example10/relocation.cu
+++ b/examples/Example10/relocation.cu
@@ -3,6 +3,7 @@
 
 #include "example10.cuh"
 
+#include <AdePT/LoopNavigator.h>
 #include <AdePT/MParray.h>
 
 #include <VecGeom/base/Vector3D.h>
@@ -51,13 +52,13 @@ __global__ void RelocateToNextVolume(Track *allTracks, const adept::MParray *rel
     // variable localCoordinates.
     if (lane == 0) {
       // Push the point inside the next volume.
-      static constexpr double kPush = 10. * vecgeom::kTolerance;
-      currentTrack.pos += kPush * currentTrack.dir;
+      static constexpr double kPush = LoopNavigator::kBoundaryPush;
+      vecgeom::Vector3D<vecgeom::Precision> pushed = currentTrack.pos + kPush * currentTrack.dir;
 
       // Calculate local point from global point.
       vecgeom::Transformation3D m;
       state.TopMatrix(m);
-      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(currentTrack.pos);
+      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(pushed);
 
       currentVolume = state.Top();
 

--- a/examples/Example6/example6.cu
+++ b/examples/Example6/example6.cu
@@ -295,13 +295,13 @@ __global__ void RelocateToNextVolume(adept::BlockData<track> *allTracks, adept::
     // variable localCoordinates.
     if (lane == 0) {
       // Push the point inside the next volume.
-      static constexpr double kPush = 10. * vecgeom::kTolerance;
-      currentTrack.pos += kPush * currentTrack.dir;
+      static constexpr double kPush = LoopNavigator::kBoundaryPush;
+      vecgeom::Vector3D<vecgeom::Precision> pushed = currentTrack.pos + kPush * currentTrack.dir;
 
       // Calculate local point from global point.
       vecgeom::Transformation3D m;
       state.TopMatrix(m);
-      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(currentTrack.pos);
+      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(pushed);
 
       currentVolume = state.Top();
 

--- a/examples/Example7/relocation.cu
+++ b/examples/Example7/relocation.cu
@@ -3,6 +3,7 @@
 
 #include "TestEm3.cuh"
 
+#include <AdePT/LoopNavigator.h>
 #include <AdePT/MParray.h>
 
 #include <VecGeom/base/Vector3D.h>
@@ -51,13 +52,13 @@ __global__ void RelocateToNextVolume(Track *allTracks, const adept::MParray *rel
     // variable localCoordinates.
     if (lane == 0) {
       // Push the point inside the next volume.
-      static constexpr double kPush = 1.e-8;
-      currentTrack.pos += kPush * currentTrack.dir;
+      static constexpr double kPush = LoopNavigator::kBoundaryPush;
+      vecgeom::Vector3D<vecgeom::Precision> pushed = currentTrack.pos + kPush * currentTrack.dir;
 
       // Calculate local point from global point.
       vecgeom::Transformation3D m;
       state.TopMatrix(m);
-      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(currentTrack.pos);
+      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(pushed);
 
       currentVolume = state.Top();
 

--- a/examples/Example8/example8.cu
+++ b/examples/Example8/example8.cu
@@ -489,13 +489,13 @@ __global__ void RelocateToNextVolume(Track *allTracks, const adept::MParray *rel
     // variable localCoordinates.
     if (lane == 0) {
       // Push the point inside the next volume.
-      static constexpr double kPush = 1.e-8;
-      currentTrack.pos += kPush * currentTrack.dir;
+      static constexpr double kPush = LoopNavigator::kBoundaryPush;
+      vecgeom::Vector3D<vecgeom::Precision> pushed = currentTrack.pos + kPush * currentTrack.dir;
 
       // Calculate local point from global point.
       vecgeom::Transformation3D m;
       state.TopMatrix(m);
-      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(currentTrack.pos);
+      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(pushed);
 
       currentVolume = state.Top();
 

--- a/examples/Example9/relocation.cu
+++ b/examples/Example9/relocation.cu
@@ -3,6 +3,7 @@
 
 #include "example9.cuh"
 
+#include <AdePT/LoopNavigator.h>
 #include <AdePT/MParray.h>
 
 #include <VecGeom/base/Vector3D.h>
@@ -51,13 +52,13 @@ __global__ void RelocateToNextVolume(Track *allTracks, const adept::MParray *rel
     // variable localCoordinates.
     if (lane == 0) {
       // Push the point inside the next volume.
-      static constexpr double kPush = 10. * vecgeom::kTolerance;
-      currentTrack.pos += kPush * currentTrack.dir;
+      static constexpr double kPush = LoopNavigator::kBoundaryPush;
+      vecgeom::Vector3D<vecgeom::Precision> pushed = currentTrack.pos + kPush * currentTrack.dir;
 
       // Calculate local point from global point.
       vecgeom::Transformation3D m;
       state.TopMatrix(m);
-      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(currentTrack.pos);
+      vecgeom::Vector3D<vecgeom::Precision> localPoint = m.Transform(pushed);
 
       currentVolume = state.Top();
 


### PR DESCRIPTION
With VecGeom compiled using single precision, `kTolerance` is one micrometer and pushing 10um on every boundary crossing creates a measurable systematic error. Thus only push temporarily in the relocation logic and another time in the `ComputeStep` functions, which needed another fix.