### PR TITLE
Explicitly increase device stack size for the examples needing it

### DIFF
--- a/base/inc/CopCore/include/CopCore/Global.h
+++ b/base/inc/CopCore/include/CopCore/Global.h
@@ -26,7 +26,7 @@ namespace copcore {
 enum BackendType { CPU = 0, CUDA, HIP };
 
 /** @brief CUDA error checking */
-#ifndef COPCORE_CUDA_COMPILER
+#ifndef __CUDA_RUNTIME_H__
 static inline void error_check(int, const char *, int) {}
 #else
 static inline void error_check(cudaError_t err, const char *file, int line)
@@ -55,7 +55,10 @@ static inline void error_check(cudaError_t err, const char *file, int line)
 
 /** @brief Get number of SMs on the current device */
 #ifndef COPCORE_CUDA_COMPILER
-static inline int get_num_SMs() { return 0; }
+static inline int get_num_SMs()
+{
+  return 0;
+}
 #else
 static inline int get_num_SMs()
 {

--- a/examples/Example12/example12.cpp
+++ b/examples/Example12/example12.cpp
@@ -37,7 +37,7 @@ static constexpr double DefaultCut = 0.7 * mm;
 const G4VPhysicalVolume *InitGeant4(const std::string &gdml_file)
 {
   auto defaultRegion = new G4Region("DefaultRegionForTheWorld"); // deleted by store
-  auto pcuts = G4ProductionCutsTable::GetProductionCutsTable()->GetDefaultProductionCuts();
+  auto pcuts         = G4ProductionCutsTable::GetProductionCutsTable()->GetDefaultProductionCuts();
   pcuts->SetProductionCut(DefaultCut, "gamma");
   pcuts->SetProductionCut(DefaultCut, "e-");
   pcuts->SetProductionCut(DefaultCut, "e+");
@@ -184,7 +184,7 @@ int main(int argc, char *argv[])
   OPTION_STRING(gdml_file, "cms2018.gdml");
   OPTION_INT(cache_depth, 0); // 0 = full depth
   OPTION_INT(particles, 100);
-  OPTION_DOUBLE(energy, 10); // entered in GeV
+  OPTION_DOUBLE(energy, 10);  // entered in GeV
   energy *= copcore::units::GeV;
   OPTION_INT(batch, -1);
 
@@ -219,6 +219,8 @@ int main(int argc, char *argv[])
 
   // Load and synchronize the geometry on the GPU
   std::cout << "synchronizing VecGeom geometry to GPU ...\n";
+  // Adjust stack size to avoid lane user stack overflow
+  COPCORE_CUDA_CHECK(vecgeom::cxx::CudaDeviceSetStackLimit(8192));
   auto &cudaManager = vecgeom::cxx::CudaManager::Instance();
   cudaManager.LoadGeometry(world);
   cudaManager.Synchronize();

--- a/examples/Example13/example13.cpp
+++ b/examples/Example13/example13.cpp
@@ -40,7 +40,7 @@ static constexpr double DefaultCut = 0.7 * mm;
 const G4VPhysicalVolume *InitGeant4(const std::string &gdml_file)
 {
   auto defaultRegion = new G4Region("DefaultRegionForTheWorld"); // deleted by store
-  auto pcuts = G4ProductionCutsTable::GetProductionCutsTable()->GetDefaultProductionCuts();
+  auto pcuts         = G4ProductionCutsTable::GetProductionCutsTable()->GetDefaultProductionCuts();
   pcuts->SetProductionCut(DefaultCut, "gamma");
   pcuts->SetProductionCut(DefaultCut, "e-");
   pcuts->SetProductionCut(DefaultCut, "e+");
@@ -192,7 +192,7 @@ int main(int argc, char *argv[])
   OPTION_STRING(gdml_file, "cms2018.gdml");
   OPTION_INT(cache_depth, 0); // 0 = full depth
   OPTION_INT(particles, 100);
-  OPTION_DOUBLE(energy, 10); // entered in GeV
+  OPTION_DOUBLE(energy, 10);  // entered in GeV
   energy *= copcore::units::GeV;
   OPTION_INT(batch, -1);
   OPTION_BOOL(rotatingParticleGun, false);
@@ -206,7 +206,7 @@ int main(int argc, char *argv[])
   BenchmarkManager<std::string> aBenchmarkManager;
   aBenchmarkManager.setOutputDirectory(benchmark_directory);
   aBenchmarkManager.setOutputFilename(benchmark_filename);
-  
+
   aBenchmarkManager.timerStart("Total time");
   aBenchmarkManager.timerStart("InitG4");
 
@@ -251,6 +251,8 @@ int main(int argc, char *argv[])
   aBenchmarkManager.timerStart("SyncGeom");
   std::cout << "synchronizing VecGeom geometry to GPU ...\n";
   auto &cudaManager = vecgeom::cxx::CudaManager::Instance();
+  // Adjust stack size to avoid lane user stack overflow
+  COPCORE_CUDA_CHECK(vecgeom::cxx::CudaDeviceSetStackLimit(8192));
   cudaManager.LoadGeometry(world);
   cudaManager.Synchronize();
 

--- a/examples/Example16/example16.cpp
+++ b/examples/Example16/example16.cpp
@@ -39,7 +39,7 @@ static constexpr double DefaultCut = 0.7 * mm;
 const G4VPhysicalVolume *InitGeant4(const std::string &gdml_file)
 {
   auto defaultRegion = new G4Region("DefaultRegionForTheWorld"); // deleted by store
-  auto pcuts = G4ProductionCutsTable::GetProductionCutsTable()->GetDefaultProductionCuts();
+  auto pcuts         = G4ProductionCutsTable::GetProductionCutsTable()->GetDefaultProductionCuts();
   pcuts->SetProductionCut(DefaultCut, "gamma");
   pcuts->SetProductionCut(DefaultCut, "e-");
   pcuts->SetProductionCut(DefaultCut, "e+");
@@ -191,7 +191,7 @@ int main(int argc, char *argv[])
   OPTION_STRING(gdml_file, "cms2018.gdml");
   OPTION_INT(cache_depth, 0); // 0 = full depth
   OPTION_INT(particles, 100);
-  OPTION_DOUBLE(energy, 10); // entered in GeV
+  OPTION_DOUBLE(energy, 10);  // entered in GeV
   energy *= copcore::units::GeV;
   OPTION_INT(batch, -1);
   OPTION_BOOL(rotatingParticleGun, false);
@@ -234,6 +234,8 @@ int main(int argc, char *argv[])
   tracer.setTag("SyncGeom");
   std::cout << "synchronizing VecGeom geometry to GPU ...\n";
   auto &cudaManager = vecgeom::cxx::CudaManager::Instance();
+  // Adjust stack size to avoid lane user stack overflow
+  COPCORE_CUDA_CHECK(vecgeom::cxx::CudaDeviceSetStackLimit(8192));
   cudaManager.LoadGeometry(world);
   cudaManager.Synchronize();
 

--- a/examples/Example18/example18.cpp
+++ b/examples/Example18/example18.cpp
@@ -191,7 +191,7 @@ int main(int argc, char *argv[])
   OPTION_STRING(gdml_file, "cms2018.gdml");
   OPTION_INT(cache_depth, 0); // 0 = full depth
   OPTION_INT(particles, 100);
-  OPTION_DOUBLE(energy, 10); // entered in GeV
+  OPTION_DOUBLE(energy, 10);  // entered in GeV
   energy *= copcore::units::GeV;
   OPTION_INT(batch, -1);
   OPTION_BOOL(rotatingParticleGun, false);
@@ -234,6 +234,8 @@ int main(int argc, char *argv[])
   tracer.setTag("SyncGeom");
   std::cout << "synchronizing VecGeom geometry to GPU ...\n";
   auto &cudaManager = vecgeom::cxx::CudaManager::Instance();
+  // Adjust stack size to avoid lane user stack overflow
+  COPCORE_CUDA_CHECK(vecgeom::cxx::CudaDeviceSetStackLimit(8192));
   cudaManager.LoadGeometry(world);
   cudaManager.Synchronize();
 

--- a/examples/Example19/main.cpp
+++ b/examples/Example19/main.cpp
@@ -191,7 +191,7 @@ int main(int argc, char *argv[])
   OPTION_STRING(gdml_file, "cms2018.gdml");
   OPTION_INT(cache_depth, 0); // 0 = full depth
   OPTION_INT(particles, 100);
-  OPTION_DOUBLE(energy, 10); // entered in GeV
+  OPTION_DOUBLE(energy, 10);  // entered in GeV
   energy *= copcore::units::GeV;
   OPTION_INT(batch, 52);
   OPTION_STRING(gunpos, "0,0,0");
@@ -242,6 +242,8 @@ int main(int argc, char *argv[])
   tracer.setTag("SyncGeom");
   std::cout << "synchronizing VecGeom geometry to GPU ...\n";
   auto &cudaManager = vecgeom::cxx::CudaManager::Instance();
+  // Adjust stack size to avoid lane user stack overflow
+  COPCORE_CUDA_CHECK(vecgeom::cxx::CudaDeviceSetStackLimit(8192));
   cudaManager.LoadGeometry(world);
   cudaManager.Synchronize();
 

--- a/examples/Example20/main.cpp
+++ b/examples/Example20/main.cpp
@@ -191,7 +191,7 @@ int main(int argc, char *argv[])
   OPTION_STRING(gdml_file, "cms2018.gdml");
   OPTION_INT(cache_depth, 0); // 0 = full depth
   OPTION_INT(particles, 100);
-  OPTION_DOUBLE(energy, 10); // entered in GeV
+  OPTION_DOUBLE(energy, 10);  // entered in GeV
   energy *= copcore::units::GeV;
   OPTION_INT(batch, 52);
   OPTION_STRING(gunpos, "0,0,0");
@@ -242,6 +242,8 @@ int main(int argc, char *argv[])
   tracer.setTag("SyncGeom");
   std::cout << "synchronizing VecGeom geometry to GPU ...\n";
   auto &cudaManager = vecgeom::cxx::CudaManager::Instance();
+  // Adjust stack size to avoid lane user stack overflow
+  COPCORE_CUDA_CHECK(vecgeom::cxx::CudaDeviceSetStackLimit(8192));
   cudaManager.LoadGeometry(world);
   cudaManager.Synchronize();
 


### PR DESCRIPTION
This implements  a backend-dependent way (for now just supporting CUDA) to request a different than default stack size on device, and uses it explicitly for the stack-hungry examples. This is needed due to the future removal of altering the stack size in VecGeom, as per this [MR](https://gitlab.cern.ch/VecGeom/VecGeom/-/merge_requests/975)