### PR TITLE
Use -gdml_file in all examples

### DIFF
--- a/examples/Example10/CMakeLists.txt
+++ b/examples/Example10/CMakeLists.txt
@@ -10,4 +10,4 @@ add_executable(example10  example10.cpp example10.cu electrons.cu gammas.cu relo
 target_link_libraries(example10 PRIVATE AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml ${Geant4_LIBRARIES} G4HepEm::g4HepEmData G4HepEm::g4HepEmInit G4HepEm::g4HepEmRun)
 set_target_properties(example10 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
-add_test(NAME example10 COMMAND example10 -gdml_name "${TESTING_GDML}")
+add_test(NAME example10 COMMAND example10 -gdml_file "${TESTING_GDML}")

--- a/examples/Example10/example10.cpp
+++ b/examples/Example10/example10.cpp
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
   return 2;
 #endif
 
-  OPTION_STRING(gdml_name, "trackML.gdml");
+  OPTION_STRING(gdml_file, "trackML.gdml");
   OPTION_INT(cache_depth, 0); // 0 = full depth
   OPTION_INT(particles, 1);
   OPTION_DOUBLE(energy, 100); // entered in GeV
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
 #ifdef VECGEOM_GDML
   vecgeom::GeoManager::Instance().SetTransformationCacheDepth(cache_depth);
   // The vecgeom millimeter unit is the last parameter of vgdml::Frontend::Load
-  bool load = vgdml::Frontend::Load(gdml_name.c_str(), false, copcore::units::mm);
+  bool load = vgdml::Frontend::Load(gdml_file.c_str(), false, copcore::units::mm);
   if (!load) return 3;
 #endif
 

--- a/examples/Example11/CMakeLists.txt
+++ b/examples/Example11/CMakeLists.txt
@@ -10,4 +10,4 @@ add_executable(example11 example11.cpp example11.cu electrons.cu gammas.cu)
 target_link_libraries(example11 PRIVATE AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml ${Geant4_LIBRARIES} G4HepEm::g4HepEmData G4HepEm::g4HepEmInit G4HepEm::g4HepEmRun)
 set_target_properties(example11 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
-add_test(NAME example11 COMMAND example11 -gdml_name "${TESTING_GDML}")
+add_test(NAME example11 COMMAND example11 -gdml_file "${TESTING_GDML}")

--- a/examples/Example11/example11.cpp
+++ b/examples/Example11/example11.cpp
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
   return 2;
 #endif
 
-  OPTION_STRING(gdml_name, "trackML.gdml");
+  OPTION_STRING(gdml_file, "trackML.gdml");
   OPTION_INT(cache_depth, 0); // 0 = full depth
   OPTION_INT(particles, 1);
   OPTION_DOUBLE(energy, 100); // entered in GeV
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 #ifdef VECGEOM_GDML
   vecgeom::GeoManager::Instance().SetTransformationCacheDepth(cache_depth);
   // The vecgeom millimeter unit is the last parameter of vgdml::Frontend::Load
-  bool load = vgdml::Frontend::Load(gdml_name.c_str(), false, copcore::units::mm);
+  bool load = vgdml::Frontend::Load(gdml_file.c_str(), false, copcore::units::mm);
   if (!load) return 3;
 #endif
 

--- a/examples/Example6/CMakeLists.txt
+++ b/examples/Example6/CMakeLists.txt
@@ -10,4 +10,4 @@ add_executable(example6 example6.cpp example6.cu)
 target_link_libraries(example6 PRIVATE AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml ${Geant4_LIBRARIES} G4HepEm::g4HepEmData G4HepEm::g4HepEmInit G4HepEm::g4HepEmRun)
 set_target_properties(example6 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
-add_test(NAME example6 COMMAND example6 -gdml_name "${TESTING_GDML}")
+add_test(NAME example6 COMMAND example6 -gdml_file "${TESTING_GDML}")

--- a/examples/Example6/example6.cpp
+++ b/examples/Example6/example6.cpp
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
   return 2;
 #endif
 
-  OPTION_STRING(gdml_name, "trackML.gdml");
+  OPTION_STRING(gdml_file, "trackML.gdml");
   OPTION_INT(cache_depth, 0); // 0 = full depth
 
   InitGeant4();
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
 #ifdef VECGEOM_GDML
   vecgeom::GeoManager::Instance().SetTransformationCacheDepth(cache_depth);
   // The vecgeom millimeter unit is the last parameter of vgdml::Frontend::Load
-  bool load = vgdml::Frontend::Load(gdml_name.c_str(), false, 1);
+  bool load = vgdml::Frontend::Load(gdml_file.c_str(), false, 1);
   if (!load) return 3;
 #endif
 

--- a/examples/Example8/CMakeLists.txt
+++ b/examples/Example8/CMakeLists.txt
@@ -10,4 +10,4 @@ add_executable(example8 example8.cpp example8.cu)
 target_link_libraries(example8 PRIVATE AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml ${Geant4_LIBRARIES} G4HepEm::g4HepEmData G4HepEm::g4HepEmInit G4HepEm::g4HepEmRun)
 set_target_properties(example8 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
-add_test(NAME example8 COMMAND example8 -gdml_name "${TESTING_GDML}")
+add_test(NAME example8 COMMAND example8 -gdml_file "${TESTING_GDML}")

--- a/examples/Example8/example8.cpp
+++ b/examples/Example8/example8.cpp
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
   return 2;
 #endif
 
-  OPTION_STRING(gdml_name, "trackML.gdml");
+  OPTION_STRING(gdml_file, "trackML.gdml");
   OPTION_INT(cache_depth, 0); // 0 = full depth
   OPTION_INT(particles, 1);
   OPTION_DOUBLE(energy, 100); // entered in GeV
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
 #ifdef VECGEOM_GDML
   vecgeom::GeoManager::Instance().SetTransformationCacheDepth(cache_depth);
   // The vecgeom millimeter unit is the last parameter of vgdml::Frontend::Load
-  bool load = vgdml::Frontend::Load(gdml_name.c_str(), false, copcore::units::mm);
+  bool load = vgdml::Frontend::Load(gdml_file.c_str(), false, copcore::units::mm);
   if (!load) return 3;
 #endif
 

--- a/examples/Example9/CMakeLists.txt
+++ b/examples/Example9/CMakeLists.txt
@@ -10,4 +10,4 @@ add_executable(example9 example9.cpp example9.cu electrons.cu gammas.cu relocati
 target_link_libraries(example9 PRIVATE AdePT CopCore::CopCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml ${Geant4_LIBRARIES} G4HepEm::g4HepEmData G4HepEm::g4HepEmInit G4HepEm::g4HepEmRun)
 set_target_properties(example9 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
-add_test(NAME example9 COMMAND example9 -gdml_name "${TESTING_GDML}")
+add_test(NAME example9 COMMAND example9 -gdml_file "${TESTING_GDML}")

--- a/examples/Example9/example9.cpp
+++ b/examples/Example9/example9.cpp
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
   return 2;
 #endif
 
-  OPTION_STRING(gdml_name, "trackML.gdml");
+  OPTION_STRING(gdml_file, "trackML.gdml");
   OPTION_INT(cache_depth, 0); // 0 = full depth
   OPTION_INT(particles, 1);
   OPTION_DOUBLE(energy, 100); // entered in GeV
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
 #ifdef VECGEOM_GDML
   vecgeom::GeoManager::Instance().SetTransformationCacheDepth(cache_depth);
   // The vecgeom millimeter unit is the last parameter of vgdml::Frontend::Load
-  bool load = vgdml::Frontend::Load(gdml_name.c_str(), false, copcore::units::mm);
+  bool load = vgdml::Frontend::Load(gdml_file.c_str(), false, copcore::units::mm);
   if (!load) return 3;
 #endif
 

--- a/examples/Raytracer_Benchmark/CMakeLists.txt
+++ b/examples/Raytracer_Benchmark/CMakeLists.txt
@@ -50,11 +50,11 @@ target_compile_options(RaytraceBenchmark PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$
 set_target_properties(RaytraceBenchmark PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
 add_test(NAME RaytraceBenchmarkCPU
-  COMMAND $<TARGET_FILE:RaytraceBenchmark> -gdml_name ${CMAKE_BINARY_DIR}/trackML.gdml -on_gpu 0)
+  COMMAND $<TARGET_FILE:RaytraceBenchmark> -gdml_file ${CMAKE_BINARY_DIR}/trackML.gdml -on_gpu 0)
 set_tests_properties(RaytraceBenchmarkCPU PROPERTIES ATTACHED_FILES_ON_FAIL "output-cpu.ppm")
 
 add_test(NAME RaytraceBenchmarkGPU
-  COMMAND $<TARGET_FILE:RaytraceBenchmark> -gdml_name ${CMAKE_BINARY_DIR}/trackML.gdml -on_gpu 1)
+  COMMAND $<TARGET_FILE:RaytraceBenchmark> -gdml_file ${CMAKE_BINARY_DIR}/trackML.gdml -on_gpu 1)
 set_tests_properties(RaytraceBenchmarkGPU PROPERTIES ATTACHED_FILES_ON_FAIL "output-gpu.ppm")
 
 add_test(NAME RaytraceBenchmarkDiff

--- a/examples/Raytracer_Benchmark/README.md
+++ b/examples/Raytracer_Benchmark/README.md
@@ -25,7 +25,7 @@ The current version of scheduling is: get the ray using the index from the first
 ## How to use:
 
 ```console
-$ ./RaytraceBenchmark -gdml_name <path to gdml file>
+$ ./RaytraceBenchmark -gdml_file <path to gdml file>
 ```
 
 ## Parameters

--- a/examples/Raytracer_Benchmark/RaytraceBenchmark.cpp
+++ b/examples/Raytracer_Benchmark/RaytraceBenchmark.cpp
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
   return 2;
 #endif
 
-  OPTION_STRING(gdml_name, "trackML.gdml");
+  OPTION_STRING(gdml_file, "trackML.gdml");
   OPTION_INT(cache_depth, 0); // 0 = full depth
 
   OPTION_INT(on_gpu, 1); // run on GPU
@@ -72,7 +72,7 @@ int main(int argc, char *argv[])
   vecgeom::GeoManager::Instance().SetTransformationCacheDepth(cache_depth);
 
   // The vecgeom millimeter unit is the last parameter of vgdml::Frontend::Load
-  bool load = vgdml::Frontend::Load(gdml_name.c_str(), false, 1);
+  bool load = vgdml::Frontend::Load(gdml_file.c_str(), false, 1);
   if (!load) return 2;
 #endif
 


### PR DESCRIPTION
I'm getting mad trying to remember which example has `-gdml_name`. The option name chosen by later examples makes more sense to me, use it everywhere.