### PR TITLE
Use `PROJECT_{SOURCE,BINARY}_DIR` in place of `CMAKE_` equivalent

### DIFF
--- a/examples/Example12/CMakeLists.txt
+++ b/examples/Example12/CMakeLists.txt
@@ -39,4 +39,4 @@ set_target_properties(example12 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RE
 
 # Tests
 add_test(NAME example12
-  COMMAND $<TARGET_FILE:example12> -gdml_file ${CMAKE_BINARY_DIR}/cms2018.gdml)
+  COMMAND $<TARGET_FILE:example12> -gdml_file ${PROJECT_BINARY_DIR}/cms2018.gdml)

--- a/examples/Example13/CMakeLists.txt
+++ b/examples/Example13/CMakeLists.txt
@@ -42,4 +42,4 @@ target_link_libraries(example13 PRIVATE NVTX)
 
 # Tests
 add_test(NAME example13
-  COMMAND $<TARGET_FILE:example13> -gdml_file ${CMAKE_BINARY_DIR}/cms2018.gdml)
+  COMMAND $<TARGET_FILE:example13> -gdml_file ${PROJECT_BINARY_DIR}/cms2018.gdml)

--- a/examples/Example14/CMakeLists.txt
+++ b/examples/Example14/CMakeLists.txt
@@ -72,17 +72,17 @@ set_target_properties(example14 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RE
 
 # Install macros and geometry file
 
-set(TESTEM3_GDML ${CMAKE_BINARY_DIR}/testEm3.gdml)
-set(LHCB_GDML ${CMAKE_BINARY_DIR}/LHCb_Upgrade_fullLHCb.gdml)
-configure_file("macros/testEm3.gdml" "${CMAKE_BINARY_DIR}/testEm3.gdml")
-configure_file("macros/testEm3.mac.in" "${CMAKE_BINARY_DIR}/testEm3.mac")
-configure_file("macros/testEm3G4.mac.in" "${CMAKE_BINARY_DIR}/testEm3G4.mac")
-configure_file("macros/example14.mac.in" "${CMAKE_BINARY_DIR}/example14.mac")
-configure_file("macros/LHCb_Upgrade_fullLHCb.gdml" "${CMAKE_BINARY_DIR}/LHCb_Upgrade_fullLHCb.gdml")
-configure_file("macros/lhcb.mac.in" "${CMAKE_BINARY_DIR}/lhcb.mac")
+set(TESTEM3_GDML ${PROJECT_BINARY_DIR}/testEm3.gdml)
+set(LHCB_GDML ${PROJECT_BINARY_DIR}/LHCb_Upgrade_fullLHCb.gdml)
+configure_file("macros/testEm3.gdml" "${PROJECT_BINARY_DIR}/testEm3.gdml")
+configure_file("macros/testEm3.mac.in" "${PROJECT_BINARY_DIR}/testEm3.mac")
+configure_file("macros/testEm3G4.mac.in" "${PROJECT_BINARY_DIR}/testEm3G4.mac")
+configure_file("macros/example14.mac.in" "${PROJECT_BINARY_DIR}/example14.mac")
+configure_file("macros/LHCb_Upgrade_fullLHCb.gdml" "${PROJECT_BINARY_DIR}/LHCb_Upgrade_fullLHCb.gdml")
+configure_file("macros/lhcb.mac.in" "${PROJECT_BINARY_DIR}/lhcb.mac")
 
 # Tests
 add_test(NAME example14-adept-em3
-  COMMAND $<TARGET_FILE:example14> -m ${CMAKE_BINARY_DIR}/testEm3.mac)
+  COMMAND $<TARGET_FILE:example14> -m ${PROJECT_BINARY_DIR}/testEm3.mac)
 add_test(NAME example14-g4-em3
-  COMMAND $<TARGET_FILE:example14> -m ${CMAKE_BINARY_DIR}/testEm3G4.mac)
+  COMMAND $<TARGET_FILE:example14> -m ${PROJECT_BINARY_DIR}/testEm3G4.mac)

