### PR TITLE
Continue tracking of strongly curling particles

### DIFF
--- a/examples/Example10/electrons.cu
+++ b/examples/Example10/electrons.cu
@@ -82,17 +82,8 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
           currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
           currentTrack.currentState, currentTrack.nextState, propagated);
 
-      if (!propagated) {
-        // error condition from field propagator. Just kill the track here and account for it explicitly.
-        atomicAdd(&scoring->killedInPropagation, 1);
-        // Particles are killed by not enqueuing them into the new activeQueue.
-        continue;
-      }
-
-      if (currentTrack.nextState.IsOnBoundary()) {
-        theTrack->SetGStepLength(geometryStepLength);
-        theTrack->SetOnBoundary(true);
-      }
+      theTrack->SetGStepLength(geometryStepLength);
+      theTrack->SetOnBoundary(currentTrack.nextState.IsOnBoundary());
 
       // Apply continuous effects.
       bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack, nullptr);
@@ -153,6 +144,10 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
         // Cannot continue for now: either the particles left the world, or we
         // need to relocate it to the next volume.
         break;
+      } else if (!propagated) {
+        // Did not yet reach the interaction point due to error in the magnetic
+        // field propagation. Try again next time.
+        continue;
       } else if (winnerProcessIndex < 0) {
         // No discrete process, move on.
         continue;

--- a/examples/Example10/example10.cu
+++ b/examples/Example10/example10.cu
@@ -369,8 +369,6 @@ void example10(const vecgeom::cxx::VPlacedVolume *world, int numParticles, doubl
               << " energy deposition: " << std::setw(10) << stats->scoring.energyDeposit / copcore::units::GeV
               << " number of secondaries: " << std::setw(5) << stats->scoring.secondaries
               << " number of hits: " << std::setw(4) << stats->scoring.hits;
-    if (stats->scoring.killedInPropagation)
-      std::cout << " killed in propagation: " << std::setw(4) << stats->scoring.killedInPropagation;
     std::cout << std::endl;
 
     iterNo++;

--- a/examples/Example10/example10.cuh
+++ b/examples/Example10/example10.cuh
@@ -95,7 +95,6 @@ public:
 struct GlobalScoring {
   int hits;
   int secondaries;
-  int killedInPropagation;
   double energyDeposit;
 };
 

--- a/examples/Example11/example11.cu
+++ b/examples/Example11/example11.cu
@@ -328,8 +328,6 @@ void example11(const vecgeom::cxx::VPlacedVolume *world, int numParticles, doubl
               << " energy deposition: " << std::setw(10) << stats->scoring.energyDeposit / copcore::units::GeV
               << " number of secondaries: " << std::setw(5) << stats->scoring.secondaries
               << " number of hits: " << std::setw(4) << stats->scoring.hits;
-    if (stats->scoring.killedInPropagation)
-      std::cout << " killed in propagation: " << std::setw(4) << stats->scoring.killedInPropagation;
     std::cout << std::endl;
 
     // Check if only charged particles are left that are looping.

--- a/examples/Example11/example11.cuh
+++ b/examples/Example11/example11.cuh
@@ -86,7 +86,6 @@ public:
 struct GlobalScoring {
   int hits;
   int secondaries;
-  int killedInPropagation;
   double energyDeposit;
 };
 

--- a/examples/Example12/electrons.cu
+++ b/examples/Example12/electrons.cu
@@ -97,20 +97,11 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       currentTrack.pos += geometryStepLength * currentTrack.dir;
     }
 
-    if (!propagated) {
-      // error condition from field propagator. Just kill the track here and account for it explicitly.
-      atomicAdd(&globalScoring->killedInPropagation, 1);
-      // Particles are killed by not enqueuing them into the new activeQueue.
-      continue;
-    }
-
     atomicAdd(&globalScoring->chargedSteps, 1);
     atomicAdd(&scoringPerVolume->chargedTrackLength[volumeID], geometryStepLength);
 
-    if (nextState.IsOnBoundary()) {
-      theTrack->SetGStepLength(geometryStepLength);
-      theTrack->SetOnBoundary(true);
-    }
+    theTrack->SetGStepLength(geometryStepLength);
+    theTrack->SetOnBoundary(nextState.IsOnBoundary());
 
     // Apply continuous effects.
     bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack, nullptr);
@@ -167,6 +158,11 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
         // Move to the next boundary.
         currentTrack.navState = nextState;
       }
