### PR TITLE
Minimal tidy of CMake scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2020 CERN
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.18...3.28)
+cmake_minimum_required(VERSION 3.18...3.24)
 
 # Record the command line invoking the cmake command. Replay with recmake_initial.sh.
 include(cmake/RecordCmdLine.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2020 CERN
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.18...3.28)
 
 # Record the command line invoking the cmake command. Replay with recmake_initial.sh.
 include(cmake/RecordCmdLine.cmake)
@@ -9,10 +9,12 @@ include(cmake/RecordCmdLine.cmake)
 project(AdePT
   VERSION 0.1.0
   DESCRIPTION "Accelerated demonstrator of electromagnetic Particle Transport"
-  LANGUAGES C CXX CUDA)
+  LANGUAGES C CXX CUDA
+)
 
-include(GNUInstallDirs)
-
+#----------------------------------------------------------------------------#
+# CMake and Build Settings
+#----------------------------------------------------------------------------#
 # - Include needed custom/core modules
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 include(CMakeSettings) 
@@ -28,7 +30,8 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
   endif()
   set(CMAKE_BUILD_TYPE "${__DEFAULT_CMAKE_BUILD_TYPE}"
     CACHE STRING "Choose the type of build, options are: None Release MinSizeRel Debug RelWithDebInfo MinSizeRel."
-    FORCE)
+    FORCE
+  )
 endif()
 
 set(CMAKE_CXX_STANDARD 17)
@@ -39,6 +42,15 @@ set(CMAKE_CUDA_STANDARD_REQUIRED ${CMAKE_CXX_STANDARD_REQUIRED})
 set(CMAKE_CUDA_EXTENSIONS OFF)
 set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
 
+#----------------------------------------------------------------------------#
+# User options
+#----------------------------------------------------------------------------#
+# Options
+option(ADEPT_USE_SURF "Enable surface model navigation on GPU" OFF)
+
+#----------------------------------------------------------------------------#
+# Dependencies
+#----------------------------------------------------------------------------#
 # With CUDA language enabled above, this should find the toolkit alongside the compiler
 find_package(CUDAToolkit REQUIRED)
 
@@ -48,8 +60,6 @@ set(VecCore_BACKEND CUDA)
 find_package(VecCore ${VecCore_VERSION} REQUIRED COMPONENTS ${VecCore_BACKEND})
 message(STATUS "Using VecCore version ${VecCore_VERSION}")
 
-option(ADEPT_USE_SURF "Enable surface model navigation on GPU" OFF)
-
 # Before looking for other packages, try to find XercesC explicitly to avoid
 # problems with G4HepEm not finding Geant4 11.1 even though we find it here.
 find_package(XercesC REQUIRED)
@@ -58,23 +68,21 @@ find_package(XercesC REQUIRED)
 set(VecGeom_VERSION_REQ 2.0.0-dev.3)
 find_package(VecGeom REQUIRED)
 # Older versions did not provide VecGeom_VERSION_STRING, but only VecGeom_VERSION
-if (NOT VecGeom_VERSION_STRING)
+if(NOT VecGeom_VERSION_STRING)
   set(VecGeom_VERSION_STRING ${VecGeom_VERSION})
 endif()
-if (VecGeom_VERSION_STRING STRLESS VecGeom_VERSION_REQ)
+if(VecGeom_VERSION_STRING STRLESS VecGeom_VERSION_REQ)
   message(FATAL_ERROR "AdePT requires at least VecGeom ${VecGeom_VERSION_REQ}, found ${VecGeom_VERSION_STRING}" )
 else()
   message(STATUS "Using VecGeom version ${VecGeom_VERSION_STRING}")
 endif()
-# make sure we import VecGeom architecture flags - is this needed?
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${VECGEOM_CXX_FLAGS}")
 # Make sure VecGeom::vgdml is enabled
 if(NOT TARGET VecGeom::vgdml)
   message(FATAL_ERROR "AdePT requires VecGeom compiled with GDML support")
 endif()
 # Check for surface model support in VecGeom
-if (ADEPT_USE_SURF)
-  if (VecGeom_SURF_FOUND)
+if(ADEPT_USE_SURF)
+  if(VecGeom_SURF_FOUND)
     message(STATUS "Surface model in VecGeom is enabled")
     add_compile_definitions(ADEPT_USE_SURF)
   else()
