### PR TITLE
Added sensitivegroup command allowing to group scoring by name prefix.

### DIFF
--- a/examples/Example14/include/DetectorConstruction.hh
+++ b/examples/Example14/include/DetectorConstruction.hh
@@ -44,6 +44,7 @@ public:
   void SetGDMLFile(G4String &file) { fGDML_file = file; }
   void SetRegionName(G4String &reg) { fRegion_name = reg; }
   void AddSensitiveVolume(G4String volume) { fSensitive_volumes.push_back(volume); }
+  void AddSensitiveGroup(G4String group) { fSensitive_group.push_back(group); }
 
   // Set uniform magnetic field
   inline void SetMagField(const G4ThreeVector &fv) { fMagFieldVector = fv; }
@@ -64,6 +65,8 @@ public:
   // Set total number of track slots on GPU
   void SetTrackSlots(int value) { fTrackSlotsGPU = value; }
 
+  std::vector<G4String> &GetSensitiveGroups() { return fSensitive_group; }
+
 private:
   int fVerbosity{0};        ///< Actually verbosity for AdePT integration
   int fBufferThreshold{20}; ///< Buffer threshold for AdePT transport
@@ -71,6 +74,7 @@ private:
   G4String fGDML_file;
   G4String fRegion_name;
   std::vector<G4String> fSensitive_volumes;
+  std::vector<G4String> fSensitive_group;
   bool fActivate_AdePT{true};
 
   /// Messenger that allows to modify geometry

--- a/examples/Example14/include/DetectorMessenger.hh
+++ b/examples/Example14/include/DetectorMessenger.hh
@@ -47,6 +47,7 @@ private:
   G4UIcmdWithAString *fFileNameCmd    = nullptr;
   G4UIcmdWithAString *fRegionNameCmd  = nullptr;
   G4UIcmdWithAString *fSensVolNameCmd = nullptr;
+  G4UIcmdWithAString *fSensVolGroupCmd  = nullptr;
 
   G4UIcmdWith3VectorAndUnit *fFieldCmd = nullptr;
   /// Activation of AdePT

--- a/examples/Example14/include/EventAction.hh
+++ b/examples/Example14/include/EventAction.hh
@@ -61,6 +61,8 @@ public:
   G4int number_killed;
 
 private:
+  /// Detector construction
+  DetectorConstruction *fDetector{nullptr};
   /// Verbosity
   G4int fVerbosity{0};
   /// ID of a hit collection to analyse

--- a/examples/Example14/macros/example14.mac.in
+++ b/examples/Example14/macros/example14.mac.in
@@ -7,7 +7,7 @@
 ## Geant4 macro for modelling simplified sampling calorimeters
 ## =============================================================================
 ##
-/run/numberOfThreads 8
+/run/numberOfThreads 1
 /control/verbose 0
 /run/verbose 0
 /process/verbose 0
@@ -19,7 +19,7 @@
 ## Threshold for buffering tracks before sending to GPU
 /example14/adept/threshold 200
 ## Total number of GPU track slots (not per thread)
-/example14/adept/milliontrackslots 8
+/example14/adept/milliontrackslots 1
 
 /example14/detector/addsensitivevolume EAPD_01
 /example14/detector/addsensitivevolume EAPD_02
@@ -39,6 +39,8 @@
 /example14/detector/addsensitivevolume EAPD_16
 /example14/detector/addsensitivevolume EAPD_17
 
+/example14/detector/sensitivegroup EAPD
+
 /example14/detector/addsensitivevolume EBRY_01
 /example14/detector/addsensitivevolume EBRY_02
 /example14/detector/addsensitivevolume EBRY_03
@@ -56,6 +58,24 @@
 /example14/detector/addsensitivevolume EBRY_15
 /example14/detector/addsensitivevolume EBRY_16
 /example14/detector/addsensitivevolume EBRY_17
+
+/example14/detector/sensitivegroup EBRY_01
+/example14/detector/sensitivegroup EBRY_02
+/example14/detector/sensitivegroup EBRY_03
+/example14/detector/sensitivegroup EBRY_04
+/example14/detector/sensitivegroup EBRY_05
+/example14/detector/sensitivegroup EBRY_06
+/example14/detector/sensitivegroup EBRY_07
+/example14/detector/sensitivegroup EBRY_08
+/example14/detector/sensitivegroup EBRY_09
+/example14/detector/sensitivegroup EBRY_10
+/example14/detector/sensitivegroup EBRY_11
+/example14/detector/sensitivegroup EBRY_12
+/example14/detector/sensitivegroup EBRY_13
+/example14/detector/sensitivegroup EBRY_14
+/example14/detector/sensitivegroup EBRY_15
+/example14/detector/sensitivegroup EBRY_16
+/example14/detector/sensitivegroup EBRY_17
 
 /example14/detector/addsensitivevolume EATJ_01
 /example14/detector/addsensitivevolume EATJ_02