+      continue;
+    } else if (!propagated) {
+      // Did not yet reach the interaction point due to error in the magnetic
+      // field propagation. Try again next time.
+      activeQueue->push_back(slot);
       continue;
     } else if (winnerProcessIndex < 0) {
       // No discrete process, move on.

--- a/examples/Example12/example12.cpp
+++ b/examples/Example12/example12.cpp
@@ -245,8 +245,6 @@ int main(int argc, char *argv[])
             << "Mean number of charged steps " << ((double)globalScoring.chargedSteps / particles) << "\n"
             << "Mean number of neutral steps " << ((double)globalScoring.neutralSteps / particles) << "\n"
             << "Mean number of hits          " << ((double)globalScoring.hits / particles) << "\n";
-  if (globalScoring.killedInPropagation)
-    std::cout << "Killed in propagation:       " << globalScoring.killedInPropagation << "\n";
   std::cout << std::endl;
 
   // Average charged track length and energy deposit per particle.

--- a/examples/Example12/example12.h
+++ b/examples/Example12/example12.h
@@ -17,7 +17,6 @@ struct GlobalScoring {
   unsigned long long numGammas;
   unsigned long long numElectrons;
   unsigned long long numPositrons;
-  unsigned long long killedInPropagation;
 };
 
 struct ScoringPerVolume {

--- a/examples/Example13/electrons.cu
+++ b/examples/Example13/electrons.cu
@@ -118,13 +118,6 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       currentTrack.pos += geometryStepLength * currentTrack.dir;
     }
 
-    if (!propagated) {
-      // error condition from field propagator. Just kill the track here and account for it explicitly.
-      atomicAdd(&globalScoring->killedInPropagation, 1);
-      // Particles are killed by not enqueuing them into the new activeQueue.
-      continue;
-    }
-
     // Set boundary state in navState so the next step and secondaries get the
     // correct information (currentTrack.navState = nextState only if relocated
     // in case of a boundary; see below)
@@ -233,6 +226,11 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
         // Move to the next boundary.
         currentTrack.navState = nextState;
       }