@@ -105,7 +113,6 @@ endif()
 
 # Find HepMC3, used by integration examples to load realistic events
 find_package(HepMC3 QUIET)
-
 if(HepMC3_FOUND)
   message(STATUS "HepMC3 found ${HEPMC3_INCLUDE_DIR}")
   add_compile_definitions(HEPMC3_FOUND)
@@ -127,138 +134,157 @@ if(G4HepEm_FOUND)
   message(STATUS "G4HepEm found ${G4HepEm_INCLUDE_DIR}")
 endif()
 
-if(BUILD_TESTING)
-  set(TESTING_GDML "${PROJECT_BINARY_DIR}/trackML.gdml")
-  set(CMS2018_GDML "${PROJECT_BINARY_DIR}/cms2018.gdml")
-  file(DOWNLOAD https://gitlab.cern.ch/VecGeom/VecGeom/raw/v1.2.0/persistency/gdml/gdmls/trackML.gdml "${TESTING_GDML}"
-    EXPECTED_HASH SHA256=2c53e0f2f4673c61f8679702532647bf71ec64c1613aae330fa835e7d7087064)
-  file(DOWNLOAD https://gitlab.cern.ch/VecGeom/VecGeom/raw/v1.2.0/persistency/gdml/gdmls/cms2018.gdml "${CMS2018_GDML}"
-    EXPECTED_HASH SHA256=a6538d8f196fbfe4c14e806df3439d5a0d7050d538d364faabe882c750970e63)
-endif()
-
-configure_file(examples/data/cms2018_sd.gdml ${CMAKE_BINARY_DIR}/cms2018_sd.gdml)
-configure_file(examples/data/ppttbar.hepmc3 ${CMAKE_BINARY_DIR}/ppttbar.hepmc3)
-
+#----------------------------------------------------------------------------#
+# Build Targets
+#----------------------------------------------------------------------------#
 set(ADEPT_G4_INTEGRATION_SRCS
   src/AdePTTrackingManager.cc
   src/AdePTPhysics.cc
   src/HepEMPhysics.cc
-  src/AdePTGeant4Integration.cpp)
+  src/AdePTGeant4Integration.cpp
+)
 
 set(ADEPT_SRCS
   src/AdePTTransport.cpp
-  src/AdePTConfigurationMessenger.cc)
+  src/AdePTConfigurationMessenger.cc
+)
 
 set(ADEPT_CUDA_SRCS
   src/AdePTTransport.cu
-  src/HostScoring.cu)
+  src/HostScoring.cu
+)
 
 add_library(CopCore INTERFACE)