--- a/examples/Example15/CMakeLists.txt
+++ b/examples/Example15/CMakeLists.txt
@@ -39,4 +39,4 @@ set_target_properties(example15 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RE
 
 # Tests
 add_test(NAME example15
-  COMMAND $<TARGET_FILE:example15> -gdml_file ${CMAKE_BINARY_DIR}/cms2018.gdml)
+  COMMAND $<TARGET_FILE:example15> -gdml_file ${PROJECT_BINARY_DIR}/cms2018.gdml)

--- a/examples/Example16/CMakeLists.txt
+++ b/examples/Example16/CMakeLists.txt
@@ -42,4 +42,4 @@ target_link_libraries(example16 PRIVATE NVTX)
 
 # Tests
 add_test(NAME example16
-  COMMAND $<TARGET_FILE:example16> -gdml_file ${CMAKE_BINARY_DIR}/cms2018.gdml)
+  COMMAND $<TARGET_FILE:example16> -gdml_file ${PROJECT_BINARY_DIR}/cms2018.gdml)

--- a/examples/Example17/CMakeLists.txt
+++ b/examples/Example17/CMakeLists.txt
@@ -76,20 +76,20 @@ set_target_properties(example17 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RE
 
 # Install macros and geometry file
 
-set(TESTEM3_GDML ${CMAKE_BINARY_DIR}/testEm3.gdml)
-set(LHCB_GDML ${CMAKE_BINARY_DIR}/LHCb_Upgrade_fullLHCb.gdml)
-configure_file("macros/testEm3.gdml" "${CMAKE_BINARY_DIR}/testEm3.gdml")
-configure_file("macros/testEm3.mac.in" "${CMAKE_BINARY_DIR}/testEm3_e17.mac")
-configure_file("macros/testEm3G4.mac.in" "${CMAKE_BINARY_DIR}/testEm3G4_e17.mac")
-configure_file("macros/example17.mac.in" "${CMAKE_BINARY_DIR}/example17.mac")
-configure_file("macros/example17_ttbar.mac.in" "${CMAKE_BINARY_DIR}/example17_ttbar.mac")
-configure_file("macros/example17_validation.mac.in" "${CMAKE_BINARY_DIR}/example17_validation.mac")
-configure_file("macros/LHCb_Upgrade_fullLHCb.gdml" "${CMAKE_BINARY_DIR}/LHCb_Upgrade_fullLHCb.gdml")
-configure_file("macros/lhcb.mac.in" "${CMAKE_BINARY_DIR}/lhcb_e17.mac")
-configure_file("macros/lhcb_validation.mac.in" "${CMAKE_BINARY_DIR}/lhcb_validation.mac")
+set(TESTEM3_GDML ${PROJECT_BINARY_DIR}/testEm3.gdml)
+set(LHCB_GDML ${PROJECT_BINARY_DIR}/LHCb_Upgrade_fullLHCb.gdml)
+configure_file("macros/testEm3.gdml" "${PROJECT_BINARY_DIR}/testEm3.gdml")
+configure_file("macros/testEm3.mac.in" "${PROJECT_BINARY_DIR}/testEm3_e17.mac")
+configure_file("macros/testEm3G4.mac.in" "${PROJECT_BINARY_DIR}/testEm3G4_e17.mac")
+configure_file("macros/example17.mac.in" "${PROJECT_BINARY_DIR}/example17.mac")
+configure_file("macros/example17_ttbar.mac.in" "${PROJECT_BINARY_DIR}/example17_ttbar.mac")
+configure_file("macros/example17_validation.mac.in" "${PROJECT_BINARY_DIR}/example17_validation.mac")
+configure_file("macros/LHCb_Upgrade_fullLHCb.gdml" "${PROJECT_BINARY_DIR}/LHCb_Upgrade_fullLHCb.gdml")
+configure_file("macros/lhcb.mac.in" "${PROJECT_BINARY_DIR}/lhcb_e17.mac")
+configure_file("macros/lhcb_validation.mac.in" "${PROJECT_BINARY_DIR}/lhcb_validation.mac")
 
 # Tests
 add_test(NAME example17-adept-em3
-  COMMAND $<TARGET_FILE:example17> -m ${CMAKE_BINARY_DIR}/testEm3_e17.mac)
+  COMMAND $<TARGET_FILE:example17> -m ${PROJECT_BINARY_DIR}/testEm3_e17.mac)
 add_test(NAME example17-g4-em3
-  COMMAND $<TARGET_FILE:example17> -m ${CMAKE_BINARY_DIR}/testEm3G4_e17.mac)
+  COMMAND $<TARGET_FILE:example17> -m ${PROJECT_BINARY_DIR}/testEm3G4_e17.mac)

