### PR TITLE
Sorting tracks coming from GPU to make integration example reproducible.

### DIFF
--- a/examples/Example14/AdeptIntegration.cpp
+++ b/examples/Example14/AdeptIntegration.cpp
@@ -159,7 +159,7 @@ void AdeptIntegration::Shower(int event)
 
   // Build the secondaries and put them back on the Geant4 stack
   for (int i = 0; i < fBuffer.numFromDevice; ++i) {
-    const auto &track = fBuffer.fromDevice[i];
+    const auto &track = fBuffer.fromDevice_sorted[i];
     if (fDebugLevel > 1) {
       G4cout << "[" << tid << "] fromDevice[ " << i << "]: pdg " << track.pdg << " energy " << track.energy
              << " position " << track.position[0] << " " << track.position[1] << " " << track.position[2]

--- a/examples/Example14/AdeptIntegration.cu
+++ b/examples/Example14/AdeptIntegration.cu
@@ -494,7 +494,7 @@ void AdeptIntegration::ShowerGPU(int event, TrackBuffer &buffer) // const &buffe
     fSorted.reserve(numLeaked);
     std::iota(fSorted.begin(), fSorted.begin() + numLeaked, 0); // Fill with 0, 1, ...
     std::sort(fSorted.begin(), fSorted.begin() + numLeaked,
-              [&](int i, int j) {return fBuffer.fromDevice[i].FullSort() > fBuffer.fromDevice[j].FullSort();});
+              [&](int i, int j) {return fBuffer.fromDevice[i] < fBuffer.fromDevice[j];});
     fBuffer.fromDevice_sorted.clear();
     fBuffer.fromDevice_sorted.reserve(numLeaked);
     for (auto i = 0; i < numLeaked; ++i)

--- a/examples/Example14/AdeptIntegration.cu
+++ b/examples/Example14/AdeptIntegration.cu
@@ -32,6 +32,9 @@
 #include <iostream>
 #include <iomanip>
 #include <stdio.h>
+#include <vector>
+#include <numeric>
+#include <algorithm>
 
 #include "electrons.cuh"
 #include "gammas.cuh"
@@ -487,6 +490,15 @@ void AdeptIntegration::ShowerGPU(int event, TrackBuffer &buffer) // const &buffe
         cudaMemcpyAsync(gpuState.stats, gpuState.stats_dev, sizeof(Stats), cudaMemcpyDeviceToHost, gpuState.stream));
     COPCORE_CUDA_CHECK(cudaMemcpyAsync(fBuffer.fromDevice, gpuState.fromDevice_dev, numLeaked * sizeof(TrackData),
                                        cudaMemcpyDeviceToHost, gpuState.stream));
+    // Sort by energy the tracks coming from device to ensure reproducibility
+    fSorted.reserve(numLeaked);
+    std::iota(fSorted.begin(), fSorted.begin() + numLeaked, 0); // Fill with 0, 1, ...
+    std::sort(fSorted.begin(), fSorted.begin() + numLeaked,
+              [&](int i, int j) {return fBuffer.fromDevice[i].FullSort() > fBuffer.fromDevice[j].FullSort();});
+    fBuffer.fromDevice_sorted.clear();
+    fBuffer.fromDevice_sorted.reserve(numLeaked);
+    for (auto i = 0; i < numLeaked; ++i)
+      fBuffer.fromDevice_sorted.push_back(fBuffer.fromDevice[fSorted[i]]);
   }
 
   AllParticleQueues queues = {{electrons.queues, positrons.queues, gammas.queues}};

--- a/examples/Example14/AdeptIntegration.h
+++ b/examples/Example14/AdeptIntegration.h
@@ -71,6 +71,7 @@ private:
   G4Region *fRegion{nullptr};          ///< Region to which applies
   std::unordered_map<std::string, int> *sensitive_volume_index;    ///< Map of sensitive volumes
   std::unordered_map<const G4VPhysicalVolume *, int> *fScoringMap; ///< Map used by G4 for scoring
+  std::vector<int> fSorted;            ///< Vector used to sort tracks coming from device
 
   VolAuxData *CreateVolAuxData(const G4VPhysicalVolume *g4world, const vecgeom::VPlacedVolume *world,
                                const G4HepEmState &hepEmState);

