### PR TITLE
Use fixed tag and hash to download GDML files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,8 +98,10 @@ add_subdirectory(external)
 if(BUILD_TESTING)
   set(TESTING_GDML "${PROJECT_BINARY_DIR}/trackML.gdml")
   set(CMS2018_GDML "${PROJECT_BINARY_DIR}/cms2018.gdml")
-  file(DOWNLOAD https://gitlab.cern.ch/VecGeom/VecGeom/raw/master/persistency/gdml/gdmls/trackML.gdml "${TESTING_GDML}")
-  file(DOWNLOAD https://gitlab.cern.ch/VecGeom/VecGeom/raw/master/persistency/gdml/gdmls/cms2018.gdml "${CMS2018_GDML}")
+  file(DOWNLOAD https://gitlab.cern.ch/VecGeom/VecGeom/raw/v1.2.0/persistency/gdml/gdmls/trackML.gdml "${TESTING_GDML}"
+    EXPECTED_HASH SHA256=2c53e0f2f4673c61f8679702532647bf71ec64c1613aae330fa835e7d7087064)
+  file(DOWNLOAD https://gitlab.cern.ch/VecGeom/VecGeom/raw/v1.2.0/persistency/gdml/gdmls/cms2018.gdml "${CMS2018_GDML}"
+    EXPECTED_HASH SHA256=a6538d8f196fbfe4c14e806df3439d5a0d7050d538d364faabe882c750970e63)
 endif()
 
 # Builds...


### PR DESCRIPTION
Following recent changes to VecGeom (see [MR 956](https://gitlab.cern.ch/VecGeom/VecGeom/-/merge_requests/956)) testing, the `cms2018` and `trackML` GDML files have changed location. AdePT's configure step didn't pick this up as an empty file was still downloaded so "o.k." but naturally tests then failed.

This PR updates the download URLs to use a recent tag (the GDML file content is near constant anyway) instead of the `master` branch. It also adds the known SHA256 hash of the files to confirm the expected file has been downloaded correctly.