### PR TITLE
Recompute macroscopic cross-section in example19

### DIFF
--- a/examples/Example19/example.cuh
+++ b/examples/Example19/example.cuh
@@ -57,7 +57,6 @@ struct Track {
 // Struct for communication between kernels
 struct SOAData {
   char *nextInteraction = nullptr;
-  double *gamma_PEmxSec = nullptr;
 };
 
 #ifdef __CUDA_ARCH__

--- a/examples/Example19/gammas.cu
+++ b/examples/Example19/gammas.cu
@@ -117,7 +117,6 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     currentTrack.numIALeft[winnerProcessIndex] = -1.0;
 
     soaData.nextInteraction[i] = winnerProcessIndex;
-    soaData.gamma_PEmxSec[i] = gammaTrack.GetPEmxSec();
     survive(false);
   }
 }
@@ -217,8 +216,12 @@ __device__ void GammaInteraction(int const globalSlot, SOAData const &soaData, i
     // Invoke photoelectric process.
     const double theLowEnergyThreshold = 1 * copcore::units::eV;
 
+    // (Re)compute total macroscopic cross section
+    const int theMatIndx = g4HepEmData.fTheMatCutData->fMatCutData[theMCIndex].fHepEmMatIndex;
+    double mxsec = G4HepEmGammaManager::GetMacXSecPE(&g4HepEmData, theMatIndx, energy);
+
     const double bindingEnergy = G4HepEmGammaInteractionPhotoelectric::SelectElementBindingEnergy(
-        &g4HepEmData, theMCIndex, soaData.gamma_PEmxSec[soaSlot], energy, &rnge);
+        &g4HepEmData, theMCIndex, mxsec, energy, &rnge);
 
     double edep             = bindingEnergy;
     const double photoElecE = energy - edep;

--- a/examples/Example19/main.cu
+++ b/examples/Example19/main.cu
@@ -218,8 +218,6 @@ void runGPU(int numParticles, double energy, int batch, const int *MCIndex_host,
     COPCORE_CUDA_CHECK(
         cudaMalloc(&particles[i].soaData.nextInteraction, sizeof(SOAData::nextInteraction[0]) * Capacity));
   }
-  COPCORE_CUDA_CHECK(
-      cudaMalloc(&particles[ParticleType::Gamma].soaData.gamma_PEmxSec, sizeof(SOAData::gamma_PEmxSec[0]) * Capacity));
   COPCORE_CUDA_CHECK(cudaDeviceSynchronize());
 
   ParticleType &electrons = particles[ParticleType::Electron];
@@ -506,6 +504,5 @@ void runGPU(int numParticles, double energy, int batch, const int *MCIndex_host,
     COPCORE_CUDA_CHECK(cudaEventDestroy(particles[i].event));
 
     COPCORE_CUDA_CHECK(cudaFree(particles[i].soaData.nextInteraction));
-    if (particles[i].soaData.gamma_PEmxSec) COPCORE_CUDA_CHECK(cudaFree(particles[i].soaData.gamma_PEmxSec));
   }
 }


### PR DESCRIPTION
Instead of storing to memory, just redo the computation in case a photoelectric interaction was selected. No performance difference, but less memory usage.