--- a/examples/Example14/CommonStruct.h
+++ b/examples/Example14/CommonStruct.h
@@ -29,12 +29,18 @@ struct TrackData {
       : position{x, y, z}, direction{dirx, diry, dirz}, energy{ene}, pdg{pdg_id}
   {
   }
+  
+  inline double FullSort()
+  {
+    return pdg * energy * position[0] * position[1] * position[2] * direction[0] * direction[1] * direction[2];
+  }
 };
 
 /// @brief Buffer holding input tracks to be transported on GPU and output tracks to be
 /// re-injected in the Geant4 stack
 struct TrackBuffer {
   std::vector<TrackData> toDevice; ///< Tracks to be transported on the device
+  std::vector<TrackData> fromDevice_sorted; ///< Tracks from device sorted by energy
   TrackData *fromDevice{nullptr};  ///< Tracks coming from device to be transported on the CPU
   int eventId{-1};                 ///< Index of current transported event
   int startTrack{0};               ///< Track counter for the current event

--- a/examples/Example14/CommonStruct.h
+++ b/examples/Example14/CommonStruct.h
@@ -30,11 +30,25 @@ struct TrackData {
   {
   }
 
-  inline double FullSort()
+  inline bool operator<(TrackData const &t)
   {
-    auto NonZero = [](double a) { return (a + 1.e-30); };
-    return pdg * energy * NonZero(position[0]) * NonZero(position[1]) * NonZero(position[2]) * 
-           NonZero(direction[0]) * NonZero(direction[1]) * NonZero(direction[2]);
+    if (pdg < t.pdg) return true;
+    if (pdg > t.pdg) return false;
+    if (energy < t.energy) return true;
+    if (energy > t.energy) return false;
+    if (position[0] < t.position[0]) return true;
+    if (position[0] > t.position[0]) return false;
+    if (position[1] < t.position[1]) return true;
+    if (position[1] > t.position[1]) return false;
+    if (position[2] < t.position[2]) return true;
+    if (position[2] > t.position[2]) return false;
+    if (direction[0] < t.direction[0]) return true;
+    if (direction[0] > t.direction[0]) return false;
+    if (direction[1] < t.direction[1]) return true;
+    if (direction[1] > t.direction[1]) return false;
+    if (direction[2] < t.direction[2]) return true;
+    if (direction[2] > t.direction[2]) return false;
+    return false;
   }
 };
 

--- a/examples/Example14/CommonStruct.h
+++ b/examples/Example14/CommonStruct.h
@@ -29,10 +29,12 @@ struct TrackData {
       : position{x, y, z}, direction{dirx, diry, dirz}, energy{ene}, pdg{pdg_id}
   {
   }
-  
+
   inline double FullSort()
   {
-    return pdg * energy * position[0] * position[1] * position[2] * direction[0] * direction[1] * direction[2];
+    auto NonZero = [](double a) { return (a + 1.e-30); };
+    return pdg * energy * NonZero(position[0]) * NonZero(position[1]) * NonZero(position[2]) * 
+           NonZero(direction[0]) * NonZero(direction[1]) * NonZero(direction[2]);
   }
 };
 

--- a/examples/Example14/CommonStruct.h
+++ b/examples/Example14/CommonStruct.h
@@ -32,22 +32,14 @@ struct TrackData {
 
   inline bool operator<(TrackData const &t)
   {
-    if (pdg < t.pdg) return true;
-    if (pdg > t.pdg) return false;
-    if (energy < t.energy) return true;
-    if (energy > t.energy) return false;
-    if (position[0] < t.position[0]) return true;
-    if (position[0] > t.position[0]) return false;
-    if (position[1] < t.position[1]) return true;
-    if (position[1] > t.position[1]) return false;
-    if (position[2] < t.position[2]) return true;
-    if (position[2] > t.position[2]) return false;
-    if (direction[0] < t.direction[0]) return true;
-    if (direction[0] > t.direction[0]) return false;
-    if (direction[1] < t.direction[1]) return true;
-    if (direction[1] > t.direction[1]) return false;
-    if (direction[2] < t.direction[2]) return true;
-    if (direction[2] > t.direction[2]) return false;
+    if (pdg != t.pdg) return pdg < t.pdg;
+    if (energy != t.energy) return energy < t.energy;
+    if (position[0] != t.position[0]) return position[0] < t.position[0];
+    if (position[1] != t.position[1]) return position[1] < t.position[1];
+    if (position[2] != t.position[2]) return position[2] < t.position[2];
+    if (direction[0] != t.direction[0]) return direction[0] < t.direction[0];
+    if (direction[1] != t.direction[1]) return direction[1] < t.direction[1];
+    if (direction[2] != t.direction[2]) return direction[2] < t.direction[2];
     return false;
   }
 };


### PR DESCRIPTION
To make the integration example reproducible, we have to do a full sort of the tracks leaked from the device back to Geant4. This is because the order of the tracks depends on device concurrency, and the random seed sequence on the host depends on the order since it is per CPU thread, not per track.

This change sorts tracks by the product of PDG number, energy, position and momentum components to ensure to a reasonable level the uniqueness of the sorting metric (energy is not sufficient for the gun generator with exa14). 

I am now getting numerically identical results when running multiple times with multiple threads.