### PR TITLE
[cmake] Find HepMC3 only once

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,14 @@ else()
   message(STATUS "Did not find Geant4")
 endif()
 
+# Find HepMC3, used by integration examples to load realistic events
+find_package(HepMC3 QUIET)
+
+if(HepMC3_FOUND)
+  message(STATUS "HepMC3 found ${HEPMC3_INCLUDE_DIR}")
+  add_compile_definitions(HEPMC3_FOUND)
+endif()
+
 # Set up debugging levels for CUDA:
 # - For RelWithDebInfo (the default), generate line info to enable profiling.
 add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:RelWithDebInfo>>:--generate-line-info>")

--- a/examples/Example14/CMakeLists.txt
+++ b/examples/Example14/CMakeLists.txt
@@ -1,14 +1,6 @@
 # SPDX-FileCopyrightText: 2022 CERN
 # SPDX-License-Identifier: Apache-2.0
 
-find_package(HepMC3 QUIET)
-
-if(HepMC3_FOUND)
-  message(STATUS "HepMC3 found ${HEPMC3_INCLUDE_DIR}") 
-  add_definitions(-DHEPMC3_FOUND)
-endif()
-
-
 if(NOT TARGET G4HepEm::g4HepEm)
   message(STATUS "Disabling example14 (needs G4HepEm)")
   return()

--- a/examples/Example17/CMakeLists.txt
+++ b/examples/Example17/CMakeLists.txt
@@ -1,14 +1,6 @@
 # SPDX-FileCopyrightText: 2022 CERN
 # SPDX-License-Identifier: Apache-2.0
 
-find_package(HepMC3 QUIET)
-
-if(HepMC3_FOUND)
-  message(STATUS "HepMC3 found ${HEPMC3_INCLUDE_DIR}") 
-  add_definitions(-DHEPMC3_FOUND)
-endif()
-
-
 if(NOT TARGET G4HepEm::g4HepEm)
   message(STATUS "Disabling example17 (needs G4HepEm)")
   return()


### PR DESCRIPTION
The package warns that "multiple calls to `find_package(HepMC3)` are not recommended", so move it to the top-level `CMakeLists.txt`. Also replace `add_definitions` by the more specific `add_compile_definitions`.