### PR TITLE
Fix assignment of const variable

### DIFF
--- a/magneticfield/inc/fieldPropagatorConstBz.h
+++ b/magneticfield/inc/fieldPropagatorConstBz.h
@@ -67,7 +67,7 @@ template <class Navigator>
 __host__ __device__ Precision fieldPropagatorConstBz::ComputeStepAndNextVolume(
     double kinE, double mass, int charge, Precision physicsStep, vecgeom::Vector3D<vecgeom::Precision> &position,
     vecgeom::Vector3D<vecgeom::Precision> &direction, vecgeom::NavStateIndex const &current_state,
-    vecgeom::NavStateIndex &next_state, bool &propagated, const Precision safety, const int max_iterations)
+    vecgeom::NavStateIndex &next_state, bool &propagated, Precision safety, const int max_iterations)
 {
   using Precision = vecgeom::Precision;
   #ifdef VECGEOM_FLOAT_PRECISION


### PR DESCRIPTION
This error occurred to me now with g++-12 and nvcc 11.7:

```
[ 88%] Building CUDA object examples/TestEm3/CMakeFiles/TestEm3.dir/electrons.cu.o
/home/bgruber/dev/AdePT/magneticfield/inc/fieldPropagatorConstBz.h(139): error: expression must be a modifiable lvalue
          detected during:
            instantiation of "fieldPropagatorConstBz::Precision fieldPropagatorConstBz::ComputeStepAndNextVolume(double, double, int, fieldPropagatorConstBz::Precision, fieldPropagatorConstBz::Vector3D &, fieldPropagatorConstBz::Vector3D &, const vecgeom::cuda::NavStateIndex &, vecgeom::cuda::NavStateIndex &, __nv_bool &, fieldPropagatorConstBz::Precision, int) [with Navigator=cuda::BVHNavigator]" 
/home/bgruber/dev/AdePT/examples/TestEm3/electrons.cu(112): here
            instantiation of "void TransportElectrons<IsElectron>(Track *, const adept::MParray *, Secondaries &, adept::MParray *, GlobalScoring *, ScoringPerVolume *) [with IsElectron=true]" 
/home/bgruber/dev/AdePT/examples/TestEm3/electrons.cu(346): here
```