@@ -75,12 +95,17 @@
 /example14/detector/addsensitivevolume EATJ_16
 /example14/detector/addsensitivevolume EATJ_17
 
+/example14/detector/sensitivegroup EATJ
+
 /example14/detector/addsensitivevolume EFRY
+
+/example14/detector/sensitivegroup EFRY
 
 ## -----------------------------------------------------------------------------
 ## Optionally, set a constant magnetic filed:
 ## -----------------------------------------------------------------------------
-/example14/detector/setField 0 0 3.8 tesla
+#/example14/detector/setField 0 0 3.8 tesla
+/example14/detector/setField 0 0 0 tesla
 
 ##
 ## -----------------------------------------------------------------------------
@@ -99,7 +124,7 @@
 /run/initialize
 
 ## Event verbosity: 1 = total edep, 2 = energy deposit per placed sensitive volume
-/example14/event/verbose 0
+/example14/event/verbose 2
 
 /example14/gun/setDefault
 /gun/particle e-
@@ -119,9 +144,9 @@
 # by default all created models are active
 /param/ActivateModel AdePT
 #/analysis/setFileName example14_fastsim_100events.root
-/run/beamOn 8
+/run/beamOn 1
 
 # run events with full (detailed) simulation
 /param/InActivateModel AdePT
 #/analysis/setFileName example14_fullsim_100events.root
-/run/beamOn 8
+/run/beamOn 1

--- a/examples/Example14/src/DetectorMessenger.cc
+++ b/examples/Example14/src/DetectorMessenger.cc
@@ -36,6 +36,9 @@ DetectorMessenger::DetectorMessenger(DetectorConstruction *aDetector) : G4UImess
   fSensVolNameCmd = new G4UIcmdWithAString("/example14/detector/addsensitivevolume", this);
   fSensVolNameCmd->SetGuidance("Add a sensitive volume to the list");
   //
+  fSensVolGroupCmd = new G4UIcmdWithAString("/example14/detector/sensitivegroup", this);
+  fSensVolGroupCmd->SetGuidance("Define a wildcard for a sensitive volumes group");
+  //
   fActivationCmd = new G4UIcmdWithABool("/example14/adept/activate", this);
   fActivationCmd->SetGuidance("(Activate AdePT");
   //
@@ -65,6 +68,7 @@ DetectorMessenger::~DetectorMessenger()
   delete fAdeptDir;
   delete fFieldCmd;
   delete fSensVolNameCmd;
+  delete fSensVolGroupCmd;
   delete fRegionNameCmd;
   delete fFileNameCmd;
   delete fActivationCmd;
@@ -87,6 +91,8 @@ void DetectorMessenger::SetNewValue(G4UIcommand *aCommand, G4String aNewValue)
     fDetector->SetMagField(fFieldCmd->GetNew3VectorValue(aNewValue));
   } else if (aCommand == fSensVolNameCmd) {
     fDetector->AddSensitiveVolume(aNewValue);
+  } else if (aCommand == fSensVolGroupCmd) {
+    fDetector->AddSensitiveGroup(aNewValue);
   } else if (aCommand == fActivationCmd) {
     fDetector->SetActivateAdePT(fActivationCmd->GetNewBoolValue(aNewValue));
   } else if (aCommand == fVerbosityCmd) {

--- a/examples/Example14/src/EMShowerModel.cc
+++ b/examples/Example14/src/EMShowerModel.cc
@@ -113,7 +113,6 @@ void EMShowerModel::Initialize(bool adept)
   bool sequential             = (rmType == G4RunManager::sequentialRM);
 
   fAdept->SetSensitiveVolumes(sensitive_volume_index);
-  printf("setting adept scoring map: %p\n", fScoringMap);
   fAdept->SetScoringMap(fScoringMap);
   fAdept->SetRegion(fRegion);
 

--- a/examples/Example14/src/EventAction.cc
+++ b/examples/Example14/src/EventAction.cc
@@ -38,7 +38,7 @@
 #include "G4GlobalFastSimulationManager.hh"
 #include "AdeptIntegration.h"
 
-EventAction::EventAction(DetectorConstruction *aDetector) : G4UserEventAction(), fHitCollectionID(-1), fTimer()
+EventAction::EventAction(DetectorConstruction *aDetector) : G4UserEventAction(), fDetector(aDetector), fHitCollectionID(-1), fTimer()
 {
   fMessenger = new EventActionMessenger(this);
 }
@@ -93,22 +93,43 @@ void EventAction::EndOfEventAction(const G4Event *aEvent)
     G4cout << "EndOfEventAction " << eventId << ": killed    " << number_killed << G4endl;
   }
 
