### PR TITLE
[cmake] Fix configuration with Geant4 11.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ message(STATUS "Using VecCore version ${VecCore_VERSION}")
 
 option(ADEPT_USE_SURF "Enable surface model navigation on GPU" OFF)
 
+# Before looking for other packages, try to find XercesC explicitly to avoid
+# problems with G4HepEm not finding Geant4 11.1 even though we find it here.
+find_package(XercesC REQUIRED)
+
 # Find VecGeom geometry headers library
 set(VecGeom_VERSION_REQ 2.0.0-dev.3)
 find_package(VecGeom REQUIRED)


### PR DESCRIPTION
When trying to configure with Geant4 11.1, G4HepEm seems to have problems finding Geant4 even though AdePT's correctly found it before. As a reason, CMake quotes not finding XercesC even though both Vecgeom and Geant4 (searched from AdePT) find it. It seems explicitly looking for XercesC solves the problem (not sure why).