### PR TITLE
Fix multiple events in integration examples

### DIFF
--- a/examples/Example10/example10.cuh
+++ b/examples/Example10/example10.cuh
@@ -53,6 +53,7 @@ struct Track {
   }
 };
 
+#ifdef __CUDA_ARCH__
 // Define inline implementations of the RNG methods for the device.
 // (nvcc ignores the __device__ attribute in definitions, so this is only to
 // communicate the intent.)
@@ -67,6 +68,7 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
+#endif
 
 // A data structure for some global scoring. The accessors must make sure to use
 // atomic operations if needed.

--- a/examples/Example11/example11.cuh
+++ b/examples/Example11/example11.cuh
@@ -44,6 +44,7 @@ struct Track {
   }
 };
 
+#ifdef __CUDA_ARCH__
 // Define inline implementations of the RNG methods for the device.
 // (nvcc ignores the __device__ attribute in definitions, so this is only to
 // communicate the intent.)
@@ -58,6 +59,7 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
+#endif
 
 // A data structure for some global scoring. The accessors must make sure to use
 // atomic operations if needed.

--- a/examples/Example12/example12.cuh
+++ b/examples/Example12/example12.cuh
@@ -45,6 +45,7 @@ struct Track {
   }
 };
 
+#ifdef __CUDA_ARCH__
 // Define inline implementations of the RNG methods for the device.
 // (nvcc ignores the __device__ attribute in definitions, so this is only to
 // communicate the intent.)
@@ -59,6 +60,7 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
+#endif
 
 // A data structure to manage slots in the track storage.
 class SlotManager {

--- a/examples/Example13/example13.cuh
+++ b/examples/Example13/example13.cuh
@@ -52,6 +52,7 @@ struct Track {
   }
 };
 
+#ifdef __CUDA_ARCH__
 // Define inline implementations of the RNG methods for the device.
 // (nvcc ignores the __device__ attribute in definitions, so this is only to
 // communicate the intent.)
