### PR TITLE
example17: Fix warning about string literals

### DIFF
--- a/examples/Example17/example17.cpp
+++ b/examples/Example17/example17.cpp
@@ -63,10 +63,10 @@ int main(int argc, char **argv)
   if (!doBenchmark && !doValidation) {
     G4Exception(
         "main()", "Notification", JustWarning,
-        "Testing is enabled but no option has been selected, data will not be collected for this run.\n
-        Available options are:\n
-        --do_benchmark\n
-        --do_validation");
+        "Testing is enabled but no option has been selected, data will not be collected for this run.\n"
+        "Available options are:\n"
+        "--do_benchmark\n"
+        "--do_validation");
   }
 #else
   if (doBenchmark || doValidation) {


### PR DESCRIPTION
At least on my system, the compiler warns about the 'missing terminating " character'.