### PR TITLE
Try curand in TestEm3

### DIFF
--- a/examples/Example10/electrons.cu
+++ b/examples/Example10/electrons.cu
@@ -64,7 +64,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       }
 
       // Call G4HepEm to compute the physics step limit.
-      G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack, nullptr);
+      G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack, static_cast<G4HepEmRandomEngine*>(nullptr));
 
       // Get result into variables.
       double geometricalStepLengthFromPhysics = theTrack->GetGStepLength();
@@ -87,7 +87,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       theTrack->SetOnBoundary(currentTrack.nextState.IsOnBoundary());
 
       // Apply continuous effects.
-      bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack, nullptr);
+      bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack, static_cast<G4HepEmRandomEngine*>(nullptr));
       // Collect the changes.
       currentTrack.energy = theTrack->GetEKin();
       atomicAdd(&scoring->energyDeposit, theTrack->GetEnergyDeposit());

--- a/examples/Example11/electrons.cu
+++ b/examples/Example11/electrons.cu
@@ -61,7 +61,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     }
 
     // Call G4HepEm to compute the physics step limit.
-    G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack, nullptr);
+    G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack, static_cast<G4HepEmRandomEngine*>(nullptr));
 
     // Get result into variables.
     double geometricalStepLengthFromPhysics = theTrack->GetGStepLength();
@@ -85,7 +85,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     theTrack->SetOnBoundary(nextState.IsOnBoundary());
 
     // Apply continuous effects.
-    bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack, nullptr);
+    bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack, static_cast<G4HepEmRandomEngine*>(nullptr));
     // Collect the changes.
     currentTrack.energy = theTrack->GetEKin();
     atomicAdd(&scoring->energyDeposit, theTrack->GetEnergyDeposit());

--- a/examples/Example12/electrons.cu
+++ b/examples/Example12/electrons.cu
@@ -70,7 +70,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     }
 
     // Call G4HepEm to compute the physics step limit.
-    G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack, nullptr);
+    G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack, static_cast<G4HepEmRandomEngine*>(nullptr));
 
     // Get result into variables.
     double geometricalStepLengthFromPhysics = theTrack->GetGStepLength();
@@ -105,7 +105,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     theTrack->SetOnBoundary(nextState.IsOnBoundary());
 
     // Apply continuous effects.
-    bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack, nullptr);
+    bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack, static_cast<G4HepEmRandomEngine*>(nullptr));
     // Collect the changes.
     currentTrack.energy  = theTrack->GetEKin();
     double energyDeposit = theTrack->GetEnergyDeposit();

--- a/examples/Example5/example5.cu
+++ b/examples/Example5/example5.cu
@@ -39,6 +39,7 @@ struct G4HepEmState {
   G4HepEmParameters parameters;
 };
 
+
 static G4HepEmState *InitG4HepEm()
 {
   G4HepEmState *state = new G4HepEmState;
@@ -125,12 +126,12 @@ __global__ void TransportParticle()
       }
     }
 
-    G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, theElTrack, nullptr);
+    G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, theElTrack, static_cast<G4HepEmRandomEngine*>(nullptr));
     printf("sampled process: %d, particle travels %fmm\n", theTrack->GetWinnerProcessIndex(),
            theTrack->GetGStepLength());
 
     const int iDProc = theTrack->GetWinnerProcessIndex();
-    bool stopped     = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, theElTrack, nullptr);
+    bool stopped     = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, theElTrack, static_cast<G4HepEmRandomEngine*>(nullptr));
     printf("energy after continuous process: %fMeV\n", theTrack->GetEKin());
     if (stopped) {
       // call annihilation for e+ !!!

--- a/examples/Example6/example6.cu
+++ b/examples/Example6/example6.cu
@@ -166,7 +166,7 @@ __global__ void PerformStep(adept::BlockData<track> *allTracks, adept::MParray *
     }
 
     // Call G4HepEm to compute the physics step limit.
-    G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack, nullptr);
+    G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack, static_cast<G4HepEmRandomEngine*>(nullptr));
 
     // Get result into variables.
     double geometricalStepLengthFromPhysics = theTrack->GetGStepLength();
@@ -190,7 +190,7 @@ __global__ void PerformStep(adept::BlockData<track> *allTracks, adept::MParray *
     theTrack->SetOnBoundary(currentTrack.next_state.IsOnBoundary());
 
     // Apply continuous effects.
-    bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack, nullptr);
+    bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack, static_cast<G4HepEmRandomEngine*>(nullptr));
     // Collect the changes.
     currentTrack.energy = theTrack->GetEKin();
     scoring->totalEnergyDeposit.fetch_add(theTrack->GetEnergyDeposit());