+      continue;
+    } else if (!propagated) {
+      // Did not yet reach the interaction point due to error in the magnetic
+      // field propagation. Try again next time.
+      activeQueue->push_back(slot);
       continue;
     } else if (winnerProcessIndex < 0) {
       // No discrete process, move on.

--- a/examples/Example13/example13.cpp
+++ b/examples/Example13/example13.cpp
@@ -264,6 +264,9 @@ int main(int argc, char *argv[])
             << "Mean number of charged steps " << ((double)globalScoring.chargedSteps / particles) << "\n"
             << "Mean number of neutral steps " << ((double)globalScoring.neutralSteps / particles) << "\n"
             << "Mean number of hits          " << ((double)globalScoring.hits / particles) << "\n";
+  if (globalScoring.numKilled > 0) {
+    std::cout << "Total killed particles       " << globalScoring.numKilled << "\n";
+  }
   std::cout << std::endl;
 
   // Average charged track length and energy deposit per particle.

--- a/examples/Example13/example13.cpp
+++ b/examples/Example13/example13.cpp
@@ -264,8 +264,6 @@ int main(int argc, char *argv[])
             << "Mean number of charged steps " << ((double)globalScoring.chargedSteps / particles) << "\n"
             << "Mean number of neutral steps " << ((double)globalScoring.neutralSteps / particles) << "\n"
             << "Mean number of hits          " << ((double)globalScoring.hits / particles) << "\n";
-  if (globalScoring.killedInPropagation)
-    std::cout << "Killed in propagation:       " << globalScoring.killedInPropagation << "\n";
   std::cout << std::endl;
 
   // Average charged track length and energy deposit per particle.

--- a/examples/Example13/example13.cu
+++ b/examples/Example13/example13.cu
@@ -262,6 +262,8 @@ void example13(int numParticles, double energy, int batch, const int *MCIndex_ho
     std::cout << "... " << std::flush;
   }
 
+  unsigned long long killed = 0;
+
   for (int startEvent = 1; startEvent <= numParticles; startEvent += batch) {
     if (detailed) {
       std::cout << startEvent << " ... " << std::flush;
@@ -397,6 +399,7 @@ void example13(int numParticles, double energy, int batch, const int *MCIndex_ho
     } while (inFlight > 0 && loopingNo < 200);
 
     if (inFlight > 0) {
+      killed += inFlight;
       for (int i = 0; i < ParticleType::NumParticleTypes; i++) {
         ParticleType &pType   = particles[i];
         int inFlightParticles = stats->inFlight[i];
@@ -416,6 +419,7 @@ void example13(int numParticles, double energy, int batch, const int *MCIndex_ho
 
   // Transfer back scoring.
   COPCORE_CUDA_CHECK(cudaMemcpy(globalScoring_host, globalScoring, sizeof(GlobalScoring), cudaMemcpyDeviceToHost));
+  globalScoring_host->numKilled = killed;
 
   // Transfer back the scoring per volume (charged track length and energy deposit).
   COPCORE_CUDA_CHECK(cudaMemcpy(scoringPerVolume_host->chargedTrackLength, scoringPerVolume_devPtrs.chargedTrackLength,

--- a/examples/Example13/example13.h
+++ b/examples/Example13/example13.h
@@ -17,6 +17,8 @@ struct GlobalScoring {
   unsigned long long numGammas;
   unsigned long long numElectrons;
   unsigned long long numPositrons;
+  // Not used on the device, filled in by the host.
+  unsigned long long numKilled;
 };
 
 struct ScoringPerVolume {

--- a/examples/Example13/example13.h
+++ b/examples/Example13/example13.h
@@ -17,7 +17,6 @@ struct GlobalScoring {
   unsigned long long numGammas;
   unsigned long long numElectrons;
   unsigned long long numPositrons;
-  unsigned long long killedInPropagation;
 };
 
 struct ScoringPerVolume {

--- a/examples/Example14/AdeptIntegration.cpp
+++ b/examples/Example14/AdeptIntegration.cpp
@@ -195,6 +195,7 @@ void AdeptIntegration::Shower(int event)
   evAct->number_gammas    = evAct->number_gammas + fScoring->fGlobalScoring.numGammas;
   evAct->number_electrons = evAct->number_electrons + fScoring->fGlobalScoring.numElectrons;
   evAct->number_positrons = evAct->number_positrons + fScoring->fGlobalScoring.numPositrons;
+  evAct->number_killed    = evAct->number_killed + fScoring->fGlobalScoring.numKilled;
 
   fBuffer.Clear();
   fScoring->ClearGPU();

--- a/examples/Example14/AdeptIntegration.cu
+++ b/examples/Example14/AdeptIntegration.cu
@@ -493,4 +493,5 @@ void AdeptIntegration::ShowerGPU(int event, TrackBuffer &buffer) // const &buffe
 
   // Transfer back scoring.
   fScoring->CopyHitsToHost();
+  fScoring->fGlobalScoring.numKilled = inFlight;
 }

--- a/examples/Example14/BasicScoring.cu
+++ b/examples/Example14/BasicScoring.cu
@@ -106,9 +106,3 @@ __device__ void BasicScoring::AccountProduced(int num_ele, int num_pos, int num_
   atomicAdd(&fGlobalScoring_dev->numPositrons, num_pos);
   atomicAdd(&fGlobalScoring_dev->numGammas, num_gam);
 }
-
-__device__ void BasicScoring::AccountKilled(vecgeom::NavStateIndex const & /*crt_state*/, int /*charge*/,
-                                            double /*energy*/)
-{
-  atomicAdd(&fGlobalScoring_dev->killedInPropagation, 1);
-}

--- a/examples/Example14/BasicScoring.h
+++ b/examples/Example14/BasicScoring.h
@@ -23,12 +23,11 @@ struct GlobalScoring {
   unsigned long long numGammas;
   unsigned long long numElectrons;
   unsigned long long numPositrons;
-  unsigned long long killedInPropagation;
 
   void Print()
   {
-    printf("Global scoring: stpChg=%llu stpNeu=%llu hits=%llu numGam=%llu numEle=%llu numPos=%llu numKilled=%llu\n",
-           chargedSteps, neutralSteps, hits, numGammas, numElectrons, numPositrons, killedInPropagation);
+    printf("Global scoring: stpChg=%llu stpNeu=%llu hits=%llu numGam=%llu numEle=%llu numPos=%llu\n",
+           chargedSteps, neutralSteps, hits, numGammas, numElectrons, numPositrons);
   }
 };
 
@@ -78,9 +77,6 @@ struct BasicScoring {
 
   /// @brief Account for the number of produced secondaries
   __device__ void AccountProduced(int num_ele, int num_pos, int num_gam);
-
-  /// @brief Account for a killed track
-  __device__ void AccountKilled(vecgeom::NavStateIndex const &crt_state, int charge, double energy);
 
   /// @brief Initialize hit data structures on device
   BasicScoring *InitializeOnGPU();

--- a/examples/Example14/BasicScoring.h
+++ b/examples/Example14/BasicScoring.h
@@ -23,11 +23,13 @@ struct GlobalScoring {
   unsigned long long numGammas;
   unsigned long long numElectrons;
   unsigned long long numPositrons;
+  // Not used on the device, filled in by the host.
+  unsigned long long numKilled;
 
   void Print()
   {
-    printf("Global scoring: stpChg=%llu stpNeu=%llu hits=%llu numGam=%llu numEle=%llu numPos=%llu\n",
-           chargedSteps, neutralSteps, hits, numGammas, numElectrons, numPositrons);
+    printf("Global scoring: stpChg=%llu stpNeu=%llu hits=%llu numGam=%llu numEle=%llu numPos=%llu numKilled=%llu\n",
+           chargedSteps, neutralSteps, hits, numGammas, numElectrons, numPositrons, numKilled);
   }
 };
 

--- a/examples/Example14/electrons.cuh
+++ b/examples/Example14/electrons.cuh
@@ -119,13 +119,6 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       currentTrack.pos += geometryStepLength * currentTrack.dir;
     }
 
-    if (!propagated) {
-      // error condition from field propagator. Just kill the track here and account for it explicitly.
-      userScoring->AccountKilled(currentTrack.navState, Charge, currentTrack.energy);
-      // Particles are killed by not enqueuing them into the new activeQueue.
-      continue;
-    }
-
     // Set boundary state in navState so the next step and secondaries get the
     // correct information (currentTrack.navState = nextState only if relocated
     // in case of a boundary; see below)
@@ -244,6 +237,11 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
           currentTrack.pos += kPushOutRegion * currentTrack.dir;
         }
       }
+      continue;
+    } else if (!propagated) {
+      // Did not yet reach the interaction point due to error in the magnetic
+      // field propagation. Try again next time.
+      activeQueue->push_back(slot);
       continue;
     } else if (winnerProcessIndex < 0) {
       // No discrete process, move on.

--- a/examples/Example14/include/EventAction.hh
+++ b/examples/Example14/include/EventAction.hh
@@ -58,6 +58,7 @@ public:
   G4int number_electrons;
   G4int number_positrons;
   G4int number_gammas;
+  G4int number_killed;
 
 private:
   /// Verbosity

--- a/examples/Example14/src/EventAction.cc
+++ b/examples/Example14/src/EventAction.cc
@@ -57,6 +57,7 @@ void EventAction::BeginOfEventAction(const G4Event *)
   number_electrons = 0;
   number_positrons = 0;
   number_gammas    = 0;
+  number_killed    = 0;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -89,6 +90,7 @@ void EventAction::EndOfEventAction(const G4Event *aEvent)
     G4cout << "EndOfEventAction " << eventId << ": electrons " << number_electrons << G4endl;
     G4cout << "EndOfEventAction " << eventId << ": positrons " << number_positrons << G4endl;
     G4cout << "EndOfEventAction " << eventId << ": gammas    " << number_gammas << G4endl;
+    G4cout << "EndOfEventAction " << eventId << ": killed    " << number_killed << G4endl;
   }
 
   for (size_t iHit = 0; iHit < hitsCollection->entries(); iHit++) {

--- a/examples/Example7/TestEm3.h
+++ b/examples/Example7/TestEm3.h
@@ -22,7 +22,6 @@ struct GlobalScoring {
   unsigned long long numGammas;
   unsigned long long numElectrons;
   unsigned long long numPositrons;
-  unsigned long long killedInPropagation;
 };
 
 struct ScoringPerVolume {

--- a/examples/Example9/electrons.cu
+++ b/examples/Example9/electrons.cu
@@ -79,17 +79,8 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
         currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
         currentTrack.navState, nextState, propagated);
 
-    if (!propagated) {
-      // error condition from field propagator. Just kill the track here and account for it explicitly.
-      atomicAdd(&scoring->killedInPropagation, 1);
-      // Particles are killed by not enqueuing them into the new activeQueue.
-      continue;
-    }
-
-    if (nextState.IsOnBoundary()) {
-      theTrack->SetGStepLength(geometryStepLength);
-      theTrack->SetOnBoundary(true);
-    }
+    theTrack->SetGStepLength(geometryStepLength);
+    theTrack->SetOnBoundary(nextState.IsOnBoundary());
 
     // Apply continuous effects.
     bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack, nullptr);
@@ -144,6 +135,11 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
         // Move to the next boundary.
         currentTrack.navState = nextState;
       }
+      continue;
+    } else if (!propagated) {
+      // Did not yet reach the interaction point due to error in the magnetic
+      // field propagation. Try again next time.
+      activeQueue->push_back(slot);
       continue;
     } else if (winnerProcessIndex < 0) {
       // No discrete process, move on.

--- a/examples/Example9/example9.cu
+++ b/examples/Example9/example9.cu
@@ -363,8 +363,6 @@ void example9(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double
               << " energy deposition: " << std::setw(10) << stats->scoring.energyDeposit / copcore::units::GeV
               << " number of secondaries: " << std::setw(5) << stats->scoring.secondaries
               << " number of hits: " << std::setw(4) << stats->scoring.hits;
-    if (stats->scoring.killedInPropagation)
-      std::cout << " killed in propagation: " << std::setw(4) << stats->scoring.killedInPropagation;
     std::cout << std::endl;
 
     // Check if only charged particles are left that are looping.

--- a/examples/Example9/example9.cuh
+++ b/examples/Example9/example9.cuh
@@ -86,7 +86,6 @@ public:
 struct GlobalScoring {
   int hits;
   int secondaries;
-  int killedInPropagation;
   double energyDeposit;
 };
 

--- a/examples/TestEm3/TestEm3.cpp
+++ b/examples/TestEm3/TestEm3.cpp
@@ -237,6 +237,9 @@ int main(int argc, char *argv[])
             << "Mean number of charged steps " << ((double)globalScoring.chargedSteps / particles) << "\n"
             << "Mean number of neutral steps " << ((double)globalScoring.neutralSteps / particles) << "\n"
             << "Mean number of hits          " << ((double)globalScoring.hits / particles) << "\n";
+  if (globalScoring.numKilled > 0) {
+    std::cout << "Total killed particles       " << globalScoring.numKilled << "\n";
+  }
   std::cout << std::endl;
 
   // Average charged track length and energy deposit per particle.

--- a/examples/TestEm3/TestEm3.cpp
+++ b/examples/TestEm3/TestEm3.cpp
@@ -237,8 +237,6 @@ int main(int argc, char *argv[])
             << "Mean number of charged steps " << ((double)globalScoring.chargedSteps / particles) << "\n"
             << "Mean number of neutral steps " << ((double)globalScoring.neutralSteps / particles) << "\n"
             << "Mean number of hits          " << ((double)globalScoring.hits / particles) << "\n";
-  if (globalScoring.killedInPropagation)
-    std::cout << "Killed in propagation:       " << globalScoring.killedInPropagation << "\n";
   std::cout << std::endl;
 
   // Average charged track length and energy deposit per particle.

--- a/examples/TestEm3/TestEm3.cu
+++ b/examples/TestEm3/TestEm3.cu
@@ -282,6 +282,8 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
     std::cout << "... " << std::flush;
   }
 
+  unsigned long long killed = 0;
+
   for (int startEvent = 1; startEvent <= numParticles; startEvent += batch) {
     if (detailed) {
       std::cout << startEvent << " ... " << std::flush;
@@ -400,6 +402,7 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
     } while (inFlight > 0 && loopingNo < 200);
 
     if (inFlight > 0) {
+      killed += inFlight;
       for (int i = 0; i < ParticleType::NumParticleTypes; i++) {
         ParticleType &pType   = particles[i];
         int inFlightParticles = stats->inFlight[i];
@@ -419,6 +422,7 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
 
   // Transfer back scoring.
   COPCORE_CUDA_CHECK(cudaMemcpy(globalScoring_host, globalScoring, sizeof(GlobalScoring), cudaMemcpyDeviceToHost));
+  globalScoring_host->numKilled = killed;
 
   // Transfer back the scoring per volume (charged track length and energy deposit).
   COPCORE_CUDA_CHECK(cudaMemcpy(scoringPerVolume_host->chargedTrackLength, scoringPerVolume_devPtrs.chargedTrackLength,

--- a/examples/TestEm3/TestEm3.h
+++ b/examples/TestEm3/TestEm3.h
@@ -20,7 +20,6 @@ struct GlobalScoring {
   unsigned long long numGammas;
   unsigned long long numElectrons;
   unsigned long long numPositrons;
-  unsigned long long killedInPropagation;
 };
 
 struct ScoringPerVolume {

--- a/examples/TestEm3/TestEm3.h
+++ b/examples/TestEm3/TestEm3.h
@@ -20,6 +20,8 @@ struct GlobalScoring {
   unsigned long long numGammas;
   unsigned long long numElectrons;
   unsigned long long numPositrons;
+  // Not used on the device, filled in by the host.
+  unsigned long long numKilled;
 };
 
 struct ScoringPerVolume {

--- a/examples/TestEm3MT/TestEm3.cpp
+++ b/examples/TestEm3MT/TestEm3.cpp
@@ -238,8 +238,6 @@ int main(int argc, char *argv[])
             << "Mean number of charged steps " << ((double)globalScoring.chargedSteps / particles) << "\n"
             << "Mean number of neutral steps " << ((double)globalScoring.neutralSteps / particles) << "\n"
             << "Mean number of hits          " << ((double)globalScoring.hits / particles) << "\n";
-  if (globalScoring.killedInPropagation)
-    std::cout << "Killed in propagation:       " << globalScoring.killedInPropagation << "\n";
   std::cout << std::endl;
 
   // Average charged track length and energy deposit per particle.

--- a/examples/TestEm3MT/TestEm3.h
+++ b/examples/TestEm3MT/TestEm3.h
@@ -20,7 +20,6 @@ struct GlobalScoring {
   unsigned long long numGammas;
   unsigned long long numElectrons;
   unsigned long long numPositrons;
-  unsigned long long killedInPropagation;
 };
 
 struct ScoringPerVolume {


### PR DESCRIPTION
Before, if a track did not arrive at its interaction point due to an error in field propagation, it was simply killed on the basis that it was likely a low-energetic electron. Instead keep it alive, apply the continuous energy loss up to that intermediate point and enqueue the particle for the next iteration step. In case it doesn't make progress, the track will eventually be killed by the general infrastructure that stops tracking if only electrons are left and no new secondary appeared for 200 steps.

This approach also opens the door for optimizations such as limiting the number of chord steps attempted in one tracking step, imposing a maximum step limit, or only operating within the geometrical safety sphere, if possible. However, experiments indicate that at least the first approach, limiting the number of attempted chord steps, is not effective or even counter-productive for more complex geometry setups such as cms2018, so it is not attempted here.