+  auto &groups = fDetector->GetSensitiveGroups();
+  int ngroups = groups.size();
+  double *edep_groups = nullptr;
+  if (ngroups > 0) edep_groups = new double[ngroups];
+  for (auto i = 0; i< ngroups; ++i) edep_groups[i] = 0;
+
   for (size_t iHit = 0; iHit < hitsCollection->entries(); iHit++) {
     hit   = static_cast<SimpleHit *>(hitsCollection->GetHit(iHit));
     hitEn = hit->GetEdep();
+    totalEnergy += hitEn;
 
-    const char *vol_name = vecgeom::GeoManager::Instance().FindPlacedVolume(iHit)->GetLogicalVolume()->GetName();
+    G4String vol_name = vecgeom::GeoManager::Instance().FindPlacedVolume(iHit)->GetLogicalVolume()->GetName();
+    bool group_found = false;
+    for (int igroup = 0; igroup < ngroups; ++igroup) {
+      if (vol_name.rfind(groups[igroup], 0) == 0) {
+        edep_groups[igroup] += hitEn;
+        group_found = true;
+        break;
+      }
+    }
+    if (group_found) continue;
     const char *type     = (hit->GetType() == 1) ? "AdePT" : "G4";
     if (hitEn > 1 && fVerbosity > 1)
       G4cout << "EndOfEventAction " << eventId << " : id " << std::setw(5) << iHit << "  edep " << std::setprecision(2)
              << std::setw(12) << std::fixed << hitEn / MeV << " [MeV] logical " << vol_name << G4endl;
 
-    if (hitEn > 0) {
-      totalEnergy += hitEn;
+  }
+
+  if (fVerbosity > 1) {
+    for (int igroup = 0; igroup < ngroups; ++igroup) {
+      G4cout << "EndOfEventAction " << eventId << " : group " << std::setw(5) << groups[igroup] << "  edep " << std::setprecision(2)
+             << std::setw(12) << std::fixed << edep_groups[igroup] / MeV << " [MeV]\n";
     }
   }
 
   if (fVerbosity > 0) {
     G4cout << "EndOfEventAction " << eventId << "Total energy deposited: " << totalEnergy / MeV << " MeV" << G4endl;
   }
+  delete [] edep_groups;
 }

--- a/examples/Example17/CMakeLists.txt
+++ b/examples/Example17/CMakeLists.txt
@@ -83,14 +83,16 @@ set_target_properties(example17 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RE
 set(TESTEM3_GDML ${CMAKE_BINARY_DIR}/testEm3.gdml)
 set(LHCB_GDML ${CMAKE_BINARY_DIR}/LHCb_Upgrade_fullLHCb.gdml)
 configure_file("macros/testEm3.gdml" "${CMAKE_BINARY_DIR}/testEm3.gdml")
-configure_file("macros/testEm3.mac.in" "${CMAKE_BINARY_DIR}/testEm3_compact.mac")
-configure_file("macros/testEm3G4.mac.in" "${CMAKE_BINARY_DIR}/testEm3G4_compact.mac")
-configure_file("macros/example17.mac.in" "${CMAKE_BINARY_DIR}/example17_compact.mac")
+configure_file("macros/testEm3.mac.in" "${CMAKE_BINARY_DIR}/testEm3_e17.mac")
+configure_file("macros/testEm3G4.mac.in" "${CMAKE_BINARY_DIR}/testEm3G4_e17.mac")
+configure_file("macros/example17.mac.in" "${CMAKE_BINARY_DIR}/example17.mac")
+configure_file("macros/example17_validation.mac.in" "${CMAKE_BINARY_DIR}/example17_validation.mac")
 configure_file("macros/LHCb_Upgrade_fullLHCb.gdml" "${CMAKE_BINARY_DIR}/LHCb_Upgrade_fullLHCb.gdml")
-configure_file("macros/lhcb.mac.in" "${CMAKE_BINARY_DIR}/lhcb_compact.mac")
+configure_file("macros/lhcb.mac.in" "${CMAKE_BINARY_DIR}/lhcb_e17.mac")
+configure_file("macros/lhcb_validation.mac.in" "${CMAKE_BINARY_DIR}/lhcb_validation.mac")
 
 # Tests
 add_test(NAME example17-adept-em3
-  COMMAND $<TARGET_FILE:example17> -m ${CMAKE_BINARY_DIR}/testEm3_compact.mac)
+  COMMAND $<TARGET_FILE:example17> -m ${CMAKE_BINARY_DIR}/testEm3_e17.mac)
 add_test(NAME example17-g4-em3
-  COMMAND $<TARGET_FILE:example17> -m ${CMAKE_BINARY_DIR}/testEm3G4_compact.mac)
+  COMMAND $<TARGET_FILE:example17> -m ${CMAKE_BINARY_DIR}/testEm3G4_e17.mac)

