### PR TITLE
Fix for assigning sensitive reflected volumes in Example14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ find_package(VecCore ${VecCore_VERSION} REQUIRED COMPONENTS ${VecCore_BACKEND})
 message(STATUS "Using VecCore version ${VecCore_VERSION}")
 
 # Find VecGeom geometry headers library
-set(VecGeom_VERSION 1.1.17)
+set(VecGeom_VERSION 1.1.20)
 find_package(VecGeom ${VecGeom_VERSION} REQUIRED)
 message(STATUS "Using VecGeom version ${VecGeom_VERSION}")
 # make sure we import VecGeom architecture flags - is this needed?

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following packages are a required to build and run:
 - C/C++ Compiler with C++14 support
 - CUDA Toolkit (tested 10.1, min version TBD)
 - VecCore [library](https://github.com/root-project/veccore) 0.7.0 (recommended, but older versions >= 0.5.0 also work)
-- VecGeom [library](https://gitlab.cern.ch/VecGeom/VecGeom) >= 1.1.17
+- VecGeom [library](https://gitlab.cern.ch/VecGeom/VecGeom) >= 1.1.20
 
 To configure and build VecCore, simply run:
 ```console

--- a/examples/Example14/AdeptIntegration.cu
+++ b/examples/Example14/AdeptIntegration.cu
@@ -46,6 +46,7 @@ __constant__ __device__ int Zero = 0;
 
 G4HepEmState *AdeptIntegration::fg4hepem_state{nullptr};
 SlotManager *slotManagerInit_dev = nullptr;
+int AdeptIntegration::kCapacity = 1024 * 1024;
 
 void AdeptIntegration::VolAuxArray::InitializeOnGPU()
 {
@@ -254,7 +255,7 @@ void AdeptIntegration::InitializeGPU()
   //  * objects to manage slots inside the memory,
   //  * queues of slots to remember active particle and those needing relocation,
   //  * a stream and an event for synchronization of kernels.
-  constexpr size_t TracksSize  = sizeof(Track) * kCapacity;
+  size_t TracksSize            = sizeof(Track) * kCapacity;
   constexpr size_t ManagerSize = sizeof(SlotManager);
   const size_t QueueSize       = adept::MParray::SizeOfInstance(kCapacity);
   // Create a stream to synchronize kernels of all particle types.

--- a/examples/Example14/AdeptIntegration.h
+++ b/examples/Example14/AdeptIntegration.h
@@ -32,7 +32,7 @@ class AdeptIntegration {
 public:
   static constexpr int kMaxThreads = 256;
   // Track capacity
-  static constexpr int kCapacity = 1024 * 1024;
+  static int kCapacity;
 
   using TrackBuffer = adeptint::TrackBuffer;
   using VolAuxData  = adeptint::VolAuxData;
@@ -92,6 +92,8 @@ public:
 
   /// @brief Adds a track to the buffer
   void AddTrack(int pdg, double energy, double x, double y, double z, double dirx, double diry, double dirz);
+  /// @brief Set track capacity on GPU
+  static void SetTrackCapacity(size_t capacity) { kCapacity = capacity; }
   /// @brief Set maximum batch size
   void SetMaxBatch(int npart) { fMaxBatch = npart; }
   /// @brief Set buffer threshold

--- a/examples/Example14/include/DetectorConstruction.hh
+++ b/examples/Example14/include/DetectorConstruction.hh
@@ -61,9 +61,13 @@ public:
   // Set AdePT buffer threshold
   void SetBufferThreshold(int value) { fBufferThreshold = value; }
 
+  // Set total number of track slots on GPU
+  void SetTrackSlots(int value) { fTrackSlotsGPU = value; }
+
 private:
   int fVerbosity{0};        ///< Actually verbosity for AdePT integration
   int fBufferThreshold{20}; ///< Buffer threshold for AdePT transport
+  int fTrackSlotsGPU{8};    ///< Total number of track slots allocated on GPU (millions)
   G4String fGDML_file;
   G4String fRegion_name;
   std::vector<G4String> fSensitive_volumes;

--- a/examples/Example14/include/DetectorMessenger.hh
+++ b/examples/Example14/include/DetectorMessenger.hh
@@ -55,7 +55,8 @@ private:
   G4UIcmdWithAnInteger *fVerbosityCmd = nullptr;
   /// Buffer threshold for injecting into AdePT
   G4UIcmdWithAnInteger *fBufferThresholdCmd = nullptr;
-  //
+  /// Total number of track slots for the gpu
+  G4UIcmdWithAnInteger *fTrackSlotsCmd = nullptr;
 };
 
 #endif

--- a/examples/Example14/include/EMShowerModel.hh
+++ b/examples/Example14/include/EMShowerModel.hh
@@ -87,6 +87,8 @@ public:
 
   void SetScoringMap(std::unordered_map<const G4VPhysicalVolume *, int> *sm) { fScoringMap = sm; }
 
+  // Set total number of track slots on GPU
+  void SetTrackSlots(int value) { fTrackSlotsGPU = value; }
 private:
   /// Messenger for configuration
   EMShowerMessenger *fMessenger;
@@ -106,6 +108,7 @@ private:
   G4double ProductionCut = 0.7 * copcore::units::mm;
 
   int MCIndex[100];
+  int fTrackSlotsGPU{8};     ///< Total number of track slots allocated on GPU (in millions)
   std::unordered_map<std::string, int> *sensitive_volume_index;
   std::unordered_map<const G4VPhysicalVolume *, int> *fScoringMap;
 };

--- a/examples/Example14/macros/example14.mac.in
+++ b/examples/Example14/macros/example14.mac.in
@@ -7,7 +7,7 @@
 ## Geant4 macro for modelling simplified sampling calorimeters
 ## =============================================================================
 ##
-/run/numberOfThreads 1
+/run/numberOfThreads 8
 /control/verbose 0
 /run/verbose 0
 /process/verbose 0
@@ -16,7 +16,10 @@
 /example14/detector/filename @CMS2018_GDML@
 /example14/detector/regionname EcalRegion
 /example14/adept/verbose 0
-/example14/adept/threshold 50
+## Threshold for buffering tracks before sending to GPU
+/example14/adept/threshold 200
+## Total number of GPU track slots (not per thread)
+/example14/adept/milliontrackslots 8
 
 /example14/detector/addsensitivevolume EAPD_01
 /example14/detector/addsensitivevolume EAPD_02
@@ -101,7 +104,7 @@
 /example14/gun/setDefault
 /gun/particle e-
 /gun/energy 10 GeV
-/gun/number 100
+/gun/number 200
 /gun/position 0 0 0
 #/example14/gun/print
 
@@ -116,9 +119,9 @@
 # by default all created models are active
 /param/ActivateModel AdePT
 #/analysis/setFileName example14_fastsim_100events.root
-/run/beamOn 1
+/run/beamOn 8
 
 # run events with full (detailed) simulation
 /param/InActivateModel AdePT
 #/analysis/setFileName example14_fullsim_100events.root
-/run/beamOn 1
+/run/beamOn 8

--- a/examples/Example14/src/DetectorConstruction.cc
+++ b/examples/Example14/src/DetectorConstruction.cc
@@ -145,8 +145,14 @@ void DetectorConstruction::ConstructSDandField()
     G4cout << "Making " << name << " sensitive with index " << index << G4endl;
     caloSD->fSensitive_volume_index[name] = index;
     index++;
+    // iterate G4LogicalVolumeStore and set sensitive volumes
+    auto const &store = *G4LogicalVolumeStore::GetInstance();
+    for (auto lvol : store) {
+      if (lvol->GetName().rfind(name) == 0)
+        SetSensitiveDetector(lvol, caloSD);
+    }
 
-    SetSensitiveDetector(G4LogicalVolumeStore::GetInstance()->GetVolume(name), caloSD);
+    //SetSensitiveDetector(G4LogicalVolumeStore::GetInstance()->GetVolume(name), caloSD);
   }
 
   auto detectorRegion = G4RegionStore::GetInstance()->GetRegion(fRegion_name);

--- a/examples/Example14/src/DetectorConstruction.cc
+++ b/examples/Example14/src/DetectorConstruction.cc
@@ -162,7 +162,8 @@ void DetectorConstruction::ConstructSDandField()
   fShowerModel->SetScoringMap(&gScoringMap);
   fShowerModel->SetVerbosity(fVerbosity);
   fShowerModel->SetBufferThreshold(fBufferThreshold);
-
+  fShowerModel->SetTrackSlots(fTrackSlotsGPU);
+  
   try {
     fShowerModel->Initialize(fActivate_AdePT);
   } catch (const std::runtime_error &ex) {

--- a/examples/Example14/src/DetectorMessenger.cc
+++ b/examples/Example14/src/DetectorMessenger.cc
@@ -45,6 +45,9 @@ DetectorMessenger::DetectorMessenger(DetectorConstruction *aDetector) : G4UImess
   fBufferThresholdCmd = new G4UIcmdWithAnInteger("/example14/adept/threshold", this);
   fBufferThresholdCmd->SetGuidance("Threshold for starting AdePT transport");
 
+  fTrackSlotsCmd = new G4UIcmdWithAnInteger("/example14/adept/milliontrackslots", this);
+  fTrackSlotsCmd->SetGuidance("Total number of allocated track slots per GPU");
+
   fFieldCmd = new G4UIcmdWith3VectorAndUnit("/example14/detector/setField", this);
   fFieldCmd->SetGuidance("Set the constant magenetic field vector.");
   fFieldCmd->SetUnitCategory("Magnetic flux density");
@@ -67,6 +70,7 @@ DetectorMessenger::~DetectorMessenger()
   delete fActivationCmd;
   delete fVerbosityCmd;
   delete fBufferThresholdCmd;
+  delete fTrackSlotsCmd;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -89,5 +93,7 @@ void DetectorMessenger::SetNewValue(G4UIcommand *aCommand, G4String aNewValue)
     fDetector->SetVerbosity(fVerbosityCmd->GetNewIntValue(aNewValue));
   } else if (aCommand == fBufferThresholdCmd) {
     fDetector->SetBufferThreshold(fBufferThresholdCmd->GetNewIntValue(aNewValue));
+  } else if (aCommand == fTrackSlotsCmd) {
+    fDetector->SetTrackSlots(fTrackSlotsCmd->GetNewIntValue(aNewValue));
   }
 }

--- a/examples/Example14/src/EMShowerModel.cc
+++ b/examples/Example14/src/EMShowerModel.cc
@@ -120,7 +120,10 @@ void EMShowerModel::Initialize(bool adept)
   auto tid = G4Threading::G4GetThreadId();
   if (tid < 0) {
     // This is supposed to set the max batching for Adept to allocate properly the memory
-    fAdept->Initialize(true /*common_data*/);
+     int num_threads = G4RunManager::GetRunManager()->GetNumberOfThreads();
+     int capacity = 1024 * 1024 * fTrackSlotsGPU / num_threads;
+     AdeptIntegration::SetTrackCapacity(capacity);
+     fAdept->Initialize(true /*common_data*/);
     if (sequential && adept) fAdept->Initialize();
   } else {
     if (adept) fAdept->Initialize();

--- a/examples/Example14/src/EventAction.cc
+++ b/examples/Example14/src/EventAction.cc
@@ -99,7 +99,7 @@ void EventAction::EndOfEventAction(const G4Event *aEvent)
 
     const char *vol_name = vecgeom::GeoManager::Instance().FindPlacedVolume(iHit)->GetLogicalVolume()->GetName();
     const char *type     = (hit->GetType() == 1) ? "AdePT" : "G4";
-    if (hitEn && fVerbosity > 1)
+    if (hitEn > 1 && fVerbosity > 1)
       G4cout << "EndOfEventAction " << eventId << " : id " << std::setw(5) << iHit << "  edep " << std::setprecision(2)
              << std::setw(12) << std::fixed << hitEn / MeV << " [MeV] logical " << vol_name << G4endl;
 


### PR DESCRIPTION
In addition, this adds a thorough check for local transformation consistency, comparing each local transformation while crawling in parallel through the Geant4 and VecGeom volume hierarchies. The check is done for both translation  and rotation elements, with a tolerance of 1e-8;

This can only be merged after merging VecGeom [#884](https://gitlab.cern.ch/VecGeom/VecGeom/-/merge_requests/884) and bumping the VecGeom tag (to be added in this PR) 