### PR TITLE
Minimal fetch and use of G4VG for in-memory Geant4<->VecGeom conversion

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -12,3 +12,15 @@ else()
   set(BUILD_TESTING OFF)
   add_subdirectory(g4hepem)
 endif()
+
+# Fetch g4vg
+include(FetchContent)
+
+# Load Celeritas
+FetchContent_Declare(
+  g4vg
+  EXCLUDE_FROM_ALL
+  URL https://github.com/celeritas-project/g4vg/archive/e034ada099132f857866949ec9ce8eadf1ff2251.zip)
+
+FetchContent_MakeAvailable(g4vg)
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,10 @@ endmacro()
 add_executable(test_copcore_link test_copcore_link.cpp)
 target_link_libraries(test_copcore_link PRIVATE VecCore::VecCore CopCore::CopCore)
 
+# - Test that use/link to G4VG works
+add_executable(test_g4vg_link test_g4vg_link.cpp)
+target_link_libraries(test_g4vg_link PRIVATE G4VG::g4vg)
+
 # - Unit tests
 set(ADEPT_UNIT_TESTS_BASE
   test_atomic.cu               # Unit test for atomic ops
@@ -44,3 +48,4 @@ target_link_libraries(test_launcher VecCore::VecCore CopCore::CopCore)
 
 build_tests("${ADEPT_UNIT_TESTS_BASE}")
 add_to_test("${ADEPT_UNIT_TESTS_BASE}")
+

--- a/test/test_g4vg_link.cpp
+++ b/test/test_g4vg_link.cpp
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: 2020 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include <G4VG.hh>
+
+int main() {}


### PR DESCRIPTION
As discussed at the last AdePT/Celeritas standup, and for this afternoon's hackathon, this shows the _minimal_ steps for use of [celeritas-project/g4vg](https://github.com/celeritas-project/g4vg) in AdePT. This is just:

1. Use of `FetchContent` to get the code and add it to the build
2. A smoke test of including the `G4VG.hh` public header and linking to `libg4vg`

It's been tested on a centos9 with gcc11/cuda12 and seems to build and run o.k., but it is trivial!

Also pinging @sethrj for info/double check.