--- a/examples/Example17/include/DetectorConstruction.hh
+++ b/examples/Example17/include/DetectorConstruction.hh
@@ -44,6 +44,7 @@ public:
   void SetGDMLFile(G4String &file) { fGDML_file = file; }
   void SetRegionName(G4String &reg) { fRegion_name = reg; }
   void AddSensitiveVolume(G4String volume) { fSensitive_volumes.push_back(volume); }
+  void AddSensitiveGroup(G4String group) { fSensitive_group.push_back(group); }
 
   // Set uniform magnetic field
   inline void SetMagField(const G4ThreeVector &fv) { fMagFieldVector = fv; }
@@ -64,6 +65,8 @@ public:
   // Set total number of track slots on GPU
   void SetTrackSlots(int value) { fTrackSlotsGPU = value; }
 
+  std::vector<G4String> &GetSensitiveGroups() { return fSensitive_group; }
+
 private:
   int fVerbosity{0};        ///< Actually verbosity for AdePT integration
   int fBufferThreshold{20}; ///< Buffer threshold for AdePT transport
@@ -71,6 +74,7 @@ private:
   G4String fGDML_file;
   G4String fRegion_name;
   std::vector<G4String> fSensitive_volumes;
+  std::vector<G4String> fSensitive_group;
   bool fActivate_AdePT{true};
 
   /// Messenger that allows to modify geometry

--- a/examples/Example17/include/DetectorMessenger.hh
+++ b/examples/Example17/include/DetectorMessenger.hh
@@ -47,6 +47,7 @@ private:
   G4UIcmdWithAString *fFileNameCmd    = nullptr;
   G4UIcmdWithAString *fRegionNameCmd  = nullptr;
   G4UIcmdWithAString *fSensVolNameCmd = nullptr;
+  G4UIcmdWithAString *fSensVolGroupCmd  = nullptr;
 
   G4UIcmdWith3VectorAndUnit *fFieldCmd = nullptr;
   /// Activation of AdePT

--- a/examples/Example17/include/EventAction.hh
+++ b/examples/Example17/include/EventAction.hh
@@ -61,6 +61,8 @@ public:
   G4int number_killed;
 
 private:
+  /// Detector construction
+  DetectorConstruction *fDetector{nullptr};
   /// Verbosity
   G4int fVerbosity{0};
   /// ID of a hit collection to analyse

--- a/examples/Example17/macros/example17.mac.in
+++ b/examples/Example17/macros/example17.mac.in
@@ -39,6 +39,8 @@
 /example17/detector/addsensitivevolume EAPD_16
 /example17/detector/addsensitivevolume EAPD_17
 
+/example17/detector/sensitivegroup EAPD
+
 /example17/detector/addsensitivevolume EBRY_01
 /example17/detector/addsensitivevolume EBRY_02
 /example17/detector/addsensitivevolume EBRY_03
@@ -56,6 +58,24 @@
 /example17/detector/addsensitivevolume EBRY_15
 /example17/detector/addsensitivevolume EBRY_16
 /example17/detector/addsensitivevolume EBRY_17
