### PR TITLE
Update G4HepEm and adapt RNG interface

### DIFF
--- a/base/inc/CopCore/include/CopCore/Ranluxpp.h
+++ b/base/inc/CopCore/include/CopCore/Ranluxpp.h
@@ -53,7 +53,7 @@ public:
   RanluxppEngineImpl() = default;
 
   /// Produce next block of random bits
-  __host__ __device__ void Advance()
+  __host__ __device__ void __attribute__((noinline)) Advance()
   {
     uint64_t lcg[9];
     to_lcg(fState, fCarry, lcg);

--- a/examples/Example10/electrons.cu
+++ b/examples/Example10/electrons.cu
@@ -165,7 +165,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       }
 
       // Perform the discrete interaction.
-      RanluxppDoubleEngine rnge(&currentTrack.rngState);
+      G4HepEmRandomEngine rnge(&currentTrack.rngState);
       // We will need one branched RNG state, prepare while threads are synchronized.
       RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/Example10/example10.cu
+++ b/examples/Example10/example10.cu
@@ -33,8 +33,6 @@
 __constant__ __device__ struct G4HepEmParameters g4HepEmPars;
 __constant__ __device__ struct G4HepEmData g4HepEmData;
 
-__constant__ __device__ int Zero = 0;
-
 struct G4HepEmState {
   G4HepEmData data;
   G4HepEmParameters parameters;

--- a/examples/Example10/example10.cuh
+++ b/examples/Example10/example10.cuh
@@ -53,42 +53,20 @@ struct Track {
   }
 };
 
-// Defined in example10.cu
-extern __constant__ __device__ int Zero;
+// Define inline implementations of the RNG methods for the device.
+// (nvcc ignores the __device__ attribute in definitions, so this is only to
+// communicate the intent.)
+inline __device__ double G4HepEmRandomEngine::flat()
+{
+  return ((RanluxppDouble *)fObject)->Rndm();
+}
 
-class RanluxppDoubleEngine : public G4HepEmRandomEngine {
-  // Wrapper functions to call into RanluxppDouble.
-  static __host__ __device__ __attribute__((noinline))
-  double FlatWrapper(void *object)
-  {
-    return ((RanluxppDouble *)object)->Rndm();
+inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *vect)
+{
+  for (int i = 0; i < size; i++) {
+    vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
-  static __host__ __device__ __attribute__((noinline))
-  void FlatArrayWrapper(void *object, const int size, double *vect)
-  {
-    for (int i = 0; i < size; i++) {
-      vect[i] = ((RanluxppDouble *)object)->Rndm();
-    }
-  }
-
-public:
-  __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
-      : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
-  {
-#ifdef __CUDA_ARCH__
-    // This is a hack: The compiler cannot see that we're going to call the
-    // functions through their pointers, so it underestimates the number of
-    // required registers. By including calls to the (non-inlinable) functions
-    // we force the compiler to account for the register usage, even if this
-    // particular set of calls are not executed at runtime.
-    if (Zero) {
-      FlatWrapper(engine);
-      FlatArrayWrapper(engine, 0, nullptr);
-    }
-#endif
-  }
-};
-
+}
 
 // A data structure for some global scoring. The accessors must make sure to use
 // atomic operations if needed.

--- a/examples/Example10/gammas.cu
+++ b/examples/Example10/gammas.cu
@@ -104,7 +104,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
       currentTrack.numIALeft[winnerProcessIndex] = -1.0;
 
       // Perform the discrete interaction.
-      RanluxppDoubleEngine rnge(&currentTrack.rngState);
+      G4HepEmRandomEngine rnge(&currentTrack.rngState);
       // We might need one branched RNG state, prepare while threads are synchronized.
       RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/Example11/electrons.cu
+++ b/examples/Example11/electrons.cu
@@ -161,7 +161,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     }
 
     // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
     // We will need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/Example11/example11.cu
+++ b/examples/Example11/example11.cu
@@ -32,8 +32,6 @@
 __constant__ __device__ struct G4HepEmParameters g4HepEmPars;
 __constant__ __device__ struct G4HepEmData g4HepEmData;
 
-__constant__ __device__ int Zero = 0;
-
 struct G4HepEmState {
   G4HepEmData data;
   G4HepEmParameters parameters;

--- a/examples/Example11/example11.cuh
+++ b/examples/Example11/example11.cuh
@@ -44,42 +44,20 @@ struct Track {
   }
 };
 
-// Defined in example11.cu
-extern __constant__ __device__ int Zero;
+// Define inline implementations of the RNG methods for the device.
+// (nvcc ignores the __device__ attribute in definitions, so this is only to
+// communicate the intent.)
+inline __device__ double G4HepEmRandomEngine::flat()
+{
+  return ((RanluxppDouble *)fObject)->Rndm();
+}
 
