### PR TITLE
Added possibility to make all volumes sensitive

### DIFF
--- a/examples/Example17/include/DetectorConstruction.hh
+++ b/examples/Example17/include/DetectorConstruction.hh
@@ -43,7 +43,13 @@ public:
 
   void SetGDMLFile(G4String &file) { fGDML_file = file; }
   void SetRegionName(G4String &reg) { fRegion_name = reg; }
-  void AddSensitiveVolume(G4String volume) { fSensitive_volumes.push_back(volume); }
+  void AddSensitiveVolume(G4String volume)
+  {
+    if (volume == "*")
+      fAllInRegionSensitive = true;
+    else
+      fSensitive_volumes.push_back(volume);
+  }
   void AddSensitiveGroup(G4String group) { fSensitive_group.push_back(group); }
 
   // Set uniform magnetic field
@@ -77,6 +83,7 @@ private:
   G4String fRegion_name;
   std::vector<G4String> fSensitive_volumes;
   std::vector<G4String> fSensitive_group;
+  bool fAllInRegionSensitive{false};
   bool fActivate_AdePT{true};
 
   /// Messenger that allows to modify geometry


### PR DESCRIPTION
Implemented only in Exa 17, adding in the macro:
`/example17/detector/addsensitivevolume *` will have the effect that all defined sensitive volumes and groups where we score will be ignored, and all volumes in the GPU region will become sensitive