+
+/example17/detector/sensitivegroup EBRY_01
+/example17/detector/sensitivegroup EBRY_02
+/example17/detector/sensitivegroup EBRY_03
+/example17/detector/sensitivegroup EBRY_04
+/example17/detector/sensitivegroup EBRY_05
+/example17/detector/sensitivegroup EBRY_06
+/example17/detector/sensitivegroup EBRY_07
+/example17/detector/sensitivegroup EBRY_08
+/example17/detector/sensitivegroup EBRY_09
+/example17/detector/sensitivegroup EBRY_10
+/example17/detector/sensitivegroup EBRY_11
+/example17/detector/sensitivegroup EBRY_12
+/example17/detector/sensitivegroup EBRY_13
+/example17/detector/sensitivegroup EBRY_14
+/example17/detector/sensitivegroup EBRY_15
+/example17/detector/sensitivegroup EBRY_16
+/example17/detector/sensitivegroup EBRY_17
 
 /example17/detector/addsensitivevolume EATJ_01
 /example17/detector/addsensitivevolume EATJ_02
@@ -75,12 +95,17 @@
 /example17/detector/addsensitivevolume EATJ_16
 /example17/detector/addsensitivevolume EATJ_17
 
+/example17/detector/sensitivegroup EATJ
+
 /example17/detector/addsensitivevolume EFRY
+
+/example17/detector/sensitivegroup EFRY
 
 ## -----------------------------------------------------------------------------
 ## Optionally, set a constant magnetic filed:
 ## -----------------------------------------------------------------------------
-/example17/detector/setField 0 0 3.8 tesla
+/example17/detector/setField 0 0 0 tesla
+#/example17/detector/setField 0 0 3.8 tesla
 
 ##
 ## -----------------------------------------------------------------------------
@@ -99,7 +124,7 @@
 /run/initialize
 
 ## Event verbosity: 1 = total edep, 2 = energy deposit per placed sensitive volume
-/example17/event/verbose 0
+/example17/event/verbose 2
 
 /example17/gun/setDefault
 /gun/particle e-

