### PR TITLE
Add and document use of Spack environment for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,25 @@ The following packages are a required to build and run:
 - VecCore [library](https://github.com/root-project/veccore) 0.7.0 (recommended, but older versions >= 0.5.0 also work)
 - VecGeom [library](https://gitlab.cern.ch/VecGeom/VecGeom) >= 1.1.20
 
-To configure and build VecCore, simply run:
+A suitable environment may be set up either from CVMFS (requires the sft.cern.ch and projects.cern.ch repos
+to be available on the local system):
+```console
+$ source /cvmfs/sft.cern.ch/lcg/views/devAdePT/latest/x86_64-centos7-gcc11-opt/setup.sh
+```
+
+or from the supplied [spack](https://spack.io) environment file:
+```console
+$ spack env create adept-spack ./scripts/spack.yaml
+$ spack -e adept-spack concretize -f
+$ spack -e adept-spack install
+...
+$ spack env activate -p adept-spack
+```
+
+Note that the above assumes your spack configuration defaults to use a suitable C++ compiler and has
+`cuda_arch` set appropriately for the hardware you will be running on.
+
+You can also build the packages manually as follows. To configure and build VecCore, simply run:
 ```console
 $ cmake -S. -B./veccore-build -DCMAKE_INSTALL_PREFIX="<path_to_veccore_installation>"
 $ cmake --build ./veccore-build --target install

--- a/scripts/spack.yaml
+++ b/scripts/spack.yaml
@@ -1,0 +1,28 @@
+spack:
+  specs:
+    - cmake
+    - cuda
+    - doxygen
+    - "geant4@11.1 cxxstd=17"
+    - git
+    - "googletest@1.10:"
+    - hepmc3
+    - ninja
+    - nlohmann-json
+    - root cxxstd=17
+    - "vecgeom@1.2: +gdml cxxstd=17"
+  view: true
+  concretizer:
+    unify: true
+  packages:
+    root:
+      # Note: ~gsl and ~math are removed because dd4hep requires them
+      variants: ~aqua ~davix ~examples ~opengl ~x ~tbb
+    all:
+      providers:
+        blas: [openblas]
+        lapack: [openblas]
+        mpi: [openmpi]
+      variants: cxxstd=17 +cuda
+      # NOTE: add `cuda_arch=XY` (with XY as appropriate for the cards to be run on) to your site packages.py
+      # spack config add --scope=site packages:all:variants:"cuda_arch=70"

--- a/scripts/spack.yaml
+++ b/scripts/spack.yaml
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2023 CERN
+# SPDX-License-Identifier: Apache-2.0
 spack:
   specs:
     - cmake


### PR DESCRIPTION
Provide a minimal spack environment file for providing an environment for AdePT development. Largely identical to that for the Celeritas project for commonality, with some differences:

- Latest AdePT examples require Geant4 11.1, or more specifically, the `Flush()` abstract function of G4VFastSimulationModel.
- AdePT can only be built/used with CUDA, which becomes a hard required spec of the environment and all packages.

Update README with setup instructions for both Spack and the existing LCG `devAdePT` view from CVMFS. Note requirements where known.