-target_include_directories(CopCore INTERFACE
-                           $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/AdePT/copcore/>
-                           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
+target_include_directories(CopCore
+  INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/AdePT/copcore/>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
+)
 
 add_library(AdePT_G4_integration SHARED ${ADEPT_G4_INTEGRATION_SRCS})
-target_include_directories(AdePT_G4_integration PUBLIC 
-                          #Include directory for building the library
-                          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                          #Include directory for the installed target
-                          $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
-target_link_libraries(AdePT_G4_integration PUBLIC 
-                      CopCore
-                      VecGeom::vecgeom
-                      VecGeom::vgdml
-                      ${Geant4_LIBRARIES}
-                      G4HepEm::g4HepEm
-                      G4HepEm::g4HepEmData)
+target_include_directories(AdePT_G4_integration 
+  PUBLIC 
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
+)
+target_link_libraries(AdePT_G4_integration 
+  PUBLIC 
+    CopCore
+    VecGeom::vecgeom
+    VecGeom::vgdml
+    ${Geant4_LIBRARIES}
+    G4HepEm::g4HepEm
+    G4HepEm::g4HepEmData
+)
 
 add_library(AdePT SHARED ${ADEPT_SRCS})
-target_include_directories(AdePT PUBLIC
-                          #Include directory for building the library
-                          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                          #Include directory for the installed target
-                          $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
-target_link_libraries(AdePT PUBLIC 
-                      CopCore
-                      VecGeom::vecgeom
-                      VecGeom::vgdml
-                      G4HepEm::g4HepEm
-                      G4HepEm::g4HepEmData)
+target_include_directories(AdePT 
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
+)
+target_link_libraries(AdePT 
+  PUBLIC 
+    CopCore
+    VecGeom::vecgeom
+    VecGeom::vgdml
+    G4HepEm::g4HepEm
+    G4HepEm::g4HepEmData
+)
 
 add_library(AdePT_cuda SHARED ${ADEPT_CUDA_SRCS})
-target_include_directories(AdePT_cuda PUBLIC 
-                          ${Geant4_INCLUDE_DIRS}
-                          #Include directory for building the library
-                          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                          #Include directory for the installed target
-                          $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
-target_link_libraries(AdePT_cuda PUBLIC
-                      VecGeom::vecgeomcuda_static
-                      CopCore
-                      G4HepEm::g4HepEmInit
-                      G4HepEm::g4HepEmRun)
-set_target_properties(AdePT_cuda PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
+target_include_directories(AdePT_cuda 
+  PUBLIC 
+    ${Geant4_INCLUDE_DIRS}
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
+)
+target_link_libraries(AdePT_cuda 
+  PUBLIC
+    VecGeom::vecgeomcuda_static
+    CopCore
+    G4HepEm::g4HepEmInit
+    G4HepEm::g4HepEmRun
+)
+set_target_properties(AdePT_cuda
+  PROPERTIES 
+    CUDA_SEPARABLE_COMPILATION ON 
+    CUDA_RESOLVE_DEVICE_SYMBOLS ON
+)
 
 # AdePT_cuda links against vecgeomcuda_static. This is fine as long as the final executable doesn't link with 
 # vecgeomcuda itself, as is the case with Geant4 integration examples. However for standalone applications not 
 # using geant4, that may need features from vecgeomcuda, this doesn't work. In that case AdePT_cuda has to link 
 # to the shared version of vecgeomcuda, and the final executable to vecgeomcuda_static
 add_library(AdePT_cuda_standalone SHARED ${ADEPT_CUDA_SRCS})
-target_include_directories(AdePT_cuda_standalone PUBLIC 
-                          ${Geant4_INCLUDE_DIRS}
-                          #Include directory for building the library
-                          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-                          #Include directory for the installed target
-                          $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
-target_link_libraries(AdePT_cuda_standalone PUBLIC
-                      VecGeom::vecgeomcuda
-                      CopCore
-                      G4HepEm::g4HepEmInit
-                      G4HepEm::g4HepEmRun)
-set_target_properties(AdePT_cuda_standalone PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-
+target_include_directories(AdePT_cuda_standalone 
+  PUBLIC 
+    ${Geant4_INCLUDE_DIRS}
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
+)
+target_link_libraries(AdePT_cuda_standalone
+  PUBLIC
+    VecGeom::vecgeomcuda
+    CopCore
+    G4HepEm::g4HepEmInit
+    G4HepEm::g4HepEmRun
+)
+set_target_properties(AdePT_cuda_standalone
+  PROPERTIES 
+    CUDA_SEPARABLE_COMPILATION ON
+    CUDA_RESOLVE_DEVICE_SYMBOLS ON
+)
 
 # Optional library to activate NVTX annotations for profiling:
-set(NVTX OFF CACHE BOOL "Add NVTX instrumentation for profiling (only for annotated examples)")
+option(NVTX OFF "Add NVTX instrumentation for profiling (only for annotated examples)")
 add_library(NVTX INTERFACE)
 if(NVTX)
   target_link_libraries(NVTX INTERFACE nvToolsExt)
   target_compile_definitions(NVTX INTERFACE -DUSE_NVTX)
 endif()
 
-add_subdirectory(test)
-add_subdirectory(examples)
+if(BUILD_TESTING)
+  add_subdirectory(test)
+  # This might become a separate option, e.g. "ADEPT_BUILD_EXAMPLES"
+  add_subdirectory(examples)
+endif()
 
 ####################################################################################################
 
 include(CMakePackageConfigHelpers)
 #Generate the configuration file from the template and save it to the build directory
 configure_package_config_file(cmake/${PROJECT_NAME}Config.cmake.in 
-                              "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${PROJECT_NAME}Config.cmake"
-                              INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
-                              PATH_VARS CMAKE_INSTALL_INCLUDEDIR)
+  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+  PATH_VARS CMAKE_INSTALL_INCLUDEDIR
+)
 
 #Install the libraries
 install(TARGETS CopCore AdePT AdePT_cuda AdePT_G4_integration AdePT_cuda_standalone 
-EXPORT ${PROJECT_NAME}Targets
-ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+  EXPORT ${PROJECT_NAME}Targets
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+)
 
 #Install the headers
 install(DIRECTORY include/AdePT 
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
 #Install the configuration file
 install(FILES "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/AdePTConfig.cmake" 
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)
 
 #Export the targets file
 export(TARGETS CopCore AdePT_G4_integration AdePT AdePT_cuda AdePT_cuda_standalone
-        FILE "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${PROJECT_NAME}Targets.cmake")
+  FILE "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${PROJECT_NAME}Targets.cmake"
+)
 
 #Install the targets file
 install(EXPORT ${PROJECT_NAME}Targets
-        NAMESPACE ${PROJECT_NAME}::
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
-
+  NAMESPACE ${PROJECT_NAME}::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,10 @@
 # SPDX-FileCopyrightText: 2020 CERN
 # SPDX-License-Identifier: Apache-2.0
 
+# - Common data for testing
+configure_file(data/cms2018_sd.gdml ${PROJECT_BINARY_DIR}/cms2018_sd.gdml)
+configure_file(data/ppttbar.hepmc3 ${PROJECT_BINARY_DIR}/ppttbar.hepmc3)
+
+# - Subprojects
 add_subdirectory(Example1)
 add_subdirectory(IntegrationBenchmark)

--- a/examples/Example1/CMakeLists.txt
+++ b/examples/Example1/CMakeLists.txt
@@ -40,35 +40,32 @@ set(sources_g4
 
 if(HepMC3_FOUND)
   set(sources_hepmc3
-      ${PROJECT_SOURCE_DIR}/examples/common/src/HepMC3G4AsciiReader.cc
-      ${PROJECT_SOURCE_DIR}/examples/common/src/HepMC3G4AsciiReaderMessenger.cc
-      ${PROJECT_SOURCE_DIR}/examples/common/src/HepMC3G4Interface.cc
-     )
+    ${PROJECT_SOURCE_DIR}/examples/common/src/HepMC3G4AsciiReader.cc
+    ${PROJECT_SOURCE_DIR}/examples/common/src/HepMC3G4AsciiReaderMessenger.cc
+    ${PROJECT_SOURCE_DIR}/examples/common/src/HepMC3G4Interface.cc
+  )
 endif()
 
 # example1
-add_executable(example1 
-                example1.cpp 
-                ${sources_g4} 
-                ${sources_hepmc3})
-
-target_include_directories(example1 PRIVATE 
-                          ${PROJECT_SOURCE_DIR}/examples/Example1/include 
-                          ${PROJECT_SOURCE_DIR}/examples/Example1
-                          ${PROJECT_SOURCE_DIR}/examples/common/include
-                          ${HEPMC3_INCLUDE_DIR})
-
+add_executable(example1 example1.cpp ${sources_g4} ${sources_hepmc3})
+target_include_directories(example1
+  PRIVATE 
+    ${PROJECT_SOURCE_DIR}/examples/Example1/include 
+    ${PROJECT_SOURCE_DIR}/examples/Example1
+    ${PROJECT_SOURCE_DIR}/examples/common/include
+    ${HEPMC3_INCLUDE_DIR}
+)
 target_link_libraries(example1
   PRIVATE
     AdePT_G4_integration
     AdePT
     AdePT_cuda
     ${HEPMC3_LIBRARIES} 
-    ${HEPMC3_FIO_LIBRARIES})
+    ${HEPMC3_FIO_LIBRARIES}
+)
 
 # Install macros and geometry file
-
-configure_file("macros/example1.mac.in" "${CMAKE_BINARY_DIR}/example1.mac")
-configure_file("macros/example1_ttbar.mac.in" "${CMAKE_BINARY_DIR}/example1_ttbar.mac")
+configure_file("macros/example1.mac.in" "${PROJECT_BINARY_DIR}/example1.mac")
+configure_file("macros/example1_ttbar.mac.in" "${PROJECT_BINARY_DIR}/example1_ttbar.mac")
 
 # Tests

--- a/examples/IntegrationBenchmark/CMakeLists.txt
+++ b/examples/IntegrationBenchmark/CMakeLists.txt
@@ -41,32 +41,31 @@ set(sources_g4
 
 if(HepMC3_FOUND)
   set(sources_hepmc3
-      ${PROJECT_SOURCE_DIR}/examples/common/src/HepMC3G4AsciiReader.cc
-      ${PROJECT_SOURCE_DIR}/examples/common/src/HepMC3G4AsciiReaderMessenger.cc
-      ${PROJECT_SOURCE_DIR}/examples/common/src/HepMC3G4Interface.cc
-     )
+    ${PROJECT_SOURCE_DIR}/examples/common/src/HepMC3G4AsciiReader.cc
+    ${PROJECT_SOURCE_DIR}/examples/common/src/HepMC3G4AsciiReaderMessenger.cc
+    ${PROJECT_SOURCE_DIR}/examples/common/src/HepMC3G4Interface.cc
+  )
 endif()
 
 # integrationBenchmark
-add_executable(integrationBenchmark 
-                integrationBenchmark.cpp 
-                ${sources_g4} 
-                ${sources_hepmc3})
-
-target_include_directories(integrationBenchmark PRIVATE 
-                          ${PROJECT_SOURCE_DIR}/examples/IntegrationBenchmark/include 
-                          ${PROJECT_SOURCE_DIR}/examples/IntegrationBenchmark
-                          ${PROJECT_SOURCE_DIR}/examples/common/include
-                          ${HEPMC3_INCLUDE_DIR})
-
+add_executable(integrationBenchmark integrationBenchmark.cpp ${sources_g4} ${sources_hepmc3})
+target_include_directories(integrationBenchmark
+  PRIVATE 
+    ${PROJECT_SOURCE_DIR}/examples/IntegrationBenchmark/include 
+    ${PROJECT_SOURCE_DIR}/examples/IntegrationBenchmark
+    ${PROJECT_SOURCE_DIR}/examples/common/include
+    ${HEPMC3_INCLUDE_DIR}
+)
 target_link_libraries(integrationBenchmark
   PRIVATE
     AdePT_G4_integration
     AdePT
     AdePT_cuda
     ${HEPMC3_LIBRARIES} 
-    ${HEPMC3_FIO_LIBRARIES})
+    ${HEPMC3_FIO_LIBRARIES}
+)
 
-    configure_file("macros/integrationbenchmark.mac.in" "${CMAKE_BINARY_DIR}/integrationbenchmark.mac")
+# Scripts
+configure_file("macros/integrationbenchmark.mac.in" "${CMAKE_BINARY_DIR}/integrationbenchmark.mac")
 
 # Tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,9 @@
 # SPDX-FileCopyrightText: 2020 CERN
 # SPDX-License-Identifier: Apache-2.0
 
+#----------------------------------------------------------------------------#
 # Helper Macros/Functions
+#----------------------------------------------------------------------------#
 macro(build_tests TESTS)
   foreach(TEST ${TESTS})
     get_filename_component(TARGET_NAME ${TEST} NAME_WE)
@@ -18,29 +20,49 @@ macro(add_to_test TESTS)
    endforeach()
 endmacro()
 
+#----------------------------------------------------------------------------#
+# Common Data
+#----------------------------------------------------------------------------#
+set(TESTING_GDML "${PROJECT_BINARY_DIR}/trackML.gdml")
+file(DOWNLOAD https://gitlab.cern.ch/VecGeom/VecGeom/raw/v1.2.0/persistency/gdml/gdmls/trackML.gdml
+  "${TESTING_GDML}"
+  EXPECTED_HASH SHA256=2c53e0f2f4673c61f8679702532647bf71ec64c1613aae330fa835e7d7087064
+)
+
+set(CMS2018_GDML "${PROJECT_BINARY_DIR}/cms2018.gdml")
+file(DOWNLOAD https://gitlab.cern.ch/VecGeom/VecGeom/raw/v1.2.0/persistency/gdml/gdmls/cms2018.gdml
+  "${CMS2018_GDML}"
+  EXPECTED_HASH SHA256=a6538d8f196fbfe4c14e806df3439d5a0d7050d538d364faabe882c750970e63
+)
+
+#----------------------------------------------------------------------------#
+# Detailed tests
+#----------------------------------------------------------------------------#
 add_subdirectory(testField)
 add_subdirectory(TestEm3)
 
-# - Test that linkage to CopCore target works
+#----------------------------------------------------------------------------#
+# Link/RDC tests
+#----------------------------------------------------------------------------#
+# - Check CopCore links as expected 
 add_executable(test_copcore_link test_copcore_link.cpp)
 target_include_directories(test_copcore_link PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(test_copcore_link PRIVATE CopCore)
 
-# Fetch the G4 to VecGeom geometry converter
-cmake_policy(SET CMP0135 NEW)
+# - Check G4VG links as expected 
 include(FetchContent)
-# Load Celeritas
 FetchContent_Declare(
   g4vg
   EXCLUDE_FROM_ALL
   URL https://github.com/celeritas-project/g4vg/archive/e034ada099132f857866949ec9ce8eadf1ff2251.zip)
 FetchContent_MakeAvailable(g4vg)
 
-# - Test that use/link to G4VG works
 add_executable(test_g4vg_link test_g4vg_link.cpp)
 target_link_libraries(test_g4vg_link PRIVATE G4VG::g4vg)
 
-# - Unit tests
+#----------------------------------------------------------------------------#
+# Basic Unit Tests
+#----------------------------------------------------------------------------#
 set(ADEPT_UNIT_TESTS_BASE
   test_atomic.cu               # Unit test for atomic ops
   test_ranluxpp.cu             # Unit test for RANLUX++
@@ -53,4 +75,3 @@ add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda;>")
 
 build_tests("${ADEPT_UNIT_TESTS_BASE}")
 add_to_test("${ADEPT_UNIT_TESTS_BASE}")
-

--- a/test/TestEm3/CMakeLists.txt
+++ b/test/TestEm3/CMakeLists.txt
@@ -9,9 +9,19 @@ endif()
 # TestEm3 for validation of particle transportation with GPUs.
 add_executable(TestEm3 TestEm3.cu electrons.cu gammas.cu TestEm3.cpp)
 target_include_directories(TestEm3 PRIVATE ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(TestEm3 PRIVATE CopCore AdePT_G4_integration AdePT AdePT_cuda_standalone VecGeom::vecgeomcuda_static)
-
-set_target_properties(TestEm3 PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
-SET(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-dtags")
+target_link_libraries(TestEm3 
+  PRIVATE 
+    CopCore 
+    AdePT_G4_integration
+    AdePT 
+    AdePT_cuda_standalone 
+    VecGeom::vecgeomcuda_static
+)
+set_target_properties(TestEm3 
+  PROPERTIES 
+    CUDA_SEPARABLE_COMPILATION ON 
+    CUDA_RESOLVE_DEVICE_SYMBOLS ON
+)
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--disable-new-dtags")
 
 add_test(NAME TestEm3 COMMAND TestEm3)

--- a/test/testField/CMakeLists.txt
+++ b/test/testField/CMakeLists.txt
@@ -21,11 +21,14 @@ add_executable(testField
   testField.cpp
   testField.cu
   electrons.cu
-  gammas.cu)
-target_include_directories(testField PUBLIC 
-                          $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>
-                          $<BUILD_INTERFACE:${Geant4_INCLUDE_DIRS}>
-                          $<BUILD_INTERFACE:${G4HepEm_INCLUDE_DIR}>)
+  gammas.cu
+)
+target_include_directories(testField 
+  PUBLIC 
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/>
+    $<BUILD_INTERFACE:${Geant4_INCLUDE_DIRS}>
+    $<BUILD_INTERFACE:${G4HepEm_INCLUDE_DIR}>
+)
 target_link_libraries(testField
   PRIVATE
     CopCore
@@ -34,10 +37,15 @@ target_link_libraries(testField
     VecGeom::vgdml
     ${Geant4_LIBRARIES}
     ${G4HepEm_LIBRARIES}
-    CUDA::cudart)
-
-set_target_properties(testField PROPERTIES CUDA_SEPARABLE_COMPILATION ON CUDA_RESOLVE_DEVICE_SYMBOLS ON)
+    CUDA::cudart
+)
+set_target_properties(testField 
+  PROPERTIES 
+    CUDA_SEPARABLE_COMPILATION ON 
+    CUDA_RESOLVE_DEVICE_SYMBOLS ON
+)
 
 # Tests
 add_test(NAME testField
-  COMMAND $<TARGET_FILE:testField> -gdml_file ${PROJECT_BINARY_DIR}/cms2018.gdml)
+  COMMAND $<TARGET_FILE:testField> -gdml_file ${PROJECT_BINARY_DIR}/cms2018.gdml
+)


### PR DESCRIPTION
This is a purely cosmetic cleanup of the CMake scripts to assist in the next stage of trying to simplify the library structure and linking. Split here to avoid too much in one go. There should be no changes to build or test behaviour.