--- a/examples/Example18/CMakeLists.txt
+++ b/examples/Example18/CMakeLists.txt
@@ -42,4 +42,4 @@ target_link_libraries(example18 PRIVATE NVTX)
 
 # Tests
 add_test(NAME example18
-  COMMAND $<TARGET_FILE:example18> -gdml_file ${CMAKE_BINARY_DIR}/cms2018.gdml)
+  COMMAND $<TARGET_FILE:example18> -gdml_file ${PROJECT_BINARY_DIR}/cms2018.gdml)

--- a/examples/Example19/CMakeLists.txt
+++ b/examples/Example19/CMakeLists.txt
@@ -43,5 +43,5 @@ target_link_libraries(${TargetName} PRIVATE NVTX)
 
 # Tests
 add_test(NAME ${TargetName}
-  COMMAND $<TARGET_FILE:${TargetName}> -gdml_file ${CMAKE_BINARY_DIR}/cms2018.gdml)
+  COMMAND $<TARGET_FILE:${TargetName}> -gdml_file ${PROJECT_BINARY_DIR}/cms2018.gdml)
 

--- a/examples/Example20/CMakeLists.txt
+++ b/examples/Example20/CMakeLists.txt
@@ -43,5 +43,5 @@ target_link_libraries(${TargetName} PRIVATE NVTX)
 
 # Tests
 add_test(NAME ${TargetName}
-  COMMAND $<TARGET_FILE:${TargetName}> -gdml_file ${CMAKE_BINARY_DIR}/cms2018.gdml)
+  COMMAND $<TARGET_FILE:${TargetName}> -gdml_file ${PROJECT_BINARY_DIR}/cms2018.gdml)
 

--- a/examples/Example21/CMakeLists.txt
+++ b/examples/Example21/CMakeLists.txt
@@ -77,17 +77,17 @@ set_target_properties(example21 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RE
 
 # Install macros and geometry file
 
-set(TESTEM3_GDML ${CMAKE_BINARY_DIR}/testEm3.gdml)
-set(LHCB_GDML ${CMAKE_BINARY_DIR}/LHCb_Upgrade_fullLHCb.gdml)
-configure_file("../data/testEm3.gdml" "${CMAKE_BINARY_DIR}/testEm3.gdml")
-configure_file("macros/testEm3.mac.in" "${CMAKE_BINARY_DIR}/testEm3_e21.mac")
-configure_file("macros/example21.mac.in" "${CMAKE_BINARY_DIR}/example21.mac")
-configure_file("macros/example21_ttbar.mac.in" "${CMAKE_BINARY_DIR}/example21_ttbar.mac")
-configure_file("../data/LHCb_Upgrade_fullLHCb.gdml" "${CMAKE_BINARY_DIR}/LHCb_Upgrade_fullLHCb.gdml")
-configure_file("macros/lhcb.mac.in" "${CMAKE_BINARY_DIR}/lhcb_e17.mac")
-configure_file("macros/lhcb_validation.mac.in" "${CMAKE_BINARY_DIR}/lhcb_validation.mac")
+set(TESTEM3_GDML ${PROJECT_BINARY_DIR}/testEm3.gdml)
+set(LHCB_GDML ${PROJECT_BINARY_DIR}/LHCb_Upgrade_fullLHCb.gdml)
+configure_file("../data/testEm3.gdml" "${PROJECT_BINARY_DIR}/testEm3.gdml")
+configure_file("macros/testEm3.mac.in" "${PROJECT_BINARY_DIR}/testEm3_e21.mac")
+configure_file("macros/example21.mac.in" "${PROJECT_BINARY_DIR}/example21.mac")
+configure_file("macros/example21_ttbar.mac.in" "${PROJECT_BINARY_DIR}/example21_ttbar.mac")
+configure_file("../data/LHCb_Upgrade_fullLHCb.gdml" "${PROJECT_BINARY_DIR}/LHCb_Upgrade_fullLHCb.gdml")
+configure_file("macros/lhcb.mac.in" "${PROJECT_BINARY_DIR}/lhcb_e17.mac")
+configure_file("macros/lhcb_validation.mac.in" "${PROJECT_BINARY_DIR}/lhcb_validation.mac")
 
 # Tests
 add_test(NAME example21-adept-em3
-  COMMAND $<TARGET_FILE:example21> -m ${CMAKE_BINARY_DIR}/testEm3_e21.mac)
+  COMMAND $<TARGET_FILE:example21> -m ${PROJECT_BINARY_DIR}/testEm3_e21.mac)
 