-class RanluxppDoubleEngine : public G4HepEmRandomEngine {
-  // Wrapper functions to call into RanluxppDouble.
-  static __host__ __device__ __attribute__((noinline))
-  double FlatWrapper(void *object)
-  {
-    return ((RanluxppDouble *)object)->Rndm();
+inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *vect)
+{
+  for (int i = 0; i < size; i++) {
+    vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
-  static __host__ __device__ __attribute__((noinline))
-  void FlatArrayWrapper(void *object, const int size, double *vect)
-  {
-    for (int i = 0; i < size; i++) {
-      vect[i] = ((RanluxppDouble *)object)->Rndm();
-    }
-  }
-
-public:
-  __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
-      : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
-  {
-#ifdef __CUDA_ARCH__
-    // This is a hack: The compiler cannot see that we're going to call the
-    // functions through their pointers, so it underestimates the number of
-    // required registers. By including calls to the (non-inlinable) functions
-    // we force the compiler to account for the register usage, even if this
-    // particular set of calls are not executed at runtime.
-    if (Zero) {
-      FlatWrapper(engine);
-      FlatArrayWrapper(engine, 0, nullptr);
-    }
-#endif
-  }
-};
-
+}
 
 // A data structure for some global scoring. The accessors must make sure to use
 // atomic operations if needed.

--- a/examples/Example11/gammas.cu
+++ b/examples/Example11/gammas.cu
@@ -96,7 +96,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     currentTrack.numIALeft[winnerProcessIndex] = -1.0;
 
     // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
     // We might need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/Example12/electrons.cu
+++ b/examples/Example12/electrons.cu
@@ -183,7 +183,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     }
 
     // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
     // We will need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/Example12/example12.cu
+++ b/examples/Example12/example12.cu
@@ -37,8 +37,6 @@ __constant__ __device__ struct G4HepEmData g4HepEmData;
 
 __constant__ __device__ int *MCIndex = nullptr;
 
-__constant__ __device__ int Zero = 0;
-
 void InitG4HepEmGPU(G4HepEmState *state)
 {
   // Copy to GPU.

--- a/examples/Example12/example12.cuh
+++ b/examples/Example12/example12.cuh
@@ -45,39 +45,20 @@ struct Track {
   }
 };
 
-// Defined in example12.cu
-extern __constant__ __device__ int Zero;
+// Define inline implementations of the RNG methods for the device.
+// (nvcc ignores the __device__ attribute in definitions, so this is only to
+// communicate the intent.)
+inline __device__ double G4HepEmRandomEngine::flat()
+{
+  return ((RanluxppDouble *)fObject)->Rndm();
+}
 