@@ -66,6 +67,7 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
+#endif
 
 // A data structure to manage slots in the track storage.
 class SlotManager {

--- a/examples/Example14/AdeptIntegration.cuh
+++ b/examples/Example14/AdeptIntegration.cuh
@@ -12,6 +12,7 @@
 #include <G4HepEmParameters.hh>
 #include <G4HepEmRandomEngine.hh>
 
+#ifdef __CUDA_ARCH__
 // Define inline implementations of the RNG methods for the device.
 // (nvcc ignores the __device__ attribute in definitions, so this is only to
 // communicate the intent.)
@@ -26,6 +27,7 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
+#endif
 
 // A data structure to manage slots in the track storage.
 class SlotManager {

--- a/examples/Example16/example16.cuh
+++ b/examples/Example16/example16.cuh
@@ -53,6 +53,7 @@ struct Track {
   }
 };
 
+#ifdef __CUDA_ARCH__
 // Define inline implementations of the RNG methods for the device.
 // (nvcc ignores the __device__ attribute in definitions, so this is only to
 // communicate the intent.)
@@ -67,6 +68,7 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
+#endif
 
 // A bundle of generators for the three particle types.
 struct Secondaries {

--- a/examples/Example17/AdeptIntegration.cuh
+++ b/examples/Example17/AdeptIntegration.cuh
@@ -13,6 +13,7 @@
 #include <G4HepEmParameters.hh>
 #include <G4HepEmRandomEngine.hh>
 
+#ifdef __CUDA_ARCH__
 // Define inline implementations of the RNG methods for the device.
 // (nvcc ignores the __device__ attribute in definitions, so this is only to
 // communicate the intent.)
@@ -27,6 +28,7 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
+#endif
 
 struct LeakedTracks {
   adept::TrackManager<Track> *trackmgr;

--- a/examples/Example18/example18.cuh
+++ b/examples/Example18/example18.cuh
@@ -52,6 +52,7 @@ struct Track {
   }
 };
 
+#ifdef __CUDA_ARCH__
 // Define inline implementations of the RNG methods for the device.
 // (nvcc ignores the __device__ attribute in definitions, so this is only to
 // communicate the intent.)
@@ -66,6 +67,7 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
+#endif
 
 // A data structure to manage slots in the track storage.
 class SlotManager {

--- a/examples/Example19/example.cuh
+++ b/examples/Example19/example.cuh
@@ -60,6 +60,7 @@ struct SOAData {
   double *gamma_PEmxSec = nullptr;
 };
 
+#ifdef __CUDA_ARCH__
 // Define inline implementations of the RNG methods for the device.
 // (nvcc ignores the __device__ attribute in definitions, so this is only to
 // communicate the intent.)
@@ -74,6 +75,7 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
+#endif
 
 // A data structure to manage slots in the track storage.
 class SlotManager {

--- a/examples/Example5/example5.cu
+++ b/examples/Example5/example5.cu
@@ -84,6 +84,7 @@ static void FreeG4HepEm(G4HepEmState *state)
   delete state;
 }
 
+#ifdef __CUDA_ARCH__
 // Define inline implementations of the RNG methods for the device.
 // (nvcc ignores the __device__ attribute in definitions, so this is only to
 // communicate the intent.)
@@ -98,6 +99,7 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
+#endif
 
 __global__ void TransportParticle()
 {

--- a/examples/Example6/example6.cu
+++ b/examples/Example6/example6.cu
@@ -372,6 +372,7 @@ __global__ void RelocateToNextVolume(adept::BlockData<track> *allTracks, adept::
   }
 }
 
+#ifdef __CUDA_ARCH__
 // Define inline implementations of the RNG methods for the device.
 // (nvcc ignores the __device__ attribute in definitions, so this is only to
 // communicate the intent.)
@@ -386,6 +387,7 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
+#endif
 
 __host__ __device__ void InitSecondary(track &secondary, const track &parent)
 {

--- a/examples/Example7/TestEm3.cuh
+++ b/examples/Example7/TestEm3.cuh
@@ -55,6 +55,7 @@ struct Track {
   }
 };
 
+#ifdef __CUDA_ARCH__
 // Define inline implementations of the RNG methods for the device.
 // (nvcc ignores the __device__ attribute in definitions, so this is only to
 // communicate the intent.)
@@ -69,6 +70,7 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
+#endif
 
 // A data structure to manage slots in the track storage.
 class SlotManager {

--- a/examples/Example8/example8.cu
+++ b/examples/Example8/example8.cu
@@ -167,6 +167,7 @@ static void FreeG4HepEm(G4HepEmState *state)
   delete state;
 }
 
+#ifdef __CUDA_ARCH__
 // Define inline implementations of the RNG methods for the device.
 // (nvcc ignores the __device__ attribute in definitions, so this is only to
 // communicate the intent.)
@@ -181,6 +182,7 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
+#endif
 
 __host__ __device__ void InitSecondary(Track &secondary, const Track &parent)
 {

--- a/examples/Example9/example9.cuh
+++ b/examples/Example9/example9.cuh
@@ -44,6 +44,7 @@ struct Track {
   }
 };
 
+#ifdef __CUDA_ARCH__
 // Define inline implementations of the RNG methods for the device.
 // (nvcc ignores the __device__ attribute in definitions, so this is only to
 // communicate the intent.)
@@ -58,6 +59,7 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
+#endif
 
 // A data structure for some global scoring. The accessors must make sure to use
 // atomic operations if needed.

--- a/examples/TestEm3/TestEm3.cuh
+++ b/examples/TestEm3/TestEm3.cuh
@@ -53,6 +53,7 @@ struct Track {
   }
 };
 
+#ifdef __CUDA_ARCH__
 // Define inline implementations of the RNG methods for the device.
 // (nvcc ignores the __device__ attribute in definitions, so this is only to
 // communicate the intent.)
@@ -67,6 +68,7 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
+#endif
 
 // A data structure to manage slots in the track storage.
 class SlotManager {

--- a/examples/TestEm3Compact/TestEm3.cuh
+++ b/examples/TestEm3Compact/TestEm3.cuh
@@ -53,6 +53,7 @@ struct Track {
   }
 };
 
+#ifdef __CUDA_ARCH__
 // Define inline implementations of the RNG methods for the device.
 // (nvcc ignores the __device__ attribute in definitions, so this is only to
 // communicate the intent.)
@@ -67,6 +68,7 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
+#endif
 
 // A bundle of generators for the three particle types.
 struct Secondaries {

--- a/examples/TestEm3DoubleBuffer/TestEm3.cuh
+++ b/examples/TestEm3DoubleBuffer/TestEm3.cuh
@@ -51,6 +51,7 @@ struct Track {
   }
 };
 
+#ifdef __CUDA_ARCH__
 // Define inline implementations of the RNG methods for the device.
 // (nvcc ignores the __device__ attribute in definitions, so this is only to
 // communicate the intent.)
@@ -65,6 +66,7 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
+#endif
 
 using ParticleCount = unsigned int;
 

--- a/examples/TestEm3MT/TestEm3.cuh
+++ b/examples/TestEm3MT/TestEm3.cuh
@@ -52,6 +52,7 @@ struct Track {
   }
 };
 
+#ifdef __CUDA_ARCH__
 // Define inline implementations of the RNG methods for the device.
 // (nvcc ignores the __device__ attribute in definitions, so this is only to
 // communicate the intent.)
@@ -66,6 +67,7 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
+#endif
 
 // A data structure to manage slots in the track storage.
 class SlotManager {


### PR DESCRIPTION
Commit 83836d06bc (https://github.com/apt-sim/AdePT/pull/218) updated G4HepEm and adapted the RNG interface to provide inline implementations instead of function pointers. The intent was to use RANLUX++ on the GPU and continue using the CLHEP generator (MIXMAX by default) on the CPU. However, the CUDA compiler also generates host code for the inline function, which because of symbol interception ends up being used by G4HepEm. This leads to crashes because the inline function assumes to work on an instance of `RanluxppDouble` and just writes to its members, leaving behind an invalid state for CLHEP to seed at the beginning of the next event.

To solve this problem, surround the definition of the inline functions with `#ifdef __CUDA_ARCH__` to only make it visible to the compiler when generating device code.