--- a/examples/Example17/macros/example17_validation.mac.in
+++ b/examples/Example17/macros/example17_validation.mac.in
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: 2022 CERN
+# SPDX-License-Identifier: Apache-2.0
+#  example17.in
+#
+
+## =============================================================================
+## Geant4 macro for modelling simplified sampling calorimeters
+## =============================================================================
+##
+/run/numberOfThreads 1
+/control/verbose 0
+/run/verbose 0
+/process/verbose 0
+/tracking/verbose 0
+##
+/example17/detector/filename @CMS2018_GDML@
+/example17/detector/regionname EcalRegion
+/example17/adept/verbose 0
+## Threshold for buffering tracks before sending to GPU
+/example17/adept/threshold 500
+## Total number of GPU track slots (not per thread)
+/example17/adept/milliontrackslots 4
+
+/example17/detector/addsensitivevolume EAPD_01
+/example17/detector/addsensitivevolume EAPD_02
+/example17/detector/addsensitivevolume EAPD_03
+/example17/detector/addsensitivevolume EAPD_04
+/example17/detector/addsensitivevolume EAPD_05
+/example17/detector/addsensitivevolume EAPD_06
+/example17/detector/addsensitivevolume EAPD_07
+/example17/detector/addsensitivevolume EAPD_08
+/example17/detector/addsensitivevolume EAPD_09
+/example17/detector/addsensitivevolume EAPD_10
+/example17/detector/addsensitivevolume EAPD_11
+/example17/detector/addsensitivevolume EAPD_12
+/example17/detector/addsensitivevolume EAPD_13
+/example17/detector/addsensitivevolume EAPD_14
+/example17/detector/addsensitivevolume EAPD_15
+/example17/detector/addsensitivevolume EAPD_16
+/example17/detector/addsensitivevolume EAPD_17
+
+/example17/detector/sensitivegroup EAPD
+
+/example17/detector/addsensitivevolume EBRY_01
+/example17/detector/addsensitivevolume EBRY_02
+/example17/detector/addsensitivevolume EBRY_03
+/example17/detector/addsensitivevolume EBRY_04
+/example17/detector/addsensitivevolume EBRY_05
+/example17/detector/addsensitivevolume EBRY_06
+/example17/detector/addsensitivevolume EBRY_07
+/example17/detector/addsensitivevolume EBRY_08
+/example17/detector/addsensitivevolume EBRY_09
+/example17/detector/addsensitivevolume EBRY_10
+/example17/detector/addsensitivevolume EBRY_11
+/example17/detector/addsensitivevolume EBRY_12
+/example17/detector/addsensitivevolume EBRY_13
+/example17/detector/addsensitivevolume EBRY_14
+/example17/detector/addsensitivevolume EBRY_15
+/example17/detector/addsensitivevolume EBRY_16
+/example17/detector/addsensitivevolume EBRY_17
+
+/example17/detector/sensitivegroup EBRY_01
+/example17/detector/sensitivegroup EBRY_02
+/example17/detector/sensitivegroup EBRY_03
+/example17/detector/sensitivegroup EBRY_04
+/example17/detector/sensitivegroup EBRY_05
+/example17/detector/sensitivegroup EBRY_06
+/example17/detector/sensitivegroup EBRY_07
+/example17/detector/sensitivegroup EBRY_08
+/example17/detector/sensitivegroup EBRY_09
+/example17/detector/sensitivegroup EBRY_10
+/example17/detector/sensitivegroup EBRY_11
+/example17/detector/sensitivegroup EBRY_12
+/example17/detector/sensitivegroup EBRY_13
+/example17/detector/sensitivegroup EBRY_14
+/example17/detector/sensitivegroup EBRY_15
+/example17/detector/sensitivegroup EBRY_16
+/example17/detector/sensitivegroup EBRY_17
+
+/example17/detector/addsensitivevolume EATJ_01
+/example17/detector/addsensitivevolume EATJ_02
+/example17/detector/addsensitivevolume EATJ_03
+/example17/detector/addsensitivevolume EATJ_04
+/example17/detector/addsensitivevolume EATJ_05
+/example17/detector/addsensitivevolume EATJ_06
+/example17/detector/addsensitivevolume EATJ_07
+/example17/detector/addsensitivevolume EATJ_08
+/example17/detector/addsensitivevolume EATJ_09
+/example17/detector/addsensitivevolume EATJ_10
+/example17/detector/addsensitivevolume EATJ_11
+/example17/detector/addsensitivevolume EATJ_12
+/example17/detector/addsensitivevolume EATJ_13
+/example17/detector/addsensitivevolume EATJ_14
+/example17/detector/addsensitivevolume EATJ_15
+/example17/detector/addsensitivevolume EATJ_16
+/example17/detector/addsensitivevolume EATJ_17
+
+/example17/detector/sensitivegroup EATJ
+
+/example17/detector/addsensitivevolume EFRY
+
+/example17/detector/sensitivegroup EFRY
+
+## -----------------------------------------------------------------------------
+## Optionally, set a constant magnetic filed:
+## -----------------------------------------------------------------------------
+/example17/detector/setField 0 0 0 tesla
+#/example17/detector/setField 0 0 3.8 tesla
+
+##
+## -----------------------------------------------------------------------------
+## Set the physics list (more exactly, the EM physics constructor):
+##   = 'HepEm'           : the G4HepEm EM physics c.t.r.
+##   =  'G4Em'           : the G4 EM physics c.t.r. that corresponds to G4HepEm
+##   = 'emstandard_opt0' : the original, G4 EM-Opt0 physics c.t.r.
+## -----------------------------------------------------------------------------
+##/testem/phys/addPhysics   HepEm
+##/testem/phys/addPhysics   G4Em
+##
+## -----------------------------------------------------------------------------
+## Set secondary production threshold, init. the run and set primary properties
+## -----------------------------------------------------------------------------
+/run/setCut 0.7 mm
+/run/initialize
+
+## Event verbosity: 1 = total edep, 2 = energy deposit per placed sensitive volume
+/example17/event/verbose 2
+
+/example17/gun/setDefault
+/gun/particle e-
+/gun/energy 10 GeV
+/gun/number 1000
+/gun/position 0 0 0
+/gun/direction 0.8 0.5 0.1
+#/gun/direction 0.8 -0.5 0.1
+/example17/gun/print
+
+##
+## -----------------------------------------------------------------------------
+## Run the simulation with the given number of events and print list of processes
+## -----------------------------------------------------------------------------
+##/tracking/verbose 1
+##/process/list
+
+# run events with parametrised simulation
+# by default all created models are active
+/param/ActivateModel AdePT
+/run/beamOn 10
+
+# run events with full (detailed) simulation
+/param/InActivateModel AdePT
+/run/beamOn 10

