### PR TITLE
Enable alpaka CUDA backend by default

### DIFF
--- a/examples/FisherPrice_Alpaka/CMakeLists.txt
+++ b/examples/FisherPrice_Alpaka/CMakeLists.txt
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: 2020 CERN
 # SPDX-License-Identifier: Apache-2.0
 
+# Our example depends on types in alpaka's CUDA backend, so we must have it enabled
+set(alpaka_ACC_GPU_CUDA_ENABLE ON CACHE BOOL "Enable the CUDA GPU back-end" FORCE)
+
 #We must specify that we want to use alpaka
 find_package(alpaka 0.9.0 QUIET)
 


### PR DESCRIPTION
This PR enables the alpaka CUDA backend by default by forcing the cmake CACHE variable `alpaka_ACC_GPU_CUDA_ENABLE` to `ON`.