--- a/examples/Raytracer_Benchmark/CMakeLists.txt
+++ b/examples/Raytracer_Benchmark/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(raytracercu ${ADEPT_CUDA_SRCS})
 target_include_directories(raytracercu PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/base/inc>
 )
 
 target_link_libraries(raytracercu VecCore::VecCore VecGeom::vecgeom VecGeom::vecgeomcuda_static CopCore::CopCore)
@@ -42,7 +42,7 @@ set_target_properties(raytracercu PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 add_executable(RaytraceBenchmark Raytracer.cpp RaytraceBenchmark.cpp)
 target_include_directories(RaytraceBenchmark PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/base/inc>
   $<INSTALL_INTERFACE:base>
 )
 target_link_libraries(RaytraceBenchmark VecCore::VecCore VecGeom::vecgeom VecGeom::vecgeomcuda_static VecGeom::vgdml raytracercu CopCore::CopCore)
@@ -50,11 +50,11 @@ target_compile_options(RaytraceBenchmark PRIVATE "$<$<AND:$<OR:$<CONFIG:Debug>,$
 set_target_properties(RaytraceBenchmark PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
 
 add_test(NAME RaytraceBenchmarkCPU
-  COMMAND $<TARGET_FILE:RaytraceBenchmark> -gdml_file ${CMAKE_BINARY_DIR}/trackML.gdml -on_gpu 0)
+  COMMAND $<TARGET_FILE:RaytraceBenchmark> -gdml_file ${PROJECT_BINARY_DIR}/trackML.gdml -on_gpu 0)
 set_tests_properties(RaytraceBenchmarkCPU PROPERTIES ATTACHED_FILES_ON_FAIL "output-cpu.ppm")
 
 add_test(NAME RaytraceBenchmarkGPU
-  COMMAND $<TARGET_FILE:RaytraceBenchmark> -gdml_file ${CMAKE_BINARY_DIR}/trackML.gdml -on_gpu 1)
+  COMMAND $<TARGET_FILE:RaytraceBenchmark> -gdml_file ${PROJECT_BINARY_DIR}/trackML.gdml -on_gpu 1)
 set_tests_properties(RaytraceBenchmarkGPU PROPERTIES ATTACHED_FILES_ON_FAIL "output-gpu.ppm")
 
 add_test(NAME RaytraceBenchmarkDiff

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,7 +37,7 @@ add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda;>")
 
 add_executable(test_launcher test_launcher.cu test_launcher.cpp)
 target_include_directories(test_launcher PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/base/inc>
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/base/inc>
   $<INSTALL_INTERFACE:base>
 )
 target_link_libraries(test_launcher VecCore::VecCore CopCore::CopCore)


### PR DESCRIPTION
When included as a subproject as `add_subdirectory` or similar, the `CMAKE_{SOURCE,BINARY}_DIR` variables will point to those of the highest level project. This will not be the same as the root of the AdePT source code. Include/etc paths will not then be correct, leading to compile time errors. Additionally, generated files may appear in the wrong place, or clash with higher level projects. This _may_ be one of the methods experiments use to integrate the code, so good to support it, and will also help co-working with Celeritas.

Use `PROJECT_{SOURCE,BINARY}_DIR` in place of the `CMAKE_` versions to guarantee pointing to the AdePT root source/build directories.