--- a/examples/Example17/macros/lhcb_validation.mac.in
+++ b/examples/Example17/macros/lhcb_validation.mac.in
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2022 CERN
+# SPDX-License-Identifier: Apache-2.0
+#  lhcb.mac.in
+#
+
+## =============================================================================
+## Geant4 macro for modelling simplified sampling calorimeters
+## =============================================================================
+##
+/run/numberOfThreads 1
+/control/verbose 0
+/run/verbose 0
+/process/verbose 0
+/tracking/verbose 0
+/event/verbose 0
+
+##
+/example17/detector/filename @LHCB_GDML@
+/example17/detector/regionname EcalRegion
+/example17/adept/verbose 0
+## Threshold for buffering tracks before sending to GPU
+/example17/adept/threshold 500
+## Total number of GPU track slots (not per thread)
+/example17/adept/milliontrackslots 4
+
+/example17/detector/addsensitivevolume _dd_Geometry_DownstreamRegion_Ecal_Modules_InnCell
+/example17/detector/sensitivegroup _dd_Geometry_DownstreamRegion_Ecal_Modules_InnCell
+
+/example17/detector/addsensitivevolume _dd_Geometry_DownstreamRegion_Ecal_Modules_MidCell
+/example17/detector/sensitivegroup _dd_Geometry_DownstreamRegion_Ecal_Modules_MidCell
+
+/example17/detector/addsensitivevolume _dd_Geometry_DownstreamRegion_Ecal_Modules_OutCell
+/example17/detector/sensitivegroup _dd_Geometry_DownstreamRegion_Ecal_Modules_OutCell
+
+## -----------------------------------------------------------------------------
+## Optionally, set a constant magnetic filed:
+## -----------------------------------------------------------------------------
+/example17/detector/setField 0 0 0 tesla
+#/example17/detector/setField 0 0 1.0 tesla
+
+##
+## -----------------------------------------------------------------------------
+## Set the physics list (more exactly, the EM physics constructor):
+##   = 'HepEm'           : the G4HepEm EM physics c.t.r.
+##   =  'G4Em'           : the G4 EM physics c.t.r. that corresponds to G4HepEm
+##   = 'emstandard_opt0' : the original, G4 EM-Opt0 physics c.t.r.
+## -----------------------------------------------------------------------------
+##/testem/phys/addPhysics   HepEm
+##/testem/phys/addPhysics   G4Em
+##
+## -----------------------------------------------------------------------------
+## Set secondary production threshold, init. the run and set primary properties
+## -----------------------------------------------------------------------------
+/run/setCut 0.7 mm
+/run/initialize
+
+## Event verbosity: 1 = total edep, 2 = energy deposit per placed sensitive volume
+/example17/event/verbose 2
+
+#/example17/gun/hepmc
+#/generator/hepmcAscii/open ppminbias.hepmc3
+#/generator/hepmcAscii/verbose 1
+
+/example17/gun/setDefault
+/gun/particle e-
+/gun/energy 10 GeV
+/gun/number 100
+/gun/position 0 0 0
+/gun/direction 0.085 0.085 0.99
+/example17/gun/rndmDir 0.0
+#/example17/gun/print
+
+##
+## -----------------------------------------------------------------------------
+## Run the simulation with the given number of events and print list of processes
+## -----------------------------------------------------------------------------
+##/tracking/verbose 1
+##/process/list
+
+# run events with parametrised simulation
+# by default all created models are active
+/param/ActivateModel AdePT
+/run/beamOn 10
+
+# run events with full (detailed) simulation
+/param/InActivateModel AdePT
+/run/beamOn 10

--- a/examples/Example17/src/DetectorMessenger.cc
+++ b/examples/Example17/src/DetectorMessenger.cc
@@ -36,6 +36,9 @@ DetectorMessenger::DetectorMessenger(DetectorConstruction *aDetector) : G4UImess
   fSensVolNameCmd = new G4UIcmdWithAString("/example17/detector/addsensitivevolume", this);
   fSensVolNameCmd->SetGuidance("Add a sensitive volume to the list");
   //
+  fSensVolGroupCmd = new G4UIcmdWithAString("/example17/detector/sensitivegroup", this);
+  fSensVolGroupCmd->SetGuidance("Define a wildcard for a sensitive volumes group");
+  //
   fActivationCmd = new G4UIcmdWithABool("/example17/adept/activate", this);
   fActivationCmd->SetGuidance("(Activate AdePT");
   //
@@ -65,6 +68,7 @@ DetectorMessenger::~DetectorMessenger()
   delete fAdeptDir;
   delete fFieldCmd;
   delete fSensVolNameCmd;
+  delete fSensVolGroupCmd;
   delete fRegionNameCmd;
   delete fFileNameCmd;
   delete fActivationCmd;