--- a/examples/Example7/electrons.cu
+++ b/examples/Example7/electrons.cu
@@ -68,7 +68,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     }
 
     // Call G4HepEm to compute the physics step limit.
-    G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack, nullptr);
+    G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack, static_cast<G4HepEmRandomEngine*>(nullptr));
 
     // Get result into variables.
     double geometricalStepLengthFromPhysics = theTrack->GetGStepLength();
@@ -102,7 +102,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     theTrack->SetOnBoundary(currentTrack.nextState.IsOnBoundary());
 
     // Apply continuous effects.
-    bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack, nullptr);
+    bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack, static_cast<G4HepEmRandomEngine*>(nullptr));
     // Collect the changes.
     currentTrack.energy  = theTrack->GetEKin();
     double energyDeposit = theTrack->GetEnergyDeposit();

--- a/examples/Example8/example8.cu
+++ b/examples/Example8/example8.cu
@@ -270,7 +270,7 @@ __global__ void PerformStep(Track *allTracks, SlotManager *manager, const adept:
     }
 
     // Call G4HepEm to compute the physics step limit.
-    G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack, nullptr);
+    G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack, static_cast<G4HepEmRandomEngine*>(nullptr));
 
     // Get result into variables.
     double geometricalStepLengthFromPhysics = theTrack->GetGStepLength();
@@ -293,7 +293,7 @@ __global__ void PerformStep(Track *allTracks, SlotManager *manager, const adept:
     theTrack->SetOnBoundary(currentTrack.next_state.IsOnBoundary());
 
     // Apply continuous effects.
-    bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack, nullptr);
+    bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack, static_cast<G4HepEmRandomEngine*>(nullptr));
     // Collect the changes.
     currentTrack.energy = theTrack->GetEKin();
     scoring->totalEnergyDeposit.fetch_add(theTrack->GetEnergyDeposit());

--- a/examples/Example9/electrons.cu
+++ b/examples/Example9/electrons.cu
@@ -60,7 +60,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     }
 
     // Call G4HepEm to compute the physics step limit.
-    G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack, nullptr);
+    G4HepEmElectronManager::HowFar(&g4HepEmData, &g4HepEmPars, &elTrack, static_cast<G4HepEmRandomEngine*>(nullptr));
 
     // Get result into variables.
     double geometricalStepLengthFromPhysics = theTrack->GetGStepLength();
@@ -84,7 +84,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     theTrack->SetOnBoundary(nextState.IsOnBoundary());
 
     // Apply continuous effects.
-    bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack, nullptr);
+    bool stopped = G4HepEmElectronManager::PerformContinuous(&g4HepEmData, &g4HepEmPars, &elTrack, static_cast<G4HepEmRandomEngine*>(nullptr));
     // Collect the changes.
     currentTrack.energy = theTrack->GetEKin();
     atomicAdd(&scoring->energyDeposit, theTrack->GetEnergyDeposit());

