### PR TITLE
New macro allowing to run integration TestEm3 with interlaced CPU-GPU regions

### DIFF
--- a/examples/Example14/AdeptIntegration.cpp
+++ b/examples/Example14/AdeptIntegration.cpp
@@ -112,7 +112,7 @@ void AdeptIntegration::Cleanup()
 
 void AdeptIntegration::Shower(int event)
 {
-  constexpr double tolerance = 10. * vecgeom::kTolerance;
+  constexpr double tolerance = 0.1 * vecgeom::kTolerance;
 
   int tid = G4Threading::G4GetThreadId();
   if (fDebugLevel > 0 && fBuffer.toDevice.size() == 0) {
@@ -197,7 +197,7 @@ void AdeptIntegration::Shower(int event)
   evAct->number_killed    = evAct->number_killed + fScoring->fGlobalScoring.numKilled;
 
   fBuffer.Clear();
-  fScoring->ClearGPU();
+  //fScoring->ClearGPU();
 }
 
 adeptint::VolAuxData *AdeptIntegration::CreateVolAuxData(const G4VPhysicalVolume *g4world,

--- a/examples/Example14/BasicScoring.cu
+++ b/examples/Example14/BasicScoring.cu
@@ -49,26 +49,6 @@ void BasicScoring::FreeGPU()
   COPCORE_CUDA_CHECK(cudaFree(fScoringPerVolume_dev));
 }
 
-void BasicScoring::ClearGPU()
-{
-  // Clear the device hits content
-  COPCORE_CUDA_CHECK(cudaMemset(fGlobalScoring_dev, 0, sizeof(GlobalScoring)));
-  COPCORE_CUDA_CHECK(cudaMemset(fChargedTrackLength_dev, 0, sizeof(double) * fNumSensitive));
-  COPCORE_CUDA_CHECK(cudaMemset(fEnergyDeposit_dev, 0, sizeof(double) * fNumSensitive));
-}
-
-void BasicScoring::CopyHitsToHost()
-{
-  // Transfer back scoring.
-  COPCORE_CUDA_CHECK(cudaMemcpy(&fGlobalScoring, fGlobalScoring_dev, sizeof(GlobalScoring), cudaMemcpyDeviceToHost));
-
-  // Transfer back the scoring per volume (charged track length and energy deposit).
-  COPCORE_CUDA_CHECK(cudaMemcpy(fScoringPerVolume.chargedTrackLength, fChargedTrackLength_dev,
-                                sizeof(double) * fNumSensitive, cudaMemcpyDeviceToHost));
-  COPCORE_CUDA_CHECK(cudaMemcpy(fScoringPerVolume.energyDeposit, fEnergyDeposit_dev, sizeof(double) * fNumSensitive,
-                                cudaMemcpyDeviceToHost));
-}
-
 __device__ void BasicScoring::Score(vecgeom::NavStateIndex const &crt_state, int charge, double geomStep, double edep)
 {
   assert(fGlobalScoring_dev && "Scoring not initialized on device");

--- a/examples/Example14/CMakeLists.txt
+++ b/examples/Example14/CMakeLists.txt
@@ -81,9 +81,12 @@ set_target_properties(example14 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RE
 # Install macros and geometry file
 
 set(TESTEM3_GDML ${CMAKE_BINARY_DIR}/testEm3.gdml)
+set(TESTEM3_INTERLACED_GDML ${CMAKE_BINARY_DIR}/testEm3_interlaced.gdml)
 set(LHCB_GDML ${CMAKE_BINARY_DIR}/LHCb_Upgrade_fullLHCb.gdml)
 configure_file("macros/testEm3.gdml" "${CMAKE_BINARY_DIR}/testEm3.gdml")
+configure_file("macros/testEm3_interlaced.gdml" "${CMAKE_BINARY_DIR}/testEm3_interlaced.gdml")
 configure_file("macros/testEm3.mac.in" "${CMAKE_BINARY_DIR}/testEm3.mac")
+configure_file("macros/testEm3_interlaced.mac.in" "${CMAKE_BINARY_DIR}/testEm3_interlaced.mac")
 configure_file("macros/testEm3G4.mac.in" "${CMAKE_BINARY_DIR}/testEm3G4.mac")
 configure_file("macros/example14.mac.in" "${CMAKE_BINARY_DIR}/example14.mac")
 configure_file("macros/LHCb_Upgrade_fullLHCb.gdml" "${CMAKE_BINARY_DIR}/LHCb_Upgrade_fullLHCb.gdml")

--- a/examples/Example14/macros/testEm3.mac.in
+++ b/examples/Example14/macros/testEm3.mac.in
@@ -17,7 +17,8 @@
 /example14/detector/regionname caloregion
 /example14/adept/activate true
 /example14/adept/verbose 0
-/example14/adept/threshold 100
+/example14/adept/milliontrackslots 4
+/example14/adept/threshold 200
 
 /example14/detector/addsensitivevolume G4_Pb
 /example14/detector/addsensitivevolume G4_lAr
@@ -25,8 +26,8 @@
 ## -----------------------------------------------------------------------------
 ## Optionally, set a constant magnetic filed:
 ## -----------------------------------------------------------------------------
-/example14/detector/setField 0 0 0.1 tesla
-#/example14/detector/setField 0 0 0 tesla
+#/example14/detector/setField 0 0 0.1 tesla
+/example14/detector/setField 0 0 0 tesla
 
 ##
 ## -----------------------------------------------------------------------------
@@ -45,12 +46,12 @@
 /run/initialize
 
 ## Event verbosity: 1 = total edep, 2 = energy deposit per placed sensitive volume
-/example14/event/verbose 0
+/example14/event/verbose 2
 
 /example14/gun/setDefault
 /gun/particle e-
 /gun/energy 10 GeV
-/gun/number 100
+/gun/number 10000
 /gun/position -220 0 0 mm
 /gun/direction 1 0 0
 #/example14/gun/print

--- a/examples/Example14/macros/testEm3_interlaced.gdml
+++ b/examples/Example14/macros/testEm3_interlaced.gdml
@@ -1,0 +1,1431 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!-- SPDX-FileCopyrightText: 2022 CERN -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+
+  <define>
+    <position name="G4_Pb_pos" unit="mm" x="-2.85" y="0" z="0"/>
+    <position name="G4_lApos" unit="mm" x="1.15" y="0" z="0"/>
+  </define>
+
+  <materials>
+    <material name="G4_Galactic" state="gas">
+      <T unit="K" value="2.73"/>
+      <P unit="pascal" value="3e-18"/>
+      <MEE unit="eV" value="21.8"/>
+      <D unit="g/cm3" value="1e-25"/>
+      <fraction n="1" ref="H"/>
+    </material>
+    <isotope N="204" Z="82" name="Pb204">
+      <atom unit="g/mole" value="203.973"/>
+    </isotope>
+    <isotope N="206" Z="82" name="Pb206">
+      <atom unit="g/mole" value="205.974"/>
+    </isotope>
+    <isotope N="207" Z="82" name="Pb207">
+      <atom unit="g/mole" value="206.976"/>
+    </isotope>
+    <isotope N="208" Z="82" name="Pb208">
+      <atom unit="g/mole" value="207.977"/>
+    </isotope>
+    <element name="Pb">
+      <fraction n="0.014" ref="Pb204"/>
+      <fraction n="0.241" ref="Pb206"/>
+      <fraction n="0.221" ref="Pb207"/>
+      <fraction n="0.524" ref="Pb208"/>
+    </element>
+    <material name="G4_Pb" state="solid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="823"/>
+      <D unit="g/cm3" value="11.35"/>
+      <fraction n="1" ref="Pb"/>
+    </material>
+    <isotope N="36" Z="18" name="Ar36">
+      <atom unit="g/mole" value="35.9675"/>
+    </isotope>
+    <isotope N="38" Z="18" name="Ar38">
+      <atom unit="g/mole" value="37.9627"/>
+    </isotope>
+    <isotope N="40" Z="18" name="Ar40">
+      <atom unit="g/mole" value="39.9624"/>
+    </isotope>
+    <element name="Ar">
+      <fraction n="0.003365" ref="Ar36"/>
+      <fraction n="0.000632" ref="Ar38"/>
+      <fraction n="0.996003" ref="Ar40"/>
+    </element>
+    <material name="G4_lAr" state="liquid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="188"/>
+      <D unit="g/cm3" value="1.396"/>
+      <fraction n="1" ref="Ar"/>
+    </material>
+    <isotope N="1" Z="1" name="H1">
+      <atom unit="g/mole" value="1.00782503081372"/>
+    </isotope>
+    <isotope N="2" Z="1" name="H2">
+      <atom unit="g/mole" value="2.01410199966617"/>
+    </isotope>
+    <element name="H">
+      <fraction n="0.999885" ref="H1"/>
+      <fraction n="0.000115" ref="H2"/>
+    </element>
+  </materials>
+
+  <solids>
+    <box lunit="mm" name="Absorber1" x="2.3" y="400" z="400"/>
+    <box lunit="mm" name="Absorber2" x="5.7" y="400" z="400"/>
+    <box lunit="mm" name="Layer" x="8" y="400" z="400"/>
+    <box lunit="mm" name="Calorimeter" x="400" y="400" z="400"/>
+    <box lunit="mm" name="World" x="480" y="480" z="480"/>
+  </solids>
+
+  <structure>
+    <volume name="G4_Pb1">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb2">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb3">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb4">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb5">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb6">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb7">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb8">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb9">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb10">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb11">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb12">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb13">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb14">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb15">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb16">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb17">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb18">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb19">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb20">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb21">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb22">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb23">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb24">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb25">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb26">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb27">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb28">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb29">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb30">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb31">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb32">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb33">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb34">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb35">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb36">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb37">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb38">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb39">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb40">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb41">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb42">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb43">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb44">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb45">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb46">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb47">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb48">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb49">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_Pb50">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr1">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr2">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr3">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr4">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr5">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr6">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr7">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr8">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr9">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr10">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr11">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr12">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr13">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr14">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr15">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr16">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr17">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr18">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr19">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr20">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr21">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr22">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr23">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr24">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr25">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr26">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr27">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr28">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr29">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr30">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr31">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr32">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr33">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr34">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr35">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr36">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr37">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr38">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr39">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr40">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr41">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr42">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr43">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr44">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr45">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr46">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr47">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr48">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr49">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="G4_lAr50">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+    <volume name="Layer1">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb1"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr1"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer2">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb2"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr2"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer3">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb3"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr3"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer4">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb4"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr4"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer5">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb5"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr5"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer6">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb6"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr6"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer7">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb7"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr7"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer8">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb8"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr8"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer9">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb9"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr9"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer10">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb10"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr10"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer11">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb11"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr11"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer12">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb12"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr12"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer13">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb13"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr13"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer14">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb14"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr14"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer15">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb15"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr15"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer16">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb16"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr16"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer17">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb17"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr17"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer18">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb18"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr18"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer19">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb19"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr19"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer20">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb20"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr20"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer21">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb21"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr21"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer22">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb22"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr22"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer23">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb23"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr23"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer24">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb24"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr24"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer25">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb25"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr25"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer26">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb26"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr26"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer27">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb27"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr27"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer28">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb28"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr28"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer29">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb29"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr29"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer30">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb30"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr30"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer31">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb31"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr31"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer32">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb32"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr32"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer33">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb33"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr33"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer34">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb34"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr34"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer35">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb35"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr35"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer36">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb36"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr36"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer37">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb37"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr37"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer38">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb38"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr38"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer39">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb39"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr39"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer40">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb40"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr40"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer41">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb41"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr41"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer42">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb42"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr42"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer43">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb43"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr43"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer44">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb44"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr44"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer45">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb45"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr45"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer46">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb46"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr46"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer47">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb47"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr47"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer48">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb48"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr48"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer49">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb49"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr49"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Layer50">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb50"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr50"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+    <volume name="Calorimeter">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Calorimeter"/>
+      <physvol copynumber="1" name="Layer0x560dcd38d7b0">
+        <volumeref ref="Layer1"/>
+        <position name="Layer0x560dcd38d7b0_pos" unit="mm" x="-196" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="2" name="Layer0x560dcd38d8c0">
+        <volumeref ref="Layer2"/>
+        <position name="Layer0x560dcd38d8c0_pos" unit="mm" x="-188" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="3" name="Layer0x560dcd38d970">
+        <volumeref ref="Layer3"/>
+        <position name="Layer0x560dcd38d970_pos" unit="mm" x="-180" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="4" name="Layer0x560dcd38da60">
+        <volumeref ref="Layer4"/>
+        <position name="Layer0x560dcd38da60_pos" unit="mm" x="-172" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="5" name="Layer0x560dcd38daf0">
+        <volumeref ref="Layer5"/>
+        <position name="Layer0x560dcd38daf0_pos" unit="mm" x="-164" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="6" name="Layer0x560dcd38dc20">
+        <volumeref ref="Layer6"/>
+        <position name="Layer0x560dcd38dc20_pos" unit="mm" x="-156" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="7" name="Layer0x560dcd38dc80">
+        <volumeref ref="Layer7"/>
+        <position name="Layer0x560dcd38dc80_pos" unit="mm" x="-148" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="8" name="Layer0x560dcd38dce0">
+        <volumeref ref="Layer8"/>
+        <position name="Layer0x560dcd38dce0_pos" unit="mm" x="-140" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="9" name="Layer0x560dcd38dd70">
+        <volumeref ref="Layer9"/>
+        <position name="Layer0x560dcd38dd70_pos" unit="mm" x="-132" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="10" name="Layer0x560dcd38df20">
+        <volumeref ref="Layer10"/>
+        <position name="Layer0x560dcd38df20_pos" unit="mm" x="-124" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="11" name="Layer0x560dcd38dfb0">
+        <volumeref ref="Layer11"/>
+        <position name="Layer0x560dcd38dfb0_pos" unit="mm" x="-116" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="12" name="Layer0x560dcd38e040">
+        <volumeref ref="Layer12"/>
+        <position name="Layer0x560dcd38e040_pos" unit="mm" x="-108" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="13" name="Layer0x560dcd38e0d0">
+        <volumeref ref="Layer13"/>
+        <position name="Layer0x560dcd38e0d0_pos" unit="mm" x="-100" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="14" name="Layer0x560dcd38e160">
+        <volumeref ref="Layer14"/>
+        <position name="Layer0x560dcd38e160_pos" unit="mm" x="-92" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="15" name="Layer0x560dcd38e1f0">
+        <volumeref ref="Layer15"/>
+        <position name="Layer0x560dcd38e1f0_pos" unit="mm" x="-84" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="16" name="Layer0x560dcd38e280">
+        <volumeref ref="Layer16"/>
+        <position name="Layer0x560dcd38e280_pos" unit="mm" x="-76" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="17" name="Layer0x560dcd38e310">
+        <volumeref ref="Layer17"/>
+        <position name="Layer0x560dcd38e310_pos" unit="mm" x="-68" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="18" name="Layer0x560dcd38e4b0">
+        <volumeref ref="Layer18"/>
+        <position name="Layer0x560dcd38e4b0_pos" unit="mm" x="-60" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="19" name="Layer0x560dcd38e540">
+        <volumeref ref="Layer19"/>
+        <position name="Layer0x560dcd38e540_pos" unit="mm" x="-52" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="20" name="Layer0x560dcd38e5d0">
+        <volumeref ref="Layer20"/>
+        <position name="Layer0x560dcd38e5d0_pos" unit="mm" x="-44" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="21" name="Layer0x560dcd38e660">
+        <volumeref ref="Layer21"/>
+        <position name="Layer0x560dcd38e660_pos" unit="mm" x="-36" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="22" name="Layer0x560dcd38e6f0">
+        <volumeref ref="Layer22"/>
+        <position name="Layer0x560dcd38e6f0_pos" unit="mm" x="-28" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="23" name="Layer0x560dcd38e780">
+        <volumeref ref="Layer23"/>
+        <position name="Layer0x560dcd38e780_pos" unit="mm" x="-20" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="24" name="Layer0x560dcd38e810">
+        <volumeref ref="Layer24"/>
+        <position name="Layer0x560dcd38e810_pos" unit="mm" x="-12" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="25" name="Layer0x560dcd38e8a0">
+        <volumeref ref="Layer25"/>
+        <position name="Layer0x560dcd38e8a0_pos" unit="mm" x="-4" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="26" name="Layer0x560dcd38e930">
+        <volumeref ref="Layer26"/>
+        <position name="Layer0x560dcd38e930_pos" unit="mm" x="4" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="27" name="Layer0x560dcd38e9c0">
+        <volumeref ref="Layer27"/>
+        <position name="Layer0x560dcd38e9c0_pos" unit="mm" x="12" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="28" name="Layer0x560dcd38ea50">
+        <volumeref ref="Layer28"/>
+        <position name="Layer0x560dcd38ea50_pos" unit="mm" x="20" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="29" name="Layer0x560dcd38eae0">
+        <volumeref ref="Layer29"/>
+        <position name="Layer0x560dcd38eae0_pos" unit="mm" x="28" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="30" name="Layer0x560dcd38eb70">
+        <volumeref ref="Layer30"/>
+        <position name="Layer0x560dcd38eb70_pos" unit="mm" x="36" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="31" name="Layer0x560dcd38ec00">
+        <volumeref ref="Layer31"/>
+        <position name="Layer0x560dcd38ec00_pos" unit="mm" x="44" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="32" name="Layer0x560dcd38ec90">
+        <volumeref ref="Layer32"/>
+        <position name="Layer0x560dcd38ec90_pos" unit="mm" x="52" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="33" name="Layer0x560dcd38ed20">
+        <volumeref ref="Layer33"/>
+        <position name="Layer0x560dcd38ed20_pos" unit="mm" x="60" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="34" name="Layer0x560dcd38edb0">
+        <volumeref ref="Layer34"/>
+        <position name="Layer0x560dcd38edb0_pos" unit="mm" x="68" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="35" name="Layer0x560dcd38ee40">
+        <volumeref ref="Layer35"/>
+        <position name="Layer0x560dcd38ee40_pos" unit="mm" x="76" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="36" name="Layer0x560dcd38eed0">
+        <volumeref ref="Layer36"/>
+        <position name="Layer0x560dcd38eed0_pos" unit="mm" x="84" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="37" name="Layer0x560dcd38ef60">
+        <volumeref ref="Layer37"/>
+        <position name="Layer0x560dcd38ef60_pos" unit="mm" x="92" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="38" name="Layer0x560dcd38eff0">
+        <volumeref ref="Layer38"/>
+        <position name="Layer0x560dcd38eff0_pos" unit="mm" x="100" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="39" name="Layer0x560dcd38f080">
+        <volumeref ref="Layer39"/>
+        <position name="Layer0x560dcd38f080_pos" unit="mm" x="108" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="40" name="Layer0x560dcd38f110">
+        <volumeref ref="Layer40"/>
+        <position name="Layer0x560dcd38f110_pos" unit="mm" x="116" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="41" name="Layer0x560dcd38f1a0">
+        <volumeref ref="Layer41"/>
+        <position name="Layer0x560dcd38f1a0_pos" unit="mm" x="124" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="42" name="Layer0x560dcd38f230">
+        <volumeref ref="Layer42"/>
+        <position name="Layer0x560dcd38f230_pos" unit="mm" x="132" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="43" name="Layer0x560dcd38f2c0">
+        <volumeref ref="Layer43"/>
+        <position name="Layer0x560dcd38f2c0_pos" unit="mm" x="140" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="44" name="Layer0x560dcd38f350">
+        <volumeref ref="Layer44"/>
+        <position name="Layer0x560dcd38f350_pos" unit="mm" x="148" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="45" name="Layer0x560dcd38f3e0">
+        <volumeref ref="Layer45"/>
+        <position name="Layer0x560dcd38f3e0_pos" unit="mm" x="156" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="46" name="Layer0x560dcd38f470">
+        <volumeref ref="Layer46"/>
+        <position name="Layer0x560dcd38f470_pos" unit="mm" x="164" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="47" name="Layer0x560dcd38f500">
+        <volumeref ref="Layer47"/>
+        <position name="Layer0x560dcd38f500_pos" unit="mm" x="172" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="48" name="Layer0x560dcd38f590">
+        <volumeref ref="Layer48"/>
+        <position name="Layer0x560dcd38f590_pos" unit="mm" x="180" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="49" name="Layer0x560dcd38f620">
+        <volumeref ref="Layer49"/>
+        <position name="Layer0x560dcd38f620_pos" unit="mm" x="188" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="50" name="Layer0x560dcd38f6b0">
+        <volumeref ref="Layer50"/>
+        <position name="Layer0x560dcd38f6b0_pos" unit="mm" x="196" y="0" z="0"/>
+      </physvol>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="0"/>
+    </volume>
+    <volume name="World">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="World"/>
+      <physvol name="Calorimeter">
+        <volumeref ref="Calorimeter"/>
+      </physvol>
+    </volume>
+  </structure>
+
+  <userinfo>
+    <auxiliary auxtype="Region" auxvalue="caloregion">
+      <auxiliary auxtype="volume" auxvalue="Layer1"/>
+      <auxiliary auxtype="volume" auxvalue="Layer2"/>
+      <auxiliary auxtype="volume" auxvalue="Layer3"/>
+      <auxiliary auxtype="volume" auxvalue="Layer4"/>
+      <auxiliary auxtype="volume" auxvalue="Layer5"/>
+      <auxiliary auxtype="volume" auxvalue="Layer6"/>
+      <auxiliary auxtype="volume" auxvalue="Layer7"/>
+      <auxiliary auxtype="volume" auxvalue="Layer8"/>
+      <auxiliary auxtype="volume" auxvalue="Layer9"/>
+      <auxiliary auxtype="volume" auxvalue="Layer10"/>
+      <auxiliary auxtype="volume" auxvalue="Layer41"/>
+      <auxiliary auxtype="volume" auxvalue="Layer42"/>
+      <auxiliary auxtype="volume" auxvalue="Layer43"/>
+      <auxiliary auxtype="volume" auxvalue="Layer44"/>
+      <auxiliary auxtype="volume" auxvalue="Layer45"/>
+      <auxiliary auxtype="volume" auxvalue="Layer46"/>
+      <auxiliary auxtype="volume" auxvalue="Layer47"/>
+      <auxiliary auxtype="volume" auxvalue="Layer48"/>
+      <auxiliary auxtype="volume" auxvalue="Layer49"/>
+      <auxiliary auxtype="volume" auxvalue="Layer50"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+  </userinfo>
+
+  <setup name="Default" version="1.0">
+    <world ref="World"/>
+  </setup>
+
+</gdml>

--- a/examples/Example14/macros/testEm3_interlaced.gdml
+++ b/examples/Example14/macros/testEm3_interlaced.gdml
@@ -1407,6 +1407,36 @@
       <auxiliary auxtype="volume" auxvalue="Layer8"/>
       <auxiliary auxtype="volume" auxvalue="Layer9"/>
       <auxiliary auxtype="volume" auxvalue="Layer10"/>
+      <auxiliary auxtype="volume" auxvalue="Layer11"/>
+      <auxiliary auxtype="volume" auxvalue="Layer12"/>
+      <auxiliary auxtype="volume" auxvalue="Layer13"/>
+      <auxiliary auxtype="volume" auxvalue="Layer14"/>
+      <auxiliary auxtype="volume" auxvalue="Layer15"/>
+      <auxiliary auxtype="volume" auxvalue="Layer16"/>
+      <auxiliary auxtype="volume" auxvalue="Layer17"/>
+      <auxiliary auxtype="volume" auxvalue="Layer18"/>
+      <auxiliary auxtype="volume" auxvalue="Layer19"/>
+      <auxiliary auxtype="volume" auxvalue="Layer20"/>
+      <auxiliary auxtype="volume" auxvalue="Layer21"/>
+      <auxiliary auxtype="volume" auxvalue="Layer22"/>
+      <auxiliary auxtype="volume" auxvalue="Layer23"/>
+      <auxiliary auxtype="volume" auxvalue="Layer24"/>
+      <auxiliary auxtype="volume" auxvalue="Layer25"/>
+      <auxiliary auxtype="volume" auxvalue="Layer26"/>
+      <auxiliary auxtype="volume" auxvalue="Layer27"/>
+      <auxiliary auxtype="volume" auxvalue="Layer28"/>
+      <auxiliary auxtype="volume" auxvalue="Layer29"/>
+      <auxiliary auxtype="volume" auxvalue="Layer30"/>
+      <auxiliary auxtype="volume" auxvalue="Layer31"/>
+      <auxiliary auxtype="volume" auxvalue="Layer32"/>
+      <auxiliary auxtype="volume" auxvalue="Layer33"/>
+      <auxiliary auxtype="volume" auxvalue="Layer34"/>
+      <auxiliary auxtype="volume" auxvalue="Layer35"/>
+      <auxiliary auxtype="volume" auxvalue="Layer36"/>
+      <auxiliary auxtype="volume" auxvalue="Layer37"/>
+      <auxiliary auxtype="volume" auxvalue="Layer38"/>
+      <auxiliary auxtype="volume" auxvalue="Layer39"/>
+      <auxiliary auxtype="volume" auxvalue="Layer40"/>
       <auxiliary auxtype="volume" auxvalue="Layer41"/>
       <auxiliary auxtype="volume" auxvalue="Layer42"/>
       <auxiliary auxtype="volume" auxvalue="Layer43"/>

--- a/examples/Example14/macros/testEm3_interlaced.mac.in
+++ b/examples/Example14/macros/testEm3_interlaced.mac.in
@@ -17,7 +17,8 @@
 /example14/detector/regionname caloregion
 /example14/adept/activate true
 /example14/adept/verbose 0
-/example14/adept/threshold 100
+/example14/adept/milliontrackslots 4
+/example14/adept/threshold 200
 
 /example14/detector/addsensitivevolume G4_Pb1
 /example14/detector/addsensitivevolume G4_lAr1
@@ -148,7 +149,7 @@
 /example14/gun/setDefault
 /gun/particle e-
 /gun/energy 10 GeV
-/gun/number 100
+/gun/number 10000
 /gun/position -220 0 0 mm
 /gun/direction 1 0 0
 #/example14/gun/print
@@ -164,3 +165,5 @@
 # by default all created models are active
 /param/ActivateModel AdePT
 /run/beamOn 1
+#/param/InActivateModel AdePT
+#/run/beamOn 1

--- a/examples/Example14/macros/testEm3_interlaced.mac.in
+++ b/examples/Example14/macros/testEm3_interlaced.mac.in
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: 2022 CERN
+# SPDX-License-Identifier: Apache-2.0
+#  testEm3.mac
+#
+
+## =============================================================================
+## Geant4 macro for modelling simplified sampling calorimeters with AdePT integration
+## =============================================================================
+##
+/run/numberOfThreads 1
+/control/verbose 0
+/run/verbose 0
+/process/verbose 0
+/tracking/verbose 0
+##
+/example14/detector/filename @TESTEM3_INTERLACED_GDML@
+/example14/detector/regionname caloregion
+/example14/adept/activate true
+/example14/adept/verbose 0
+/example14/adept/threshold 100
+
+/example14/detector/addsensitivevolume G4_Pb1
+/example14/detector/addsensitivevolume G4_lAr1
+/example14/detector/addsensitivevolume G4_Pb2
+/example14/detector/addsensitivevolume G4_lAr2
+/example14/detector/addsensitivevolume G4_Pb3
+/example14/detector/addsensitivevolume G4_lAr3
+/example14/detector/addsensitivevolume G4_Pb4
+/example14/detector/addsensitivevolume G4_lAr4
+/example14/detector/addsensitivevolume G4_Pb5
+/example14/detector/addsensitivevolume G4_lAr5
+/example14/detector/addsensitivevolume G4_Pb6
+/example14/detector/addsensitivevolume G4_lAr6
+/example14/detector/addsensitivevolume G4_Pb7
+/example14/detector/addsensitivevolume G4_lAr7
+/example14/detector/addsensitivevolume G4_Pb8
+/example14/detector/addsensitivevolume G4_lAr8
+/example14/detector/addsensitivevolume G4_Pb9
+/example14/detector/addsensitivevolume G4_lAr9
+/example14/detector/addsensitivevolume G4_Pb10
+/example14/detector/addsensitivevolume G4_lAr10
+/example14/detector/addsensitivevolume G4_Pb11
+/example14/detector/addsensitivevolume G4_lAr11
+/example14/detector/addsensitivevolume G4_Pb12
+/example14/detector/addsensitivevolume G4_lAr12
+/example14/detector/addsensitivevolume G4_Pb13
+/example14/detector/addsensitivevolume G4_lAr13
+/example14/detector/addsensitivevolume G4_Pb14
+/example14/detector/addsensitivevolume G4_lAr14
+/example14/detector/addsensitivevolume G4_Pb15
+/example14/detector/addsensitivevolume G4_lAr15
+/example14/detector/addsensitivevolume G4_Pb16
+/example14/detector/addsensitivevolume G4_lAr16
+/example14/detector/addsensitivevolume G4_Pb17
+/example14/detector/addsensitivevolume G4_lAr17
+/example14/detector/addsensitivevolume G4_Pb18
+/example14/detector/addsensitivevolume G4_lAr18
+/example14/detector/addsensitivevolume G4_Pb19
+/example14/detector/addsensitivevolume G4_lAr19
+/example14/detector/addsensitivevolume G4_Pb20
+/example14/detector/addsensitivevolume G4_lAr20
+/example14/detector/addsensitivevolume G4_Pb21
+/example14/detector/addsensitivevolume G4_lAr21
+/example14/detector/addsensitivevolume G4_Pb22
+/example14/detector/addsensitivevolume G4_lAr22
+/example14/detector/addsensitivevolume G4_Pb23
+/example14/detector/addsensitivevolume G4_lAr23
+/example14/detector/addsensitivevolume G4_Pb24
+/example14/detector/addsensitivevolume G4_lAr24
+/example14/detector/addsensitivevolume G4_Pb25
+/example14/detector/addsensitivevolume G4_lAr25
+/example14/detector/addsensitivevolume G4_Pb26
+/example14/detector/addsensitivevolume G4_lAr26
+/example14/detector/addsensitivevolume G4_Pb27
+/example14/detector/addsensitivevolume G4_lAr27
+/example14/detector/addsensitivevolume G4_Pb28
+/example14/detector/addsensitivevolume G4_lAr28
+/example14/detector/addsensitivevolume G4_Pb29
+/example14/detector/addsensitivevolume G4_lAr29
+/example14/detector/addsensitivevolume G4_Pb30
+/example14/detector/addsensitivevolume G4_lAr30
+/example14/detector/addsensitivevolume G4_Pb31
+/example14/detector/addsensitivevolume G4_lAr31
+/example14/detector/addsensitivevolume G4_Pb32
+/example14/detector/addsensitivevolume G4_lAr32
+/example14/detector/addsensitivevolume G4_Pb33
+/example14/detector/addsensitivevolume G4_lAr33
+/example14/detector/addsensitivevolume G4_Pb34
+/example14/detector/addsensitivevolume G4_lAr34
+/example14/detector/addsensitivevolume G4_Pb35
+/example14/detector/addsensitivevolume G4_lAr35
+/example14/detector/addsensitivevolume G4_Pb36
+/example14/detector/addsensitivevolume G4_lAr36
+/example14/detector/addsensitivevolume G4_Pb37
+/example14/detector/addsensitivevolume G4_lAr37
+/example14/detector/addsensitivevolume G4_Pb38
+/example14/detector/addsensitivevolume G4_lAr38
+/example14/detector/addsensitivevolume G4_Pb39
+/example14/detector/addsensitivevolume G4_lAr39
+/example14/detector/addsensitivevolume G4_Pb40
+/example14/detector/addsensitivevolume G4_lAr40
+/example14/detector/addsensitivevolume G4_Pb41
+/example14/detector/addsensitivevolume G4_lAr41
+/example14/detector/addsensitivevolume G4_Pb42
+/example14/detector/addsensitivevolume G4_lAr42
+/example14/detector/addsensitivevolume G4_Pb43
+/example14/detector/addsensitivevolume G4_lAr43
+/example14/detector/addsensitivevolume G4_Pb44
+/example14/detector/addsensitivevolume G4_lAr44
+/example14/detector/addsensitivevolume G4_Pb45
+/example14/detector/addsensitivevolume G4_lAr45
+/example14/detector/addsensitivevolume G4_Pb46
+/example14/detector/addsensitivevolume G4_lAr46
+/example14/detector/addsensitivevolume G4_Pb47
+/example14/detector/addsensitivevolume G4_lAr47
+/example14/detector/addsensitivevolume G4_Pb48
+/example14/detector/addsensitivevolume G4_lAr48
+/example14/detector/addsensitivevolume G4_Pb49
+/example14/detector/addsensitivevolume G4_lAr49
+/example14/detector/addsensitivevolume G4_Pb50
+/example14/detector/addsensitivevolume G4_lAr50
+
+## -----------------------------------------------------------------------------
+## Optionally, set a constant magnetic filed:
+## -----------------------------------------------------------------------------
+#/example14/detector/setField 0 0 0.1 tesla
+/example14/detector/setField 0 0 0 tesla
+
+##
+## -----------------------------------------------------------------------------
+## Set the physics list (more exactly, the EM physics constructor):
+##   = 'HepEm'           : the G4HepEm EM physics c.t.r.
+##   =  'G4Em'           : the G4 EM physics c.t.r. that corresponds to G4HepEm
+##   = 'emstandard_opt0' : the original, G4 EM-Opt0 physics c.t.r.
+## -----------------------------------------------------------------------------
+##/testem/phys/addPhysics   HepEm
+##/testem/phys/addPhysics  emstandard_opt0 
+##
+## -----------------------------------------------------------------------------
+## Set secondary production threshold, init. the run and set primary properties
+## -----------------------------------------------------------------------------
+/run/setCut 0.7 mm
+/run/initialize
+
+## Event verbosity: 1 = total edep, 2 = energy deposit per placed sensitive volume
+/example14/event/verbose 2
+
+/example14/gun/setDefault
+/gun/particle e-
+/gun/energy 10 GeV
+/gun/number 100
+/gun/position -220 0 0 mm
+/gun/direction 1 0 0
+#/example14/gun/print
+
+##
+## -----------------------------------------------------------------------------
+## Run the simulation with the given number of events and print list of processes
+## -----------------------------------------------------------------------------
+##/tracking/verbose 1
+##/process/list
+
+# run events with parametrised simulation
+# by default all created models are active
+/param/ActivateModel AdePT
+/run/beamOn 1

--- a/examples/Example14/src/DetectorConstruction.cc
+++ b/examples/Example14/src/DetectorConstruction.cc
@@ -154,6 +154,17 @@ void DetectorConstruction::ConstructSDandField()
   }
 
   auto detectorRegion = G4RegionStore::GetInstance()->GetRegion(fRegion_name);
+  
+  auto rootLVItr = detectorRegion->GetRootLogicalVolumeIterator();
+  std::size_t nRootLV = detectorRegion->GetNumberOfRootVolumes();
+  std::cout << "Adding GPU region " << fRegion_name << " having " << nRootLV << " root logical volumes:\n";
+  for(std::size_t iLV=0; iLV<nRootLV; ++iLV) {
+    G4LogicalVolume* aLV = *rootLVItr;
+    std::cout << " " << aLV->GetName();
+    ++rootLVItr;
+  }
+  std::cout << "\n";
+
   fShowerModel        = new EMShowerModel("AdePT", detectorRegion);
 
   fShowerModel->SetSensitiveVolumes(&(caloSD->fSensitive_volume_index));


### PR DESCRIPTION
We can now use the testEm3_interlaced.mac macro in example14 to test the impact of interlacing CPU with GPU simulation regions. Layer volumes are now separate and can be added to the `caloregion` region in testEm3_interlaced.gdml. The default now is that the first 10 and last 10 layers are controlled by the GPU.