### PR TITLE
adding em processes for other particles

### DIFF
--- a/examples/Example14/src/PhysListHepEm.cc
+++ b/examples/Example14/src/PhysListHepEm.cc
@@ -33,6 +33,17 @@
 
 #include "G4SystemOfUnits.hh"
 
+// from G4EmStandardPhysics
+#include "G4GenericIon.hh"
+#include "G4EmModelActivator.hh"
+#include "G4EmBuilder.hh"
+#include "G4hMultipleScattering.hh"
+#include "G4hIonisation.hh"
+#include "G4ionIonisation.hh"
+#include "G4NuclearStopping.hh"
+
+
+
 PhysListHepEm::PhysListHepEm(const G4String &name) : G4VPhysicsConstructor(name)
 {
   G4EmParameters *param = G4EmParameters::Instance();
@@ -50,7 +61,25 @@ PhysListHepEm::~PhysListHepEm() {}
 
 void PhysListHepEm::ConstructProcess()
 {
+
   G4PhysicsListHelper *ph = G4PhysicsListHelper::GetPhysicsListHelper();
+
+  // from G4EmStandardPhysics
+  G4EmBuilder::PrepareEMPhysics();
+
+  G4EmParameters* param = G4EmParameters::Instance();
+
+  // processes used by several particles
+  G4hMultipleScattering* hmsc = new G4hMultipleScattering("ionmsc");
+
+  // nuclear stopping is enabled if th eenergy limit above zero
+  G4double nielEnergyLimit = param->MaxNIELEnergy();
+  G4NuclearStopping* pnuc = nullptr;
+  if(nielEnergyLimit > 0.0) {
+    pnuc = new G4NuclearStopping();
+    pnuc->SetMaxKinEnergy(nielEnergyLimit);
+  }
+  // end of G4EmStandardPhysics
 
   // creae the only one G4HepEm process that will be assigned to e-/e+ and gamma
   G4HepEmProcess *hepEmProcess = new G4HepEmProcess();
@@ -80,4 +109,21 @@ void PhysListHepEm::ConstructProcess()
       particle->GetProcessManager()->AddProcess(hepEmProcess, -1, -1, 1);
     }
   }
+
+  // from G4EmStandardPhysics
+
+  // generic ion
+  G4ParticleDefinition* particle = G4GenericIon::GenericIon();
+  G4ionIonisation* ionIoni = new G4ionIonisation();
+  ph->RegisterProcess(hmsc, particle);
+  ph->RegisterProcess(ionIoni, particle);
+  if(nullptr != pnuc) { ph->RegisterProcess(pnuc, particle); }
+
+  // muons, hadrons ions
+  G4EmBuilder::ConstructCharged(hmsc, pnuc);
+
+  // extra configuration
+  G4EmModelActivator mact(GetPhysicsName());
+
+  //end of G4EmStandardPhysics
 }


### PR DESCRIPTION
We now have EM processes for other then e+, e-, gamma particles as in FTFP_BERT (so standard EM). The EM physics for e+, e-, gamma is provided by G4HepEm.