--- a/examples/TestEm3/TestEm3.cu
+++ b/examples/TestEm3/TestEm3.cu
@@ -135,7 +135,8 @@ __global__ void InitPrimaries(ParticleGenerator generator, int startEvent, int n
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < numEvents; i += blockDim.x * gridDim.x) {
     Track &track = generator.NextTrack();
 
-    track.rngState.SetSeed(startEvent + i);
+//    track.rngState.SetSeed(startEvent + i);
+    curand_init(startEvent + i, 0, 0, &track.rngState);
     track.energy       = energy;
     track.numIALeft[0] = -1.0;
     track.numIALeft[1] = -1.0;

--- a/examples/TestEm3/TestEm3.cu
+++ b/examples/TestEm3/TestEm3.cu
@@ -310,7 +310,7 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
     stats->inFlight[ParticleType::Gamma]    = 0;
 
     constexpr int MaxBlocks        = 1024;
-    constexpr int TransportThreads = 32;
+    constexpr int TransportThreads = 256;
     int transportBlocks;
 
     int inFlight;

--- a/examples/TestEm3/TestEm3.cuh
+++ b/examples/TestEm3/TestEm3.cuh
@@ -56,37 +56,20 @@ struct Track {
 // Defined in TestEm3.cu
 extern __constant__ __device__ int Zero;
 
-class RanluxppDoubleEngine : public G4HepEmRandomEngine {
-  // Wrapper functions to call into RanluxppDouble.
-  static __host__ __device__ __attribute__((noinline))
-  double FlatWrapper(void *object)
-  {
-    return ((RanluxppDouble *)object)->Rndm();
-  }
-  static __host__ __device__ __attribute__((noinline))
-  void FlatArrayWrapper(void *object, const int size, double *vect)
+struct RanluxppDoubleAdaptor : G4HepEmEngineBase<RanluxppDoubleAdaptor> {
+  G4HepEmHostDevice RanluxppDoubleAdaptor(RanluxppDouble& ranlux) : ranlux(ranlux) {}
+
+  G4HepEmHostDevice double flat() { return ranlux.Rndm(); }
+
+  G4HepEmHostDevice void flatArray(const int size, double *vect)
   {
     for (int i = 0; i < size; i++) {
-      vect[i] = ((RanluxppDouble *)object)->Rndm();
+      vect[i] = ranlux.Rndm();
     }
   }
 
-public:
-  __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
-      : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
-  {
-#ifdef __CUDA_ARCH__
-    // This is a hack: The compiler cannot see that we're going to call the
-    // functions through their pointers, so it underestimates the number of
-    // required registers. By including calls to the (non-inlinable) functions
-    // we force the compiler to account for the register usage, even if this
-    // particular set of calls are not executed at runtime.
-    if (Zero) {
-      FlatWrapper(engine);
-      FlatArrayWrapper(engine, 0, nullptr);
-    }
-#endif
-  }
+private:
+  RanluxppDouble& ranlux;
 };
 
 
@@ -133,7 +116,6 @@ struct Secondaries {
   ParticleGenerator positrons;
   ParticleGenerator gammas;
 };
-
 
 // Kernels in different TUs.
 __global__ void TransportElectrons(

--- a/examples/TestEm3/electrons.cu
+++ b/examples/TestEm3/electrons.cu
@@ -62,7 +62,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     // Prepare a branched RNG state while threads are synchronized. Even if not
     // used, this provides a fresh round of random numbers and reduces thread
     // divergence because the RNG state doesn't need to be advanced later.
-    RanluxppDouble newRNG(currentTrack.rngState.BranchNoAdvance());
+    curandState newRNG(currentTrack.rngState/*.BranchNoAdvance()*/);
 
     // Compute safety, needed for MSC step limit.
     double safety = 0;
@@ -71,7 +71,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     }
     theTrack->SetSafety(safety);
 
-    RanluxppDoubleAdaptor rnge{currentTrack.rngState};
+    CurandAdaptor rnge{currentTrack.rngState};
 
     // Sample the `number-of-interaction-left` and put it into the track.
     for (int ip = 0; ip < 3; ++ip) {
@@ -197,7 +197,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
         sincos(phi, &sinPhi, &cosPhi);
 
         gamma1.InitAsSecondary(/*parent=*/currentTrack);
-        newRNG.Advance();
+        //newRNG.Advance();
         gamma1.rngState = newRNG;
         gamma1.energy = copcore::units::kElectronMassC2;
         gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
@@ -249,10 +249,10 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
 
     // Perform the discrete interaction, make sure the branched RNG state is
     // ready to be used.
-    newRNG.Advance();
+    //newRNG.Advance();
     // Also advance the current RNG state to provide a fresh round of random
     // numbers after MSC used up a fair share for sampling the displacement.
-    currentTrack.rngState.Advance();
+    //currentTrack.rngState.Advance();
 
     const double energy   = currentTrack.energy;
     const double theElCut = g4HepEmData.fTheMatCutData->fMatCutData[theMCIndex].fSecElProdCutE;

--- a/examples/TestEm3/electrons.cu
+++ b/examples/TestEm3/electrons.cu
@@ -71,7 +71,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     }
     theTrack->SetSafety(safety);
 
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    RanluxppDoubleAdaptor rnge{currentTrack.rngState};
 
     // Sample the `number-of-interaction-left` and put it into the track.
     for (int ip = 0; ip < 3; ++ip) {

--- a/examples/TestEm3/gammas.cu
+++ b/examples/TestEm3/gammas.cu
@@ -104,7 +104,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     currentTrack.numIALeft[winnerProcessIndex] = -1.0;
 
     // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    RanluxppDoubleAdaptor rnge{currentTrack.rngState};
     // We might need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/TestEm3/gammas.cu
+++ b/examples/TestEm3/gammas.cu
@@ -104,9 +104,9 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     currentTrack.numIALeft[winnerProcessIndex] = -1.0;
 
     // Perform the discrete interaction.
-    RanluxppDoubleAdaptor rnge{currentTrack.rngState};
+    CurandAdaptor rnge{currentTrack.rngState};
     // We might need one branched RNG state, prepare while threads are synchronized.
-    RanluxppDouble newRNG(currentTrack.rngState.Branch());
+    curandState newRNG(currentTrack.rngState/*.Branch()*/);
 
     const double energy = currentTrack.energy;
 


### PR DESCRIPTION
This PR replaces the Ranlux RNG engine by curand in TestEm3. RNG state branching has not been implemented yet.

Running `TestEm3 --batch 100 `:
Run time before: 2.61261
Run time after: 2.06132
That is a 26% improvement.

Depends on:

- [ ] #192