@@ -87,6 +91,8 @@ void DetectorMessenger::SetNewValue(G4UIcommand *aCommand, G4String aNewValue)
     fDetector->SetMagField(fFieldCmd->GetNew3VectorValue(aNewValue));
   } else if (aCommand == fSensVolNameCmd) {
     fDetector->AddSensitiveVolume(aNewValue);
+  } else if (aCommand == fSensVolGroupCmd) {
+    fDetector->AddSensitiveGroup(aNewValue);
   } else if (aCommand == fActivationCmd) {
     fDetector->SetActivateAdePT(fActivationCmd->GetNewBoolValue(aNewValue));
   } else if (aCommand == fVerbosityCmd) {

--- a/examples/Example17/src/EMShowerModel.cc
+++ b/examples/Example17/src/EMShowerModel.cc
@@ -113,7 +113,6 @@ void EMShowerModel::Initialize(bool adept)
   bool sequential             = (rmType == G4RunManager::sequentialRM);
 
   fAdept->SetSensitiveVolumes(sensitive_volume_index);
-  printf("setting adept scoring map: %p\n", fScoringMap);
   fAdept->SetScoringMap(fScoringMap);
   fAdept->SetRegion(fRegion);
 

--- a/examples/Example17/src/EventAction.cc
+++ b/examples/Example17/src/EventAction.cc
@@ -38,7 +38,7 @@
 #include "G4GlobalFastSimulationManager.hh"
 #include "AdeptIntegration.h"
 
-EventAction::EventAction(DetectorConstruction *aDetector) : G4UserEventAction(), fHitCollectionID(-1), fTimer()
+EventAction::EventAction(DetectorConstruction *aDetector) : G4UserEventAction(), fDetector(aDetector), fHitCollectionID(-1), fTimer()
 {
   fMessenger = new EventActionMessenger(this);
 }
@@ -93,22 +93,43 @@ void EventAction::EndOfEventAction(const G4Event *aEvent)
     G4cout << "EndOfEventAction " << eventId << ": killed    " << number_killed << G4endl;
   }
 
+  auto &groups = fDetector->GetSensitiveGroups();
+  int ngroups = groups.size();
+  double *edep_groups = nullptr;
+  if (ngroups > 0) edep_groups = new double[ngroups];
+  for (auto i = 0; i< ngroups; ++i) edep_groups[i] = 0;
+
   for (size_t iHit = 0; iHit < hitsCollection->entries(); iHit++) {
     hit   = static_cast<SimpleHit *>(hitsCollection->GetHit(iHit));
     hitEn = hit->GetEdep();
+    totalEnergy += hitEn;
 
-    const char *vol_name = vecgeom::GeoManager::Instance().FindPlacedVolume(iHit)->GetLogicalVolume()->GetName();
+    G4String vol_name = vecgeom::GeoManager::Instance().FindPlacedVolume(iHit)->GetLogicalVolume()->GetName();
+    bool group_found = false;
+    for (int igroup = 0; igroup < ngroups; ++igroup) {
+      if (vol_name.rfind(groups[igroup], 0) == 0) {
+        edep_groups[igroup] += hitEn;
+        group_found = true;
+        break;
+      }
+    }
+    if (group_found) continue;
     const char *type     = (hit->GetType() == 1) ? "AdePT" : "G4";
     if (hitEn > 1 && fVerbosity > 1)
       G4cout << "EndOfEventAction " << eventId << " : id " << std::setw(5) << iHit << "  edep " << std::setprecision(2)
              << std::setw(12) << std::fixed << hitEn / MeV << " [MeV] logical " << vol_name << G4endl;
 
-    if (hitEn > 0) {
-      totalEnergy += hitEn;
+  }
+
+  if (fVerbosity > 1) {
+    for (int igroup = 0; igroup < ngroups; ++igroup) {
+      G4cout << "EndOfEventAction " << eventId << " : group " << std::setw(5) << groups[igroup] << "  edep " << std::setprecision(2)
+             << std::setw(12) << std::fixed << edep_groups[igroup] / MeV << " [MeV]\n";
     }
   }
 
   if (fVerbosity > 0) {
     G4cout << "EndOfEventAction " << eventId << "Total energy deposited: " << totalEnergy / MeV << " MeV" << G4endl;
   }
+  delete [] edep_groups;
 }


### PR DESCRIPTION
This introduces the command: `/example17/detector/sensitivegroup prefix`  (and the same for example14) allowing to sum-up hits for all placed volumes having the name starting with `prefix`.

Added also 2 new macros in Example17: example17_validation.in and lhcb_validation.in to be used for physics validation