### PR TITLE
Show in-flight particle count at peak occupancy

### DIFF
--- a/base/inc/AdePT/NVTX.h
+++ b/base/inc/AdePT/NVTX.h
@@ -30,14 +30,13 @@ public:
   NVTXTracer(const std::string &name) { setTag(name, true); }
   ~NVTXTracer() { nvtxRangeEnd(_id); }
 
-  void setTag(const std::string& name, bool first = false)
+  void setTag(const std::string &name, bool first = false)
   {
     if (_name == name) return;
 
     _name = name;
 
-    if (!first)
-      nvtxRangeEnd(_id);
+    if (!first) nvtxRangeEnd(_id);
     nvtxEventAttributes_t eventAttrib = {0};
     eventAttrib.version               = NVTX_VERSION;
     eventAttrib.size                  = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
@@ -51,9 +50,9 @@ public:
   void setOccupancy(unsigned long occupancy)
   {
     // Require the occupancy to be larger than the majority of previous iterations to call it rising
-    const bool rising =
-        2 * std::count_if(_lastOccups.begin(), _lastOccups.end(), [occupancy](auto elm) { return occupancy > elm + 1; }) >
-        _lastOccups.size();
+    const bool rising = 2 * std::count_if(_lastOccups.begin(), _lastOccups.end(),
+                                          [occupancy](auto elm) { return occupancy > elm + 1; }) >
+                        _lastOccups.size();
 
     if (rising) {
       setTag("occupancy rising");

--- a/base/inc/AdePT/NVTX.h
+++ b/base/inc/AdePT/NVTX.h
@@ -23,38 +23,28 @@ class NVTXTracer {
                                                        0xff00ffff, 0xffff0000, 0xffffffff};
   std::string _name;
   nvtxRangeId_t _id;
-  std::array<unsigned long, 10> _lastOccups;
+  std::array<unsigned long, 10> _lastOccups{};
   decltype(_lastOccups)::iterator _occupIt = _lastOccups.begin();
 
 public:
-  NVTXTracer(const char *name) : _name{name}
-  {
-    nvtxEventAttributes_t eventAttrib = {0};
-    eventAttrib.version               = NVTX_VERSION;
-    eventAttrib.size                  = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
-    eventAttrib.colorType             = NVTX_COLOR_ARGB;
-    eventAttrib.color                 = nextColour();
-    eventAttrib.messageType           = NVTX_MESSAGE_TYPE_ASCII;
-    eventAttrib.message.ascii         = name;
-    _id                               = nvtxRangeStartEx(&eventAttrib);
-    _lastOccups.fill(0);
-  }
+  NVTXTracer(const std::string &name) { setTag(name, true); }
   ~NVTXTracer() { nvtxRangeEnd(_id); }
 
-  void setTag(const char *name)
+  void setTag(const std::string& name, bool first = false)
   {
     if (_name == name) return;
 
     _name = name;
 
-    nvtxRangeEnd(_id);
+    if (!first)
+      nvtxRangeEnd(_id);
     nvtxEventAttributes_t eventAttrib = {0};
     eventAttrib.version               = NVTX_VERSION;
     eventAttrib.size                  = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
     eventAttrib.colorType             = NVTX_COLOR_ARGB;
     eventAttrib.color                 = nextColour();
     eventAttrib.messageType           = NVTX_MESSAGE_TYPE_ASCII;
-    eventAttrib.message.ascii         = name;
+    eventAttrib.message.ascii         = _name.c_str();
     _id                               = nvtxRangeStartEx(&eventAttrib);
   }
 

--- a/base/inc/AdePT/NVTX.h
+++ b/base/inc/AdePT/NVTX.h
@@ -58,7 +58,7 @@ public:
     if (rising) {
       setTag("occupancy rising");
     } else if (_name == "occupancy rising") {
-      setTag("peak occupancy");
+      setTag("peak occupancy (" + std::to_string(occupancy) + " in-flight)");
     } else {
       setTag("occupancy falling");
     }


### PR DESCRIPTION
This PR removes a redundancy when setting up and calling `nvtxRangeStartEx`, then adds information about the in-flight particle count to the shown tag at peak occupancy. Finally, I ran clang-format.