### PR TITLE
Fix oversight in LoopNavigator::RelocateToNextVolume

### DIFF
--- a/base/inc/AdePT/LoopNavigator.h
+++ b/base/inc/AdePT/LoopNavigator.h
@@ -294,7 +294,7 @@ public:
     VPlacedVolumePtr_t pvol = state.Top();
 
     state.Pop();
-    LocatePointIn(pvol, localpoint, state, false);
+    LocatePointIn(pvol, localpoint, state, false, state.GetLastExited());
 
     if (state.Top() != nullptr) {
       while (state.Top()->IsAssembly()) {


### PR DESCRIPTION
I forgot this in commit 586a9c4391 ("Improve robustness of navigators"): `RelocateToNextVolume()` must exclude the volume that we just exited from to not accidentally re-enter into it.