### PR TITLE
Support use of VecGeom shared CPU library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,12 +59,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${VECGEOM_CXX_FLAGS}")
 if(NOT TARGET VecGeom::vgdml)
   message(FATAL_ERROR "AdePT requires VecGeom compiled with GDML support")
 endif()
-get_property(_vecgeom_lib_type TARGET VecGeom::vecgeom
-  PROPERTY TYPE)
-if(NOT _vecgeom_lib_type STREQUAL "STATIC_LIBRARY")
-  message(SEND_ERROR "AdePT requires VecGeom to be built a static library, but "
-    "it is of type '${_vecgeom_lib_type}'")
-endif()
 
 # Find Geant4, optional for now
 find_package(Geant4 QUIET)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,8 @@ macro(build_tests TESTS)
   foreach(TEST ${TESTS})
     get_filename_component(TARGET_NAME ${TEST} NAME_WE)
     add_executable(${TARGET_NAME} ${TEST})
-    target_link_libraries(${TARGET_NAME} AdePT VecCore::VecCore VecGeom::vecgeom)
+    set_target_properties(${TARGET_NAME} PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+    target_link_libraries(${TARGET_NAME} AdePT VecCore::VecCore VecGeom::vecgeomcuda_static VecGeom::vecgeom)
    endforeach()
 endmacro()
 
@@ -42,6 +43,3 @@ target_link_libraries(test_launcher VecCore::VecCore CopCore::CopCore)
 
 build_tests("${ADEPT_UNIT_TESTS_BASE}")
 add_to_test("${ADEPT_UNIT_TESTS_BASE}")
-
-# Specific options for test_sparsevector
-set_target_properties(test_sparsevector PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)


### PR DESCRIPTION
Currently AdePT does not build/link correctly if the found VecGeom built its CPU library (`libvecgeom`) as a shared library. Because of the dependency between this and the (separate) CUDA library (`libvecgeomcuda`), consumers of either of these libraries must link to both.

This PR fixes builds in `test` that don't do this. Linking is now to both `VecGeom::vecgeom` and `VecGeom::vecgeomcuda_static` with the consuming target built with separable compilation to handle device linking correctly. The static CUDA library is still used to minimise issues with device linking, though support for shared CUDA libraries should be possible after support is available in VecGeom (see: https://gitlab.cern.ch/VecGeom/VecGeom/-/merge_requests/822).

Pinging @sethrj for info.