### PR TITLE
Requesting VecGeom version >= 2.0.0-dev.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,10 @@ option(ADEPT_USE_SURF "Enable surface model navigation on GPU" OFF)
 # Find VecGeom geometry headers library
 set(VecGeom_VERSION_REQ 2.0.0-dev.3)
 find_package(VecGeom REQUIRED)
+# Older versions did not provide VecGeom_VERSION_STRING, but only VecGeom_VERSION
+if (NOT VecGeom_VERSION_STRING)
+  set(VecGeom_VERSION_STRING ${VecGeom_VERSION})
+endif()
 if (VecGeom_VERSION_STRING STRLESS VecGeom_VERSION_REQ)
   message(FATAL_ERROR "AdePT requires at least VecGeom ${VecGeom_VERSION_REQ}, found ${VecGeom_VERSION_STRING}" )
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,9 +52,13 @@ message(STATUS "Using VecCore version ${VecCore_VERSION}")
 option(ADEPT_USE_SURF "Enable surface model navigation on GPU" OFF)
 
 # Find VecGeom geometry headers library
-set(VecGeom_VERSION 1.1.20)
-find_package(VecGeom ${VecGeom_VERSION} REQUIRED)
-message(STATUS "Using VecGeom version ${VecGeom_VERSION}")
+set(VecGeom_VERSION_REQ 2.0.0-dev.3)
+find_package(VecGeom REQUIRED)
+if (VecGeom_VERSION_STRING STRLESS VecGeom_VERSION_REQ)
+  message(FATAL_ERROR "AdePT requires at least VecGeom ${VecGeom_VERSION_REQ}, found ${VecGeom_VERSION_STRING}" )
+else()
+  message(STATUS "Using VecGeom version ${VecGeom_VERSION_STRING}")
+endif()
 # make sure we import VecGeom architecture flags - is this needed?
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${VECGEOM_CXX_FLAGS}")
 # Make sure VecGeom::vgdml is enabled


### PR DESCRIPTION
This moves the requested version of VecGeom to 2.0.0-dev.3, which contains the navigators moved from AdePT, and needed by #261 
We need to use VecGeom_VERSION_STRING to select dev versions of VecGeom until the 2.0.0 release 

The CI build is supposed to fail on this PR until we enable 2.0.0-dev.3 in the LCG build used by AdePT