### PR TITLE
fixing hepmc reader for MT

### DIFF
--- a/examples/Example14/include/HepMC3G4AsciiReader.hh
+++ b/examples/Example14/include/HepMC3G4AsciiReader.hh
@@ -21,10 +21,12 @@ protected:
   G4String filename;
   HepMC3::ReaderAscii* asciiInput;
 
+  static std::vector<HepMC3::GenEvent*>* fEvents;
+
   G4int verbose;
   HepMC3G4AsciiReaderMessenger* messenger;
 
-  virtual HepMC3::GenEvent* GenerateHepMCEvent();
+  virtual HepMC3::GenEvent* GenerateHepMCEvent(int eventId);
 
 public:
   HepMC3G4AsciiReader();

--- a/examples/Example14/include/HepMC3G4Interface.hh
+++ b/examples/Example14/include/HepMC3G4Interface.hh
@@ -36,7 +36,7 @@ protected:
 
   // Implement this method in his/her own concrete class.
   // An empty event will be created in default.
-  virtual HepMC3::GenEvent* GenerateHepMCEvent();
+  virtual HepMC3::GenEvent* GenerateHepMCEvent(int);
 
 public:
   HepMC3G4Interface();

--- a/examples/Example14/src/ActionInitialisation.cc
+++ b/examples/Example14/src/ActionInitialisation.cc
@@ -44,6 +44,7 @@ ActionInitialisation::~ActionInitialisation() {}
 
 void ActionInitialisation::BuildForMaster() const
 {
+  new PrimaryGeneratorAction(fDetector);
   SetUserAction(new RunAction(fDetector));
 }
 

--- a/examples/Example14/src/HepMC3G4AsciiReaderMessenger.cc
+++ b/examples/Example14/src/HepMC3G4AsciiReaderMessenger.cc
@@ -13,6 +13,7 @@
 #include "HepMC3G4AsciiReaderMessenger.hh"
 #include "HepMC3G4AsciiReader.hh"
 
+#include "G4Threading.hh"
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 HepMC3G4AsciiReaderMessenger::HepMC3G4AsciiReaderMessenger
@@ -51,12 +52,9 @@ void HepMC3G4AsciiReaderMessenger::SetNewValue(G4UIcommand* command,
     gen-> SetVerboseLevel(level);
   } else if (command==open) {
     gen-> SetFileName(newValues);
-    G4cout << "HepMC Ascii inputfile: "
-           << gen-> GetFileName() << G4endl;
-    gen-> Initialize();
+    if (G4Threading::G4GetThreadId()==-1) gen->Initialize();
   }
 }
-
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 G4String HepMC3G4AsciiReaderMessenger::GetCurrentValue(G4UIcommand* command)

--- a/examples/Example14/src/HepMC3G4Interface.cc
+++ b/examples/Example14/src/HepMC3G4Interface.cc
@@ -83,7 +83,7 @@ void HepMC3G4Interface::HepMC2G4(const HepMC3::GenEvent* hepmcevt,
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
-HepMC3::GenEvent* HepMC3G4Interface::GenerateHepMCEvent()
+HepMC3::GenEvent* HepMC3G4Interface::GenerateHepMCEvent(int i)
 {
   HepMC3::GenEvent* aevent= new HepMC3::GenEvent();
   return aevent;
@@ -96,7 +96,7 @@ void HepMC3G4Interface::GeneratePrimaryVertex(G4Event* anEvent)
   delete hepmcEvent;
 
   // generate next event
-  hepmcEvent= GenerateHepMCEvent();
+  hepmcEvent= GenerateHepMCEvent(anEvent->GetEventID());
   if(! hepmcEvent) {
     G4cout << "HepMCInterface: no generated particles. run terminated..."
            << G4endl;


### PR DESCRIPTION
A new version of HepMC reader which should work fine for MT. File is read once into a vector of events and each thread accesses it by the event number. If event number is larger than the size of the vector, the event number is taken modulo the number of events read from the file.
