### PR TITLE
Optimize field propagation with safety

### DIFF
--- a/examples/Example13/electrons.cu
+++ b/examples/Example13/electrons.cu
@@ -110,7 +110,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     if (BzFieldValue != 0) {
       geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume<BVHNavigator>(
           currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
-          currentTrack.navState, nextState, propagated);
+          currentTrack.navState, nextState, propagated, safety);
     } else {
       geometryStepLength =
           BVHNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics,

--- a/examples/Example14/electrons.cuh
+++ b/examples/Example14/electrons.cuh
@@ -111,7 +111,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     if (BzFieldValue != 0) {
       geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume<BVHNavigator>(
           currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
-          currentTrack.navState, nextState, propagated);
+          currentTrack.navState, nextState, propagated, safety);
     } else {
       geometryStepLength =
           BVHNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics,

--- a/examples/TestEm3/electrons.cu
+++ b/examples/TestEm3/electrons.cu
@@ -103,7 +103,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     if (BzFieldValue != 0) {
       geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume<BVHNavigator>(
           currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
-          currentTrack.navState, nextState, propagated);
+          currentTrack.navState, nextState, propagated, safety);
     } else {
       geometryStepLength = BVHNavigator::ComputeStepAndNextVolume(
           currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics, currentTrack.navState, nextState);

--- a/examples/TestEm3MT/electrons.cu
+++ b/examples/TestEm3MT/electrons.cu
@@ -103,7 +103,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     if (BzFieldValue != 0) {
       geometryStepLength = fieldPropagatorBz.ComputeStepAndNextVolume<BVHNavigator>(
           currentTrack.energy, Mass, Charge, geometricalStepLengthFromPhysics, currentTrack.pos, currentTrack.dir,
-          currentTrack.navState, nextState, propagated);
+          currentTrack.navState, nextState, propagated, safety);
     } else {
       geometryStepLength = BVHNavigator::ComputeStepAndNextVolume(
           currentTrack.pos, currentTrack.dir, geometricalStepLengthFromPhysics, currentTrack.navState, nextState);

--- a/magneticfield/inc/fieldPropagatorConstBz.h
+++ b/magneticfield/inc/fieldPropagatorConstBz.h
@@ -129,7 +129,17 @@ __host__ __device__ Precision fieldPropagatorConstBz::ComputeStepAndNextVolume(
       if (currentSafety > chordLen) {
         move = chordLen;
       } else {
-        move = Navigator::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state, kPush);
+        Precision newSafety = 0;
+        if (stepDone > 0) {
+          newSafety = Navigator::ComputeSafety(position, current_state);
+        }
+        if (newSafety > chordLen) {
+          move         = chordLen;
+          safetyOrigin = position;
+          safety       = newSafety;
+        } else {
+          move = Navigator::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state, kPush);
+        }
       }
 
       if (move == chordLen) {


### PR DESCRIPTION
Use the safety already available from MSC, and recompute if necessary to avoid querying geometry in multiple chord steps. In combination, the performance improvement for `example13` with `cms2018` and `Bz=1T` is around 27% and more than a factor of 2x for `Bz=3.8T`.

Closes #146