-class RanluxppDoubleEngine : public G4HepEmRandomEngine {
-  // Wrapper functions to call into RanluxppDouble.
-  static __host__ __device__ __attribute__((noinline)) double FlatWrapper(void *object)
-  {
-    return ((RanluxppDouble *)object)->Rndm();
+inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *vect)
+{
+  for (int i = 0; i < size; i++) {
+    vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
-  static __host__ __device__ __attribute__((noinline)) void FlatArrayWrapper(void *object, const int size, double *vect)
-  {
-    for (int i = 0; i < size; i++) {
-      vect[i] = ((RanluxppDouble *)object)->Rndm();
-    }
-  }
-
-public:
-  __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
-      : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
-  {
-#ifdef __CUDA_ARCH__
-    // This is a hack: The compiler cannot see that we're going to call the
-    // functions through their pointers, so it underestimates the number of
-    // required registers. By including calls to the (non-inlinable) functions
-    // we force the compiler to account for the register usage, even if this
-    // particular set of calls are not executed at runtime.
-    if (Zero) {
-      FlatWrapper(engine);
-      FlatArrayWrapper(engine, 0, nullptr);
-    }
-#endif
-  }
-};
+}
 
 // A data structure to manage slots in the track storage.
 class SlotManager {

--- a/examples/Example12/gammas.cu
+++ b/examples/Example12/gammas.cu
@@ -107,7 +107,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     currentTrack.numIALeft[winnerProcessIndex] = -1.0;
 
     // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
     // We might need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/Example13/electrons.cu
+++ b/examples/Example13/electrons.cu
@@ -78,7 +78,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     }
     theTrack->SetSafety(safety);
 
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
 
     // Sample the `number-of-interaction-left` and put it into the track.
     for (int ip = 0; ip < 3; ++ip) {

--- a/examples/Example13/example13.cu
+++ b/examples/Example13/example13.cu
@@ -38,8 +38,6 @@ __constant__ __device__ struct G4HepEmData g4HepEmData;
 
 __constant__ __device__ int *MCIndex = nullptr;
 
-__constant__ __device__ int Zero = 0;
-
 void InitG4HepEmGPU(G4HepEmState *state)
 {
   // Copy to GPU.

--- a/examples/Example13/example13.cuh
+++ b/examples/Example13/example13.cuh
@@ -52,39 +52,20 @@ struct Track {
   }
 };
 
-// Defined in example13.cu
-extern __constant__ __device__ int Zero;
+// Define inline implementations of the RNG methods for the device.
+// (nvcc ignores the __device__ attribute in definitions, so this is only to
+// communicate the intent.)
+inline __device__ double G4HepEmRandomEngine::flat()
+{
+  return ((RanluxppDouble *)fObject)->Rndm();
+}
 
-class RanluxppDoubleEngine : public G4HepEmRandomEngine {
-  // Wrapper functions to call into RanluxppDouble.
-  static __host__ __device__ __attribute__((noinline)) double FlatWrapper(void *object)
-  {
-    return ((RanluxppDouble *)object)->Rndm();
+inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *vect)
+{
+  for (int i = 0; i < size; i++) {
+    vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
-  static __host__ __device__ __attribute__((noinline)) void FlatArrayWrapper(void *object, const int size, double *vect)
-  {
-    for (int i = 0; i < size; i++) {
-      vect[i] = ((RanluxppDouble *)object)->Rndm();
-    }
-  }
-
-public:
-  __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
-      : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
-  {
-#ifdef __CUDA_ARCH__
-    // This is a hack: The compiler cannot see that we're going to call the
-    // functions through their pointers, so it underestimates the number of
-    // required registers. By including calls to the (non-inlinable) functions
-    // we force the compiler to account for the register usage, even if this
-    // particular set of calls are not executed at runtime.
-    if (Zero) {
-      FlatWrapper(engine);
-      FlatArrayWrapper(engine, 0, nullptr);
-    }
-#endif
-  }
-};
+}
 
 // A data structure to manage slots in the track storage.
 class SlotManager {

--- a/examples/Example13/gammas.cu
+++ b/examples/Example13/gammas.cu
@@ -111,7 +111,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     currentTrack.numIALeft[winnerProcessIndex] = -1.0;
 
     // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
     // We might need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/Example14/AdeptIntegration.cu
+++ b/examples/Example14/AdeptIntegration.cu
@@ -45,8 +45,6 @@ __constant__ __device__ struct G4HepEmData g4HepEmData;
 __constant__ __device__ adeptint::VolAuxData *gVolAuxData = nullptr;
 __constant__ __device__ double BzFieldValue               = 0;
 
-__constant__ __device__ int Zero = 0;
-
 G4HepEmState *AdeptIntegration::fg4hepem_state{nullptr};
 SlotManager *slotManagerInit_dev = nullptr;
 int AdeptIntegration::kCapacity = 1024 * 1024;

--- a/examples/Example14/AdeptIntegration.cuh
+++ b/examples/Example14/AdeptIntegration.cuh
@@ -12,39 +12,20 @@
 #include <G4HepEmParameters.hh>
 #include <G4HepEmRandomEngine.hh>
 
-// Defined in AdeptIntegration.cu
-extern __constant__ __device__ int Zero;
+// Define inline implementations of the RNG methods for the device.
+// (nvcc ignores the __device__ attribute in definitions, so this is only to
+// communicate the intent.)
+inline __device__ double G4HepEmRandomEngine::flat()
+{
+  return ((RanluxppDouble *)fObject)->Rndm();
+}
 
-class RanluxppDoubleEngine : public G4HepEmRandomEngine {
-  // Wrapper functions to call into RanluxppDouble.
-  static __host__ __device__ __attribute__((noinline)) double FlatWrapper(void *object)
-  {
-    return ((RanluxppDouble *)object)->Rndm();
+inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *vect)
+{
+  for (int i = 0; i < size; i++) {
+    vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
-  static __host__ __device__ __attribute__((noinline)) void FlatArrayWrapper(void *object, const int size, double *vect)
-  {
-    for (int i = 0; i < size; i++) {
-      vect[i] = ((RanluxppDouble *)object)->Rndm();
-    }
-  }
-
-public:
-  __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
-      : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
-  {
-#ifdef __CUDA_ARCH__
-    // This is a hack: The compiler cannot see that we're going to call the
-    // functions through their pointers, so it underestimates the number of
-    // required registers. By including calls to the (non-inlinable) functions
-    // we force the compiler to account for the register usage, even if this
-    // particular set of calls are not executed at runtime.
-    if (Zero) {
-      FlatWrapper(engine);
-      FlatArrayWrapper(engine, 0, nullptr);
-    }
-#endif
-  }
-};
+}
 
 // A data structure to manage slots in the track storage.
 class SlotManager {

--- a/examples/Example14/electrons.cuh
+++ b/examples/Example14/electrons.cuh
@@ -79,7 +79,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     }
     theTrack->SetSafety(safety);
 
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
 
     // Sample the `number-of-interaction-left` and put it into the track.
     for (int ip = 0; ip < 3; ++ip) {

--- a/examples/Example14/gammas.cuh
+++ b/examples/Example14/gammas.cuh
@@ -124,7 +124,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     currentTrack.numIALeft[winnerProcessIndex] = -1.0;
 
     // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
     // We might need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/Example16/electrons.cu
+++ b/examples/Example16/electrons.cu
@@ -77,7 +77,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     }
     theTrack->SetSafety(safety);
 
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
 
     // Sample the `number-of-interaction-left` and put it into the track.
     for (int ip = 0; ip < 3; ++ip) {

--- a/examples/Example16/example16.cu
+++ b/examples/Example16/example16.cu
@@ -38,8 +38,6 @@ __constant__ __device__ struct G4HepEmData g4HepEmData;
 
 __constant__ __device__ int *MCIndex = nullptr;
 
-__constant__ __device__ int Zero = 0;
-
 void InitG4HepEmGPU(G4HepEmState *state)
 {
   // Copy to GPU.

--- a/examples/Example16/example16.cuh
+++ b/examples/Example16/example16.cuh
@@ -53,39 +53,20 @@ struct Track {
   }
 };
 
-// Defined in example16.cu
-extern __constant__ __device__ int Zero;
+// Define inline implementations of the RNG methods for the device.
+// (nvcc ignores the __device__ attribute in definitions, so this is only to
+// communicate the intent.)
+inline __device__ double G4HepEmRandomEngine::flat()
+{
+  return ((RanluxppDouble *)fObject)->Rndm();
+}
 
-class RanluxppDoubleEngine : public G4HepEmRandomEngine {
-  // Wrapper functions to call into RanluxppDouble.
-  static __host__ __device__ __attribute__((noinline)) double FlatWrapper(void *object)
-  {
-    return ((RanluxppDouble *)object)->Rndm();
+inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *vect)
+{
+  for (int i = 0; i < size; i++) {
+    vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
-  static __host__ __device__ __attribute__((noinline)) void FlatArrayWrapper(void *object, const int size, double *vect)
-  {
-    for (int i = 0; i < size; i++) {
-      vect[i] = ((RanluxppDouble *)object)->Rndm();
-    }
-  }
-
-public:
-  __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
-      : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
-  {
-#ifdef __CUDA_ARCH__
-    // This is a hack: The compiler cannot see that we're going to call the
-    // functions through their pointers, so it underestimates the number of
-    // required registers. By including calls to the (non-inlinable) functions
-    // we force the compiler to account for the register usage, even if this
-    // particular set of calls are not executed at runtime.
-    if (Zero) {
-      FlatWrapper(engine);
-      FlatArrayWrapper(engine, 0, nullptr);
-    }
-#endif
-  }
-};
+}
 
 // A bundle of generators for the three particle types.
 struct Secondaries {

--- a/examples/Example16/gammas.cu
+++ b/examples/Example16/gammas.cu
@@ -110,7 +110,7 @@ int activeSize = gammas->fActiveTracks->size();
     currentTrack.numIALeft[winnerProcessIndex] = -1.0;
 
     // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
     // We might need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/Example17/AdeptIntegration.cu
+++ b/examples/Example17/AdeptIntegration.cu
@@ -42,8 +42,6 @@ __constant__ __device__ struct G4HepEmData g4HepEmData;
 __constant__ __device__ adeptint::VolAuxData *gVolAuxData = nullptr;
 __constant__ __device__ double BzFieldValue               = 0;
 
-__constant__ __device__ int Zero = 0;
-
 G4HepEmState *AdeptIntegration::fg4hepem_state{nullptr};
 int AdeptIntegration::kCapacity = 1024 * 1024;
 

--- a/examples/Example17/AdeptIntegration.cuh
+++ b/examples/Example17/AdeptIntegration.cuh
@@ -13,39 +13,20 @@
 #include <G4HepEmParameters.hh>
 #include <G4HepEmRandomEngine.hh>
 
-// Defined in AdeptIntegration.cu
-extern __constant__ __device__ int Zero;
+// Define inline implementations of the RNG methods for the device.
+// (nvcc ignores the __device__ attribute in definitions, so this is only to
+// communicate the intent.)
+inline __device__ double G4HepEmRandomEngine::flat()
+{
+  return ((RanluxppDouble *)fObject)->Rndm();
+}
 
-class RanluxppDoubleEngine : public G4HepEmRandomEngine {
-  // Wrapper functions to call into RanluxppDouble.
-  static __host__ __device__ __attribute__((noinline)) double FlatWrapper(void *object)
-  {
-    return ((RanluxppDouble *)object)->Rndm();
+inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *vect)
+{
+  for (int i = 0; i < size; i++) {
+    vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
-  static __host__ __device__ __attribute__((noinline)) void FlatArrayWrapper(void *object, const int size, double *vect)
-  {
-    for (int i = 0; i < size; i++) {
-      vect[i] = ((RanluxppDouble *)object)->Rndm();
-    }
-  }
-
-public:
-  __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
-      : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
-  {
-#ifdef __CUDA_ARCH__
-    // This is a hack: The compiler cannot see that we're going to call the
-    // functions through their pointers, so it underestimates the number of
-    // required registers. By including calls to the (non-inlinable) functions
-    // we force the compiler to account for the register usage, even if this
-    // particular set of calls are not executed at runtime.
-    if (Zero) {
-      FlatWrapper(engine);
-      FlatArrayWrapper(engine, 0, nullptr);
-    }
-#endif
-  }
-};
+}
 
 struct LeakedTracks {
   adept::TrackManager<Track> *trackmgr;

--- a/examples/Example17/electrons.cuh
+++ b/examples/Example17/electrons.cuh
@@ -78,7 +78,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     }
     theTrack->SetSafety(safety);
 
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
 
     // Sample the `number-of-interaction-left` and put it into the track.
     for (int ip = 0; ip < 3; ++ip) {

--- a/examples/Example17/gammas.cuh
+++ b/examples/Example17/gammas.cuh
@@ -124,7 +124,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
     currentTrack.numIALeft[winnerProcessIndex] = -1.0;
 
     // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
     // We might need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/Example18/electrons.cu
+++ b/examples/Example18/electrons.cu
@@ -78,7 +78,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     }
     theTrack->SetSafety(safety);
 
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
 
     // Sample the `number-of-interaction-left` and put it into the track.
     for (int ip = 0; ip < 3; ++ip) {

--- a/examples/Example18/example18.cu
+++ b/examples/Example18/example18.cu
@@ -38,8 +38,6 @@ __constant__ __device__ struct G4HepEmData g4HepEmData;
 
 __constant__ __device__ int *MCIndex = nullptr;
 
-__constant__ __device__ int Zero = 0;
-
 void InitG4HepEmGPU(G4HepEmState *state)
 {
   // Copy to GPU.

--- a/examples/Example18/example18.cuh
+++ b/examples/Example18/example18.cuh
@@ -52,39 +52,20 @@ struct Track {
   }
 };
 
-// Defined in example18.cu
-extern __constant__ __device__ int Zero;
+// Define inline implementations of the RNG methods for the device.
+// (nvcc ignores the __device__ attribute in definitions, so this is only to
+// communicate the intent.)
+inline __device__ double G4HepEmRandomEngine::flat()
+{
+  return ((RanluxppDouble *)fObject)->Rndm();
+}
 
-class RanluxppDoubleEngine : public G4HepEmRandomEngine {
-  // Wrapper functions to call into RanluxppDouble.
-  static __host__ __device__ __attribute__((noinline)) double FlatWrapper(void *object)
-  {
-    return ((RanluxppDouble *)object)->Rndm();
+inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *vect)
+{
+  for (int i = 0; i < size; i++) {
+    vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
-  static __host__ __device__ __attribute__((noinline)) void FlatArrayWrapper(void *object, const int size, double *vect)
-  {
-    for (int i = 0; i < size; i++) {
-      vect[i] = ((RanluxppDouble *)object)->Rndm();
-    }
-  }
-
-public:
-  __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
-      : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
-  {
-#ifdef __CUDA_ARCH__
-    // This is a hack: The compiler cannot see that we're going to call the
-    // functions through their pointers, so it underestimates the number of
-    // required registers. By including calls to the (non-inlinable) functions
-    // we force the compiler to account for the register usage, even if this
-    // particular set of calls are not executed at runtime.
-    if (Zero) {
-      FlatWrapper(engine);
-      FlatArrayWrapper(engine, 0, nullptr);
-    }
-#endif
-  }
-};
+}
 
 // A data structure to manage slots in the track storage.
 class SlotManager {

--- a/examples/Example18/gammas.cu
+++ b/examples/Example18/gammas.cu
@@ -111,7 +111,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     currentTrack.numIALeft[winnerProcessIndex] = -1.0;
 
     // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
     // We might need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/Example19/electrons.cu
+++ b/examples/Example19/electrons.cu
@@ -81,7 +81,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     }
     theTrack->SetSafety(safety);
 
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
 
     // Sample the `number-of-interaction-left` and put it into the track.
     for (int ip = 0; ip < 3; ++ip) {
@@ -318,7 +318,7 @@ __device__ void ElectronInteraction(int const globalSlot, SOAData const & /*soaD
   const double theElCut = g4HepEmData.fTheMatCutData->fMatCutData[theMCIndex].fSecElProdCutE;
 
   RanluxppDouble newRNG{currentTrack.rngState.Branch()};
-  RanluxppDoubleEngine rnge{&currentTrack.rngState};
+  G4HepEmRandomEngine rnge{&currentTrack.rngState};
 
   if constexpr (ProcessIndex == 0) {
     // Invoke ionization (for e-/e+):

--- a/examples/Example19/example.cuh
+++ b/examples/Example19/example.cuh
@@ -60,39 +60,20 @@ struct SOAData {
   double *gamma_PEmxSec = nullptr;
 };
 
-// Defined in example18.cu
-extern __constant__ __device__ int Zero;
+// Define inline implementations of the RNG methods for the device.
+// (nvcc ignores the __device__ attribute in definitions, so this is only to
+// communicate the intent.)
+inline __device__ double G4HepEmRandomEngine::flat()
+{
+  return ((RanluxppDouble *)fObject)->Rndm();
+}
 
-class RanluxppDoubleEngine : public G4HepEmRandomEngine {
-  // Wrapper functions to call into RanluxppDouble.
-  static __host__ __device__ __attribute__((noinline)) double FlatWrapper(void *object)
-  {
-    return ((RanluxppDouble *)object)->Rndm();
+inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *vect)
+{
+  for (int i = 0; i < size; i++) {
+    vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
-  static __host__ __device__ __attribute__((noinline)) void FlatArrayWrapper(void *object, const int size, double *vect)
-  {
-    for (int i = 0; i < size; i++) {
-      vect[i] = ((RanluxppDouble *)object)->Rndm();
-    }
-  }
-
-public:
-  __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
-      : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
-  {
-#ifdef __CUDA_ARCH__
-    // This is a hack: The compiler cannot see that we're going to call the
-    // functions through their pointers, so it underestimates the number of
-    // required registers. By including calls to the (non-inlinable) functions
-    // we force the compiler to account for the register usage, even if this
-    // particular set of calls are not executed at runtime.
-    if (Zero) {
-      FlatWrapper(engine);
-      FlatArrayWrapper(engine, 0, nullptr);
-    }
-#endif
-  }
-};
+}
 
 // A data structure to manage slots in the track storage.
 class SlotManager {

--- a/examples/Example19/gammas.cu
+++ b/examples/Example19/gammas.cu
@@ -132,7 +132,7 @@ __device__ void GammaInteraction(int const globalSlot, SOAData const &soaData, i
   const auto energy = currentTrack.energy;
 
   RanluxppDouble newRNG{currentTrack.rngState.Branch()};
-  RanluxppDoubleEngine rnge{&currentTrack.rngState};
+  G4HepEmRandomEngine rnge{&currentTrack.rngState};
 
   if constexpr (ProcessIndex == 0) {
     // Invoke gamma conversion to e-/e+ pairs, if the energy is above the threshold.

--- a/examples/Example19/main.cu
+++ b/examples/Example19/main.cu
@@ -38,8 +38,6 @@ __constant__ __device__ struct G4HepEmData g4HepEmData;
 
 __constant__ __device__ int *MCIndex = nullptr;
 
-__constant__ __device__ int Zero = 0;
-
 void InitG4HepEmGPU(G4HepEmState *state)
 {
   // Copy to GPU.

--- a/examples/Example7/TestEm3.cu
+++ b/examples/Example7/TestEm3.cu
@@ -32,8 +32,6 @@ __constant__ __device__ struct G4HepEmData g4HepEmData;
 
 __constant__ __device__ int *MCIndex = nullptr;
 
-__constant__ __device__ int Zero = 0;
-
 G4HepEmData dataOnDevice;
 
 static void CopyG4HepEmToDevice(G4HepEmState *hostState)

--- a/examples/Example7/TestEm3.cuh
+++ b/examples/Example7/TestEm3.cuh
@@ -55,42 +55,20 @@ struct Track {
   }
 };
 
-// Defined in TestEm3.cu
-extern __constant__ __device__ int Zero;
+// Define inline implementations of the RNG methods for the device.
+// (nvcc ignores the __device__ attribute in definitions, so this is only to
+// communicate the intent.)
+inline __device__ double G4HepEmRandomEngine::flat()
+{
+  return ((RanluxppDouble *)fObject)->Rndm();
+}
 
-class RanluxppDoubleEngine : public G4HepEmRandomEngine {
-  // Wrapper functions to call into RanluxppDouble.
-  static __host__ __device__ __attribute__((noinline))
-  double FlatWrapper(void *object)
-  {
-    return ((RanluxppDouble *)object)->Rndm();
+inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *vect)
+{
+  for (int i = 0; i < size; i++) {
+    vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
-  static __host__ __device__ __attribute__((noinline))
-  void FlatArrayWrapper(void *object, const int size, double *vect)
-  {
-    for (int i = 0; i < size; i++) {
-      vect[i] = ((RanluxppDouble *)object)->Rndm();
-    }
-  }
-
-public:
-  __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
-      : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
-  {
-#ifdef __CUDA_ARCH__
-    // This is a hack: The compiler cannot see that we're going to call the
-    // functions through their pointers, so it underestimates the number of
-    // required registers. By including calls to the (non-inlinable) functions
-    // we force the compiler to account for the register usage, even if this
-    // particular set of calls are not executed at runtime.
-    if (Zero) {
-      FlatWrapper(engine);
-      FlatArrayWrapper(engine, 0, nullptr);
-    }
-#endif
-  }
-};
-
+}
 
 // A data structure to manage slots in the track storage.
 class SlotManager {

--- a/examples/Example7/electrons.cu
+++ b/examples/Example7/electrons.cu
@@ -180,7 +180,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     }
 
     // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
     // We will need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/Example7/gammas.cu
+++ b/examples/Example7/gammas.cu
@@ -105,7 +105,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     currentTrack.numIALeft[winnerProcessIndex] = -1.0;
 
     // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
     // We might need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/Example9/electrons.cu
+++ b/examples/Example9/electrons.cu
@@ -160,7 +160,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     }
 
     // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
     // We will need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/Example9/example9.cu
+++ b/examples/Example9/example9.cu
@@ -35,8 +35,6 @@
 __constant__ __device__ struct G4HepEmParameters g4HepEmPars;
 __constant__ __device__ struct G4HepEmData g4HepEmData;
 
-__constant__ __device__ int Zero = 0;
-
 struct G4HepEmState {
   G4HepEmData data;
   G4HepEmParameters parameters;

--- a/examples/Example9/gammas.cu
+++ b/examples/Example9/gammas.cu
@@ -101,7 +101,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     currentTrack.numIALeft[winnerProcessIndex] = -1.0;
 
     // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
     // We might need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/TestEm3/TestEm3.cu
+++ b/examples/TestEm3/TestEm3.cu
@@ -35,8 +35,6 @@ __constant__ __device__ struct G4HepEmData g4HepEmData;
 
 __constant__ __device__ int *MCIndex = nullptr;
 
-__constant__ __device__ int Zero = 0;
-
 struct G4HepEmState {
   G4HepEmData data;
   G4HepEmParameters parameters;

--- a/examples/TestEm3/TestEm3.cuh
+++ b/examples/TestEm3/TestEm3.cuh
@@ -53,42 +53,20 @@ struct Track {
   }
 };
 
-// Defined in TestEm3.cu
-extern __constant__ __device__ int Zero;
+// Define inline implementations of the RNG methods for the device.
+// (nvcc ignores the __device__ attribute in definitions, so this is only to
+// communicate the intent.)
+inline __device__ double G4HepEmRandomEngine::flat()
+{
+  return ((RanluxppDouble *)fObject)->Rndm();
+}
 
-class RanluxppDoubleEngine : public G4HepEmRandomEngine {
-  // Wrapper functions to call into RanluxppDouble.
-  static __host__ __device__ __attribute__((noinline))
-  double FlatWrapper(void *object)
-  {
-    return ((RanluxppDouble *)object)->Rndm();
+inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *vect)
+{
+  for (int i = 0; i < size; i++) {
+    vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
-  static __host__ __device__ __attribute__((noinline))
-  void FlatArrayWrapper(void *object, const int size, double *vect)
-  {
-    for (int i = 0; i < size; i++) {
-      vect[i] = ((RanluxppDouble *)object)->Rndm();
-    }
-  }
-
-public:
-  __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
-      : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
-  {
-#ifdef __CUDA_ARCH__
-    // This is a hack: The compiler cannot see that we're going to call the
-    // functions through their pointers, so it underestimates the number of
-    // required registers. By including calls to the (non-inlinable) functions
-    // we force the compiler to account for the register usage, even if this
-    // particular set of calls are not executed at runtime.
-    if (Zero) {
-      FlatWrapper(engine);
-      FlatArrayWrapper(engine, 0, nullptr);
-    }
-#endif
-  }
-};
-
+}
 
 // A data structure to manage slots in the track storage.
 class SlotManager {

--- a/examples/TestEm3/electrons.cu
+++ b/examples/TestEm3/electrons.cu
@@ -74,7 +74,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     }
     theTrack->SetSafety(safety);
 
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
 
     // Sample the `number-of-interaction-left` and put it into the track.
     for (int ip = 0; ip < 3; ++ip) {

--- a/examples/TestEm3/gammas.cu
+++ b/examples/TestEm3/gammas.cu
@@ -107,7 +107,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     currentTrack.numIALeft[winnerProcessIndex] = -1.0;
 
     // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
     // We might need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/TestEm3Compact/TestEm3.cu
+++ b/examples/TestEm3Compact/TestEm3.cu
@@ -35,8 +35,6 @@ __constant__ __device__ struct G4HepEmData g4HepEmData;
 
 __constant__ __device__ int *MCIndex = nullptr;
 
-__constant__ __device__ int Zero = 0;
-
 struct G4HepEmState {
   G4HepEmData data;
   G4HepEmParameters parameters;

--- a/examples/TestEm3Compact/TestEm3.cuh
+++ b/examples/TestEm3Compact/TestEm3.cuh
@@ -53,39 +53,20 @@ struct Track {
   }
 };
 
-// Defined in TestEm3.cu
-extern __constant__ __device__ int Zero;
+// Define inline implementations of the RNG methods for the device.
+// (nvcc ignores the __device__ attribute in definitions, so this is only to
+// communicate the intent.)
+inline __device__ double G4HepEmRandomEngine::flat()
+{
+  return ((RanluxppDouble *)fObject)->Rndm();
+}
 
-class RanluxppDoubleEngine : public G4HepEmRandomEngine {
-  // Wrapper functions to call into RanluxppDouble.
-  static __host__ __device__ __attribute__((noinline)) double FlatWrapper(void *object)
-  {
-    return ((RanluxppDouble *)object)->Rndm();
+inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *vect)
+{
+  for (int i = 0; i < size; i++) {
+    vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
-  static __host__ __device__ __attribute__((noinline)) void FlatArrayWrapper(void *object, const int size, double *vect)
-  {
-    for (int i = 0; i < size; i++) {
-      vect[i] = ((RanluxppDouble *)object)->Rndm();
-    }
-  }
-
-public:
-  __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
-      : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
-  {
-#ifdef __CUDA_ARCH__
-    // This is a hack: The compiler cannot see that we're going to call the
-    // functions through their pointers, so it underestimates the number of
-    // required registers. By including calls to the (non-inlinable) functions
-    // we force the compiler to account for the register usage, even if this
-    // particular set of calls are not executed at runtime.
-    if (Zero) {
-      FlatWrapper(engine);
-      FlatArrayWrapper(engine, 0, nullptr);
-    }
-#endif
-  }
-};
+}
 
 // A bundle of generators for the three particle types.
 struct Secondaries {

--- a/examples/TestEm3Compact/electrons.cu
+++ b/examples/TestEm3Compact/electrons.cu
@@ -73,7 +73,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     }
     theTrack->SetSafety(safety);
 
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
 
     // Sample the `number-of-interaction-left` and put it into the track.
     for (int ip = 0; ip < 3; ++ip) {

--- a/examples/TestEm3Compact/gammas.cu
+++ b/examples/TestEm3Compact/gammas.cu
@@ -106,7 +106,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
     currentTrack.numIALeft[winnerProcessIndex] = -1.0;
 
     // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
     // We might need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/TestEm3DoubleBuffer/TestEm3.cu
+++ b/examples/TestEm3DoubleBuffer/TestEm3.cu
@@ -35,8 +35,6 @@ __constant__ __device__ struct G4HepEmData g4HepEmData;
 
 __constant__ __device__ int *MCIndex = nullptr;
 
-__constant__ __device__ int Zero = 0;
-
 struct G4HepEmState {
   G4HepEmData data;
   G4HepEmParameters parameters;

--- a/examples/TestEm3DoubleBuffer/TestEm3.cuh
+++ b/examples/TestEm3DoubleBuffer/TestEm3.cuh
@@ -51,39 +51,20 @@ struct Track {
   }
 };
 
-// Defined in TestEm3.cu
-extern __constant__ __device__ int Zero;
+// Define inline implementations of the RNG methods for the device.
+// (nvcc ignores the __device__ attribute in definitions, so this is only to
+// communicate the intent.)
+inline __device__ double G4HepEmRandomEngine::flat()
+{
+  return ((RanluxppDouble *)fObject)->Rndm();
+}
 
-class RanluxppDoubleEngine : public G4HepEmRandomEngine {
-  // Wrapper functions to call into RanluxppDouble.
-  static __host__ __device__ __attribute__((noinline)) double FlatWrapper(void *object)
-  {
-    return ((RanluxppDouble *)object)->Rndm();
+inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *vect)
+{
+  for (int i = 0; i < size; i++) {
+    vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
-  static __host__ __device__ __attribute__((noinline)) void FlatArrayWrapper(void *object, const int size, double *vect)
-  {
-    for (int i = 0; i < size; i++) {
-      vect[i] = ((RanluxppDouble *)object)->Rndm();
-    }
-  }
-
-public:
-  __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
-      : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
-  {
-#ifdef __CUDA_ARCH__
-    // This is a hack: The compiler cannot see that we're going to call the
-    // functions through their pointers, so it underestimates the number of
-    // required registers. By including calls to the (non-inlinable) functions
-    // we force the compiler to account for the register usage, even if this
-    // particular set of calls are not executed at runtime.
-    if (Zero) {
-      FlatWrapper(engine);
-      FlatArrayWrapper(engine, 0, nullptr);
-    }
-#endif
-  }
-};
+}
 
 using ParticleCount = unsigned int;
 

--- a/examples/TestEm3DoubleBuffer/electrons.cu
+++ b/examples/TestEm3DoubleBuffer/electrons.cu
@@ -76,7 +76,7 @@ static __device__ __forceinline__ void TransportElectrons(const ParticleCount *e
     }
     theTrack->SetSafety(safety);
 
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
 
     // Sample the `number-of-interaction-left` and put it into the track.
     for (int ip = 0; ip < 3; ++ip) {

--- a/examples/TestEm3DoubleBuffer/gammas.cu
+++ b/examples/TestEm3DoubleBuffer/gammas.cu
@@ -105,7 +105,7 @@ __global__ void TransportGammas(const ParticleCount *gammasCount, Track *gammas,
     currentTrack.numIALeft[winnerProcessIndex] = -1.0;
 
     // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
     // We might need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/examples/TestEm3MT/TestEm3.cu
+++ b/examples/TestEm3MT/TestEm3.cu
@@ -37,8 +37,6 @@ __constant__ __device__ struct G4HepEmData g4HepEmData;
 
 __constant__ __device__ int *MCIndex = nullptr;
 
-__constant__ __device__ int Zero = 0;
-
 struct G4HepEmState {
   G4HepEmData data;
   G4HepEmParameters parameters;

--- a/examples/TestEm3MT/TestEm3.cuh
+++ b/examples/TestEm3MT/TestEm3.cuh
@@ -52,39 +52,20 @@ struct Track {
   }
 };
 
-// Defined in TestEm3.cu
-extern __constant__ __device__ int Zero;
+// Define inline implementations of the RNG methods for the device.
+// (nvcc ignores the __device__ attribute in definitions, so this is only to
+// communicate the intent.)
+inline __device__ double G4HepEmRandomEngine::flat()
+{
+  return ((RanluxppDouble *)fObject)->Rndm();
+}
 
-class RanluxppDoubleEngine : public G4HepEmRandomEngine {
-  // Wrapper functions to call into RanluxppDouble.
-  static __host__ __device__ __attribute__((noinline)) double FlatWrapper(void *object)
-  {
-    return ((RanluxppDouble *)object)->Rndm();
+inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *vect)
+{
+  for (int i = 0; i < size; i++) {
+    vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
-  static __host__ __device__ __attribute__((noinline)) void FlatArrayWrapper(void *object, const int size, double *vect)
-  {
-    for (int i = 0; i < size; i++) {
-      vect[i] = ((RanluxppDouble *)object)->Rndm();
-    }
-  }
-
-public:
-  __host__ __device__ RanluxppDoubleEngine(RanluxppDouble *engine)
-      : G4HepEmRandomEngine(/*object=*/engine, &FlatWrapper, &FlatArrayWrapper)
-  {
-#ifdef __CUDA_ARCH__
-    // This is a hack: The compiler cannot see that we're going to call the
-    // functions through their pointers, so it underestimates the number of
-    // required registers. By including calls to the (non-inlinable) functions
-    // we force the compiler to account for the register usage, even if this
-    // particular set of calls are not executed at runtime.
-    if (Zero) {
-      FlatWrapper(engine);
-      FlatArrayWrapper(engine, 0, nullptr);
-    }
-#endif
-  }
-};
+}
 
 // A data structure to manage slots in the track storage.
 class SlotManager {

--- a/examples/TestEm3MT/electrons.cu
+++ b/examples/TestEm3MT/electrons.cu
@@ -74,7 +74,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     }
     theTrack->SetSafety(safety);
 
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
 
     // Sample the `number-of-interaction-left` and put it into the track.
     for (int ip = 0; ip < 3; ++ip) {

--- a/examples/TestEm3MT/gammas.cu
+++ b/examples/TestEm3MT/gammas.cu
@@ -107,7 +107,7 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     currentTrack.numIALeft[winnerProcessIndex] = -1.0;
 
     // Perform the discrete interaction.
-    RanluxppDoubleEngine rnge(&currentTrack.rngState);
+    G4HepEmRandomEngine rnge(&currentTrack.rngState);
     // We might need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 


### PR DESCRIPTION
Instead of function pointers, provide inline implementations of the `G4HepEmRandomEngine` methods. This allows to remove the compiler hack from commit https://github.com/apt-sim/AdePT/commit/cd1b441c830211548bdabd66672add0ed330fd66 ("Work around underestimated register count") and enables more inlining of the RNG methods.