### PR TITLE
Fix navigation for zero steps

### DIFF
--- a/base/inc/AdePT/BVHNavigator.h
+++ b/base/inc/AdePT/BVHNavigator.h
@@ -87,6 +87,13 @@ private:
                                                          vecgeom::NavStateIndex &out_state,
                                                          VPlacedVolumePtr_t &hitcandidate)
   {
+    if (step_limit <= 0) {
+      // We don't need to ask any solid, this step is not limited by geometry.
+      in_state.CopyTo(&out_state);
+      out_state.SetBoundaryState(false);
+      return 0;
+    }
+
     Precision step          = step_limit;
     VPlacedVolumePtr_t pvol = in_state.Top();
 

--- a/base/inc/AdePT/LoopNavigator.h
+++ b/base/inc/AdePT/LoopNavigator.h
@@ -95,6 +95,13 @@ private:
                                                          vecgeom::NavStateIndex &out_state,
                                                          VPlacedVolumePtr_t &hitcandidate)
   {
+    if (step_limit <= 0) {
+      // We don't need to ask any solid, this step is not limited by geometry.
+      in_state.CopyTo(&out_state);
+      out_state.SetBoundaryState(false);
+      return 0;
+    }
+
     Precision step          = step_limit;
     VPlacedVolumePtr_t pvol = in_state.Top();
 


### PR DESCRIPTION
If `step_limit <= 0`, the step is not limited by geometry and there is no need to ask any solid. In fact, some solids return NaN if passed a `step_max = 0`.