### PR TITLE
Fixed raytrace benchmark to work with current VecGeom master

### DIFF
--- a/examples/Raytracer_Benchmark/Material.h
+++ b/examples/Raytracer_Benchmark/Material.h
@@ -22,7 +22,7 @@ void SetMaterialStruct(MyMediumProp *volume_container, std::vector<vecgeom::Logi
   int i = 0;
 
   for (auto lvol : logicalvolumes) {
-    // lvol->Print();
+    int i = lvol->id();
     if (!strcmp(lvol->GetName(), "World")) {
       volume_container[i].material            = kRTtransparent;
       volume_container[i].fObjColor           = 0x0000FF80;
@@ -99,9 +99,8 @@ void SetMaterialStruct(MyMediumProp *volume_container, std::vector<vecgeom::Logi
       volume_container[i].transparency_per_cm = 1.;
     }
 
-    if (!on_gpu) lvol->SetBasketManagerPtr(&volume_container[i]);
-
-    i++;
+    // Cannot attach any more stuff to volumes using special hooks
+    // if (!on_gpu) lvol->SetBasketManagerPtr(&volume_container[i]);
   }
 }
 

--- a/examples/Raytracer_Benchmark/Material.h
+++ b/examples/Raytracer_Benchmark/Material.h
@@ -18,9 +18,7 @@
 void SetMaterialStruct(MyMediumProp *volume_container, std::vector<vecgeom::LogicalVolume *> logicalvolumes,
                        bool on_gpu)
 {
-
-  int i = 0;
-
+  // Loop all logical volumes and assign according to the volume name
   for (auto lvol : logicalvolumes) {
     int i = lvol->id();
     if (!strcmp(lvol->GetName(), "World")) {

--- a/examples/Raytracer_Benchmark/RaytraceBenchmark.cpp
+++ b/examples/Raytracer_Benchmark/RaytraceBenchmark.cpp
@@ -33,22 +33,21 @@ void InitBVH(bool on_gpu)
 {
   vecgeom::cxx::BVHManager::Init();
 
-  if (on_gpu)
-    vecgeom::cxx::BVHManager::DeviceInit();
+  if (on_gpu) vecgeom::cxx::BVHManager::DeviceInit();
 }
 
 namespace cuda {
 struct MyMediumProp;
 } // namespace cuda
 
-int executePipelineGPU(const cuda::MyMediumProp *volume_container, const vecgeom::cxx::VPlacedVolume *world,
-                       std::vector<vecgeom::cxx::LogicalVolume *> logicalvolumes, int argc, char *argv[]);
+int executePipelineGPU(const cuda::MyMediumProp *volume_container, const vecgeom::cxx::VPlacedVolume *world, int argc,
+                       char *argv[]);
 
-int executePipelineCPU(const MyMediumProp *volume_container, const vecgeom::cxx::VPlacedVolume *world,
-                       std::vector<vecgeom::cxx::LogicalVolume *> logicalvolumes, int argc, char *argv[])
+int executePipelineCPU(const MyMediumProp *volume_container, const vecgeom::cxx::VPlacedVolume *world, int argc,
+                       char *argv[])
 {
 
-  int result = runSimulation<copcore::BackendType::CPU>(volume_container, world, logicalvolumes, argc, argv);
+  int result = runSimulation<copcore::BackendType::CPU>(volume_container, world, argc, argv);
   return result;
 }
 
@@ -93,9 +92,9 @@ int main(int argc, char *argv[])
 
   if (on_gpu) {
     auto volume_container_cuda = reinterpret_cast<cuda::MyMediumProp *>(volume_container);
-    ierr                       = executePipelineGPU(volume_container_cuda, world, logicalvolumes, argc, argv);
+    ierr                       = executePipelineGPU(volume_container_cuda, world, argc, argv);
   } else {
-    ierr = executePipelineCPU(volume_container, world, logicalvolumes, argc, argv);
+    ierr = executePipelineCPU(volume_container, world, argc, argv);
   }
   if (ierr) std::cout << "TestNavIndex FAILED\n";
 

--- a/examples/Raytracer_Benchmark/Raytracer.cpp
+++ b/examples/Raytracer_Benchmark/Raytracer.cpp
@@ -200,8 +200,8 @@ void ApplyRTmodel(Ray_t &ray, vecgeom::Precision step, RaytracerData_t const &rt
   auto nextvol = (Ray_t::VPlacedVolumePtr_t)ray.fNextState.Top();
 
   // Get material structure for last and next volumes
-  auto medium_prop_last = (MyMediumProp *)lastvol->GetLogicalVolume()->GetBasketManagerPtr();
-  auto medium_prop_next = (MyMediumProp *)nextvol->GetLogicalVolume()->GetBasketManagerPtr();
+  auto const *medium_prop_last = &rtdata.fMediaProp[lastvol->GetLogicalVolume()->id()];
+  auto const *medium_prop_next = &rtdata.fMediaProp[nextvol->GetLogicalVolume()->id()];
 
   bool exit_transparent        = medium_prop_last->material == kRTtransparent;
   bool transparent_transparent = medium_prop_next->material == kRTtransparent &&

--- a/examples/Raytracer_Benchmark/Raytracer.h
+++ b/examples/Raytracer_Benchmark/Raytracer.h
@@ -170,8 +170,9 @@ struct RaytracerData_t {
   bool fReflection         = false;           ///< Reflection model
   bool fApproach           = false;           ///< approach solid to bbox before calculating distance
 
-  VPlacedVolumePtr_t fWorld = nullptr; ///< World volume
-  vecgeom::NavStateIndex fVPstate;     ///< Navigation state corresponding to the viewpoint
+  VPlacedVolumePtr_t fWorld = nullptr;     ///< World volume
+  vecgeom::NavStateIndex fVPstate;         ///< Navigation state corresponding to the viewpoint
+  MyMediumProp const *fMediaProp{nullptr}; ///< Array of media properties per volume
 
   Vector_t *sparse_rays         = nullptr; ///< pointer to the rays containers
   Vector_t_int *sparse_int      = nullptr; ///<


### PR DESCRIPTION
VecGeom commit [8359663a](https://gitlab.cern.ch/VecGeom/VecGeom/-/commit/8359663a625c3d6e9fdcd62cbcede1a3b1ca7d68) removed the user hooks in LogicalVolume, which were used in the ray-tracer benchmark for storing custom optical properties. This commit replaces the hooks with an array using volume indices to retrieve the same information.