### PR TITLE
Add check for VecGeom being built as static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ project(Adept
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 include(CMakeSettings)
 include(CTest)
-include(CheckCXXSourceCompiles)  
+include(CheckCXXSourceCompiles)
 
 # - Core/C++/CUDA build and dependency settings
 # For single-mode generators, default to Optimized with Debug if nothing is specified
@@ -58,6 +58,12 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${VECGEOM_CXX_FLAGS}")
 # Make sure VecGeom::vgdml is enabled
 if(NOT TARGET VecGeom::vgdml)
   message(FATAL_ERROR "AdePT requires VecGeom compiled with GDML support")
+endif()
+get_property(_vecgeom_lib_type TARGET VecGeom::vecgeom
+  PROPERTY TYPE)
+if(NOT _vecgeom_lib_type STREQUAL "STATIC_LIBRARY")
+  message(SEND_ERROR "AdePT requires VecGeom to be built a static library, but "
+    "it is of type '${_vecgeom_lib_type}'")
 endif()
 
 # Find Geant4, optional for now


### PR DESCRIPTION
@stognini discovered (and @drbenmorgan confirmed) that AdePT requires VecGeom to be built as static to link correctly. This PR adds a small configure-time check to ensure this is the case. If it fails, it prints a message:
```
CMake Error at CMakeLists.txt:65 (message):
  AdePT requires VecGeom to be built a static library, but it is of type
  'SHARED_LIBRARY'
```