### PR TITLE
clang-format entire codebase

### DIFF
--- a/examples/Example1/include/DetectorMessenger.hh
+++ b/examples/Example1/include/DetectorMessenger.hh
@@ -41,7 +41,7 @@ private:
   /// Command printing current settings
   G4UIcmdWithoutParameter *fPrintCmd = nullptr;
 
-  G4UIcmdWithAString *fFileNameCmd     = nullptr;
+  G4UIcmdWithAString *fFileNameCmd = nullptr;
 
   G4UIcmdWith3VectorAndUnit *fFieldCmd = nullptr;
 };

--- a/examples/Example1/include/EventActionMessenger.hh
+++ b/examples/Example1/include/EventActionMessenger.hh
@@ -49,7 +49,7 @@ public:
 private:
   EventAction *fEventAction = nullptr;
 
-  G4UIdirectory *fDir      = nullptr;
+  G4UIdirectory *fDir                 = nullptr;
   G4UIcmdWithAnInteger *fVerbosityCmd = nullptr;
 };
 

--- a/examples/Example1/include/SensitiveDetector.hh
+++ b/examples/Example1/include/SensitiveDetector.hh
@@ -47,7 +47,7 @@ class G4VPhysicalVolume;
 class SensitiveDetector : public G4VSensitiveDetector {
 public:
   SensitiveDetector(G4String aName);
-  SensitiveDetector(G4String aName, std::set<const G4VPhysicalVolume*> *aSensitivePhysicalVolumes);
+  SensitiveDetector(G4String aName, std::set<const G4VPhysicalVolume *> *aSensitivePhysicalVolumes);
   ~SensitiveDetector() = default;
   /// Create hit collection
   virtual void Initialize(G4HCofThisEvent *HCE) final;
@@ -56,9 +56,9 @@ public:
 
   SimpleHit *RetrieveAndSetupHit(G4TouchableHistory *aTouchable);
 
-  std::vector<G4LogicalVolume*> fSensitiveLogicalVolumes;
+  std::vector<G4LogicalVolume *> fSensitiveLogicalVolumes;
   /// Physical Volumes where we want to score
-  std::set<const G4VPhysicalVolume*> fSensitivePhysicalVolumes;
+  std::set<const G4VPhysicalVolume *> fSensitivePhysicalVolumes;
 
   std::unordered_map<size_t, size_t> fScoringMap;
 

--- a/examples/Example1/include/SimpleHit.hh
+++ b/examples/Example1/include/SimpleHit.hh
@@ -86,7 +86,7 @@ public:
   inline G4int GetType() const { return fType; }
 
   /// Set PhysicalVolumeName
-  inline void SetPhysicalVolumeName(G4String aPhysicalVolumeName) { fPhysicalVolumeName = aPhysicalVolumeName;}
+  inline void SetPhysicalVolumeName(G4String aPhysicalVolumeName) { fPhysicalVolumeName = aPhysicalVolumeName; }
   /// Get PhysicalVolumeName
   inline G4String GetPhysicalVolumeName() const { return fPhysicalVolumeName; }
 
@@ -99,8 +99,8 @@ public:
   G4double fTime = -1;
   /// Type: 0 = full sim, 1 = fast sim
   G4int fType = -1;
-  /// These hits will be associated to PhysicalVolumes  
-  G4String fPhysicalVolumeName = ""; 
+  /// These hits will be associated to PhysicalVolumes
+  G4String fPhysicalVolumeName = "";
 };
 
 typedef G4THitsCollection<SimpleHit> SimpleHitsCollection;

--- a/examples/Example1/include/TrackingAction.hh
+++ b/examples/Example1/include/TrackingAction.hh
@@ -50,10 +50,10 @@ public:
   virtual void PreUserTrackingAction(const G4Track *);
   virtual void PostUserTrackingAction(const G4Track *);
 
-  inline void setSteppingAction(SteppingAction* aSteppingAction){fSteppingAction = aSteppingAction;}
+  inline void setSteppingAction(SteppingAction *aSteppingAction) { fSteppingAction = aSteppingAction; }
 
 private:
-  SteppingAction* fSteppingAction;
+  SteppingAction *fSteppingAction;
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/examples/Example1/src/ActionInitialisation.cc
+++ b/examples/Example1/src/ActionInitialisation.cc
@@ -32,9 +32,7 @@
 #include "TrackingAction.hh"
 #include "SteppingAction.hh"
 
-ActionInitialisation::ActionInitialisation() : G4VUserActionInitialization()
-{
-}
+ActionInitialisation::ActionInitialisation() : G4VUserActionInitialization() {}
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 

--- a/examples/Example1/src/DetectorConstruction.cc
+++ b/examples/Example1/src/DetectorConstruction.cc
@@ -31,9 +31,7 @@ DetectorConstruction::DetectorConstruction() : G4VUserDetectorConstruction()
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-DetectorConstruction::~DetectorConstruction()
-{
-}
+DetectorConstruction::~DetectorConstruction() {}
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
@@ -97,45 +95,40 @@ void DetectorConstruction::ConstructSDandField()
 
   We will have one hit per Placement of a sensitive LogicalVolume
   SensitiveDetector will store the mapping of PhysicalVolumes to hits, and use it in ProcessHits
-  
-  fSensitive_volumes Contains the names of the LogicalVolumes we want to make sensitive, at this point 
+
+  fSensitive_volumes Contains the names of the LogicalVolumes we want to make sensitive, at this point
   it has been already filled through macro commands
 
   In order to find all placements of these sensitive volumes, we need to walk the tree
   */
   int numSensitiveTouchables = 0;
-  int numTouchables = 0;
+  int numTouchables          = 0;
 
   SensitiveDetector *caloSD = new SensitiveDetector("AdePTDetector");
-  
+
   G4SDManager::GetSDMpointer()->AddNewDetector(caloSD);
-  std::vector<G4LogicalVolume*> aSensitiveLogicalVolumes;
+  std::vector<G4LogicalVolume *> aSensitiveLogicalVolumes;
 
   std::function<void(G4VPhysicalVolume const *)> visitAndSetupScoring = [&](G4VPhysicalVolume const *pvol) {
     const auto lvol = pvol->GetLogicalVolume();
-    int nd           = lvol->GetNoDaughters();
+    int nd          = lvol->GetNoDaughters();
     numTouchables++;
 
     // Check if the LogicalVolume is sensitive
     auto aAuxInfoList = fParser.GetVolumeAuxiliaryInformation(lvol);
-    for(auto iaux = aAuxInfoList.begin(); iaux != aAuxInfoList.end(); iaux++ )
-    {
-      G4String str=iaux->type;
-      G4String val=iaux->value;
-      G4String unit=iaux->unit;
+    for (auto iaux = aAuxInfoList.begin(); iaux != aAuxInfoList.end(); iaux++) {
+      G4String str  = iaux->type;
+      G4String val  = iaux->value;
+      G4String unit = iaux->unit;
 
-      if(str == "SensDet")
-      {
+      if (str == "SensDet") {
         // If it is, record the PV
-        if( caloSD->fSensitivePhysicalVolumes.find(pvol) == caloSD->fSensitivePhysicalVolumes.end() )
-        {
-          caloSD->fSensitivePhysicalVolumes.insert(pvol); 
+        if (caloSD->fSensitivePhysicalVolumes.find(pvol) == caloSD->fSensitivePhysicalVolumes.end()) {
+          caloSD->fSensitivePhysicalVolumes.insert(pvol);
         }
         // If this is the first time we see this LV
-        if(std::find(caloSD->fSensitiveLogicalVolumes.begin(), 
-            caloSD->fSensitiveLogicalVolumes.end(), 
-            lvol) == caloSD->fSensitiveLogicalVolumes.end())
-        {
+        if (std::find(caloSD->fSensitiveLogicalVolumes.begin(), caloSD->fSensitiveLogicalVolumes.end(), lvol) ==
+            caloSD->fSensitiveLogicalVolumes.end()) {
           // Make LogicalVolume sensitive by registering a SensitiveDetector for it
           SetSensitiveDetector(lvol, caloSD);
           // We keep a list of Logical sensitive volumes, used for initializing AdePTTransport

--- a/examples/Example1/src/EventAction.cc
+++ b/examples/Example1/src/EventAction.cc
@@ -37,7 +37,7 @@
 #include "G4PhysicalVolumeStore.hh"
 #include "G4SystemOfUnits.hh"
 
-EventAction::EventAction(): G4UserEventAction(), fHitCollectionID(-1), fTimer()
+EventAction::EventAction() : G4UserEventAction(), fHitCollectionID(-1), fTimer()
 {
   fMessenger = new EventActionMessenger(this);
 }
@@ -50,7 +50,7 @@ EventAction::~EventAction() {}
 
 void EventAction::BeginOfEventAction(const G4Event *)
 {
-  auto eventId         = G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID();
+  auto eventId = G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID();
 
   fTimer.Start();
 }
@@ -59,7 +59,7 @@ void EventAction::BeginOfEventAction(const G4Event *)
 
 void EventAction::EndOfEventAction(const G4Event *aEvent)
 {
-  auto eventId         = G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID();
+  auto eventId = G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID();
 
   fTimer.Stop();
 
@@ -82,14 +82,14 @@ void EventAction::EndOfEventAction(const G4Event *aEvent)
 
   // Store the original IO precission and width
   auto aOriginalPrecission = std::cout.precision();
-  auto aOriginalWidth = std::cout.width();
+  auto aOriginalWidth      = std::cout.width();
 
   for (size_t iHit = 0; iHit < hitsCollection->entries(); iHit++) {
     hit   = static_cast<SimpleHit *>(hitsCollection->GetHit(iHit));
     hitEn = hit->GetEdep();
     totalEnergy += hitEn;
     G4String vol_name = hit->GetPhysicalVolumeName();
-    
+
     if (hitEn > 1 && fVerbosity > 1)
       G4cout << "EndOfEventAction " << eventId << " : id " << std::setw(5) << iHit << "  edep " << std::setprecision(2)
              << std::setw(12) << std::fixed << hitEn / MeV << " [MeV] logical " << vol_name << G4endl;

--- a/examples/Example1/src/PrimaryGeneratorAction.cc
+++ b/examples/Example1/src/PrimaryGeneratorAction.cc
@@ -13,10 +13,9 @@
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-PrimaryGeneratorAction::PrimaryGeneratorAction()
-    : G4VUserPrimaryGeneratorAction(), fParticleGun(0)
+PrimaryGeneratorAction::PrimaryGeneratorAction() : G4VUserPrimaryGeneratorAction(), fParticleGun(0)
 {
-  fParticleGun     = new ParticleGun();
+  fParticleGun = new ParticleGun();
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -32,5 +31,3 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event *aEvent)
 {
   fParticleGun->GeneratePrimaries(aEvent);
 }
-
-

--- a/examples/Example1/src/RunAction.cc
+++ b/examples/Example1/src/RunAction.cc
@@ -30,10 +30,7 @@
 #include <thread>
 #include <mutex>
 
-RunAction::RunAction()
-    : G4UserRunAction()
-{
-}
+RunAction::RunAction() : G4UserRunAction() {}
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 

--- a/examples/Example1/src/SensitiveDetector.cc
+++ b/examples/Example1/src/SensitiveDetector.cc
@@ -51,8 +51,7 @@ void SensitiveDetector::Initialize(G4HCofThisEvent *aHCE)
   // Fill calorimeter hits with zero energy deposition
   // Retrieving the hits through the map allows us to set the Volume name associated to the hits
   int hitID = 0;
-  for(auto pvol: (fSensitivePhysicalVolumes))
-  {
+  for (auto pvol : (fSensitivePhysicalVolumes)) {
     auto hit = new SimpleHit();
     hit->SetPhysicalVolumeName(pvol->GetName());
     fScoringMap.insert(std::pair<int, int>(pvol->GetInstanceID(), hitID));
@@ -84,7 +83,7 @@ G4bool SensitiveDetector::ProcessHits(G4Step *aStep, G4TouchableHistory *)
 
   // Set hit type to full simulation (only if hit is not already marked as fast sim)
   if (hit->GetType() != 1) hit->SetType(0);
-  
+
   return true;
 }
 

--- a/examples/Example1/src/SteppingAction.cc
+++ b/examples/Example1/src/SteppingAction.cc
@@ -4,9 +4,7 @@
 #include "SteppingAction.hh"
 #include "G4Step.hh"
 
-SteppingAction::SteppingAction() : G4UserSteppingAction()
-{
-}
+SteppingAction::SteppingAction() : G4UserSteppingAction() {}
 
 SteppingAction::~SteppingAction() {}
 

--- a/examples/Example1/src/TrackingAction.cc
+++ b/examples/Example1/src/TrackingAction.cc
@@ -39,7 +39,7 @@ TrackingAction::TrackingAction() : G4UserTrackingAction() {}
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-void TrackingAction::PreUserTrackingAction(const G4Track *aTrack) 
+void TrackingAction::PreUserTrackingAction(const G4Track *aTrack)
 {
   // Reset step counter
   fSteppingAction->SetNumSteps(0);

--- a/examples/IntegrationBenchmark/include/DetectorMessenger.hh
+++ b/examples/IntegrationBenchmark/include/DetectorMessenger.hh
@@ -41,7 +41,7 @@ private:
   /// Command printing current settings
   G4UIcmdWithoutParameter *fPrintCmd = nullptr;
 
-  G4UIcmdWithAString *fFileNameCmd     = nullptr;
+  G4UIcmdWithAString *fFileNameCmd = nullptr;
 
   G4UIcmdWith3VectorAndUnit *fFieldCmd = nullptr;
 };

--- a/examples/IntegrationBenchmark/include/EventActionMessenger.hh
+++ b/examples/IntegrationBenchmark/include/EventActionMessenger.hh
@@ -49,7 +49,7 @@ public:
 private:
   EventAction *fEventAction = nullptr;
 
-  G4UIdirectory *fDir      = nullptr;
+  G4UIdirectory *fDir                 = nullptr;
   G4UIcmdWithAnInteger *fVerbosityCmd = nullptr;
 };
 

--- a/examples/IntegrationBenchmark/include/Run.hh
+++ b/examples/IntegrationBenchmark/include/Run.hh
@@ -24,10 +24,10 @@ public:
   void Merge(const G4Run *run) override;
 
   TestManager<TAG_TYPE> *GetTestManager() const { return fTestManager; }
-  void SetDoBenchmark( bool aDoBenchmark ){ fDoBenchmark = aDoBenchmark; }
-  bool GetDoBenchmark(){ return fDoBenchmark; }
-  void SetDoValidation( bool aDoValidation ){ fDoValidation = aDoValidation; }
-  bool GetDoValidation(){ return fDoValidation; }
+  void SetDoBenchmark(bool aDoBenchmark) { fDoBenchmark = aDoBenchmark; }
+  bool GetDoBenchmark() { return fDoBenchmark; }
+  void SetDoValidation(bool aDoValidation) { fDoValidation = aDoValidation; }
+  bool GetDoValidation() { return fDoValidation; }
 
   /** @brief Compute and display collected metrics */
   void EndOfRunSummary(G4String aOutputDirectory, G4String aOutputFilename);

--- a/examples/IntegrationBenchmark/include/RunAction.hh
+++ b/examples/IntegrationBenchmark/include/RunAction.hh
@@ -48,8 +48,7 @@ class RunAction : public G4UserRunAction {
 public:
   /// Constructor. Defines the histograms.
   RunAction();
-  RunAction(G4String aOutputDirectory, G4String aOutputFilename,
-            bool aDoBenchmark, bool aDoValidation);
+  RunAction(G4String aOutputDirectory, G4String aOutputFilename, bool aDoBenchmark, bool aDoValidation);
   virtual ~RunAction();
 
   /// Open the file for the analysis
@@ -57,7 +56,7 @@ public:
   /// Write and close the file
   virtual void EndOfRunAction(const G4Run *) final;
 
-  G4Run* GenerateRun() override;
+  G4Run *GenerateRun() override;
 
 private:
   /// Pointer to detector construction to retrieve the detector dimensions to
@@ -67,7 +66,7 @@ private:
   bool fDoBenchmark;
   bool fDoValidation;
   vecgeom::Stopwatch fTimer;
-  Run* fRun;
+  Run *fRun;
 };
 
 #endif /* RUNACTION_HH */

--- a/examples/IntegrationBenchmark/include/SensitiveDetector.hh
+++ b/examples/IntegrationBenchmark/include/SensitiveDetector.hh
@@ -55,7 +55,7 @@ class G4VPhysicalVolume;
 class SensitiveDetector : public G4VSensitiveDetector {
 public:
   SensitiveDetector(G4String aName);
-  SensitiveDetector(G4String aName, std::set<const G4VPhysicalVolume*> *aSensitivePhysicalVolumes);
+  SensitiveDetector(G4String aName, std::set<const G4VPhysicalVolume *> *aSensitivePhysicalVolumes);
   ~SensitiveDetector() = default;
   /// Create hit collection
   virtual void Initialize(G4HCofThisEvent *HCE) final;
@@ -64,9 +64,9 @@ public:
 
   SimpleHit *RetrieveAndSetupHit(G4TouchableHistory *aTouchable);
 
-  std::vector<G4LogicalVolume*> fSensitiveLogicalVolumes;
+  std::vector<G4LogicalVolume *> fSensitiveLogicalVolumes;
   /// Physical Volumes where we want to score
-  std::set<const G4VPhysicalVolume*> fSensitivePhysicalVolumes;
+  std::set<const G4VPhysicalVolume *> fSensitivePhysicalVolumes;
 
   std::unordered_map<size_t, size_t> fScoringMap;
 

--- a/examples/IntegrationBenchmark/include/SimpleHit.hh
+++ b/examples/IntegrationBenchmark/include/SimpleHit.hh
@@ -86,7 +86,7 @@ public:
   inline G4int GetType() const { return fType; }
 
   /// Set PhysicalVolumeName
-  inline void SetPhysicalVolumeName(G4String aPhysicalVolumeName) { fPhysicalVolumeName = aPhysicalVolumeName;}
+  inline void SetPhysicalVolumeName(G4String aPhysicalVolumeName) { fPhysicalVolumeName = aPhysicalVolumeName; }
   /// Get PhysicalVolumeName
   inline G4String GetPhysicalVolumeName() const { return fPhysicalVolumeName; }
 
@@ -99,8 +99,8 @@ public:
   G4double fTime = -1;
   /// Type: 0 = full sim, 1 = fast sim
   G4int fType = -1;
-  /// These hits will be associated to PhysicalVolumes  
-  G4String fPhysicalVolumeName = ""; 
+  /// These hits will be associated to PhysicalVolumes
+  G4String fPhysicalVolumeName = "";
 };
 
 typedef G4THitsCollection<SimpleHit> SimpleHitsCollection;

--- a/examples/IntegrationBenchmark/include/TrackingAction.hh
+++ b/examples/IntegrationBenchmark/include/TrackingAction.hh
@@ -51,22 +51,22 @@ public:
   virtual void PreUserTrackingAction(const G4Track *);
   virtual void PostUserTrackingAction(const G4Track *);
 
-  void setInsideEcal(bool insideEcal){fInsideEcal = insideEcal;}
-  bool getInsideEcal(){return fInsideEcal;}
+  void setInsideEcal(bool insideEcal) { fInsideEcal = insideEcal; }
+  bool getInsideEcal() { return fInsideEcal; }
 
-  inline G4Region* getGPURegion(){return fGPURegion;}
-  inline G4Region* getCurrentRegion(){return fCurrentRegion;}
-  inline void setCurrentRegion(G4Region* aCurrentRegion){fCurrentRegion = aCurrentRegion;}
-  inline G4VPhysicalVolume* getCurrentVolume(){return fCurrentVolume;}
-  inline void setCurrentVolume(G4VPhysicalVolume* aCurrentVolume){fCurrentVolume = aCurrentVolume;}
-  inline void setSteppingAction(SteppingAction* aSteppingAction){fSteppingAction = aSteppingAction;}
+  inline G4Region *getGPURegion() { return fGPURegion; }
+  inline G4Region *getCurrentRegion() { return fCurrentRegion; }
+  inline void setCurrentRegion(G4Region *aCurrentRegion) { fCurrentRegion = aCurrentRegion; }
+  inline G4VPhysicalVolume *getCurrentVolume() { return fCurrentVolume; }
+  inline void setCurrentVolume(G4VPhysicalVolume *aCurrentVolume) { fCurrentVolume = aCurrentVolume; }
+  inline void setSteppingAction(SteppingAction *aSteppingAction) { fSteppingAction = aSteppingAction; }
 
 private:
   bool fInsideEcal;
-  G4Region* fCurrentRegion;
-  G4VPhysicalVolume* fCurrentVolume;
-  G4Region* fGPURegion;
-  SteppingAction* fSteppingAction;
+  G4Region *fCurrentRegion;
+  G4VPhysicalVolume *fCurrentVolume;
+  G4Region *fGPURegion;
+  SteppingAction *fSteppingAction;
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/examples/IntegrationBenchmark/src/ActionInitialisation.cc
+++ b/examples/IntegrationBenchmark/src/ActionInitialisation.cc
@@ -35,8 +35,8 @@
 
 ActionInitialisation::ActionInitialisation(G4String aOutputDirectory, G4String aOutputFilename, bool aDoBenchmark,
                                            bool aDoValidation)
-    : G4VUserActionInitialization(), fOutputDirectory(aOutputDirectory),
-      fOutputFilename(aOutputFilename), fDoBenchmark(aDoBenchmark), fDoValidation(aDoValidation)
+    : G4VUserActionInitialization(), fOutputDirectory(aOutputDirectory), fOutputFilename(aOutputFilename),
+      fDoBenchmark(aDoBenchmark), fDoValidation(aDoValidation)
 {
 }
 

--- a/examples/IntegrationBenchmark/src/DetectorConstruction.cc
+++ b/examples/IntegrationBenchmark/src/DetectorConstruction.cc
@@ -47,9 +47,7 @@ DetectorConstruction::DetectorConstruction() : G4VUserDetectorConstruction()
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-DetectorConstruction::~DetectorConstruction()
-{
-}
+DetectorConstruction::~DetectorConstruction() {}
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
@@ -113,45 +111,40 @@ void DetectorConstruction::ConstructSDandField()
 
   We will have one hit per Placement of a sensitive LogicalVolume
   SensitiveDetector will store the mapping of PhysicalVolumes to hits, and use it in ProcessHits
-  
-  fSensitive_volumes Contains the names of the LogicalVolumes we want to make sensitive, at this point 
+
+  fSensitive_volumes Contains the names of the LogicalVolumes we want to make sensitive, at this point
   it has been already filled through macro commands
 
   In order to find all placements of these sensitive volumes, we need to walk the tree
   */
   int numSensitiveTouchables = 0;
-  int numTouchables = 0;
+  int numTouchables          = 0;
 
   SensitiveDetector *caloSD = new SensitiveDetector("AdePTDetector");
-  //SensitiveDetector *caloSD = new SensitiveDetector("AdePTDetector", &fSensitivePhysicalVolumes);
+  // SensitiveDetector *caloSD = new SensitiveDetector("AdePTDetector", &fSensitivePhysicalVolumes);
   G4SDManager::GetSDMpointer()->AddNewDetector(caloSD);
-  std::vector<G4LogicalVolume*> aSensitiveLogicalVolumes;
+  std::vector<G4LogicalVolume *> aSensitiveLogicalVolumes;
 
   std::function<void(G4VPhysicalVolume const *)> visitAndSetupScoring = [&](G4VPhysicalVolume const *pvol) {
     const auto lvol = pvol->GetLogicalVolume();
-    int nd           = lvol->GetNoDaughters();
+    int nd          = lvol->GetNoDaughters();
     numTouchables++;
 
     // Check if the LogicalVolume is sensitive
     auto aAuxInfoList = fParser.GetVolumeAuxiliaryInformation(lvol);
-    for(auto iaux = aAuxInfoList.begin(); iaux != aAuxInfoList.end(); iaux++ )
-    {
-      G4String str=iaux->type;
-      G4String val=iaux->value;
-      G4String unit=iaux->unit;
+    for (auto iaux = aAuxInfoList.begin(); iaux != aAuxInfoList.end(); iaux++) {
+      G4String str  = iaux->type;
+      G4String val  = iaux->value;
+      G4String unit = iaux->unit;
 
-      if(str == "SensDet")
-      {
+      if (str == "SensDet") {
         // If it is, record the PV
-        if( caloSD->fSensitivePhysicalVolumes.find(pvol) == caloSD->fSensitivePhysicalVolumes.end() )
-        {
-          caloSD->fSensitivePhysicalVolumes.insert(pvol); 
+        if (caloSD->fSensitivePhysicalVolumes.find(pvol) == caloSD->fSensitivePhysicalVolumes.end()) {
+          caloSD->fSensitivePhysicalVolumes.insert(pvol);
         }
         // If this is the first time we see this LV
-        if(std::find(caloSD->fSensitiveLogicalVolumes.begin(), 
-            caloSD->fSensitiveLogicalVolumes.end(), 
-            lvol) == caloSD->fSensitiveLogicalVolumes.end())
-        {
+        if (std::find(caloSD->fSensitiveLogicalVolumes.begin(), caloSD->fSensitiveLogicalVolumes.end(), lvol) ==
+            caloSD->fSensitiveLogicalVolumes.end()) {
           // Make LogicalVolume sensitive by registering a SensitiveDetector for it
           SetSensitiveDetector(lvol, caloSD);
           // We keep a list of Logical sensitive volumes, used for initializing AdePTTransport

--- a/examples/IntegrationBenchmark/src/EventAction.cc
+++ b/examples/IntegrationBenchmark/src/EventAction.cc
@@ -41,7 +41,7 @@
 #include <AdePT/benchmarking/TestManagerStore.h>
 #include "Run.hh"
 
-EventAction::EventAction(): G4UserEventAction(), fHitCollectionID(-1), fTimer()
+EventAction::EventAction() : G4UserEventAction(), fHitCollectionID(-1), fTimer()
 {
   fMessenger = new EventActionMessenger(this);
 }
@@ -54,12 +54,12 @@ EventAction::~EventAction() {}
 
 void EventAction::BeginOfEventAction(const G4Event *)
 {
-  auto eventId         = G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID();
+  auto eventId = G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID();
 
   fTimer.Start();
 
-  //Get the Run object associated to this thread and start the timer for this event
-  Run* currentRun = static_cast< Run* > ( G4RunManager::GetRunManager()->GetNonConstCurrentRun() );
+  // Get the Run object associated to this thread and start the timer for this event
+  Run *currentRun = static_cast<Run *>(G4RunManager::GetRunManager()->GetNonConstCurrentRun());
   currentRun->GetTestManager()->timerStart(Run::timers::EVENT);
 
   // zero the counters
@@ -73,15 +73,14 @@ void EventAction::BeginOfEventAction(const G4Event *)
 
 void EventAction::EndOfEventAction(const G4Event *aEvent)
 {
-  auto eventId         = G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID();
+  auto eventId = G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID();
 
   fTimer.Stop();
 
-  //Get the Run object associated to this thread and stop the timer for this event
-  Run* currentRun = static_cast< Run* > ( G4RunManager::GetRunManager()->GetNonConstCurrentRun() );
+  // Get the Run object associated to this thread and stop the timer for this event
+  Run *currentRun   = static_cast<Run *>(G4RunManager::GetRunManager()->GetNonConstCurrentRun());
   auto aTestManager = currentRun->GetTestManager();
-  if(currentRun->GetDoBenchmark())
-  {
+  if (currentRun->GetDoBenchmark()) {
     aTestManager->timerStop(Run::timers::EVENT);
   }
   aTestManager->addToAccumulator(Run::accumulators::NUM_PARTICLES, aEvent->GetPrimaryVertex()->GetNumberOfParticle());
@@ -102,7 +101,7 @@ void EventAction::EndOfEventAction(const G4Event *aEvent)
   SimpleHit *hit       = nullptr;
   G4double hitEn       = 0;
   G4double totalEnergy = 0;
-  
+
   // print number of secondaries std::setw(24) << std::fixed
   if (fVerbosity > 0) {
     G4cout << "EndOfEventAction " << eventId << ": electrons " << number_electrons << G4endl;
@@ -114,14 +113,14 @@ void EventAction::EndOfEventAction(const G4Event *aEvent)
 
   // Store the original IO precission and width
   auto aOriginalPrecission = std::cout.precision();
-  auto aOriginalWidth = std::cout.width();
+  auto aOriginalWidth      = std::cout.width();
 
   for (size_t iHit = 0; iHit < hitsCollection->entries(); iHit++) {
     hit   = static_cast<SimpleHit *>(hitsCollection->GetHit(iHit));
     hitEn = hit->GetEdep();
     totalEnergy += hitEn;
     G4String vol_name = hit->GetPhysicalVolumeName();
-    
+
     if (hitEn > 1 && fVerbosity > 1)
       G4cout << "EndOfEventAction " << eventId << " : id " << std::setw(5) << iHit << "  edep " << std::setprecision(2)
              << std::setw(12) << std::fixed << hitEn / MeV << " [MeV] logical " << vol_name << G4endl;
@@ -131,10 +130,9 @@ void EventAction::EndOfEventAction(const G4Event *aEvent)
     G4cout << "EndOfEventAction " << eventId << "Total energy deposited: " << totalEnergy / MeV << " MeV" << G4endl;
   }
 
-  if(currentRun->GetDoValidation())
-  {
+  if (currentRun->GetDoValidation()) {
     /*
-    //Set an accumulator for each sensitive volume, making sure the ID doesn't collide with the 
+    //Set an accumulator for each sensitive volume, making sure the ID doesn't collide with the
     //defined timers
     for (int igroup = 0; igroup < ngroups; ++igroup) {
       G4cout << "EndOfEventAction " << eventId << " : group " << std::setw(5) << groups[igroup] << "  edep "
@@ -147,26 +145,24 @@ void EventAction::EndOfEventAction(const G4Event *aEvent)
     //Record the current contents of the TestManager in order to be able to extract per-event data
     TestManagerStore<int>::GetInstance()->RecordState(aTestManager);
     */
-  }
-  else if(currentRun->GetDoBenchmark())
-  {
-    //Get the timings
+  } else if (currentRun->GetDoBenchmark()) {
+    // Get the timings
     double eventTime = aTestManager->getDurationSeconds(Run::timers::EVENT);
     double nonEMTime = aTestManager->getAccumulator(Run::accumulators::NONEM_EVT);
-    double ecalTime = eventTime - nonEMTime;
+    double ecalTime  = eventTime - nonEMTime;
 
-    //Accumulate the results with the rest of events of this worker thread to provide global stats
+    // Accumulate the results with the rest of events of this worker thread to provide global stats
     aTestManager->addToAccumulator(Run::accumulators::EVENT_SUM, eventTime);
-    aTestManager->addToAccumulator(Run::accumulators::EVENT_SQ, eventTime*eventTime);
+    aTestManager->addToAccumulator(Run::accumulators::EVENT_SQ, eventTime * eventTime);
     aTestManager->addToAccumulator(Run::accumulators::NONEM_SUM, nonEMTime);
-    aTestManager->addToAccumulator(Run::accumulators::NONEM_SQ, nonEMTime*nonEMTime);
+    aTestManager->addToAccumulator(Run::accumulators::NONEM_SQ, nonEMTime * nonEMTime);
     aTestManager->addToAccumulator(Run::accumulators::ECAL_SUM, ecalTime);
-    aTestManager->addToAccumulator(Run::accumulators::ECAL_SQ, ecalTime*ecalTime);
+    aTestManager->addToAccumulator(Run::accumulators::ECAL_SQ, ecalTime * ecalTime);
 
-    //Record the current contents of the TestManager in order to be able to extract per-event data
+    // Record the current contents of the TestManager in order to be able to extract per-event data
     TestManagerStore<int>::GetInstance()->RecordState(aTestManager);
 
-    //Reset the timers for the next event
+    // Reset the timers for the next event
     aTestManager->removeTimer(Run::timers::EVENT);
     aTestManager->removeAccumulator(Run::accumulators::NONEM_EVT);
   }

--- a/examples/IntegrationBenchmark/src/PrimaryGeneratorAction.cc
+++ b/examples/IntegrationBenchmark/src/PrimaryGeneratorAction.cc
@@ -13,10 +13,9 @@
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-PrimaryGeneratorAction::PrimaryGeneratorAction()
-    : G4VUserPrimaryGeneratorAction(), fParticleGun(0)
+PrimaryGeneratorAction::PrimaryGeneratorAction() : G4VUserPrimaryGeneratorAction(), fParticleGun(0)
 {
-  fParticleGun     = new ParticleGun();
+  fParticleGun = new ParticleGun();
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -32,5 +31,3 @@ void PrimaryGeneratorAction::GeneratePrimaries(G4Event *aEvent)
 {
   fParticleGun->GeneratePrimaries(aEvent);
 }
-
-

--- a/examples/IntegrationBenchmark/src/Run.cc
+++ b/examples/IntegrationBenchmark/src/Run.cc
@@ -20,31 +20,25 @@ Run::~Run() {}
 
 void Run::Merge(const G4Run *run)
 {
-  if(fDoBenchmark)
-  {
+  if (fDoBenchmark) {
     const Run *localRun = static_cast<const Run *>(run);
 
     TestManager<TAG_TYPE> *aTestManager = localRun->GetTestManager();
 
-    fTestManager->addToAccumulator(accumulators::EVENT_SUM,
-                                        aTestManager->getAccumulator(accumulators::EVENT_SUM));
-    fTestManager->addToAccumulator(accumulators::EVENT_SQ,
-                                        aTestManager->getAccumulator(accumulators::EVENT_SQ));
-    fTestManager->addToAccumulator(accumulators::NONEM_SUM,
-                                        aTestManager->getAccumulator(accumulators::NONEM_SUM));
-    fTestManager->addToAccumulator(accumulators::NONEM_SQ,
-                                        aTestManager->getAccumulator(accumulators::NONEM_SQ));
-    fTestManager->addToAccumulator(accumulators::ECAL_SUM,
-                                        aTestManager->getAccumulator(accumulators::ECAL_SUM));
+    fTestManager->addToAccumulator(accumulators::EVENT_SUM, aTestManager->getAccumulator(accumulators::EVENT_SUM));
+    fTestManager->addToAccumulator(accumulators::EVENT_SQ, aTestManager->getAccumulator(accumulators::EVENT_SQ));
+    fTestManager->addToAccumulator(accumulators::NONEM_SUM, aTestManager->getAccumulator(accumulators::NONEM_SUM));
+    fTestManager->addToAccumulator(accumulators::NONEM_SQ, aTestManager->getAccumulator(accumulators::NONEM_SQ));
+    fTestManager->addToAccumulator(accumulators::ECAL_SUM, aTestManager->getAccumulator(accumulators::ECAL_SUM));
     fTestManager->addToAccumulator(accumulators::ECAL_SQ, aTestManager->getAccumulator(accumulators::ECAL_SQ));
-    fTestManager->addToAccumulator(accumulators::NUM_PARTICLES, 
-                                        aTestManager->getAccumulator(accumulators::NUM_PARTICLES));
+    fTestManager->addToAccumulator(accumulators::NUM_PARTICLES,
+                                   aTestManager->getAccumulator(accumulators::NUM_PARTICLES));
 
     // TEMP: DELETE THIS
-    fTestManager->addToAccumulator(accumulators::EVENT_HIT_COPY_SIZE, 
-                                        aTestManager->getAccumulator(accumulators::EVENT_HIT_COPY_SIZE));
-    fTestManager->addToAccumulator(accumulators::EVENT_HIT_COPY_SIZE_SQ, 
-                                        aTestManager->getAccumulator(accumulators::EVENT_HIT_COPY_SIZE_SQ));
+    fTestManager->addToAccumulator(accumulators::EVENT_HIT_COPY_SIZE,
+                                   aTestManager->getAccumulator(accumulators::EVENT_HIT_COPY_SIZE));
+    fTestManager->addToAccumulator(accumulators::EVENT_HIT_COPY_SIZE_SQ,
+                                   aTestManager->getAccumulator(accumulators::EVENT_HIT_COPY_SIZE_SQ));
   }
 
   G4Run::Merge(run);
@@ -52,8 +46,7 @@ void Run::Merge(const G4Run *run)
 
 void Run::EndOfRunSummary(G4String aOutputDirectory, G4String aOutputFilename)
 {
-  if(fDoBenchmark && !fDoValidation)
-  {
+  if (fDoBenchmark && !fDoValidation) {
     // Printout of global statistics
     double runTime    = fTestManager->getDurationSeconds(timers::TOTAL);
     double eventMean  = fTestManager->getAccumulator(accumulators::EVENT_SUM) / GetNumberOfEvent();
@@ -64,19 +57,20 @@ void Run::EndOfRunSummary(G4String aOutputDirectory, G4String aOutputFilename)
 
     double ecalMean  = fTestManager->getAccumulator(accumulators::ECAL_SUM) / GetNumberOfEvent();
     double ecalStdev = STDEV(GetNumberOfEvent(), ecalMean, fTestManager->getAccumulator(accumulators::ECAL_SQ));
-    
+
     // TEMP: DELETE THIS
-    double sizeMean  = fTestManager->getAccumulator(accumulators::EVENT_HIT_COPY_SIZE) / GetNumberOfEvent();
-    double sizeStdev = STDEV(GetNumberOfEvent(), sizeMean, fTestManager->getAccumulator(accumulators::EVENT_HIT_COPY_SIZE_SQ));
+    double sizeMean = fTestManager->getAccumulator(accumulators::EVENT_HIT_COPY_SIZE) / GetNumberOfEvent();
+    double sizeStdev =
+        STDEV(GetNumberOfEvent(), sizeMean, fTestManager->getAccumulator(accumulators::EVENT_HIT_COPY_SIZE_SQ));
 
     G4cout << "------------------------------------------------------------"
-          << "\n";
+           << "\n";
     G4cout << "BENCHMARK: Run: " << GetRunID() << "\n";
     G4cout << "BENCHMARK: Number of Events: " << GetNumberOfEvent() << "\n";
     G4cout << "BENCHMARK: Run time: " << runTime << "\n";
     G4cout << "BENCHMARK: Mean Event time: " << eventMean << "\n";
     G4cout << "BENCHMARK: Event Standard Deviation: " << eventStdev << "\n";
-    
+
     // TEMP: DELETE THIS
     G4cout << "BENCHMARK: Mean size: " << sizeMean << "MB\n";
     G4cout << "BENCHMARK: Size Standard Deviation: " << sizeStdev << "\n";
@@ -87,8 +81,7 @@ void Run::EndOfRunSummary(G4String aOutputDirectory, G4String aOutputFilename)
   TestManager<std::string> aOutputTestManager;
 
   for (int i = 0; i < aBenchmarkStates->size(); i++) {
-    if(fDoValidation)
-    {
+    if (fDoValidation) {
       /*
       // If we are taking validation data, export it to the specified file
       auto &groups = aDetector->GetSensitiveGroups();
@@ -103,9 +96,7 @@ void Run::EndOfRunSummary(G4String aOutputDirectory, G4String aOutputFilename)
 
       aOutputTestManager.reset();
       */
-    }
-    else if(fDoBenchmark)
-    {
+    } else if (fDoBenchmark) {
       // Recover the results from each event and output them to the specified file
       double eventTime = (*aBenchmarkStates)[i][Run::timers::EVENT];
       double nonEMTime = (*aBenchmarkStates)[i][Run::accumulators::NONEM_EVT];

--- a/examples/IntegrationBenchmark/src/RunAction.cc
+++ b/examples/IntegrationBenchmark/src/RunAction.cc
@@ -33,17 +33,11 @@
 #include <thread>
 #include <mutex>
 
-RunAction::RunAction()
-    : G4UserRunAction(), fOutputDirectory(""),
-      fOutputFilename("")
-{
-}
+RunAction::RunAction() : G4UserRunAction(), fOutputDirectory(""), fOutputFilename("") {}
 
-RunAction::RunAction(G4String aOutputDirectory,
-                                           G4String aOutputFilename,
-                                            bool aDoBenchmark, bool aDoValidation)
-    : G4UserRunAction(), fOutputDirectory(aOutputDirectory),
-      fOutputFilename(aOutputFilename), fDoBenchmark(aDoBenchmark), fDoValidation(aDoValidation)
+RunAction::RunAction(G4String aOutputDirectory, G4String aOutputFilename, bool aDoBenchmark, bool aDoValidation)
+    : G4UserRunAction(), fOutputDirectory(aOutputDirectory), fOutputFilename(aOutputFilename),
+      fDoBenchmark(aDoBenchmark), fDoValidation(aDoValidation)
 {
 }
 
@@ -58,8 +52,7 @@ void RunAction::BeginOfRunAction(const G4Run *)
   fTimer.Start();
   auto tid = G4Threading::G4GetThreadId();
   if (tid < 0) {
-    if(fDoBenchmark)
-    {
+    if (fDoBenchmark) {
       fRun->GetTestManager()->timerStart(Run::timers::TOTAL);
     }
   }
@@ -77,12 +70,10 @@ void RunAction::EndOfRunAction(const G4Run *)
   // Print timer just for the master thread since this is called when all workers are done
   if (tid < 0) {
     G4cout << "Run time: " << time << "\n";
-    if(fDoBenchmark)
-    {
+    if (fDoBenchmark) {
       fRun->GetTestManager()->timerStop(Run::timers::TOTAL);
     }
-    if(fDoBenchmark || fDoValidation)
-    {
+    if (fDoBenchmark || fDoValidation) {
       fRun->EndOfRunSummary(fOutputDirectory, fOutputFilename);
     }
   }

--- a/examples/IntegrationBenchmark/src/SensitiveDetector.cc
+++ b/examples/IntegrationBenchmark/src/SensitiveDetector.cc
@@ -52,8 +52,7 @@ void SensitiveDetector::Initialize(G4HCofThisEvent *aHCE)
   // Fill calorimeter hits with zero energy deposition
   // Retrieving the hits through the map allows us to set the Volume name associated to the hits
   int hitID = 0;
-  for(auto pvol: (fSensitivePhysicalVolumes))
-  {
+  for (auto pvol : (fSensitivePhysicalVolumes)) {
     auto hit = new SimpleHit();
     hit->SetPhysicalVolumeName(pvol->GetName());
     fScoringMap.insert(std::pair<int, int>(pvol->GetInstanceID(), hitID));
@@ -85,7 +84,7 @@ G4bool SensitiveDetector::ProcessHits(G4Step *aStep, G4TouchableHistory *)
 
   // Set hit type to full simulation (only if hit is not already marked as fast sim)
   if (hit->GetType() != 1) hit->SetType(0);
-  
+
   return true;
 }
 

--- a/examples/IntegrationBenchmark/src/SteppingAction.cc
+++ b/examples/IntegrationBenchmark/src/SteppingAction.cc
@@ -18,8 +18,7 @@
 #include <AdePT/benchmarking/TestManager.h>
 
 SteppingAction::SteppingAction(TrackingAction *aTrackingAction, bool aDoBenchmark)
-    : G4UserSteppingAction(), fTrackingAction(aTrackingAction),
-      fDoBenchmark(aDoBenchmark)
+    : G4UserSteppingAction(), fTrackingAction(aTrackingAction), fDoBenchmark(aDoBenchmark)
 {
 }
 
@@ -34,52 +33,52 @@ void SteppingAction::UserSteppingAction(const G4Step *theStep)
     theStep->GetTrack()->SetTrackStatus(fStopAndKill);
   }
 
-/*
-  if (fDoBenchmark) {
-    // Check if we moved to a new volume
-    if (theStep->IsLastStepInVolume()) {
-      G4VPhysicalVolume *nextVolume = theStep->GetTrack()->GetNextVolume();
-      if (nextVolume != nullptr) {
-        if (!fTrackingAction->getInsideEcal()) {
-          // Check if the new volume is in the EM calorimeter region
-          if (nextVolume->GetLogicalVolume()->GetRegion() == fTrackingAction->getGPURegion()) {
-            // If it is, stop the timer for this track and store the result
-            G4Track *aTrack = theStep->GetTrack();
+  /*
+    if (fDoBenchmark) {
+      // Check if we moved to a new volume
+      if (theStep->IsLastStepInVolume()) {
+        G4VPhysicalVolume *nextVolume = theStep->GetTrack()->GetNextVolume();
+        if (nextVolume != nullptr) {
+          if (!fTrackingAction->getInsideEcal()) {
+            // Check if the new volume is in the EM calorimeter region
+            if (nextVolume->GetLogicalVolume()->GetRegion() == fTrackingAction->getGPURegion()) {
+              // If it is, stop the timer for this track and store the result
+              G4Track *aTrack = theStep->GetTrack();
 
-            // Make sure this will only run on the first step when we enter the ECAL
-            fTrackingAction->setInsideEcal(true);
+              // Make sure this will only run on the first step when we enter the ECAL
+              fTrackingAction->setInsideEcal(true);
 
-            // We are only interested in the processing of e-, e+ and gammas in the EM calorimeter, for other
-            // particles the time keeps running
-            if (aTrack->GetDefinition() == G4Gamma::Gamma() || aTrack->GetDefinition() == G4Electron::Electron() ||
-                aTrack->GetDefinition() == G4Positron::Positron()) {
-              // Get the Run object associated to this thread and end the timer for this track
-              Run *currentRun   = static_cast<Run *>(G4RunManager::GetRunManager()->GetNonConstCurrentRun());
-              auto aTestManager = currentRun->GetTestManager();
+              // We are only interested in the processing of e-, e+ and gammas in the EM calorimeter, for other
+              // particles the time keeps running
+              if (aTrack->GetDefinition() == G4Gamma::Gamma() || aTrack->GetDefinition() == G4Electron::Electron() ||
+                  aTrack->GetDefinition() == G4Positron::Positron()) {
+                // Get the Run object associated to this thread and end the timer for this track
+                Run *currentRun   = static_cast<Run *>(G4RunManager::GetRunManager()->GetNonConstCurrentRun());
+                auto aTestManager = currentRun->GetTestManager();
 
-              aTestManager->timerStop(Run::timers::NONEM);
-              aTestManager->addToAccumulator(Run::accumulators::NONEM_EVT,
-                                             aTestManager->getDurationSeconds(Run::timers::NONEM));
-              aTestManager->removeTimer(Run::timers::NONEM);
+                aTestManager->timerStop(Run::timers::NONEM);
+                aTestManager->addToAccumulator(Run::accumulators::NONEM_EVT,
+                                               aTestManager->getDurationSeconds(Run::timers::NONEM));
+                aTestManager->removeTimer(Run::timers::NONEM);
+              }
             }
-          }
-        } else {
-          // In case this track is exiting the EM calorimeter, start the timer
-          if (nextVolume->GetLogicalVolume()->GetRegion() != fTrackingAction->getGPURegion()) {
-            G4Track *aTrack = theStep->GetTrack();
+          } else {
+            // In case this track is exiting the EM calorimeter, start the timer
+            if (nextVolume->GetLogicalVolume()->GetRegion() != fTrackingAction->getGPURegion()) {
+              G4Track *aTrack = theStep->GetTrack();
 
-            fTrackingAction->setInsideEcal(false);
+              fTrackingAction->setInsideEcal(false);
 
-            if (aTrack->GetDefinition() == G4Gamma::Gamma() || aTrack->GetDefinition() == G4Electron::Electron() ||
-                aTrack->GetDefinition() == G4Positron::Positron()) {
-              // Get the Run object associated to this thread and start the timer for this track
-              Run *currentRun = static_cast<Run *>(G4RunManager::GetRunManager()->GetNonConstCurrentRun());
-              currentRun->GetTestManager()->timerStart(Run::timers::NONEM);
+              if (aTrack->GetDefinition() == G4Gamma::Gamma() || aTrack->GetDefinition() == G4Electron::Electron() ||
+                  aTrack->GetDefinition() == G4Positron::Positron()) {
+                // Get the Run object associated to this thread and start the timer for this track
+                Run *currentRun = static_cast<Run *>(G4RunManager::GetRunManager()->GetNonConstCurrentRun());
+                currentRun->GetTestManager()->timerStart(Run::timers::NONEM);
+              }
             }
           }
         }
       }
     }
-  }
-*/
+  */
 }

--- a/examples/IntegrationBenchmark/src/TrackingAction.cc
+++ b/examples/IntegrationBenchmark/src/TrackingAction.cc
@@ -49,40 +49,32 @@
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-TrackingAction::TrackingAction() : G4UserTrackingAction(), 
-                                   fCurrentRegion(nullptr), 
-                                   fCurrentVolume(nullptr)
-                                   //, fGPURegion(G4RegionStore::GetInstance()->GetRegion(aDetector->getRegionName()))
-                                   {}
+TrackingAction::TrackingAction() : G4UserTrackingAction(), fCurrentRegion(nullptr), fCurrentVolume(nullptr)
+//, fGPURegion(G4RegionStore::GetInstance()->GetRegion(aDetector->getRegionName()))
+{
+}
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-void TrackingAction::PreUserTrackingAction(const G4Track *aTrack) 
+void TrackingAction::PreUserTrackingAction(const G4Track *aTrack)
 {
   // Reset step counter
   fSteppingAction->SetNumSteps(0);
-  //For leptons, get the Run object associated to this thread and start the timer for this track, only if it is outside 
-  //the GPU region
-  Run* currentRun = static_cast< Run* > ( G4RunManager::GetRunManager()->GetNonConstCurrentRun() );
-  if(currentRun->GetDoBenchmark())
-  {
-    if (aTrack->GetDefinition() == G4Gamma::Gamma() || 
-        aTrack->GetDefinition() == G4Electron::Electron() ||
-        aTrack->GetDefinition() == G4Positron::Positron())
-    {
-      if(aTrack->GetVolume()->GetLogicalVolume()->GetRegion() != fGPURegion)
-      {
+  // For leptons, get the Run object associated to this thread and start the timer for this track, only if it is outside
+  // the GPU region
+  Run *currentRun = static_cast<Run *>(G4RunManager::GetRunManager()->GetNonConstCurrentRun());
+  if (currentRun->GetDoBenchmark()) {
+    if (aTrack->GetDefinition() == G4Gamma::Gamma() || aTrack->GetDefinition() == G4Electron::Electron() ||
+        aTrack->GetDefinition() == G4Positron::Positron()) {
+      if (aTrack->GetVolume()->GetLogicalVolume()->GetRegion() != fGPURegion) {
         currentRun->GetTestManager()->timerStart(Run::timers::NONEM);
         setInsideEcal(false);
-      }
-      else
-      {
+      } else {
         setInsideEcal(true);
       }
     }
-    //For other particles we always count the time, get the Run object and start the timer
-    else
-    {
+    // For other particles we always count the time, get the Run object and start the timer
+    else {
       currentRun->GetTestManager()->timerStart(Run::timers::NONEM);
     }
   }
@@ -94,18 +86,17 @@ void TrackingAction::PostUserTrackingAction(const G4Track *aTrack)
 {
   // Reset step counter
   fSteppingAction->SetNumSteps(0);
-  //Get the Run object associated to this thread and end the timer for this track
-  Run* currentRun = static_cast< Run* > ( G4RunManager::GetRunManager()->GetNonConstCurrentRun() );
-  if(currentRun->GetDoBenchmark())
-  {
-    //Timer may have been stopped in the stepping action
-    if(!getInsideEcal())
-    {
-      const G4Event* currentEvent = G4EventManager::GetEventManager()->GetConstCurrentEvent();
-      auto aTestManager = currentRun->GetTestManager();
-      
+  // Get the Run object associated to this thread and end the timer for this track
+  Run *currentRun = static_cast<Run *>(G4RunManager::GetRunManager()->GetNonConstCurrentRun());
+  if (currentRun->GetDoBenchmark()) {
+    // Timer may have been stopped in the stepping action
+    if (!getInsideEcal()) {
+      const G4Event *currentEvent = G4EventManager::GetEventManager()->GetConstCurrentEvent();
+      auto aTestManager           = currentRun->GetTestManager();
+
       aTestManager->timerStop(Run::timers::NONEM);
-      aTestManager->addToAccumulator(Run::accumulators::NONEM_EVT, aTestManager->getDurationSeconds(Run::timers::NONEM));
+      aTestManager->addToAccumulator(Run::accumulators::NONEM_EVT,
+                                     aTestManager->getDurationSeconds(Run::timers::NONEM));
       aTestManager->removeTimer(Run::timers::NONEM);
     }
   }

--- a/examples/common/include/FTFP_BERT_AdePT.hh
+++ b/examples/common/include/FTFP_BERT_AdePT.hh
@@ -16,10 +16,10 @@ public:
   FTFP_BERT_AdePT(G4int ver = 1);
   virtual ~FTFP_BERT_AdePT() = default;
 
-  FTFP_BERT_AdePT(const FTFP_BERT_AdePT &) = delete;
+  FTFP_BERT_AdePT(const FTFP_BERT_AdePT &)            = delete;
   FTFP_BERT_AdePT &operator=(const FTFP_BERT_AdePT &) = delete;
-  
-  AdePTPhysics *GetAdePTPhysicsList(){return fAdePTPhysicsList;}
+
+  AdePTPhysics *GetAdePTPhysicsList() { return fAdePTPhysicsList; }
 
 private:
   // NEVER INITIALIZED!

--- a/examples/common/include/FTFP_BERT_HepEm.hh
+++ b/examples/common/include/FTFP_BERT_HepEm.hh
@@ -14,7 +14,7 @@ public:
   FTFP_BERT_HepEm(G4int ver = 1);
   virtual ~FTFP_BERT_HepEm() = default;
 
-  FTFP_BERT_HepEm(const FTFP_BERT_HepEm &) = delete;
+  FTFP_BERT_HepEm(const FTFP_BERT_HepEm &)            = delete;
   FTFP_BERT_HepEm &operator=(const FTFP_BERT_HepEm &) = delete;
 };
 

--- a/examples/common/include/ParticleGun.hh
+++ b/examples/common/include/ParticleGun.hh
@@ -16,14 +16,14 @@ public:
   ~ParticleGun();
   virtual void GeneratePrimaries(G4Event *) final;
   void GenerateRandomPrimaryVertex(G4Event *aEvent, G4double aMinPhi, G4double aMaxPhi, G4double aMinTheta,
-                                   G4double aMaxTheta, std::vector<G4ParticleDefinition*> *aParticleList, 
+                                   G4double aMaxTheta, std::vector<G4ParticleDefinition *> *aParticleList,
                                    std::vector<float> *aParticleWeights, std::vector<float> *aParticleEnergies);
   void Print();
-  void PrintPrimaries(G4Event* aEvent) const;
-  void SetHepMC() {fUseHepMC = true;}
+  void PrintPrimaries(G4Event *aEvent) const;
+  void SetHepMC() { fUseHepMC = true; }
   void SetDefaultKinematic();
   void SetRandomizeGun(G4bool val) { fRandomizeGun = val; }
-  void AddParticle(G4ParticleDefinition* val, float weight=-1, double energy=-1);
+  void AddParticle(G4ParticleDefinition *val, float weight = -1, double energy = -1);
   void SetMinPhi(G4double val) { fMinPhi = val; }
   void SetMaxPhi(G4double val) { fMaxPhi = val; }
   void SetMinTheta(G4double val) { fMinTheta = val; }
@@ -33,12 +33,12 @@ public:
    * among the particles with undefined weight.
    */
   void ReWeight();
-  
+
 private:
   G4double fPrintGun;
-  //Gun randomization
+  // Gun randomization
   bool fRandomizeGun;
-  std::vector<G4ParticleDefinition*> *fParticleList;
+  std::vector<G4ParticleDefinition *> *fParticleList;
   std::vector<float> *fParticleWeights;
   std::vector<float> *fParticleEnergies;
   bool fInitializationDone;
@@ -48,11 +48,10 @@ private:
   G4double fMaxTheta;
 
   // HepMC3 reader
-  G4VPrimaryGenerator* fHepmcAscii;
+  G4VPrimaryGenerator *fHepmcAscii;
   G4bool fUseHepMC;
 
   ParticleGunMessenger *fMessenger;
-
 };
 
 #endif /* PARTICLEGUN_HH */

--- a/examples/common/src/ParticleGun.cc
+++ b/examples/common/src/ParticleGun.cc
@@ -24,7 +24,7 @@ ParticleGun::ParticleGun() : G4ParticleGun()
 #ifdef HEPMC3_FOUND
   fHepmcAscii = new HepMC3G4AsciiReader();
 #endif
-  
+
   fParticleList     = new std::vector<G4ParticleDefinition *>();
   fParticleWeights  = new std::vector<float>();
   fParticleEnergies = new std::vector<float>();
@@ -52,22 +52,18 @@ void ParticleGun::GeneratePrimaries(G4Event *aEvent)
       // Re-balance the user-provided weights if needed
       ReWeight();
       // Make sure all particles have a user-defined energy
-      for(int i=0; i<fParticleEnergies->size(); i++)
-      {
-        if((*fParticleEnergies)[i] < 0)
-        {
+      for (int i = 0; i < fParticleEnergies->size(); i++) {
+        if ((*fParticleEnergies)[i] < 0) {
           G4Exception("PrimaryGeneratorAction::GeneratePrimaries()", "Notification", FatalErrorInArgument,
-                  ("Energy undefined for  " + (*fParticleList)[i]->GetParticleName()).c_str());
+                      ("Energy undefined for  " + (*fParticleList)[i]->GetParticleName()).c_str());
         }
       }
-      // In case the upper range for Phi or Theta was not defined, or is lower than the 
+      // In case the upper range for Phi or Theta was not defined, or is lower than the
       // lower range
-      if(fMaxPhi < fMinPhi)
-      {
+      if (fMaxPhi < fMinPhi) {
         fMaxPhi = fMinPhi;
       }
-      if(fMaxTheta < fMinTheta)
-      {
+      if (fMaxTheta < fMinTheta) {
         fMaxTheta = fMinTheta;
       }
     }
@@ -77,8 +73,8 @@ void ParticleGun::GeneratePrimaries(G4Event *aEvent)
     fHepmcAscii->GeneratePrimaryVertex(aEvent);
   } else {
     if (fRandomizeGun) {
-      GenerateRandomPrimaryVertex(aEvent, fMinPhi, fMaxPhi, fMinTheta, fMaxTheta, fParticleList,
-                                                fParticleWeights, fParticleEnergies);
+      GenerateRandomPrimaryVertex(aEvent, fMinPhi, fMaxPhi, fMinTheta, fMaxTheta, fParticleList, fParticleWeights,
+                                  fParticleEnergies);
     } else {
       GeneratePrimaryVertex(aEvent);
     }
@@ -230,26 +226,23 @@ void ParticleGun::Print()
   }
 }
 
-void ParticleGun::PrintPrimaries(G4Event* aEvent) const
+void ParticleGun::PrintPrimaries(G4Event *aEvent) const
 {
-  std::map<G4String, G4int> aParticleCounts = {};
+  std::map<G4String, G4int> aParticleCounts             = {};
   std::map<G4String, G4double> aParticleAverageEnergies = {};
 
-  for(int i=0; i<aEvent->GetPrimaryVertex()->GetNumberOfParticle(); i++)
-  {
-    G4String aParticleName = aEvent->GetPrimaryVertex()->GetPrimary(i)->GetParticleDefinition()->GetParticleName();
+  for (int i = 0; i < aEvent->GetPrimaryVertex()->GetNumberOfParticle(); i++) {
+    G4String aParticleName   = aEvent->GetPrimaryVertex()->GetPrimary(i)->GetParticleDefinition()->GetParticleName();
     G4double aParticleEnergy = aEvent->GetPrimaryVertex()->GetPrimary(i)->GetKineticEnergy();
-    if(!aParticleCounts.count(aParticleName))
-    {
-      aParticleCounts[aParticleName] = 0;
+    if (!aParticleCounts.count(aParticleName)) {
+      aParticleCounts[aParticleName]          = 0;
       aParticleAverageEnergies[aParticleName] = 0;
     }
     aParticleCounts[aParticleName] += 1;
     aParticleAverageEnergies[aParticleName] += aParticleEnergy;
   }
-    
-  for(auto pd : aParticleCounts)
-  {
-    G4cout << pd.first << ": " << pd.second << ", " << aParticleAverageEnergies[pd.first]/pd.second << G4endl;
+
+  for (auto pd : aParticleCounts) {
+    G4cout << pd.first << ": " << pd.second << ", " << aParticleAverageEnergies[pd.first] / pd.second << G4endl;
   }
 }

--- a/examples/common/src/ParticleGunMessenger.cc
+++ b/examples/common/src/ParticleGunMessenger.cc
@@ -20,8 +20,7 @@
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-ParticleGunMessenger::ParticleGunMessenger(ParticleGun *Gun)
-    : G4UImessenger(), fGun(Gun), fDir(0), fDefaultCmd(0)
+ParticleGunMessenger::ParticleGunMessenger(ParticleGun *Gun) : G4UImessenger(), fGun(Gun), fDir(0), fDefaultCmd(0)
 {
   fDir = new G4UIdirectory("/gun/");
   fDir->SetGuidance("gun control");
@@ -125,27 +124,22 @@ void ParticleGunMessenger::SetNewValue(G4UIcommand *command, G4String newValue)
     while ((str = tkn()) != "") {
       token_vector->push_back(str);
     }
-    //The particle type is mandatory and must be the first argument
+    // The particle type is mandatory and must be the first argument
     G4ParticleDefinition *pd;
-    float weight = -1;
+    float weight  = -1;
     double energy = -1;
     if (token_vector->size() >= 1) {
       pd = G4ParticleTable::GetParticleTable()->FindParticle((*token_vector)[0]);
-    }
-    else
-    {
+    } else {
       G4Exception("ParticleGunMessenger::SetNewValue()", "Notification", JustWarning,
                   "No arguments provided. Usage: addParticle type [\"weight\" weight] [\"energy\" energy unit]");
     }
 
-    for(int i=1; i<token_vector->size(); i++)
-    {
-      if((*token_vector)[i] == "weight")
-      {
+    for (int i = 1; i < token_vector->size(); i++) {
+      if ((*token_vector)[i] == "weight") {
         weight = stof((*token_vector)[++i]);
       }
-      if((*token_vector)[i] == "energy")
-      {
+      if ((*token_vector)[i] == "energy") {
         energy = stof((*token_vector)[++i]) * G4UnitDefinition::GetValueOf((*token_vector)[++i]);
       }
     }

--- a/include/AdePT/base/Atomic.h
+++ b/include/AdePT/base/Atomic.h
@@ -35,20 +35,16 @@ struct AtomicBase_t {
   AtomicType_t fData{0}; ///< Atomic data
 
   /** @brief Constructor taking an address */
-  __host__ __device__
-  AtomicBase_t() : fData{0} {}
+  __host__ __device__ AtomicBase_t() : fData{0} {}
 
   /** @brief Copy constructor */
-  __host__ __device__
-  AtomicBase_t(AtomicBase_t const &other) { store(other.load()); }
+  __host__ __device__ AtomicBase_t(AtomicBase_t const &other) { store(other.load()); }
 
   /** @brief Assignment */
-  __host__ __device__
-  AtomicBase_t &operator=(AtomicBase_t const &other) { store(other.load()); }
+  __host__ __device__ AtomicBase_t &operator=(AtomicBase_t const &other) { store(other.load()); }
 
   /** @brief Emplace the data at a given address */
-  __host__ __device__
-  static AtomicBase_t *MakeInstanceAt(void *addr)
+  __host__ __device__ static AtomicBase_t *MakeInstanceAt(void *addr)
   {
     assert(addr != nullptr && "cannot allocate at nullptr address");
     assert((((unsigned long long)addr) % alignof(AtomicType_t)) == 0 && "addr does not satisfy alignment");
@@ -78,12 +74,10 @@ struct AtomicBase_t {
 #else
 
   /** @brief Atomically replaces the current value with desired. */
-  __device__
-  void store(Type desired) { atomicExch(&fData, desired); }
+  __device__ void store(Type desired) { atomicExch(&fData, desired); }
 
   /** @brief Atomically loads and returns the current value of the atomic variable. */
-  __device__
-  Type load() const
+  __device__ Type load() const
   {
     // There is no atomic load on CUDA. Issue a memory fence to get the required
     // semantics and make sure that the value is really loaded from memory.
@@ -92,13 +86,11 @@ struct AtomicBase_t {
   }
 
   /** @brief Atomically replaces the underlying value with desired. */
-  __device__
-  Type exchange(Type desired) { return atomicExch(&fData, desired); }
+  __device__ Type exchange(Type desired) { return atomicExch(&fData, desired); }
 
   /** @brief Atomically compares the stored value with the expected one, and if equal stores desired.
    * If not loads the old value into expected. Returns true if swap was successful. */
-  __device__
-  bool compare_exchange_strong(Type &expected, Type desired)
+  __device__ bool compare_exchange_strong(Type &expected, Type desired)
   {
     Type old    = atomicCAS(&fData, expected, desired);
     bool worked = (old == expected);
@@ -107,48 +99,37 @@ struct AtomicBase_t {
   }
 
   /** @brief Atomically replaces the current value with the result of arithmetic addition of the value and arg. */
-  __device__
-  Type fetch_add(Type arg) { return atomicAdd(&fData, arg); }
+  __device__ Type fetch_add(Type arg) { return atomicAdd(&fData, arg); }
 
   /** @brief Atomically replaces the current value with the result of arithmetic subtraction of the value and arg. */
-  __device__
-  Type fetch_sub(Type arg) { return atomicAdd(&fData, -arg); }
+  __device__ Type fetch_sub(Type arg) { return atomicAdd(&fData, -arg); }
 
   /** @brief Atomically replaces the current value with the result of bitwise AND of the value and arg. */
-  __device__
-  Type fetch_and(Type arg) { return atomicAnd(&fData, arg); }
+  __device__ Type fetch_and(Type arg) { return atomicAnd(&fData, arg); }
 
   /** @brief Atomically replaces the current value with the result of bitwise OR of the value and arg. */
-  __device__
-  Type fetch_or(Type arg) { return atomicOr(&fData, arg); }
+  __device__ Type fetch_or(Type arg) { return atomicOr(&fData, arg); }
 
   /** @brief Atomically replaces the current value with the result of bitwise XOR of the value and arg. */
-  __device__
-  Type fetch_xor(Type arg) { return atomicXor(&fData, arg); }
+  __device__ Type fetch_xor(Type arg) { return atomicXor(&fData, arg); }
 
   /** @brief Performs atomic add. */
-  __device__
-  Type operator+=(Type arg) { return (fetch_add(arg) + arg); }
+  __device__ Type operator+=(Type arg) { return (fetch_add(arg) + arg); }
 
   /** @brief Performs atomic subtract. */
-  __device__
-  Type operator-=(Type arg) { return (fetch_sub(arg) - arg); }
+  __device__ Type operator-=(Type arg) { return (fetch_sub(arg) - arg); }
 
   /** @brief Performs atomic pre-increment. */
-  __device__
-  Type operator++() { return (fetch_add(1) + 1); }
+  __device__ Type operator++() { return (fetch_add(1) + 1); }
 
   /** @brief Performs atomic post-increment. */
-  __device__
-  Type operator++(int) { return fetch_add(1); }
+  __device__ Type operator++(int) { return fetch_add(1); }
 
   /** @brief Performs atomic pre-decrement. */
-  __device__
-  Type operator--() { return (fetch_sub(1) - 1); }
+  __device__ Type operator--() { return (fetch_sub(1) - 1); }
 
   /** @brief Performs atomic post-decrement. */
-  __device__
-  Type operator--(int) { return fetch_sub(1); }
+  __device__ Type operator--(int) { return fetch_sub(1); }
 
 #endif
 };
@@ -202,8 +183,7 @@ struct Atomic_t<Type, typename std::enable_if<std::is_integral<Type>::value>::ty
   Type operator--(int) { return fetch_sub(1); }
 #else
   /** @brief Atomically assigns the desired value to the atomic variable. */
-  __device__
-  Type operator=(Type desired)
+  __device__ Type operator=(Type desired)
   {
     atomicExch(&fData, desired);
     return desired;
@@ -257,8 +237,7 @@ struct Atomic_t<Type, typename std::enable_if<!std::is_integral<Type>::value>::t
 #else
 
   /** @brief Atomically assigns the desired value to the atomic variable. */
-  __device__
-  Type operator=(Type desired)
+  __device__ Type operator=(Type desired)
   {
     atomicExch(&fData, desired);
     return desired;

--- a/include/AdePT/base/BlockData.h
+++ b/include/AdePT/base/BlockData.h
@@ -41,46 +41,36 @@ private:
   friend Base_t;
 
   /** @brief Functions required by VariableSizeObjectInterface */
-  __host__ __device__
-  __forceinline__
-  ArrayData_t &GetVariableData() { return fData; }
+  __host__ __device__ __forceinline__ ArrayData_t &GetVariableData() { return fData; }
 
-  __host__ __device__
-  __forceinline__
-  const ArrayData_t &GetVariableData() const { return fData; }
+  __host__ __device__ __forceinline__ const ArrayData_t &GetVariableData() const { return fData; }
 
   // constructors and assignment operators are private
   // states have to be constructed using MakeInstance() function
-  __host__ __device__
-  __forceinline__
-  BlockData(size_t nvalues) : fCapacity(nvalues), fData(nvalues)
+  __host__ __device__ __forceinline__ BlockData(size_t nvalues) : fCapacity(nvalues), fData(nvalues)
   {
     char *address = (char *)this + Base_t::SizeOfAlignAware(nvalues) - BlockData<Type>::SizeOfExtra(nvalues);
     fHoles        = (Queue_t *)address;
     Queue_t::MakeInstanceAt(nvalues, address);
   }
 
-  __host__ __device__
-  __forceinline__
-  BlockData(BlockData const &other) : BlockData(other.fCapacity, other) {}
+  __host__ __device__ __forceinline__ BlockData(BlockData const &other) : BlockData(other.fCapacity, other) {}
 
-  __host__ __device__
-  __forceinline__
-  BlockData(size_t new_size, BlockData const &other) : Base_t(other), fCapacity(new_size), fData(new_size, other.fData)
+  __host__ __device__ __forceinline__ BlockData(size_t new_size, BlockData const &other)
+      : Base_t(other), fCapacity(new_size), fData(new_size, other.fData)
   {
     char *address = (char *)this + Base_t::SizeOfAlignAware(new_size) - BlockData<Type>::SizeOfExtra(new_size);
     fHoles        = (Queue_t *)address;
     Queue_t::MakeCopyAt(new_size, *other.fHoles, address);
   }
 
-  __forceinline__
-  __host__ __device__
-  ~BlockData() {}
+  __forceinline__ __host__ __device__ ~BlockData() {}
 
   /** @brief Returns the size in bytes of extra queue data needed by BlockData object with given capacity */
-  __host__ __device__
-  __forceinline__
-  static size_t SizeOfExtra(int capacity) { return Queue_t::SizeOfAlignAware(capacity); }
+  __host__ __device__ __forceinline__ static size_t SizeOfExtra(int capacity)
+  {
+    return Queue_t::SizeOfAlignAware(capacity);
+  }
 
 public:
   ///< Enumerate the part of the private interface, we want to expose.
@@ -93,38 +83,26 @@ public:
   using Base_t::SizeOfAlignAware;
 
   /** @brief Returns the size in bytes of a BlockData object with given capacity */
-  __host__ __device__
-  __forceinline__
-  static size_t SizeOfInstance(int capacity) { return Base_t::SizeOf(capacity); }
+  __host__ __device__ __forceinline__ static size_t SizeOfInstance(int capacity) { return Base_t::SizeOf(capacity); }
 
   /** @brief Maximum number of elements */
-  __host__ __device__
-  __forceinline__
-  int Capacity() const { return fCapacity; }
+  __host__ __device__ __forceinline__ int Capacity() const { return fCapacity; }
 
   /** @brief Clear the content */
-  __host__ __device__
-  __forceinline__
-  void Clear()
+  __host__ __device__ __forceinline__ void Clear()
   {
     fNused.store(0);
     fNbooked.store(0);
   }
 
   /** @brief Read-only index operator */
-  __host__ __device__
-  __forceinline__
-  Type const &operator[](const int index) const { return fData[index]; }
+  __host__ __device__ __forceinline__ Type const &operator[](const int index) const { return fData[index]; }
 
   /** @brief Read/write index operator */
-  __host__ __device__
-  __forceinline__
-  Type &operator[](const int index) { return fData[index]; }
+  __host__ __device__ __forceinline__ Type &operator[](const int index) { return fData[index]; }
 
   /** @brief Dispatch next free element, nullptr if none left */
-  __host__ __device__
-  __forceinline__
-  Type *NextElement()
+  __host__ __device__ __forceinline__ Type *NextElement()
   {
     // Try to get a hole index if any
     int index = -1;
@@ -139,9 +117,7 @@ public:
   }
 
   /** @brief Release an element */
-  __host__ __device__
-  __forceinline__
-  void ReleaseElement(int index)
+  __host__ __device__ __forceinline__ void ReleaseElement(int index)
   {
     // No checks currently done that the index was given via NextElement
     // or that it wasn't already released. Either case will produce errors.
@@ -150,19 +126,13 @@ public:
   }
 
   /** @brief Number of elements currently distributed */
-  __host__ __device__
-  __forceinline__
-  int GetNused() { return fNused.load(); }
+  __host__ __device__ __forceinline__ int GetNused() { return fNused.load(); }
 
   /** @brief Number of holes in the block */
-  __host__ __device__
-  __forceinline__
-  int GetNholes() { return fHoles->size(); }
+  __host__ __device__ __forceinline__ int GetNholes() { return fHoles->size(); }
 
   /** @brief Check if container is fully distributed */
-  __host__ __device__
-  __forceinline__
-  bool IsFull() const { return (GetNused() == fCapacity); }
+  __host__ __device__ __forceinline__ bool IsFull() const { return (GetNused() == fCapacity); }
 
 }; // End BlockData
 } // End namespace adept

--- a/include/AdePT/base/Utils.h
+++ b/include/AdePT/base/Utils.h
@@ -27,9 +27,7 @@ __host__ __device__ Type round_up_align(Type value, size_t padding)
 }
 
 /** @brief CPP/CUDA Portable memset operation */
-__host__ __device__
-__forceinline__
-void memset(void *ptr, int value, size_t num)
+__host__ __device__ __forceinline__ void memset(void *ptr, int value, size_t num)
 {
 #ifndef COPCORE_DEVICE_COMPILATION
   memset(ptr, value, num);
@@ -39,9 +37,7 @@ void memset(void *ptr, int value, size_t num)
 }
 
 /** @brief CPP/CUDA Portable memcpy operation */
-__host__ __device__
-__forceinline__
-void memcpy(void *destination, const void *source, size_t num, int type = 0)
+__host__ __device__ __forceinline__ void memcpy(void *destination, const void *source, size_t num, int type = 0)
 {
 #ifndef COPCORE_DEVICE_COMPILATION
   memcpy(destination, source, num);

--- a/include/AdePT/base/mpmc_bounded_queue.h
+++ b/include/AdePT/base/mpmc_bounded_queue.h
@@ -51,13 +51,9 @@ private:
   friend Base_t;
 
   /** @brief Functions required by VariableSizeObjectInterface */
-  __host__ __device__
-  __forceinline__
-  ArrayData_t &GetVariableData() { return fBuffer; }
+  __host__ __device__ __forceinline__ ArrayData_t &GetVariableData() { return fBuffer; }
 
-  __host__ __device__
-  __forceinline__
-  const ArrayData_t &GetVariableData() const { return fBuffer; }
+  __host__ __device__ __forceinline__ const ArrayData_t &GetVariableData() const { return fBuffer; }
 
   // constructors and assignment operators are private
   // states have to be constructed using MakeInstance() function
@@ -68,9 +64,8 @@ private:
    * @param addr Address where the queue is allocated.
    * The user should make sure to allocate at least SizeofInstance(fBuffersize) bytes
    */
-  __host__ __device__
-  __forceinline__
-  mpmc_bounded_queue(int nvalues) : fCapacity(nvalues), fMask(nvalues - 1), fBuffer(nvalues)
+  __host__ __device__ __forceinline__ mpmc_bounded_queue(int nvalues)
+      : fCapacity(nvalues), fMask(nvalues - 1), fBuffer(nvalues)
   {
     // The queue size must be a power of 2 (for fast access)
     assert((nvalues >= 2) && ((nvalues & (nvalues - 1)) == 0) && "buffer size has to be a power of 2");
@@ -78,18 +73,15 @@ private:
       fBuffer[i].fSequence.store(i);
   }
 
-  __host__ __device__
-  __forceinline__
-  mpmc_bounded_queue(int /*nvalues*/, mpmc_bounded_queue const & /*other*/) {}
+  __host__ __device__ __forceinline__ mpmc_bounded_queue(int /*nvalues*/, mpmc_bounded_queue const & /*other*/) {}
   /** @brief MPMC bounded queue copy constructor */
-  __host__ __device__
-  __forceinline__
-  mpmc_bounded_queue(mpmc_bounded_queue const &other) : mpmc_bounded_queue(other.fCapacity, other) {}
+  __host__ __device__ __forceinline__ mpmc_bounded_queue(mpmc_bounded_queue const &other)
+      : mpmc_bounded_queue(other.fCapacity, other)
+  {
+  }
 
   /** @brief MPMC bounded queue copy constructor with given size */
-  __host__ __device__
-  __forceinline__
-  mpmc_bounded_queue(size_t new_size, mpmc_bounded_queue const &other)
+  __host__ __device__ __forceinline__ mpmc_bounded_queue(size_t new_size, mpmc_bounded_queue const &other)
       : fCapacity(new_size), fMask(new_size - 1), fEnqueue(other.fEnqueue), fDequeue(other.fDequeue),
         fNstored(other.fNstored), fBuffer(new_size, other.fBuffer)
   {
@@ -110,19 +102,13 @@ public:
   using Base_t::SizeOfAlignAware;
 
   /** @brief Returns the size in bytes of a BlockData object with given capacity */
-  __host__ __device__
-  __forceinline__
-  static size_t SizeOfInstance(int capacity) { return Base_t::SizeOf(capacity); }
+  __host__ __device__ __forceinline__ static size_t SizeOfInstance(int capacity) { return Base_t::SizeOf(capacity); }
 
   /** @brief Maximum number of elements */
-  __host__ __device__
-  __forceinline__
-  int Capacity() const { return fCapacity; }
+  __host__ __device__ __forceinline__ int Capacity() const { return fCapacity; }
 
   /** @brief Size function */
-  __host__ __device__
-  __forceinline__
-  void clear()
+  __host__ __device__ __forceinline__ void clear()
   {
     fEnqueue.store(0);
     fDequeue.store(0);
@@ -132,14 +118,10 @@ public:
   }
 
   /** @brief Size function */
-  __host__ __device__
-  __forceinline__
-  int size() const { return fNstored.load(); }
+  __host__ __device__ __forceinline__ int size() const { return fNstored.load(); }
 
   /** @brief MPMC enqueue function */
-  __host__ __device__
-  __forceinline__
-  bool enqueue(Type const &data)
+  __host__ __device__ __forceinline__ bool enqueue(Type const &data)
   {
     Value_t *cell;
     int pos = fEnqueue.load();
@@ -161,9 +143,7 @@ public:
   }
 
   /** @brief MPMC dequeue function */
-  __host__ __device__
-  __forceinline__
-  bool dequeue(Type &data)
+  __host__ __device__ __forceinline__ bool dequeue(Type &data)
   {
     Value_t *cell;
     int pos = fDequeue.load();
@@ -189,18 +169,14 @@ public:
         The index should be smaller than the number of stored elements. The range is only
         checked in debug mode.
     */
-  __host__ __device__
-  __forceinline__
-  Type &operator[](const int index)
+  __host__ __device__ __forceinline__ Type &operator[](const int index)
   {
     assert(index >= 0 && index < fNstored.load() && "Index in queue out of range");
     int pos = fDequeue.load() + index;
     return fBuffer[pos & fMask].fData;
   }
 
-  __host__ __device__
-  __forceinline__
-  Type const &operator[](const int index) const
+  __host__ __device__ __forceinline__ Type const &operator[](const int index) const
   {
     assert(index >= 0 && index < fNstored.load() && "Index in queue out of range");
     int pos = fDequeue.load() + index;

--- a/include/AdePT/benchmarking/TestManager.h
+++ b/include/AdePT/benchmarking/TestManager.h
@@ -25,7 +25,7 @@ struct TimeInfo {
   bool counting;                                                        ///< Whether the timer is running
 };
 
-//#if defined TEST
+// #if defined TEST
 
 // Entry management
 #include <map>
@@ -97,7 +97,11 @@ public:
   }
 
   /** @brief Empties the maps */
-  void reset() { fTimers.clear(); fAccumulators.clear(); }
+  void reset()
+  {
+    fTimers.clear();
+    fAccumulators.clear();
+  }
 
   /** @brief Removes a timer from the map */
   void removeTimer(TTag tag) { fTimers.erase(tag); }
@@ -112,39 +116,27 @@ public:
   bool hasAccumulator(TTag tag) const { return fAccumulators.find(tag) != fAccumulators.end(); }
 
   /** @brief Returns the timer map */
-  std::map<TTag, TimeInfo>* getTimers() 
-  {
-    return &fTimers;
-  }
-  
+  std::map<TTag, TimeInfo> *getTimers() { return &fTimers; }
+
   /** @brief Returns the accumulator map */
-  std::map<TTag, double>* getAccumulators() 
-  {
-    return &fAccumulators;
-  }
+  std::map<TTag, double> *getAccumulators() { return &fAccumulators; }
 
   /** @brief Sets the output directory variable */
-  void setOutputDirectory(std::string aOutputDir)
-  {
-    fOutputDir = aOutputDir;
-  }
+  void setOutputDirectory(std::string aOutputDir) { fOutputDir = aOutputDir; }
 
   /** @brief Returns the output directory */
-  std::string getOutputDirectory(){ return fOutputDir; }
+  std::string getOutputDirectory() { return fOutputDir; }
 
   /** @brief Sets the output filename variable */
-  void setOutputFilename(std::string aOutputFilename)
-  {
-    fOutputFilename = aOutputFilename;
-  }
+  void setOutputFilename(std::string aOutputFilename) { fOutputFilename = aOutputFilename; }
 
   /** @brief Returns the output filename */
-  std::string getOutputFilename(){ return fOutputFilename; }
+  std::string getOutputFilename() { return fOutputFilename; }
 
   /** @brief Export a CSV file with the timer names as labels and the accumulated time for each */
   // If the file is not empty, write only the times
   void exportCSV(bool overwrite = true)
-  { 
+  {
     std::string aOutputDir;
     std::string aOutputFilename;
     fOutputDir.empty() ? aOutputDir = "benchmark" : aOutputDir = fOutputDir;

--- a/include/AdePT/benchmarking/TestManagerStore.h
+++ b/include/AdePT/benchmarking/TestManagerStore.h
@@ -9,7 +9,7 @@
 #ifndef TEST_AGGREGATOR_H
 #define TEST_AGGREGATOR_H
 
-//#if defined TEST
+// #if defined TEST
 
 #include <mutex>
 #include <vector>
@@ -21,8 +21,8 @@ class TestManagerStore {
 
 private:
   static TestManagerStore *fInstance; ///< This class is a Singleton
-  static std::mutex fInitMutex;            ///< Mutex for initialization
-  static std::mutex fAccessMutex;          ///< Mutex for adding BenchmarkStates
+  static std::mutex fInitMutex;       ///< Mutex for initialization
+  static std::mutex fAccessMutex;     ///< Mutex for adding BenchmarkStates
   std::vector<std::map<TTag, double>>
       *fBenchmarkStates; ///< This vector holds one map with the information from each TestManager
 
@@ -49,8 +49,7 @@ public:
     for (auto iter = aTestManager->getTimers()->begin(); iter != aTestManager->getTimers()->end(); ++iter) {
       aBenchmarkState[iter->first] = aTestManager->getDurationSeconds(iter->first);
     }
-    for (auto iter = aTestManager->getAccumulators()->begin(); iter != aTestManager->getAccumulators()->end();
-         ++iter) {
+    for (auto iter = aTestManager->getAccumulators()->begin(); iter != aTestManager->getAccumulators()->end(); ++iter) {
       aBenchmarkState[iter->first] = iter->second;
     }
     // Make sure only one thread is adding a State at a time
@@ -83,6 +82,6 @@ public:
   void Reset() {}
 };
 
-//#endif
+// #endif
 
 #endif

--- a/include/AdePT/copcore/Allocator.h
+++ b/include/AdePT/copcore/Allocator.h
@@ -19,8 +19,7 @@
 namespace copcore {
 
 template <class T, BackendType backend>
-class Allocator {
-};
+class Allocator {};
 
 #ifdef COPCORE_CUDA_COMPILER
 
@@ -44,7 +43,7 @@ public:
   bool operator!=(const Allocator &other) const { return !(*this == other); }
 
   template <typename... P>
-  value_type *allocate(std::size_t n, const P &... params) const
+  value_type *allocate(std::size_t n, const P &...params) const
   {
     int old_device = SetDevice(fDeviceId);
 
@@ -113,7 +112,7 @@ public:
   bool operator!=(const Allocator &other) const { return !(*this == other); }
 
   template <typename... P>
-  value_type *allocate(std::size_t n, const P &... params) const
+  value_type *allocate(std::size_t n, const P &...params) const
   {
     auto obj_size       = sizeof(T);
     value_type *result  = (value_type *)malloc(n * obj_size);

--- a/include/AdePT/copcore/CopCore.h
+++ b/include/AdePT/copcore/CopCore.h
@@ -15,6 +15,4 @@
 #include <AdePT/copcore/VariableSizeObj.h>
 #include <AdePT/copcore/VariableSizeObjAllocator.h>
 
-
-
 #endif // COPCORE_COPCORE_H_

--- a/include/AdePT/copcore/Macros.h
+++ b/include/AdePT/copcore/Macros.h
@@ -46,34 +46,32 @@
  * Expands to the relevant CUDA keyword or host compiler attribute
  */
 
-
 #ifndef COPCORE_MACROS_H_
 #define COPCORE_MACROS_H_
 
 // Macros for separating CUDA compiler from others
 #ifdef __CUDACC__
-#  define COPCORE_CUDA_COMPILER
+#define COPCORE_CUDA_COMPILER
 #endif
 
 // Define function keywords if not already present.
 #ifndef __host__
-#  define __host__
+#define __host__
 #endif
 
 #ifndef __device__
-#  define __device__
+#define __device__
 #endif
 
 #ifndef __forceinline__
-#  define __forceinline__ inline __attribute__((always_inline))
+#define __forceinline__ inline __attribute__((always_inline))
 #endif
 
 // Definition of __CUDA_ARCH__ means we are compiling CUDA *and*
 // on the device compile pass
 // COPCORE_DEVICE_COMPILATION is defined in this case
 #ifdef __CUDA_ARCH__
-#  define COPCORE_DEVICE_COMPILATION
+#define COPCORE_DEVICE_COMPILATION
 #endif
-
 
 #endif // COPCORE_MACROS_H_

--- a/include/AdePT/copcore/Ranluxpp.h
+++ b/include/AdePT/copcore/Ranluxpp.h
@@ -33,16 +33,14 @@ private:
   static constexpr int kMaxPos        = 9 * 64;
 
 protected:
-  __host__ __device__
-  void SaveState(uint64_t *state) const
+  __host__ __device__ void SaveState(uint64_t *state) const
   {
     for (int i = 0; i < 9; i++) {
       state[i] = fState[i];
     }
   }
 
-  __host__ __device__
-  void XORstate(const uint64_t *state)
+  __host__ __device__ void XORstate(const uint64_t *state)
   {
     for (int i = 0; i < 9; i++) {
       fState[i] ^= state[i];

--- a/include/AdePT/copcore/VariableSizeObj.h
+++ b/include/AdePT/copcore/VariableSizeObj.h
@@ -147,20 +147,15 @@ public:
 
   VariableSizeObj(TRootIOCtor *) : fSelfAlloc(false), fN(0) {}
 
-  __forceinline__
-  __host__ __device__
-  VariableSizeObj(unsigned int nvalues) : fSelfAlloc(false), fN(nvalues) {}
+  __forceinline__ __host__ __device__ VariableSizeObj(unsigned int nvalues) : fSelfAlloc(false), fN(nvalues) {}
 
-  __forceinline__
-  __host__ __device__
-  VariableSizeObj(const VariableSizeObj &other) : fSelfAlloc(false), fN(other.fN)
+  __forceinline__ __host__ __device__ VariableSizeObj(const VariableSizeObj &other) : fSelfAlloc(false), fN(other.fN)
   {
     if (other.fN) memcpy(GetValues(), other.GetValues(), (other.fN) * sizeof(V));
   }
 
-  __forceinline__
-  __host__ __device__
-  VariableSizeObj(size_t new_size, const VariableSizeObj &other) : fSelfAlloc(false), fN(new_size)
+  __forceinline__ __host__ __device__ VariableSizeObj(size_t new_size, const VariableSizeObj &other)
+      : fSelfAlloc(false), fN(new_size)
   {
     if (other.fN) memcpy(GetValues(), other.GetValues(), (other.fN) * sizeof(V));
   }
@@ -200,7 +195,7 @@ public:
   // The static maker to be used to create an instance of the variable size object.
 
   template <typename... T>
-  __host__ __device__ static Cont *MakeInstance(size_t nvalues, const T &... params)
+  __host__ __device__ static Cont *MakeInstance(size_t nvalues, const T &...params)
   {
     // Make an instance of the class which allocates the node array. To be
     // released using ReleaseInstance.
@@ -214,7 +209,7 @@ public:
   }
 
   template <typename... T>
-  __host__ __device__ static Cont *MakeInstanceAt(size_t nvalues, void *addr, const T &... params)
+  __host__ __device__ static Cont *MakeInstanceAt(size_t nvalues, void *addr, const T &...params)
   {
     // Make an instance of the class which allocates the node array. To be
     // released using ReleaseInstance. If addr is non-zero, the user promised that
@@ -230,8 +225,7 @@ public:
   }
 
   // The equivalent of the copy constructor
-  __host__ __device__
-  static Cont *MakeCopy(const Cont &other)
+  __host__ __device__ static Cont *MakeCopy(const Cont &other)
   {
     // Make a copy of the variable size array and its container.
 
@@ -243,8 +237,7 @@ public:
     return copy;
   }
 
-  __host__ __device__
-  static Cont *MakeCopy(size_t new_size, const Cont &other)
+  __host__ __device__ static Cont *MakeCopy(size_t new_size, const Cont &other)
   {
     // Make a copy of a the variable size array and its container with
     // a new_size of the content.
@@ -258,8 +251,7 @@ public:
   }
 
   // The equivalent of the copy constructor
-  __host__ __device__
-  static Cont *MakeCopyAt(const Cont &other, void *addr)
+  __host__ __device__ static Cont *MakeCopyAt(const Cont &other, void *addr)
   {
     // Make a copy of a the variable size array and its container at the location (if indicated)
     if (addr) {
@@ -272,8 +264,7 @@ public:
   }
 
   // The equivalent of the copy constructor
-  __host__ __device__
-  static Cont *MakeCopyAt(size_t new_size, const Cont &other, void *addr)
+  __host__ __device__ static Cont *MakeCopyAt(size_t new_size, const Cont &other, void *addr)
   {
     // Make a copy of a the variable size array and its container at the location (if indicated)
     if (addr) {
@@ -286,36 +277,36 @@ public:
   }
 
   // The equivalent of the destructor
-  __host__ __device__
-  static void ReleaseInstance(Cont *obj)
+  __host__ __device__ static void ReleaseInstance(Cont *obj)
   {
     // Releases the space allocated for the object
     obj->~Cont();
-    if (obj->GetVariableData().fSelfAlloc) delete[](char *) obj;
+    if (obj->GetVariableData().fSelfAlloc) delete[] (char *)obj;
   }
 
   // Equivalent of sizeof function (not taking into account padding for alignment)
-  __host__ __device__
-  static constexpr size_t SizeOf(size_t nvalues)
+  __host__ __device__ static constexpr size_t SizeOf(size_t nvalues)
   {
     return (sizeof(Cont) + Cont::SizeOfExtra(nvalues) + sizeof(V) * (nvalues - 1));
   }
 
   // Size of the allocated derived type data members that are also variable size
-  __host__ __device__
-  static constexpr size_t SizeOfExtra(size_t nvalues) { return 0; }
+  __host__ __device__ static constexpr size_t SizeOfExtra(size_t nvalues) { return 0; }
 
   // equivalent of sizeof function taking into account padding for alignment
   // this function should be used when making arrays of VariableSizeObjects
-  __host__ __device__
-  static constexpr size_t SizeOfAlignAware(size_t nvalues) { return SizeOf(nvalues) + RealFillUp(nvalues); }
+  __host__ __device__ static constexpr size_t SizeOfAlignAware(size_t nvalues)
+  {
+    return SizeOf(nvalues) + RealFillUp(nvalues);
+  }
 
 private:
-  __host__ __device__
-  static constexpr size_t FillUp(size_t nvalues) { return alignof(Cont) - SizeOf(nvalues) % alignof(Cont); }
+  __host__ __device__ static constexpr size_t FillUp(size_t nvalues)
+  {
+    return alignof(Cont) - SizeOf(nvalues) % alignof(Cont);
+  }
 
-  __host__ __device__
-  static constexpr size_t RealFillUp(size_t nvalues)
+  __host__ __device__ static constexpr size_t RealFillUp(size_t nvalues)
   {
     return (FillUp(nvalues) == alignof(Cont)) ? 0 : FillUp(nvalues);
   }

--- a/include/AdePT/copcore/VariableSizeObjAllocator.h
+++ b/include/AdePT/copcore/VariableSizeObjAllocator.h
@@ -19,8 +19,7 @@
 namespace copcore {
 
 template <class T, BackendType backend>
-class VariableSizeObjAllocator {
-};
+class VariableSizeObjAllocator {};
 
 #ifdef COPCORE_CUDA_COMPILER
 
@@ -46,7 +45,7 @@ public:
   bool operator!=(const VariableSizeObjAllocator &other) const { return !(*this == other); }
 
   template <typename... P>
-  value_type *allocate(std::size_t n, const P &... params) const
+  value_type *allocate(std::size_t n, const P &...params) const
   {
     int old_device = SetDevice(fDeviceId);
 
@@ -123,7 +122,7 @@ public:
   bool operator!=(const VariableSizeObjAllocator &other) const { return !(*this == other); }
 
   template <typename... P>
-  value_type *allocate(std::size_t n, const P &... params) const
+  value_type *allocate(std::size_t n, const P &...params) const
   {
     value_type *result   = nullptr;
     std::size_t obj_size = T::SizeOfAlignAware(fCapacity);

--- a/include/AdePT/core/AdePTConfiguration.hh
+++ b/include/AdePT/core/AdePTConfiguration.hh
@@ -32,7 +32,7 @@ public:
   float GetHitBufferFlushThreshold() { return fHitBufferFlushThreshold; }
 
   // Temporary
-  std::string GetVecGeomGDML(){ return fVecGeomGDML; }
+  std::string GetVecGeomGDML() { return fVecGeomGDML; }
 
 private:
   int fRandomSeed;

--- a/include/AdePT/core/AdePTTransport.cuh
+++ b/include/AdePT/core/AdePTTransport.cuh
@@ -75,8 +75,8 @@ struct GPUstate {
   using TrackData = adeptint::TrackData;
 
   ParticleType particles[ParticleType::NumParticleTypes];
-  AllTrackManagers allmgr_h;          ///< Host pointers for track managers
-  AllTrackManagers allmgr_d;          ///< Device pointers for track managers
+  AllTrackManagers allmgr_h; ///< Host pointers for track managers
+  AllTrackManagers allmgr_d; ///< Device pointers for track managers
   // Create a stream to synchronize kernels of all particle types.
   cudaStream_t stream;                ///< all-particle sync stream
   TrackData *toDevice_dev{nullptr};   ///< toDevice buffer of tracks

--- a/include/AdePT/core/HostScoring.h
+++ b/include/AdePT/core/HostScoring.h
@@ -72,7 +72,6 @@ struct HostScoring {
     fGPUHitsBuffer_host = (GPUHit *)malloc(sizeof(GPUHit) * fBufferCapacity);
     // Allocate the global counters struct on host
     fGlobalCounters_host = (GlobalCounters *)malloc(sizeof(GlobalCounters));
-
   };
 
   ~HostScoring()
@@ -113,7 +112,7 @@ struct HostScoring {
   void CopyHitsToHost(Stats &aStats_host, HostScoring *aScoring_device, cudaStream_t stream);
 
   /// @brief Update the stats struct. To be called before copying it back.
-  /// @details This is an in-device update, meant to copy the state of the member variables we need 
+  /// @details This is an in-device update, meant to copy the state of the member variables we need
   /// into a struct that can be copied back to the host
   __device__ __forceinline__ void refresh_stats()
   {
@@ -123,8 +122,8 @@ struct HostScoring {
   }
 
   /// @brief Account for the number of produced secondaries
-  /// @details Atomically increase the number of produced secondaries. These numbers are used as another 
-  /// way to compare the amount of work done with Geant4. This is not part of the scoring per se and is 
+  /// @details Atomically increase the number of produced secondaries. These numbers are used as another
+  /// way to compare the amount of work done with Geant4. This is not part of the scoring per se and is
   /// copied back at the end of a shower
   __device__ void AccountProduced(int num_ele, int num_pos, int num_gam);
 

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -33,8 +33,7 @@ struct Track {
   __host__ __device__ double Uniform() { return rngState.Rndm(); }
 
   __host__ __device__ void InitAsSecondary(const vecgeom::Vector3D<Precision> &parentPos,
-                                           const vecgeom::NavStateIndex &parentNavState,
-                                           double gTime)
+                                           const vecgeom::NavStateIndex &parentNavState, double gTime)
   {
     // The caller is responsible to branch a new RNG state and to set the energy.
     this->numIALeft[0] = -1.0;
@@ -54,19 +53,19 @@ struct Track {
     this->globalTime = gTime;
   }
 
-  __host__ __device__ void CopyTo(adeptint::TrackData &tdata, int pdg) 
+  __host__ __device__ void CopyTo(adeptint::TrackData &tdata, int pdg)
   {
-    tdata.pdg = pdg;
+    tdata.pdg          = pdg;
     tdata.position[0]  = pos[0];
     tdata.position[1]  = pos[1];
     tdata.position[2]  = pos[2];
     tdata.direction[0] = dir[0];
     tdata.direction[1] = dir[1];
     tdata.direction[2] = dir[2];
-    tdata.eKin       = eKin;
-    tdata.globalTime = globalTime;
-    tdata.localTime = localTime;
-    tdata.properTime = properTime;
+    tdata.eKin         = eKin;
+    tdata.globalTime   = globalTime;
+    tdata.localTime    = localTime;
+    tdata.properTime   = properTime;
   }
 };
 #endif

--- a/include/AdePT/integration/AdePTConfigurationMessenger.hh
+++ b/include/AdePT/integration/AdePTConfigurationMessenger.hh
@@ -43,7 +43,7 @@ private:
   G4UIcmdWithADouble *fSetMillionsOfHitSlotsCmd;
   G4UIcmdWithADouble *fSetHitBufferFlushThresholdCmd;
 
-  // Temporary method for setting the VecGeom geometry. 
+  // Temporary method for setting the VecGeom geometry.
   // In the future the geometry will be converted from Geant4 rather than loaded from GDML.
   G4UIcmdWithAString *fSetGDMLCmd;
 };

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -27,53 +27,48 @@
 #include <VecGeom/volumes/PlacedVolume.h>
 #include <VecGeom/volumes/LogicalVolume.h>
 
-
 class AdePTGeant4Integration {
-    public: 
-        AdePTGeant4Integration() = default;
-        ~AdePTGeant4Integration() = default;
+public:
+  AdePTGeant4Integration()  = default;
+  ~AdePTGeant4Integration() = default;
 
-        /// @brief Initializes VecGeom geometry
-        /// @details Currently VecGeom geometry is initialized by loading it from a GDML file, 
-        /// however ideally this function will call the G4 to VecGeom geometry converter
-        static void CreateVecGeomWorld( /*Temporary parameter*/ std::string filename);
+  /// @brief Initializes VecGeom geometry
+  /// @details Currently VecGeom geometry is initialized by loading it from a GDML file,
+  /// however ideally this function will call the G4 to VecGeom geometry converter
+  static void CreateVecGeomWorld(/*Temporary parameter*/ std::string filename);
 
-        /// @brief This function compares G4 and VecGeom geometries and reports any differences
-        static void CheckGeometry(G4HepEmState *hepEmState);
+  /// @brief This function compares G4 and VecGeom geometries and reports any differences
+  static void CheckGeometry(G4HepEmState *hepEmState);
 
-        /// @brief Fills the auxiliary data needed for AdePT
-        static void InitVolAuxData(adeptint::VolAuxData *volAuxData, G4HepEmState *hepEmState, 
-                                    bool trackInAllRegions, std::vector<std::string> *gpuRegionNames);
+  /// @brief Fills the auxiliary data needed for AdePT
+  static void InitVolAuxData(adeptint::VolAuxData *volAuxData, G4HepEmState *hepEmState, bool trackInAllRegions,
+                             std::vector<std::string> *gpuRegionNames);
 
-        /// @brief Initializes the mapping of VecGeom to G4 volumes for sensitive volumes and their parents
-        void InitScoringData(adeptint::VolAuxData *volAuxData);
+  /// @brief Initializes the mapping of VecGeom to G4 volumes for sensitive volumes and their parents
+  void InitScoringData(adeptint::VolAuxData *volAuxData);
 
-        /// @brief Reconstructs GPU hits on host and calls the user-defined sensitive detector code
-        void ProcessGPUHits(HostScoring &aScoring, HostScoring::Stats &aStats);
+  /// @brief Reconstructs GPU hits on host and calls the user-defined sensitive detector code
+  void ProcessGPUHits(HostScoring &aScoring, HostScoring::Stats &aStats);
 
-        /// @brief Takes a buffer of tracks coming from the device and gives them back to Geant4
-        void ReturnTracks(std::vector<adeptint::TrackData> *tracksFromDevice, int debugLevel);
+  /// @brief Takes a buffer of tracks coming from the device and gives them back to Geant4
+  void ReturnTracks(std::vector<adeptint::TrackData> *tracksFromDevice, int debugLevel);
 
-        /// @brief Returns the Z value of the user-defined uniform magnetic field
-        /// @details This function can only be called when the user-defined field is a G4UniformMagField
-        double GetUniformFieldZ();
+  /// @brief Returns the Z value of the user-defined uniform magnetic field
+  /// @details This function can only be called when the user-defined field is a G4UniformMagField
+  double GetUniformFieldZ();
 
-        int GetEventID() { return G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID(); }
+  int GetEventID() { return G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID(); }
 
-        int GetThreadID() { return G4Threading::G4GetThreadId(); }
+  int GetThreadID() { return G4Threading::G4GetThreadId(); }
 
-    private:
-        /// @brief Reconstruct G4TouchableHistory from a VecGeom Navigation index
-        void FillG4NavigationHistory(unsigned int aNavIndex, G4NavigationHistory *aG4NavigationHistory);
+private:
+  /// @brief Reconstruct G4TouchableHistory from a VecGeom Navigation index
+  void FillG4NavigationHistory(unsigned int aNavIndex, G4NavigationHistory *aG4NavigationHistory);
 
-        void FillG4Step(GPUHit *aGPUHit, 
-                                  G4Step *aG4Step, 
-                                  G4TouchableHandle &aPreG4TouchableHandle,
-                                  G4TouchableHandle &aPostG4TouchableHandle);
+  void FillG4Step(GPUHit *aGPUHit, G4Step *aG4Step, G4TouchableHandle &aPreG4TouchableHandle,
+                  G4TouchableHandle &aPostG4TouchableHandle);
 
-        std::unordered_map<size_t, const G4VPhysicalVolume *>
-            fglobal_vecgeom_to_g4_map;  ///< Maps Vecgeom PV IDs to G4 PV IDs
+  std::unordered_map<size_t, const G4VPhysicalVolume *> fglobal_vecgeom_to_g4_map; ///< Maps Vecgeom PV IDs to G4 PV IDs
 };
 
 #endif
-

--- a/include/AdePT/integration/AdePTPhysics.hh
+++ b/include/AdePT/integration/AdePTPhysics.hh
@@ -13,7 +13,7 @@ class AdePTPhysics : public G4VPhysicsConstructor {
 public:
   AdePTPhysics(const G4String &name = "AdePT-physics-list");
   ~AdePTPhysics();
-  AdePTTrackingManager* GetTrackingManager(){return fTrackingManager;}
+  AdePTTrackingManager *GetTrackingManager() { return fTrackingManager; }
 
 public:
   // This method is dummy for physics: particles are constructed in PhysicsList
@@ -25,8 +25,8 @@ public:
   void ConstructProcess() override;
 
 private:
-  AdePTTrackingManager* fTrackingManager;
-  AdePTConfiguration* fAdePTConfiguration;
+  AdePTTrackingManager *fTrackingManager;
+  AdePTConfiguration *fAdePTConfiguration;
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -32,36 +32,34 @@ public:
   void SetVerbosity(int verbosity) { fVerbosity = verbosity; }
 
   // Set the AdePTTransport instance, also initializes the GPU region list
-  void SetAdePTTransport(AdePTTransport *adept) { 
+  void SetAdePTTransport(AdePTTransport *adept)
+  {
     fAdept = adept;
-    if(!adept->GetTrackInAllRegions())
-    {
-      for(std::string regionName: *(adept->GetGPURegionNames()))
-      {
+    if (!adept->GetTrackInAllRegions()) {
+      for (std::string regionName : *(adept->GetGPURegionNames())) {
         G4cout << "AdePTTrackingManager: Marking " << regionName << " as a GPU Region" << G4endl;
         G4Region *region = G4RegionStore::GetInstance()->GetRegion(regionName);
-        if(region != nullptr)
+        if (region != nullptr)
           fGPURegions.push_back(region);
         else
-          G4Exception("AdePTTrackingManager", "Invalid parameter", FatalErrorInArgument, 
+          G4Exception("AdePTTrackingManager", "Invalid parameter", FatalErrorInArgument,
                       ("Region given to /adept/addGPURegion: " + regionName + " Not found\n").c_str());
       }
     }
   }
 
 private:
-
-  /// @brief Steps a particle using the generic G4 tracking, until it dies or enters a user-defined 
+  /// @brief Steps a particle using the generic G4 tracking, until it dies or enters a user-defined
   /// GPU region, in which case tracking is delegated to AdePT
-  /// @details In order to be able to send tracks back and forth between the custom tracking and the generic 
-  /// G4 tracking, this function has to provide the functionality of G4TrackingManager::ProcessOneTrack, in 
+  /// @details In order to be able to send tracks back and forth between the custom tracking and the generic
+  /// G4 tracking, this function has to provide the functionality of G4TrackingManager::ProcessOneTrack, in
   /// addition to checking whether the track is in a GPU Region
   void ProcessTrack(G4Track *aTrack);
 
   /// @brief Steps a track using the Generic G4TrackingManager until it enters a GPU region or stops
   void StepInHostRegion(G4Track *aTrack);
 
-  std::vector<G4Region*> fGPURegions{};
+  std::vector<G4Region *> fGPURegions{};
   AdePTTransport *fAdept;
   int fVerbosity{0};
   G4double ProductionCut = 0.7 * copcore::units::mm;

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -28,10 +28,10 @@ using VolAuxData = AdePTTransport::VolAuxData;
 
 // Compute velocity based on the kinetic energy of the particle
 __device__ double GetVelocity(double eKin)
-{ 
+{
   // Taken from G4DynamicParticle::ComputeBeta
-  double T = eKin / copcore::units::kElectronMassC2;
-  double beta = sqrt(T*(T+2.))/(T+1.0);
+  double T    = eKin / copcore::units::kElectronMassC2;
+  double beta = sqrt(T * (T + 2.)) / (T + 1.0);
   return copcore::units::kCLight * beta;
 }
 
@@ -50,7 +50,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 #endif
   constexpr Precision kPushOutRegion = 10 * vecgeom::kTolerance;
   constexpr int Charge               = IsElectron ? -1 : 1;
-  constexpr double restMass              = copcore::units::kElectronMassC2;
+  constexpr double restMass          = copcore::units::kElectronMassC2;
   constexpr int Pdg                  = IsElectron ? 11 : -11;
   fieldPropagatorConstBz fieldPropagatorBz(BzFieldValue);
 
@@ -58,7 +58,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot      = (*electrons->fActiveTracks)[i];
     Track &currentTrack = (*electrons)[slot];
-    auto eKin         = currentTrack.eKin;
+    auto eKin           = currentTrack.eKin;
     auto preStepEnergy  = eKin;
     auto pos            = currentTrack.pos;
     vecgeom::Vector3D<Precision> preStepPos(pos);
@@ -75,7 +75,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     VolAuxData const &auxData = auxDataArray[lvolID];
 
     auto survive = [&](bool leak = false) {
-      currentTrack.eKin     = eKin;
+      currentTrack.eKin       = eKin;
       currentTrack.pos        = pos;
       currentTrack.dir        = dir;
       currentTrack.globalTime = globalTime;
@@ -230,13 +230,13 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     }
 
     // Collect the charged step length (might be changed by MSC). Collect the changes in energy and deposit.
-    eKin               = theTrack->GetEKin();
+    eKin                 = theTrack->GetEKin();
     double energyDeposit = theTrack->GetEnergyDeposit();
 
     // Update the flight times of the particle
-    // By calculating the velocity here, we assume that all the energy deposit is done at the PreStepPoint, and 
+    // By calculating the velocity here, we assume that all the energy deposit is done at the PreStepPoint, and
     // the velocity depends on the remaining energy
-    double deltaTime = elTrack.GetPStepLength()/GetVelocity(eKin);
+    double deltaTime = elTrack.GetPStepLength() / GetVelocity(eKin);
     globalTime += deltaTime;
     localTime += deltaTime;
     properTime += deltaTime * (restMass / eKin);
@@ -283,13 +283,13 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
         gamma1.InitAsSecondary(pos, navState, globalTime);
         newRNG.Advance();
         gamma1.rngState = newRNG;
-        gamma1.eKin   = copcore::units::kElectronMassC2;
+        gamma1.eKin     = copcore::units::kElectronMassC2;
         gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
 
         gamma2.InitAsSecondary(pos, navState, globalTime);
         // Reuse the RNG state of the dying track.
         gamma2.rngState = currentTrack.rngState;
-        gamma2.eKin   = copcore::units::kElectronMassC2;
+        gamma2.eKin     = copcore::units::kElectronMassC2;
         gamma2.dir      = -gamma1.dir;
       }
       // Particles are killed by not enqueuing them into the new activeQueue.
@@ -367,7 +367,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 
       secondary.InitAsSecondary(pos, navState, globalTime);
       secondary.rngState = newRNG;
-      secondary.eKin   = deltaEkin;
+      secondary.eKin     = deltaEkin;
       secondary.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
 
       eKin -= deltaEkin;
@@ -393,7 +393,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 
       gamma.InitAsSecondary(pos, navState, globalTime);
       gamma.rngState = newRNG;
-      gamma.eKin   = deltaEkin;
+      gamma.eKin     = deltaEkin;
       gamma.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
 
       eKin -= deltaEkin;
@@ -415,13 +415,13 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 
       gamma1.InitAsSecondary(pos, navState, globalTime);
       gamma1.rngState = newRNG;
-      gamma1.eKin   = theGamma1Ekin;
+      gamma1.eKin     = theGamma1Ekin;
       gamma1.dir.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
 
       gamma2.InitAsSecondary(pos, navState, globalTime);
       // Reuse the RNG state of the dying track.
       gamma2.rngState = currentTrack.rngState;
-      gamma2.eKin   = theGamma2Ekin;
+      gamma2.eKin     = theGamma2Ekin;
       gamma2.dir.Set(theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]);
 
       // The current track is killed by not enqueuing into the next activeQueue.

--- a/include/AdePT/magneticfield/CompareResponses.h
+++ b/include/AdePT/magneticfield/CompareResponses.h
@@ -8,64 +8,50 @@
 
 #include <VecGeom/base/Vector3D.h>
 
-static __device__ __host__
-bool  CompareResponseVector3D(
-   int id,
-   vecgeom::Vector3D<Precision> const & originalVec,
-   vecgeom::Vector3D<Precision> const & baselineVec,
-   vecgeom::Vector3D<Precision> const & resultVec,   // Output of new method
-   const char                   * vecName,    
-   Precision                      thresholdRel    // fraction difference allowed
-   )
+static __device__ __host__ bool CompareResponseVector3D(
+    int id, vecgeom::Vector3D<Precision> const &originalVec, vecgeom::Vector3D<Precision> const &baselineVec,
+    vecgeom::Vector3D<Precision> const &resultVec, // Output of new method
+    const char *vecName,
+    Precision thresholdRel // fraction difference allowed
+)
 // Returns 'true' if values are 'bad'...
 {
-   bool bad = false; // Good ..
-   Precision magOrig= originalVec.Mag();
-   vecgeom::Vector3D<Precision> moveBase = baselineVec-originalVec;
-   vecgeom::Vector3D<Precision> moveRes  = resultVec-originalVec;
-   Precision magMoveBase = moveBase.Mag();
-   Precision magDiffRes  = moveRes.Mag();
+  bool bad                              = false; // Good ..
+  Precision magOrig                     = originalVec.Mag();
+  vecgeom::Vector3D<Precision> moveBase = baselineVec - originalVec;
+  vecgeom::Vector3D<Precision> moveRes  = resultVec - originalVec;
+  Precision magMoveBase                 = moveBase.Mag();
+  Precision magDiffRes                  = moveRes.Mag();
 
-   if ( std::fabs( magDiffRes / magMoveBase) - 1.0 > thresholdRel
-        || 
-        ( resultVec - baselineVec ).Mag() > thresholdRel * magMoveBase 
-      ){
-      // printf("Difference seen in vector %s : ", vecName );
-      printf("\n id %3d - Diff in %s: "
-             " new-base= %14.9g %14.9g %14.9g (mag= %14.9g) "
-             " mv_Res/mv_Base-1 = %7.3g | mv/base: 3v= %14.9g %14.9g %14.9g (mag= %9.4g)"
-             " | mv/new: 3v= %14.9g %14.9g %14.9g (mag = %14.9g)"
-             " || origVec= %14.9f %14.9f %14.9f (mag=%14.9f) | base= %14.9f %14.9f %14.9f (mag=%9.4g) \n",
-             id, vecName,
-             resultVec[0]-baselineVec[0], resultVec[1]-baselineVec[1], resultVec[2]-baselineVec[2], (resultVec-baselineVec).Mag(),
-             (moveRes.Mag() / moveBase.Mag() - 1.0),
-             moveBase[0], moveBase[1], moveBase[2], moveBase.Mag(),
-//      printf("   new-original: mag= %20.16g ,  new_vec= %14.9f , %14.9f , %14.9f \n",
-             moveRes[0], moveRes[1], moveRes[2], moveRes.Mag(),
-             originalVec[0], originalVec[1], originalVec[2], originalVec.Mag(),
-             baselineVec[0], baselineVec[1], baselineVec[2], baselineVec.Mag()     
-         );      
-      bad= true;
-   }
-   return bad;
+  if (std::fabs(magDiffRes / magMoveBase) - 1.0 > thresholdRel ||
+      (resultVec - baselineVec).Mag() > thresholdRel * magMoveBase) {
+    // printf("Difference seen in vector %s : ", vecName );
+    printf("\n id %3d - Diff in %s: "
+           " new-base= %14.9g %14.9g %14.9g (mag= %14.9g) "
+           " mv_Res/mv_Base-1 = %7.3g | mv/base: 3v= %14.9g %14.9g %14.9g (mag= %9.4g)"
+           " | mv/new: 3v= %14.9g %14.9g %14.9g (mag = %14.9g)"
+           " || origVec= %14.9f %14.9f %14.9f (mag=%14.9f) | base= %14.9f %14.9f %14.9f (mag=%9.4g) \n",
+           id, vecName, resultVec[0] - baselineVec[0], resultVec[1] - baselineVec[1], resultVec[2] - baselineVec[2],
+           (resultVec - baselineVec).Mag(), (moveRes.Mag() / moveBase.Mag() - 1.0), moveBase[0], moveBase[1],
+           moveBase[2], moveBase.Mag(),
+           //      printf("   new-original: mag= %20.16g ,  new_vec= %14.9f , %14.9f , %14.9f \n",
+           moveRes[0], moveRes[1], moveRes[2], moveRes.Mag(), originalVec[0], originalVec[1], originalVec[2],
+           originalVec.Mag(), baselineVec[0], baselineVec[1], baselineVec[2], baselineVec.Mag());
+    bad = true;
+  }
+  return bad;
 };
 
-static __device__ __host__
-void ReportSameMoveVector3D( int id,
-                             vecgeom::Vector3D<Precision> const & originalVec,
-                             vecgeom::Vector3D<Precision> const & resultVec,
-                             const char                   * vecName )
+static __device__ __host__ void ReportSameMoveVector3D(int id, vecgeom::Vector3D<Precision> const &originalVec,
+                                                       vecgeom::Vector3D<Precision> const &resultVec,
+                                                       const char *vecName)
 {
-   printf( " id %3d - Same %s: "                 
-           " mv/base: 3v= %14.9f %14.9f %14.9f (mag= %9.4g)"
-           " || origVec= %14.9f %14.9f %14.9f (mag=%14.9f) | result= %14.9f %14.9f %14.9f (mag=%9.4g) \n",
-             id, vecName,
-             resultVec[0]-originalVec[0], resultVec[1]-originalVec[1], resultVec[2]-originalVec[2],
-             (resultVec-originalVec).Mag(),
-             originalVec[0], originalVec[1], originalVec[2], originalVec.Mag(),
-             resultVec[0], resultVec[1], resultVec[2], resultVec.Mag()           
-      );
-   
+  printf(" id %3d - Same %s: "
+         " mv/base: 3v= %14.9f %14.9f %14.9f (mag= %9.4g)"
+         " || origVec= %14.9f %14.9f %14.9f (mag=%14.9f) | result= %14.9f %14.9f %14.9f (mag=%9.4g) \n",
+         id, vecName, resultVec[0] - originalVec[0], resultVec[1] - originalVec[1], resultVec[2] - originalVec[2],
+         (resultVec - originalVec).Mag(), originalVec[0], originalVec[1], originalVec[2], originalVec.Mag(),
+         resultVec[0], resultVec[1], resultVec[2], resultVec.Mag());
 }
 
-#endif  /* CompareResponses_hh */
+#endif /* CompareResponses_hh */

--- a/include/AdePT/magneticfield/ConstBzFieldStepper.h
+++ b/include/AdePT/magneticfield/ConstBzFieldStepper.h
@@ -32,8 +32,7 @@ private:
   Precision fBz;
 
 public:
-  __host__ __device__
-  ConstBzFieldStepper(float Bz = 0.) : fBz(Bz) {}
+  __host__ __device__ ConstBzFieldStepper(float Bz = 0.) : fBz(Bz) {}
 
   void SetBz(Precision Bz) { fBz = Bz; }
   Precision GetBz() const { return fBz; }
@@ -62,7 +61,7 @@ public:
       BaseType const & /*diry*/, BaseType const & /*dirz*/, BaseIType const & /*charge*/, BaseType const & /*momentum*/,
       BaseType const & /*step*/, BaseType & /*newsposx*/, BaseType & /*newposy*/, BaseType & /*newposz*/,
       BaseType & /*newdirx*/, BaseType & /*newdiry*/, BaseType & /*newdirz*/
-      ) const;
+  ) const;
 
   /**
    * this function propagates the track along the helix solution by a step
@@ -71,11 +70,11 @@ public:
    */
   template <typename Vector3D, typename BaseType, typename BaseIType>
   __host__ __device__ void DoStep(Vector3D const &pos, Vector3D const &dir, BaseIType const &charge,
-                                      BaseType const &momentum, BaseType const &step, Vector3D &newpos,
-                                      Vector3D &newdir) const
+                                  BaseType const &momentum, BaseType const &step, Vector3D &newpos,
+                                  Vector3D &newdir) const
   {
-    DoStep<BaseType,BaseIType>(pos[0], pos[1], pos[2], dir[0], dir[1], dir[2], charge, momentum, step, newpos[0], newpos[1], newpos[2],
-           newdir[0], newdir[1], newdir[2]);
+    DoStep<BaseType, BaseIType>(pos[0], pos[1], pos[2], dir[0], dir[1], dir[2], charge, momentum, step, newpos[0],
+                                newpos[1], newpos[2], newdir[0], newdir[1], newdir[2]);
   }
 
 }; // end class declaration

--- a/include/AdePT/magneticfield/ConstFieldHelixStepper.h
+++ b/include/AdePT/magneticfield/ConstFieldHelixStepper.h
@@ -33,25 +33,20 @@ public:
   // __host__ __device__
   // ConstFieldHelixStepper(); // For default initialisation only
 
-  __host__ __device__
-  ConstFieldHelixStepper(Precision Bx, Precision By, Precision Bz);
+  __host__ __device__ ConstFieldHelixStepper(Precision Bx, Precision By, Precision Bz);
 
-  __host__ __device__
-  ConstFieldHelixStepper(Precision Bfield[3]);
+  __host__ __device__ ConstFieldHelixStepper(Precision Bfield[3]);
 
-  __host__ __device__
-  ConstFieldHelixStepper(Vector3D<Precision> const &Bfield);
+  __host__ __device__ ConstFieldHelixStepper(Vector3D<Precision> const &Bfield);
 
-  void __host__ __device__
-  SetB(Precision Bx, Precision By, Precision Bz)
+  void __host__ __device__ SetB(Precision Bx, Precision By, Precision Bz)
   {
     // fB.Set(Bx, By, Bz);
     Vector3D<Precision> Bfield(Bx, By, Bz);
     CalculateDerived(Bfield);
   }
 
-  __host__ __device__  
-  Vector3D<Precision> const GetFieldVec() const { return fBmag * fUnit; }
+  __host__ __device__ Vector3D<Precision> const GetFieldVec() const { return fBmag * fUnit; }
 
   /*
   template<typename RT, typename Vector3D>
@@ -70,9 +65,9 @@ public:
    */
   template <typename Real_t, typename Int_t>
   __host__ __device__ void DoStep(Real_t const &posx, Real_t const &posy, Real_t const &posz, Real_t const &dirx,
-                                      Real_t const &diry, Real_t const &dirz, Int_t const &charge,
-                                      Real_t const &momentum, Real_t const &step, Real_t &newposx, Real_t &newposy,
-                                      Real_t &newposz, Real_t &newdirx, Real_t &newdiry, Real_t &newdirz) const;
+                                  Real_t const &diry, Real_t const &dirz, Int_t const &charge, Real_t const &momentum,
+                                  Real_t const &step, Real_t &newposx, Real_t &newposy, Real_t &newposz,
+                                  Real_t &newdirx, Real_t &newdiry, Real_t &newdirz) const;
 
   /**
    * this function propagates the track along the helix solution by a step
@@ -81,8 +76,8 @@ public:
    */
   template <typename Real_t, typename Int_t>
   inline __host__ __device__ void DoStep(Vector3D<Real_t> const &position, Vector3D<Real_t> const &direction,
-                                             Int_t const &charge, Real_t const &momentum, Real_t const &step,
-                                             Vector3D<Real_t> &endPosition, Vector3D<Real_t> &endDirection) const;
+                                         Int_t const &charge, Real_t const &momentum, Real_t const &step,
+                                         Vector3D<Real_t> &endPosition, Vector3D<Real_t> &endDirection) const;
 
   // Auxiliary methods
   template <typename Real_t, typename Int_t>
@@ -91,7 +86,7 @@ public:
                  vecgeom::Vector3D<Real_t> &endPosition, vecgeom::Vector3D<Real_t> &endDirection) const;
 
 protected:
-  inline  __host__ __device__ void CalculateDerived(Vector3D<Precision> Bvec);
+  inline __host__ __device__ void CalculateDerived(Vector3D<Precision> Bvec);
 
   template <typename Real_t>
   inline __host__ __device__ bool CheckModulus(Real_t &newdirX_v, Real_t &newdirY_v, Real_t &newdirZ_v) const;
@@ -103,30 +98,27 @@ private:
 
 }; // end class declaration
 
-inline __host__ __device__
-void ConstFieldHelixStepper::CalculateDerived(Vector3D<Precision> Bvec)
+inline __host__ __device__ void ConstFieldHelixStepper::CalculateDerived(Vector3D<Precision> Bvec)
 {
-  fBmag         = Bvec.Mag();
+  fBmag             = Bvec.Mag();
   Precision bMagInv = (1 / fBmag);
   fUnit             = {1, 0, 0};
   if (fBmag > 0) fUnit = bMagInv * Bvec;
 }
 
-inline __host__ __device__
-ConstFieldHelixStepper::ConstFieldHelixStepper(Precision Bx, Precision By, Precision Bz) // : fB(Bx, By, gBz)
+inline __host__ __device__ ConstFieldHelixStepper::ConstFieldHelixStepper(Precision Bx, Precision By,
+                                                                          Precision Bz) // : fB(Bx, By, gBz)
 {
   CalculateDerived({Bx, By, Bz});
 }
 
-inline __host__ __device__
-ConstFieldHelixStepper::ConstFieldHelixStepper(Precision B[3]) // : fB(B[0], B[1], B[2])
+inline __host__ __device__ ConstFieldHelixStepper::ConstFieldHelixStepper(Precision B[3]) // : fB(B[0], B[1], B[2])
 {
   CalculateDerived({B[0], B[1], B[2]});
 }
 
-
-inline __host__ __device__ ConstFieldHelixStepper::ConstFieldHelixStepper(
-    Vector3D<Precision> const &Bfield) // : fB(Bfield)
+inline __host__ __device__
+ConstFieldHelixStepper::ConstFieldHelixStepper(Vector3D<Precision> const &Bfield) // : fB(Bfield)
 {
   CalculateDerived(Bfield);
 }
@@ -163,11 +155,11 @@ inline void ConstFieldHelixStepper::DoStep(Real_t const &x0, Real_t const &y0, R
 
 template <typename Real_t, typename Int_t>
 inline __host__ __device__ void ConstFieldHelixStepper::DoStep(vecgeom::Vector3D<Real_t> const &startPosition,
-                                                                   vecgeom::Vector3D<Real_t> const &startDirection,
-                                                                   Int_t const &charge, Real_t const &momentum,
-                                                                   Real_t const &step,
-                                                                   vecgeom::Vector3D<Real_t> &endPosition,
-                                                                   vecgeom::Vector3D<Real_t> &endDirection) const
+                                                               vecgeom::Vector3D<Real_t> const &startDirection,
+                                                               Int_t const &charge, Real_t const &momentum,
+                                                               Real_t const &step,
+                                                               vecgeom::Vector3D<Real_t> &endPosition,
+                                                               vecgeom::Vector3D<Real_t> &endDirection) const
 {
   // const Real_t kB2C_local(-0.299792458e-3);
   const Real_t kSmall(1.E-30);
@@ -213,11 +205,10 @@ inline __host__ __device__ void ConstFieldHelixStepper::DoStep(vecgeom::Vector3D
 
   double cosphiD, sinphiD;
   sincos(phi, &sinphiD, &cosphiD);
-  
+
   Real_t cosphi = cosphiD; //  = cos(phi);
   Real_t sinphi = sinphiD; //  = sin(phi);
 
-  
   endPosition = startPosition + R * (cosphi - 1) * dirCrossVB - R * sinphi * dirVelX +
                 step * UVdotUB * dir1Field; //   'Drift' along field direction
 

--- a/include/AdePT/magneticfield/DormandPrinceRK45.h
+++ b/include/AdePT/magneticfield/DormandPrinceRK45.h
@@ -5,7 +5,7 @@
 //
 // Implementation of the Dormand Price 5(4) 7-stage Runge-Kutta integrator for AdePT.
 //
-// Notes: 
+// Notes:
 //  - Current version is restricted to Magnetic fields (see EvaluateDerivatives.)
 //  - It provides the next value of dy/ds in 'next_dydx'
 //  - It uses a large number of registers and/or stack locations - 7 derivatives + In + Out + Err
@@ -13,7 +13,7 @@
 template <class Equation_t, class T_Field, unsigned int Nvar, typename Real_t>
 class DormandPrinceRK45 // : public VScalarIntegrationStepper
 {
-   // using ThreeVector = vecgeom::Vector3D<Real_t>;
+  // using ThreeVector = vecgeom::Vector3D<Real_t>;
 
 public:
   static constexpr unsigned int kMethodOrder = 4;
@@ -21,93 +21,75 @@ public:
   // DormandPrinceRK45(const DormandPrinceRK45 &) = delete;
   // ~DormandPrinceRK45() {}
 
-  static __host__ __device__
-  void EvaluateDerivatives(const T_Field & field, const Real_t y[], int charge, Real_t dydx[]) ;
+  static __host__ __device__ void EvaluateDerivatives(const T_Field &field, const Real_t y[], int charge,
+                                                      Real_t dydx[]);
 
-  static __host__ __device__   
-  void StepWithErrorEstimate( const T_Field & field,
-                                     const Real_t * yIn, 
-                                     const Real_t * dydx,   
-                                     int    charge,
-                                     Real_t   Step,
-                                     Real_t * yOut,        // Output:  y values at end,
-                                     Real_t * yerr,        //          estimated errors, 
-                                     Real_t * next_dydx);  //          next value of dydx
+  static __host__ __device__ void StepWithErrorEstimate(const T_Field &field, const Real_t *yIn, const Real_t *dydx,
+                                                        int charge, Real_t Step,
+                                                        Real_t *yOut,       // Output:  y values at end,
+                                                        Real_t *yerr,       //          estimated errors,
+                                                        Real_t *next_dydx); //          next value of dydx
 };
 
 template <class Equation_t, class T_Field, unsigned int Nvar, typename Real_t>
-__host__ __device__ void
-DormandPrinceRK45<Equation_t, T_Field, Nvar, Real_t>::
-  EvaluateDerivatives( const T_Field& field, const Real_t yIn[], int charge, Real_t dy_ds[] )
+__host__ __device__ void DormandPrinceRK45<Equation_t, T_Field, Nvar, Real_t>::EvaluateDerivatives(const T_Field &field,
+                                                                                                   const Real_t yIn[],
+                                                                                                   int charge,
+                                                                                                   Real_t dy_ds[])
 {
-/* #ifdef VERBOSE_RHS
-    using geant::units::tesla;
-    std::cout << "DormandPrinceRK45::EvaluateDerivatives called with q= " << charge
-              << " at Position = " << yIn[0] << " y= " << yIn[1] << " z= " << yIn[2]
-              << " with Momentum = " << yIn[3] << " y= " << yIn[4] << " z= " << yIn[5] << " ";
-#endif */
-   
+  /* #ifdef VERBOSE_RHS
+      using geant::units::tesla;
+      std::cout << "DormandPrinceRK45::EvaluateDerivatives called with q= " << charge
+                << " at Position = " << yIn[0] << " y= " << yIn[1] << " z= " << yIn[2]
+                << " with Momentum = " << yIn[3] << " y= " << yIn[4] << " z= " << yIn[5] << " ";
+  #endif */
+
   // Vector3D<Real_t> Bfield;
   // Equation_t::EvaluateDerivativesReturnB( field, yIn, charge, dy_ds, Bfield );
 
-  Equation_t::EvaluateDerivatives( /* const T_Field& */ field, yIn, charge, dy_ds );
+  Equation_t::EvaluateDerivatives(/* const T_Field& */ field, yIn, charge, dy_ds);
 
- /*********
-  using copcore::units::tesla;
-  using std::setw;
-  constexpr int prec= 5;
-  constexpr int nf= prec+5;
-  int old_prec = std::cout.precision(prec);
-  std::cout << " DoPri5: Evaluate Derivatives - using B-field,  Bx= " << Bfield.x() / tesla << " By= " << Bfield.y() / tesla << " Bz= " << Bfield.z() / tesla << " ";
-  std::cout << " gives Derivs dy_ds= :  " 
-            << " x = " << setw(nf) << dy_ds[0] << " y = " << setw(nf) << dy_ds[1] << " z = " << setw(nf) << dy_ds[2]
-            << " px= " << setw(nf) << dy_ds[3] << " py= " << setw(nf) << dy_ds[4] << " pz= " << setw(nf) << dy_ds[5]
-            << std::endl;
-  std::cout.precision(old_prec);
-  ********/
+  /*********
+   using copcore::units::tesla;
+   using std::setw;
+   constexpr int prec= 5;
+   constexpr int nf= prec+5;
+   int old_prec = std::cout.precision(prec);
+   std::cout << " DoPri5: Evaluate Derivatives - using B-field,  Bx= " << Bfield.x() / tesla << " By= " << Bfield.y() /
+   tesla << " Bz= " << Bfield.z() / tesla << " "; std::cout << " gives Derivs dy_ds= :  "
+             << " x = " << setw(nf) << dy_ds[0] << " y = " << setw(nf) << dy_ds[1] << " z = " << setw(nf) << dy_ds[2]
+             << " px= " << setw(nf) << dy_ds[3] << " py= " << setw(nf) << dy_ds[4] << " pz= " << setw(nf) << dy_ds[5]
+             << std::endl;
+   std::cout.precision(old_prec);
+   ********/
 }
 
 template <class Equation_t, class T_Field, unsigned int Nvar, typename Real_t>
-inline
-__host__ __device__ void
-DormandPrinceRK45<Equation_t, T_Field, Nvar, Real_t>::
-    StepWithErrorEstimate( const T_Field & field,
-                           const Real_t  * yIn, 
-                           const Real_t  * dydx,   
-                           int      charge,
-                           Real_t   Step,
-                           Real_t * yOut, 
-                           Real_t * yErr,
-                           Real_t * next_dydx )
-// yIn and yOut MUST NOT be aliases for same array   
+inline __host__ __device__ void DormandPrinceRK45<Equation_t, T_Field, Nvar, Real_t>::StepWithErrorEstimate(
+    const T_Field &field, const Real_t *yIn, const Real_t *dydx, int charge, Real_t Step, Real_t *yOut, Real_t *yErr,
+    Real_t *next_dydx)
+// yIn and yOut MUST NOT be aliases for same array
 {
-  assert( yIn != yOut );
+  assert(yIn != yOut);
 
-  static constexpr Real_t
-    b21 = 0.2 ,
-    
-    b31 = 3.0/40.0, b32 = 9.0/40.0 ,
-    
-    b41 = 44.0/45.0, b42 = -56.0/15.0, b43 = 32.0/9.0,
-    
-    b51 = 19372.0/6561.0, b52 = -25360.0/2187.0, b53 = 64448.0/6561.0,
-    b54 = -212.0/729.0 ,
-    
-    b61 = 9017.0/3168.0 , b62 =   -355.0/33.0,   b63 =  46732.0/5247.0,
-    b64 = 49.0/176.0 ,    b65 = -5103.0/18656.0 ,
-    
-    b71 = 35.0/384.0,     b72 = 0.,   b73 = 500.0/1113.0, b74 = 125.0/192.0,
-    b75 = -2187.0/6784.0, b76 = 11.0/84.0;
+  static constexpr Real_t b21 = 0.2,
 
-  static constexpr Real_t
-    dc1 = -( b71 - 5179.0/57600.0),
-    dc2 = -( b72 - .0),
-    dc3 = -( b73 - 7571.0/16695.0),
-    dc4 = -( b74 - 393.0/640.0),
-    dc5 = -( b75 + 92097.0/339200.0),
-    dc6 = -( b76 - 187.0/2100.0),
-    dc7 = -( - 1.0/40.0 ); 
-  
+                          b31 = 3.0 / 40.0, b32 = 9.0 / 40.0,
+
+                          b41 = 44.0 / 45.0, b42 = -56.0 / 15.0, b43 = 32.0 / 9.0,
+
+                          b51 = 19372.0 / 6561.0, b52 = -25360.0 / 2187.0, b53 = 64448.0 / 6561.0, b54 = -212.0 / 729.0,
+
+                          b61 = 9017.0 / 3168.0, b62 = -355.0 / 33.0, b63 = 46732.0 / 5247.0, b64 = 49.0 / 176.0,
+                          b65 = -5103.0 / 18656.0,
+
+                          b71 = 35.0 / 384.0, b72 = 0., b73 = 500.0 / 1113.0, b74 = 125.0 / 192.0,
+                          b75 = -2187.0 / 6784.0, b76 = 11.0 / 84.0;
+
+  static constexpr Real_t dc1 = -(b71 - 5179.0 / 57600.0), dc2 = -(b72 - .0), dc3 = -(b73 - 7571.0 / 16695.0),
+                          dc4 = -(b74 - 393.0 / 640.0), dc5 = -(b75 + 92097.0 / 339200.0),
+                          dc6 = -(b76 - 187.0 / 2100.0), dc7 = -(-1.0 / 40.0);
+
   // Initialise time to t0, needed when it is not updated by the integration.
   //       [ Note: Only for time dependent fields (usually electric)
   //                 is it neccessary to integrate the time.]
@@ -121,25 +103,25 @@ DormandPrinceRK45<Equation_t, T_Field, Nvar, Real_t>::
     for (unsigned int i = 0; i < Nvar; i++) {
       yTemp2[i] = yIn[i] + b21 * Step * dydx[i];
     }
-    EvaluateDerivatives( field, yTemp2, charge, ak2); // 2nd Step
+    EvaluateDerivatives(field, yTemp2, charge, ak2); // 2nd Step
   }
-  
+
   Real_t ak3[Nvar];
   {
     Real_t yTemp3[Nvar];
     for (unsigned int i = 0; i < Nvar; i++) {
       yTemp3[i] = yIn[i] + Step * (b31 * dydx[i] + b32 * ak2[i]);
     }
-    EvaluateDerivatives( field, yTemp3, charge, ak3); // 3rd Step
+    EvaluateDerivatives(field, yTemp3, charge, ak3); // 3rd Step
   }
-  
+
   Real_t ak4[Nvar];
   {
     Real_t yTemp4[Nvar];
     for (unsigned int i = 0; i < Nvar; i++) {
       yTemp4[i] = yIn[i] + Step * (b41 * dydx[i] + b42 * ak2[i] + b43 * ak3[i]);
     }
-    EvaluateDerivatives( field, yTemp4, charge, ak4); // 4th Step
+    EvaluateDerivatives(field, yTemp4, charge, ak4); // 4th Step
   }
 
   Real_t ak5[Nvar];
@@ -148,32 +130,30 @@ DormandPrinceRK45<Equation_t, T_Field, Nvar, Real_t>::
     for (unsigned int i = 0; i < Nvar; i++) {
       yTemp5[i] = yIn[i] + Step * (b51 * dydx[i] + b52 * ak2[i] + b53 * ak3[i] + b54 * ak4[i]);
     }
-    EvaluateDerivatives( field, yTemp5, charge, ak5); // 5th Step
+    EvaluateDerivatives(field, yTemp5, charge, ak5); // 5th Step
   }
-  
+
   Real_t ak6[Nvar];
   {
     Real_t yTemp6[Nvar];
     for (unsigned int i = 0; i < Nvar; i++) {
-       yTemp6[i] =
-          yIn[i] + Step * (b61 * dydx[i] + b62 * ak2[i] + b63 * ak3[i] + b64 * ak4[i] + b65 * ak5[i]);
+      yTemp6[i] = yIn[i] + Step * (b61 * dydx[i] + b62 * ak2[i] + b63 * ak3[i] + b64 * ak4[i] + b65 * ak5[i]);
     }
-    EvaluateDerivatives( field, yTemp6, charge, ak6); // 6th Step
+    EvaluateDerivatives(field, yTemp6, charge, ak6); // 6th Step
   }
-  
+
   // Real_t ak7[Nvar];  // -> Replaced by next_dydx
-  for(unsigned int i=0;i< Nvar;i++)
-  {
-     yOut[i] = yIn[i] + Step*(b71*dydx[i]   + b72*ak2[i] + b73*ak3[i] +
-                              b74*ak4[i] + b75*ak5[i] + b76*ak6[i] );
+  for (unsigned int i = 0; i < Nvar; i++) {
+    yOut[i] =
+        yIn[i] + Step * (b71 * dydx[i] + b72 * ak2[i] + b73 * ak3[i] + b74 * ak4[i] + b75 * ak5[i] + b76 * ak6[i]);
   }
-  EvaluateDerivatives( field, yOut, charge, next_dydx); //7th and Final stage
-  
+  EvaluateDerivatives(field, yOut, charge, next_dydx); // 7th and Final stage
+
   for (unsigned int i = 0; i < Nvar; i++) {
     // Estimate error as difference between 4th and 5th order methods
     //
-    yErr[i] = Step * ( dc1 * dydx[i]   + dc2 * ak2[i] + dc3 * ak3[i] + dc4 * ak4[i]
-                     + dc5 * ak5[i] + dc6 * ak6[i] + dc7 * next_dydx[i] );
+    yErr[i] = Step * (dc1 * dydx[i] + dc2 * ak2[i] + dc3 * ak3[i] + dc4 * ak4[i] + dc5 * ak5[i] + dc6 * ak6[i] +
+                      dc7 * next_dydx[i]);
     // std::cout<< "----In Stepper, yerrr is: "<<yErr[i]<<std::endl;
   }
 #if ENABLE_CHORD_DIST
@@ -181,11 +161,11 @@ DormandPrinceRK45<Equation_t, T_Field, Nvar, Real_t>::
     // Store Input and Final values, for possible use in calculating chord
     fLastInitialVector[i] = yIn[i];
     fLastFinalVector[i]   = yOut[i];
-    fInitialDyDx[i]       = dydx[i];   // At initial point 
+    fInitialDyDx[i]       = dydx[i]; // At initial point
   }
 #endif
   // fLastStepLength = Step;
-  
+
   // std::cout << " Exiting StepWithErrorEstimate of scalar " << std::endl;
 
   return;
@@ -208,8 +188,8 @@ inline Real_t DormandPrinceRK45<Equation_t, Nvar>::DistChord() const
   Real_t midVector[3];
 
   for(int i = 0; i < 3; ++i) {
-     midVector[i] = fLastInitialVector[i] + 0.5 * fLastStepLength * 
-          (hf1 * fInitialDyDx[i] + hf2 * ak2[i] + hf3 * ak3[i] + 
+     midVector[i] = fLastInitialVector[i] + 0.5 * fLastStepLength *
+          (hf1 * fInitialDyDx[i] + hf2 * ak2[i] + hf3 * ak3[i] +
            hf4 * ak4[i] + hf5 * ak5[i] + hf6 * ak6[i] + hf7 * next_dydx[i]);
   }
   Real_t  distChord;
@@ -222,7 +202,7 @@ inline Real_t DormandPrinceRK45<Equation_t, Nvar>::DistChord() const
   // Use stored values of Initial and Endpoint + new Midpoint to evaluate
   //  distance of Chord
   distChord  = GULineSection::Distline(midPoint, initialPoint, finalPoint);
-  
+
   return distChord;
 }
 #endif
@@ -231,7 +211,6 @@ inline Real_t DormandPrinceRK45<Equation_t, Nvar>::DistChord() const
 // template <class Equation_t, unsigned int Nvar>
 // inline void DormandPrinceRK45<Equation_t, Nvar>::PrintField(const char *label, const Real_t y[Nvar],
 //                                                            const vecgeom::Vector3D<Real_t> &Bfield) const
-
 
 // template <class Equation_t, unsigned int Nvar>
 // inline void DormandPrinceRK45<Equation_t, Nvar>::PrintDyDx(const char *label, const Real_t dydx[Nvar],

--- a/include/AdePT/magneticfield/ErrorEstimatorRK.h
+++ b/include/AdePT/magneticfield/ErrorEstimatorRK.h
@@ -10,73 +10,64 @@
 #ifndef ErrorEstimatorRK_h
 #define ErrorEstimatorRK_h
 
-class ErrorEstimatorRK
-{
-  public:
-    __host__ __device__   
-    ErrorEstimatorRK( float  eps_rel_max,
-                      float  minimumStep,
-                      int    noComponents = 6
-       ) :
-        fEpsRelMax (eps_rel_max ),
-        fInvEpsilonRelSq( 1.0 / (eps_rel_max * eps_rel_max) ),
-        fMinimumStep( minimumStep )    // , fNoComponents( 6 )
-        
-    {} 
-   
-    template <class Real_t>
-    __host__ __device__    
-      Real_t EstimateSquareError( const Real_t   yError[],
-                                  const Real_t & hStep,
-                                  // const Real_t yValue[fNoComponents],
-                                  const Real_t & magMomentumSq //   Initial momentum square (used for rel. error)
-         ) const;
-    //  Returns the Maximum Square Error: the maximum between 
-    //    - position relative error square (magnitude^2): (momentum error vec)^2 / (initial momentum)^2
-    //    - momentum relative error square (magnitude^2): (position error vec)^2 / (step length)^2
-    //
-    //  Last argument enables the use of initial momentum square in calculating the relative error
+class ErrorEstimatorRK {
+public:
+  __host__ __device__ ErrorEstimatorRK(float eps_rel_max, float minimumStep, int noComponents = 6)
+      : fEpsRelMax(eps_rel_max), fInvEpsilonRelSq(1.0 / (eps_rel_max * eps_rel_max)),
+        fMinimumStep(minimumStep) // , fNoComponents( 6 )
 
-    __host__ __device__     
-    float GetMaxRelativeError() const { return fEpsRelMax; }
+  {
+  }
 
-  public:
-    static constexpr const double tinyValue = 1.0e-30; // Just to ensure there is no division by zero
-    
-  private:
-    const float  fEpsRelMax;
-    const float  fInvEpsilonRelSq; // = 1.0 / (eps_rel_max * eps_rel_max);
-    const float  fMinimumStep;
-    // constexpr int    fNoComponents = 6;
-    
+  template <class Real_t>
+  __host__ __device__ Real_t
+  EstimateSquareError(const Real_t yError[], const Real_t &hStep,
+                      // const Real_t yValue[fNoComponents],
+                      const Real_t &magMomentumSq //   Initial momentum square (used for rel. error)
+  ) const;
+  //  Returns the Maximum Square Error: the maximum between
+  //    - position relative error square (magnitude^2): (momentum error vec)^2 / (initial momentum)^2
+  //    - momentum relative error square (magnitude^2): (position error vec)^2 / (step length)^2
+  //
+  //  Last argument enables the use of initial momentum square in calculating the relative error
+
+  __host__ __device__ float GetMaxRelativeError() const { return fEpsRelMax; }
+
+public:
+  static constexpr const double tinyValue = 1.0e-30; // Just to ensure there is no division by zero
+
+private:
+  const float fEpsRelMax;
+  const float fInvEpsilonRelSq; // = 1.0 / (eps_rel_max * eps_rel_max);
+  const float fMinimumStep;
+  // constexpr int    fNoComponents = 6;
 };
 
 template <class Real_t>
-__host__ __device__
-Real_t ErrorEstimatorRK::EstimateSquareError(
-             const Real_t   yEstError[],  // [fNoComponents]
-             const Real_t & hStep,
-             const Real_t & magInitMomentumSq // (Initial) momentum square (used for rel. error)
-      ) const
+__host__ __device__ Real_t
+ErrorEstimatorRK::EstimateSquareError(const Real_t yEstError[], // [fNoComponents]
+                                      const Real_t &hStep,
+                                      const Real_t &magInitMomentumSq // (Initial) momentum square (used for rel. error)
+) const
 {
-   Real_t invMagMomentumSq = 1.0 / (magInitMomentumSq + tinyValue);
-   Real_t epsPosition;
-   Real_t errpos_sq, errmom_sq;
-   
-   epsPosition = fEpsRelMax * vecCore::math::Max(hStep, Real_t(fMinimumStep));
-   // Note: it uses the remaining step 'hStep'
-   //       Could change it to use full step size ==> move it outside loop !! 2017.11.10 JA
+  Real_t invMagMomentumSq = 1.0 / (magInitMomentumSq + tinyValue);
+  Real_t epsPosition;
+  Real_t errpos_sq, errmom_sq;
 
-   Real_t invEpsPositionSq = 1.0 / (epsPosition * epsPosition);
+  epsPosition = fEpsRelMax * vecCore::math::Max(hStep, Real_t(fMinimumStep));
+  // Note: it uses the remaining step 'hStep'
+  //       Could change it to use full step size ==> move it outside loop !! 2017.11.10 JA
 
-   // Evaluate accuracy
-   errpos_sq = yEstError[0] * yEstError[0] + yEstError[1] * yEstError[1] + yEstError[2] * yEstError[2];
-   errpos_sq *= invEpsPositionSq; // Scale relative to required tolerance
-   // Accuracy for momentum
-   
-   Real_t sumerr_sq = yEstError[3] * yEstError[3] + yEstError[4] * yEstError[4] + yEstError[5] * yEstError[5];
-   errmom_sq = fInvEpsilonRelSq * invMagMomentumSq * sumerr_sq ;
-   
-   return vecCore::math::Max(errpos_sq, errmom_sq); // Maximum Square Error
+  Real_t invEpsPositionSq = 1.0 / (epsPosition * epsPosition);
+
+  // Evaluate accuracy
+  errpos_sq = yEstError[0] * yEstError[0] + yEstError[1] * yEstError[1] + yEstError[2] * yEstError[2];
+  errpos_sq *= invEpsPositionSq; // Scale relative to required tolerance
+  // Accuracy for momentum
+
+  Real_t sumerr_sq = yEstError[3] * yEstError[3] + yEstError[4] * yEstError[4] + yEstError[5] * yEstError[5];
+  errmom_sq        = fInvEpsilonRelSq * invMagMomentumSq * sumerr_sq;
+
+  return vecCore::math::Max(errpos_sq, errmom_sq); // Maximum Square Error
 }
 #endif

--- a/include/AdePT/magneticfield/MagneticFieldEquation.h
+++ b/include/AdePT/magneticfield/MagneticFieldEquation.h
@@ -10,7 +10,7 @@
 #ifndef MagneticFieldEquation_H_
 #define MagneticFieldEquation_H_
 
-#include <iostream>   // For cout only
+#include <iostream> // For cout only
 
 // #include <VecCore/Math.h>
 #include <VecGeom/base/Vector3D.h>
@@ -18,96 +18,72 @@
 #include <AdePT/copcore/PhysicalConstants.h>
 
 template <typename MagneticField_t>
-class MagneticFieldEquation
-{
+class MagneticFieldEquation {
 public:
-
   // Key methods
   // -----------
   template <typename Real_t>
-  static __host__ __device__ void
-  EvaluateDerivativesGivenB(const Real_t y[], const Real_t Bfield[3], int charge, Real_t dy_ds[]) ;
-   //  Evaluate
-   //       dy_ds = d/ds ( position(x, y, z),  momentum (px, py, pz) )
-   //  given charge and 
-   //       y  = ( x, y, z, p_x, p_y, p_z )
-   //   Bfield = ( B_x, B_y, B_z )
+  static __host__ __device__ void EvaluateDerivativesGivenB(const Real_t y[], const Real_t Bfield[3], int charge,
+                                                            Real_t dy_ds[]);
+  //  Evaluate
+  //       dy_ds = d/ds ( position(x, y, z),  momentum (px, py, pz) )
+  //  given charge and
+  //       y  = ( x, y, z, p_x, p_y, p_z )
+  //   Bfield = ( B_x, B_y, B_z )
 
   template <typename Real_t>
-  static __host__ __device__ void
-  EvaluateDerivatives(const Real_t y[],
-                      vecgeom::Vector3D<Real_t> const & Bvec,
-                      int charge,
-                      Real_t dy_ds[] )
-   { EvaluateRhsGivenB<Real_t, int>(y, charge, Bvec, dy_ds); }
+  static __host__ __device__ void EvaluateDerivatives(const Real_t y[], vecgeom::Vector3D<Real_t> const &Bvec,
+                                                      int charge, Real_t dy_ds[])
+  {
+    EvaluateRhsGivenB<Real_t, int>(y, charge, Bvec, dy_ds);
+  }
   //  Same with Vector3D arguments
 
   template <typename Real_t>
-  static __host__ __device__ void  
-  EvaluateDerivatives( MagneticField_t const & magField,      
-                       const Real_t y[],
-                       int charge,
-                       Real_t dy_ds[]);
+  static __host__ __device__ void EvaluateDerivatives(MagneticField_t const &magField, const Real_t y[], int charge,
+                                                      Real_t dy_ds[]);
   // Same, with MagneticField_t object, used to obtain B-field.
 
   template <typename Real_t>
-  static __host__ __device__ void  
-  EvaluateDerivativesReturnB( MagneticField_t const & magField,      
-                              const Real_t y[],
-                              int charge,
-                              Real_t dy_ds[],
-                              vecgeom::Vector3D<float> & BfieldVal
-     );
+  static __host__ __device__ void EvaluateDerivativesReturnB(MagneticField_t const &magField, const Real_t y[],
+                                                             int charge, Real_t dy_ds[],
+                                                             vecgeom::Vector3D<float> &BfieldVal);
   // Same, with MagneticField_t object, used to obtain B-field.
 
-   template <typename Real_t>
-   inline __host__ __device__ void  
-   EvaluateDerivativesReturnB( MagneticField_t const & magField,
-                               vecgeom::Vector3D<float> const & position,
-                               vecgeom::Vector3D<float> const & momentum,
-                               int                charge,
-                               Real_t             dy_ds[],
-                               vecgeom::Vector3D<float>& BfieldVal
-      );
-   
+  template <typename Real_t>
+  inline __host__ __device__ void EvaluateDerivativesReturnB(MagneticField_t const &magField,
+                                                             vecgeom::Vector3D<float> const &position,
+                                                             vecgeom::Vector3D<float> const &momentum, int charge,
+                                                             Real_t dy_ds[], vecgeom::Vector3D<float> &BfieldVal);
+
   // Implementation method
   // ---------------------
-  template <typename Real_t, typename Int_t>  
-  static
-  __host__ __device__ void
-  EvaluateRhsGivenB(const Real_t                      y[/*Nvar*/],
-                    const Int_t                     & charge,
-                    const vecgeom::Vector3D<Real_t> & Bvalue,
-                    Real_t                            dy_ds[/*Nvar*/])
+  template <typename Real_t, typename Int_t>
+  static __host__ __device__ void EvaluateRhsGivenB(const Real_t y[/*Nvar*/], const Int_t &charge,
+                                                    const vecgeom::Vector3D<Real_t> &Bvalue, Real_t dy_ds[/*Nvar*/])
   {
-     vecgeom::Vector3D<Real_t> momentum = { y[3], y[4], y[5] };
-     Force( momentum, charge, Bvalue, 
-            dy_ds[0], dy_ds[1], dy_ds[2], dy_ds[3], dy_ds[4], dy_ds[5] );
-     // Force(    y[4], y[5], B[0], B[1], B[2], charge,
-     //       dy_ds[0], dy_ds[1], dy_ds[2], dy_ds[3], dy_ds[4], dy_ds[5] );
+    vecgeom::Vector3D<Real_t> momentum = {y[3], y[4], y[5]};
+    Force(momentum, charge, Bvalue, dy_ds[0], dy_ds[1], dy_ds[2], dy_ds[3], dy_ds[4], dy_ds[5]);
+    // Force(    y[4], y[5], B[0], B[1], B[2], charge,
+    //       dy_ds[0], dy_ds[1], dy_ds[2], dy_ds[3], dy_ds[4], dy_ds[5] );
   }
 
   static constexpr double gCof = copcore::units::kCLight; //   / fieldUnits::meter ;
-  static constexpr int    Nvar = 6;
-   
- private:
+  static constexpr int Nvar    = 6;
 
+private:
   template <typename Real_t, typename Int_t>
-  static __host__ __device__ void
-  Force( // Vector3D<Real_t> const & position,
-     vecgeom::Vector3D<Real_t> const & momentum,
-     Int_t  const & charge,
-     vecgeom::Vector3D<Real_t> const & Bfield,
-     // Real_t const & momentumMag, //  Magnitude of initial momentum
-     // Vector3D<Real_t>  dy_ds
-     Real_t & dx_ds, Real_t &  dy_ds, Real_t &  dz_ds,
-     Real_t & dpx_ds, Real_t & dpy_ds, Real_t & dpz_ds );
+  static __host__ __device__ void Force( // Vector3D<Real_t> const & position,
+      vecgeom::Vector3D<Real_t> const &momentum, Int_t const &charge, vecgeom::Vector3D<Real_t> const &Bfield,
+      // Real_t const & momentumMag, //  Magnitude of initial momentum
+      // Vector3D<Real_t>  dy_ds
+      Real_t &dx_ds, Real_t &dy_ds, Real_t &dz_ds, Real_t &dpx_ds, Real_t &dpy_ds, Real_t &dpz_ds);
   /******
-  template <typename Real_t, typename Int_t>   
+  template <typename Real_t, typename Int_t>
   static
   __host__ __device__ void
      Force(Real_t const & momx, Real_t const & momy, Real_t const & momz,
-           Real_t const & Bx,   Real_t const & By,   Real_t const & Bz,                             
+           Real_t const & Bx,   Real_t const & By,   Real_t const & Bz,
            Int_t  const & charge,
            // Real_t const & momentumMag, //  Magnitude of initial momentum
            Real_t &  dx_ds, Real_t &  dy_ds, Real_t &  dz_ds,
@@ -115,29 +91,24 @@ public:
      ) ;
   *********/
   //  Implements the Lorentz force for RK integration of d/ds ( x, y, z, px, py, pz )
-   
 };
 // ------------------------------------------------------------------------------------
 
 template <typename MagField_t>
 template <typename Real_t, typename Int_t>
-inline
-__host__ __device__ void
-MagneticFieldEquation<MagField_t>::
-Force( vecgeom::Vector3D<Real_t> const & momentum,
-       Int_t            const & charge,
-       vecgeom::Vector3D<Real_t> const & Bfield,
-       // Real_t const & momentumMag, //  Magnitude of initial momentum
-       // Vector3D<Real_t>  dy_ds
-       // Real_t dydsArr[/*Nvar*/]
-       Real_t & dx_ds, Real_t &  dy_ds, Real_t &  dz_ds,
-       Real_t & dpx_ds, Real_t & dpy_ds, Real_t & dpz_ds
-   )
+inline __host__ __device__ void MagneticFieldEquation<MagField_t>::Force(vecgeom::Vector3D<Real_t> const &momentum,
+                                                                         Int_t const &charge,
+                                                                         vecgeom::Vector3D<Real_t> const &Bfield,
+                                                                         // Real_t const & momentumMag, //  Magnitude of
+                                                                         // initial momentum Vector3D<Real_t>  dy_ds
+                                                                         // Real_t dydsArr[/*Nvar*/]
+                                                                         Real_t &dx_ds, Real_t &dy_ds, Real_t &dz_ds,
+                                                                         Real_t &dpx_ds, Real_t &dpy_ds, Real_t &dpz_ds)
 {
-  Real_t inv_momentum_mag = Real_t(1.) /
-     // vecCore::math::Sqrt
-     std::sqrt
-        (momentum[0] * momentum[0] + momentum[1] * momentum[1] + momentum[2] * momentum[2]);
+  Real_t inv_momentum_mag =
+      Real_t(1.) /
+      // vecCore::math::Sqrt
+      std::sqrt(momentum[0] * momentum[0] + momentum[1] * momentum[1] + momentum[2] * momentum[2]);
   //    = vdt::fast_isqrt_general( momentum_sqr, 2); // Alternative
 
   dpx_ds = (momentum[1] * Bfield[2] - momentum[2] * Bfield[1]); //    Ax = a*(Vy*Bz - Vz*By)
@@ -153,15 +124,16 @@ Force( vecgeom::Vector3D<Real_t> const & momentum,
   dpx_ds *= cof;
   dpy_ds *= cof;
   dpz_ds *= cof;
-  // std::cout << "Force(v2) - mom = " << momentum[0] << " " << momentum[1] << " " << momentum[2] << " B= " << Bfield[0] << " " << Bfield[1] << " " << Bfield[2] << "\n";
-  // std::cout << "Force(v2) - d/ds  [px] = " << dpx_ds << " [py] = " << dpy_ds << " [pz] = " << dpz_ds << "\n";
+  // std::cout << "Force(v2) - mom = " << momentum[0] << " " << momentum[1] << " " << momentum[2] << " B= " << Bfield[0]
+  // << " " << Bfield[1] << " " << Bfield[2] << "\n"; std::cout << "Force(v2) - d/ds  [px] = " << dpx_ds << " [py] = "
+  // << dpy_ds << " [pz] = " << dpz_ds << "\n";
 }
 
 // ------------------------------------------------------------------------------------
 
 /***********
 template <typename MagField_t>
-template <typename Real_t, typename Int_t>   
+template <typename Real_t, typename Int_t>
 inline
 __host__ __device__ void
 MagneticFieldEquation<MagField_t>::
@@ -178,7 +150,7 @@ MagneticFieldEquation<MagField_t>::
    vecgeom::Vector3D<Real_t> Bfield = { Bx, By, Bz };
    // Real_t dydsArr[Nvar];
    Force( Momentum, charge, Bfield, dx_ds,  dy_ds, dz_ds, dpx_ds, dpy_ds, dpz_ds );
-   
+
    // dx_ds=  dydsArr[0];    dy_ds= dydsArr[1];    dz_ds= dydsArr[2];
    // dpx_ds= dydsArr[3];   dpy_ds= dydsArr[4];   dpz_ds= dydsArr[5];
 }
@@ -195,13 +167,13 @@ MagneticFieldEquation<MagField_t>::
   dpx_ds = (momy * Bz - momz * By); //    Ax = a*(Vy*Bz - Vz*By)
   dpy_ds = (momz * Bx - momx * Bz); //    Ay = a*(Vz*Bx - Vx*Bz)
   dpz_ds = (momx * By - momy * Bx); //    Az = a*(Vx*By - Vy*Bx)
-  
+
   Real_t cof = charge * Real_t(gCof) * inv_momentum_mag;
-  
+
   dx_ds = momx * inv_momentum_mag; //  (d/ds)x = Vx/V
   dy_ds = momy * inv_momentum_mag; //  (d/ds)y = Vy/V
   dz_ds = momz * inv_momentum_mag; //  (d/ds)z = Vz/V
-  
+
   dpx_ds *= cof;
   dpy_ds *= cof;
   dpz_ds *= cof;
@@ -214,95 +186,78 @@ MagneticFieldEquation<MagField_t>::
 
 template <typename MagField_t>
 template <typename Real_t>
-inline __host__ __device__ void  
-MagneticFieldEquation<MagField_t>::
-EvaluateDerivatives( MagField_t const & magField, 
-                     const Real_t        y[],
-                     int                charge,
-                     Real_t              dy_ds[])
+inline __host__ __device__ void MagneticFieldEquation<MagField_t>::EvaluateDerivatives(MagField_t const &magField,
+                                                                                       const Real_t y[], int charge,
+                                                                                       Real_t dy_ds[])
 {
-   float  Bx, By, Bz;
-   magField.Evaluate( y[0], y[1], y[2], Bx, By, Bz );
-   Real_t Bfield[3] = { Bx, By, Bz } ;
-   EvaluateDerivativesGivenB(y, Bfield, charge, dy_ds );
+  float Bx, By, Bz;
+  magField.Evaluate(y[0], y[1], y[2], Bx, By, Bz);
+  Real_t Bfield[3] = {Bx, By, Bz};
+  EvaluateDerivativesGivenB(y, Bfield, charge, dy_ds);
 }
 
 // ------------------------------------------------------------------------------------
 
 template <typename MagField_t>
 template <typename Real_t>
-inline __host__ __device__ void  
-MagneticFieldEquation<MagField_t>::
-EvaluateDerivativesReturnB( MagField_t const & magField, 
-                            const Real_t       y[],
-                            int                charge,
-                            Real_t             dy_ds[],
-                            vecgeom::Vector3D<float>& BfieldVec
-                            // float           BfieldValue[3]                                                        
-   )
+inline __host__ __device__ void MagneticFieldEquation<MagField_t>::EvaluateDerivativesReturnB(
+    MagField_t const &magField, const Real_t y[], int charge, Real_t dy_ds[], vecgeom::Vector3D<float> &BfieldVec
+    // float           BfieldValue[3]
+)
 {
-   // vecgeom::Vector3D<float>  position( y[0], y[1], y[2] );
-   // magField.Evaluate( position, BfieldVec );
-   // float Bfield[3] = { BfieldVec[0], BfieldVec[1], BfieldVec[2] } ;   
-   float Bx, By, Bz;
-   magField.Evaluate( y[0], y[1], y[2], Bx, By, Bz );
-   // std::cout << "EvalDerivRetB:  Bx= " << Bx << " By= " << By << " Bz=" << Bz << std::endl;
-   Real_t Bfield[3] = { Bx, By, Bz } ;
-   EvaluateDerivativesGivenB(y, Bfield, charge, dy_ds );
-   BfieldVec = vecgeom::Vector3D<Real_t>( Bfield[0], Bfield[1], Bfield[2] ); // Bx, By, Bz);
+  // vecgeom::Vector3D<float>  position( y[0], y[1], y[2] );
+  // magField.Evaluate( position, BfieldVec );
+  // float Bfield[3] = { BfieldVec[0], BfieldVec[1], BfieldVec[2] } ;
+  float Bx, By, Bz;
+  magField.Evaluate(y[0], y[1], y[2], Bx, By, Bz);
+  // std::cout << "EvalDerivRetB:  Bx= " << Bx << " By= " << By << " Bz=" << Bz << std::endl;
+  Real_t Bfield[3] = {Bx, By, Bz};
+  EvaluateDerivativesGivenB(y, Bfield, charge, dy_ds);
+  BfieldVec = vecgeom::Vector3D<Real_t>(Bfield[0], Bfield[1], Bfield[2]); // Bx, By, Bz);
 }
 
 // ------------------------------------------------------------------------------------
 
 template <typename MagField_t>
 template <typename Real_t>
-inline __host__ __device__ void  
-MagneticFieldEquation<MagField_t>::
-EvaluateDerivativesReturnB( MagField_t const & magField,
-                            vecgeom::Vector3D<float> const & position,
-                            vecgeom::Vector3D<float> const & momentum,
-                            int                charge,
-                            Real_t             dy_ds[],
-                            vecgeom::Vector3D<float> & BfieldVec
-                            // float           BfieldValue[3]                                                        
-   )
+inline __host__ __device__ void MagneticFieldEquation<MagField_t>::EvaluateDerivativesReturnB(
+    MagField_t const &magField, vecgeom::Vector3D<float> const &position, vecgeom::Vector3D<float> const &momentum,
+    int charge, Real_t dy_ds[], vecgeom::Vector3D<float> &BfieldVec
+    // float           BfieldValue[3]
+)
 {
-   // vecgeom::Vector3D<float>  position( y[0], y[1], y[2] );
-   // magField.Evaluate( position, BfieldVec );
-   // float Bfield[3] = { BfieldVec[0], BfieldVec[1], BfieldVec[2] } ;
-   const Real_t       y[Nvar] = { position[0], position[1], position[2], momentum[0], momentum[1], momentum[2] };
-   float Bx, By, Bz;
-   magField.Evaluate( y[0], y[1], y[2], Bx, By, Bz );
-   // std::cout << "EvalDerivRetB:  Bx= " << Bx << " By= " << By << " Bz=" << Bz << std::endl;
-   Real_t Bfield[3] = { Bx, By, Bz } ;
-   EvaluateDerivativesGivenB(y, Bfield, charge, dy_ds );
-   BfieldVec = vecgeom::Vector3D<Real_t>( Bfield[0], Bfield[1], Bfield[2] ); // Bx, By, Bz);
+  // vecgeom::Vector3D<float>  position( y[0], y[1], y[2] );
+  // magField.Evaluate( position, BfieldVec );
+  // float Bfield[3] = { BfieldVec[0], BfieldVec[1], BfieldVec[2] } ;
+  const Real_t y[Nvar] = {position[0], position[1], position[2], momentum[0], momentum[1], momentum[2]};
+  float Bx, By, Bz;
+  magField.Evaluate(y[0], y[1], y[2], Bx, By, Bz);
+  // std::cout << "EvalDerivRetB:  Bx= " << Bx << " By= " << By << " Bz=" << Bz << std::endl;
+  Real_t Bfield[3] = {Bx, By, Bz};
+  EvaluateDerivativesGivenB(y, Bfield, charge, dy_ds);
+  BfieldVec = vecgeom::Vector3D<Real_t>(Bfield[0], Bfield[1], Bfield[2]); // Bx, By, Bz);
 }
-
 
 // ------------------------------------------------------------------------------------
 
 template <typename MagField_t>
 template <typename Real_t>
-inline __host__ __device__ void
-MagneticFieldEquation<MagField_t>::
-  EvaluateDerivativesGivenB( const Real_t y[], 
-                             const Real_t Bfield[3],
-                             int charge,
-                             Real_t dy_ds[] )
+inline __host__ __device__ void MagneticFieldEquation<MagField_t>::EvaluateDerivativesGivenB(const Real_t y[],
+                                                                                             const Real_t Bfield[3],
+                                                                                             int charge, Real_t dy_ds[])
 {
-  const vecgeom::Vector3D<Real_t>  Bvec= { Bfield[0], Bfield[1], Bfield[2] };
+  const vecgeom::Vector3D<Real_t> Bvec = {Bfield[0], Bfield[1], Bfield[2]};
   EvaluateRhsGivenB<Real_t, int>(y, charge, Bvec, dy_ds);
 }
 
 // template <typename MagField_t>
 // MagneticFieldEquation<MagField_t>::
 
-/******   
+/******
   template< class Real_t>
-  static __host__ __device__ void      
+  static __host__ __device__ void
   EvaluateField(Real_t const & posx, Real_t const & posy, Real_t const & posz,
-                MagField_t const & magField, 
+                MagField_t const & magField,
                 Real_t & Bx, Real_t & By, Real_t & Bz)
   {
      magField.Evaluated (posx, posy, posz, Bx, By, Bz );

--- a/include/AdePT/magneticfield/PrintFieldVectors.h
+++ b/include/AdePT/magneticfield/PrintFieldVectors.h
@@ -6,89 +6,92 @@
 #ifndef PRINT_FIELD_VECTORS_H__
 #define PRINT_FIELD_VECTORS_H__
 
-static constexpr int NvarPrint= 6;
+static constexpr int NvarPrint = 6;
 
 #include <iostream>
 #include <iomanip>
 
 #include "VecGeom/base/Vector3D.h"
 
-namespace PrintFieldVectors { 
+namespace PrintFieldVectors {
 
-  constexpr int prec = 6;
-  constexpr int nd = prec + 4;
-  // constexpr char* numFormat= "10.6f";
-   
+constexpr int prec = 6;
+constexpr int nd   = prec + 4;
+// constexpr char* numFormat= "10.6f";
+
 template <typename Real_t>
-static inline __host__ __device__
-void Print3vec(const Real_t y[3], const char* name )
+static inline __host__ __device__ void Print3vec(const Real_t y[3], const char *name)
 {
-  char  numFormat[12];
-  char  format[64];
-  
-  sprintf( numFormat, "%%%d.%df", nd, prec );
-  sprintf( format, " %%-12s  = %s %s %s ", numFormat, numFormat, numFormat );
+  char numFormat[12];
+  char format[64];
+
+  sprintf(numFormat, "%%%d.%df", nd, prec);
+  sprintf(format, " %%-12s  = %s %s %s ", numFormat, numFormat, numFormat);
   // std::cout << " Position             = " << setw(nd) << y[0] << " " << setw(nd) << y[1] << " " << setw(nd) << y[2];
-  printf( format, name, y[0], y[1], y[2] );
+  printf(format, name, y[0], y[1], y[2]);
 }
 
 template <typename Real_t>
-static inline __host__ __device__
-void PrintScalar(const Real_t yVal, const char* name[10] )
+static inline __host__ __device__ void PrintScalar(const Real_t yVal, const char *name[10])
 {
-  char  numFormat[12];
+  char numFormat[12];
   // char  format[64];
-  
-  sprintf( numFormat, "%%%d.%df", nd, prec );
+
+  sprintf(numFormat, "%%%d.%df", nd, prec);
   // sprintf( format, " %%s            = %s ", numFormat );
   // std::cout << " Position             = " << setw(nd) << y[0] << " " << setw(nd) << y[1] << " " << setw(nd) << y[2];
   // printf( format, name, yVal );
-  printf( "%12s", name );
-  printf( numFormat, yVal );  
+  printf("%12s", name);
+  printf(numFormat, yVal);
 }
-   
+
 template <typename Real_t>
-static inline __host__ __device__
-void PrintSixvec(const Real_t y[NvarPrint], Real_t originalMomentum = -1.0, bool newline=true )
+static inline __host__ __device__ void PrintSixvec(const Real_t y[NvarPrint], Real_t originalMomentum = -1.0,
+                                                   bool newline = true)
 {
   char numFormat[12];
-  sprintf( numFormat, "%%%d.%df", nd, prec );  
+  sprintf(numFormat, "%%%d.%df", nd, prec);
 
   // printf( "\n# Six-Vector & B field \n");
-  Print3vec(  y,    "Position" );  if( newline ) { printf("\n"); }
-  Print3vec( &y[3], "Momentum" );  if( newline ) { printf("\n"); }
-
-  if( (originalMomentum != -1.0) && (originalMomentum != 0.0) ) {
-     Real_t mag = sqrt( y[3] * y[3] + y[4] * y[4]  + y[5] * y[5] );
-        //  Vector3D<Real_t>( y[3], y[4], y[5]).Mag();
-     // std::cout << " (|p|-o)/o = " << setw(nd) << (mag - originalMomentum) / originalMomentum;
-     printf( " (|p|-o)/o = " );
-     printf( numFormat, (mag - originalMomentum) / originalMomentum );
+  Print3vec(y, "Position");
+  if (newline) {
+    printf("\n");
   }
-  if( newline )   printf("\n");   
+  Print3vec(&y[3], "Momentum");
+  if (newline) {
+    printf("\n");
+  }
+
+  if ((originalMomentum != -1.0) && (originalMomentum != 0.0)) {
+    Real_t mag = sqrt(y[3] * y[3] + y[4] * y[4] + y[5] * y[5]);
+    //  Vector3D<Real_t>( y[3], y[4], y[5]).Mag();
+    // std::cout << " (|p|-o)/o = " << setw(nd) << (mag - originalMomentum) / originalMomentum;
+    printf(" (|p|-o)/o = ");
+    printf(numFormat, (mag - originalMomentum) / originalMomentum);
+  }
+  if (newline) printf("\n");
 }
 
 template <typename Real_t>
-static inline
-void PrintSixvec( vecgeom::Vector3D<Real_t> const & position, vecgeom::Vector3D<Real_t> const & momentum, Real_t origMomentumMag = -1.0  )
+static inline void PrintSixvec(vecgeom::Vector3D<Real_t> const &position, vecgeom::Vector3D<Real_t> const &momentum,
+                               Real_t origMomentumMag = -1.0)
 {
-   Real_t y[NvarPrint]= { position[0], position[1], position[2],
-                          momentum[0], momentum[1], momentum[2] };
-   PrintSixVec( y, origMomentumMag );
+  Real_t y[NvarPrint] = {position[0], position[1], position[2], momentum[0], momentum[1], momentum[2]};
+  PrintSixVec(y, origMomentumMag);
 }
 
 template <typename Real_t>
-static inline __host__ __device__
-void PrintLineSixvec(const Real_t y[NvarPrint] )
+static inline __host__ __device__ void PrintLineSixvec(const Real_t y[NvarPrint])
 {
-  Print3vec( y,     "x:" ); // std::cout << " x: " << setw(nd) << y[0] << " " << setw(nd) << y[1] << " " << setw(nd) << y[2];
-  Print3vec( &y[3],  "p:" ); // std::cout << " p: " << setw(nd) << y[3] << " " << setw(nd) << y[4] << " " << setw(nd) << y[5];
+  Print3vec(y, "x:"); // std::cout << " x: " << setw(nd) << y[0] << " " << setw(nd) << y[1] << " " << setw(nd) << y[2];
+  Print3vec(&y[3],
+            "p:"); // std::cout << " p: " << setw(nd) << y[3] << " " << setw(nd) << y[4] << " " << setw(nd) << y[5];
   printf("\n");
 }
-   
+
 template <typename Real_t>
-static inline __host__ __device__
-void PrintSixvecAndDyDx(const Real_t y[NvarPrint], int charge, const Real_t Bfield[3], Real_t const dydx[NvarPrint])
+static inline __host__ __device__ void PrintSixvecAndDyDx(const Real_t y[NvarPrint], int charge, const Real_t Bfield[3],
+                                                          Real_t const dydx[NvarPrint])
 {
   // RightHandSide<Real_t>(y, charge, dydx);
 
@@ -96,58 +99,61 @@ void PrintSixvecAndDyDx(const Real_t y[NvarPrint], int charge, const Real_t Bfie
   // Vector3D<Real_t> Bfield;
   // FieldFromY(y, Bfield);
   // EvaluateRhsGivenB(y, charge, Bfield, dydx);
-  
-  PrintSixvec( y );
+
+  PrintSixvec(y);
   // char bFieldName[12] = " B field [0-2]";
-  Print3vec<float>( Bfield, /* bFieldName ); */ " B field [0-2]"); printf("\n");
-             
+  Print3vec<float>(Bfield, /* bFieldName ); */ " B field [0-2]");
+  printf("\n");
+
   // std::cout << "# 'Force' from B field \n";
-  Print3vec( dydx ,   " dy/dx [0-2] (=dX/ds) = " );  printf("\n");
-  Print3vec( dydx+3, " dy/dx [3-5] (=dP/ds) = " );  printf("\n");
+  Print3vec(dydx, " dy/dx [0-2] (=dX/ds) = ");
+  printf("\n");
+  Print3vec(dydx + 3, " dy/dx [3-5] (=dP/ds) = ");
+  printf("\n");
 }
 
-//  std::cout.unsetf(std::ios_base::scientific);  
+//  std::cout.unsetf(std::ios_base::scientific);
 
-   
 // template <typename Real_t> static inline // __host__ __device__
-// void PrintSixvecAndDyDx(const Real_t y[NvarPrint], int charge, const Real_t Bfield[3], const Real_t dydx[NvarPrint]) { }
+// void PrintSixvecAndDyDx(const Real_t y[NvarPrint], int charge, const Real_t Bfield[3], const Real_t dydx[NvarPrint])
+// { }
 
-   
 template <typename Real_t>
 static inline // __host__ __device__
-void PrintLineSixvecDyDx(const Real_t y[NvarPrint], int charge, const Real_t Bfield[3], Real_t const dydx[NvarPrint])
+    void
+    PrintLineSixvecDyDx(const Real_t y[NvarPrint], int charge, const Real_t Bfield[3], Real_t const dydx[NvarPrint])
 {
   using std::cout;
   using std::endl;
   using std::setw;
   constexpr int linPrec = 3; // Output precision - number of significant digits
-  
-  int oldprec= std::cout.precision(linPrec);
-  
-  PrintLineSixvec( y );     // Was PrintSixvec( y, false );  
 
-  cout.setf(std::ios_base::fixed);  
+  int oldprec = std::cout.precision(linPrec);
+
+  PrintLineSixvec(y); // Was PrintSixvec( y, false );
+
+  cout.setf(std::ios_base::fixed);
   // cout << " B field [0-2]        = ";
   // cout << " B: ";
   // cout << setw(nd) << Bfield[0] << " " << setw(nd) << Bfield[1] << " " << setw(nd) << Bfield[2];
-      
+
   // cout << "# 'Force' from B field \n";
   // cout << " dy/dx [0-2] (=dX/ds) = ";
   cout << " dy_ds ";
-  cout << setw(nd) << dydx[0] << " " << setw(nd) << dydx[1] << " " << setw(nd) << dydx[2] << " | " ;
+  cout << setw(nd) << dydx[0] << " " << setw(nd) << dydx[1] << " " << setw(nd) << dydx[2] << " | ";
   // cout << " dy/dx [3-5] (=dP/ds) = ";
-  cout << setw(nd+2) << dydx[3] << " " << setw(nd+2) << dydx[4] << " " << setw(nd+2) << dydx[5]; 
+  cout << setw(nd + 2) << dydx[3] << " " << setw(nd + 2) << dydx[4] << " " << setw(nd + 2) << dydx[5];
   cout.unsetf(std::ios_base::fixed);
   cout << std::endl;
   cout.precision(oldprec);
 }
 
-//  cout.unsetf(std::ios_base::scientific);  
+//  cout.unsetf(std::ios_base::scientific);
 
-   
 // template <typename Real_t> static inline // __host__ __device__
-// void PrintSixvecAndDyDx(const Real_t y[NvarPrint], int charge, const Real_t Bfield[3], const Real_t dydx[NvarPrint]) { }
-   
-};
+// void PrintSixvecAndDyDx(const Real_t y[NvarPrint], int charge, const Real_t Bfield[3], const Real_t dydx[NvarPrint])
+// { }
+
+}; // namespace PrintFieldVectors
 
 #endif

--- a/include/AdePT/magneticfield/RkIntegrationDriver.h
+++ b/include/AdePT/magneticfield/RkIntegrationDriver.h
@@ -13,7 +13,7 @@
 // #include "VecGeom/base/Global.h"
 
 #include <VecCore/VecMath.h>
-#include <VecGeom/base/Vector3D.h>   // Needed for Vector3D
+#include <VecGeom/base/Vector3D.h> // Needed for Vector3D
 // #include <AdePT/copcore/PhysicalConstants.h>
 
 #include "ErrorEstimatorRK.h"
@@ -32,14 +32,13 @@ class RkIntegrationDriver {
 
 public:
   // No constructors!
-  // ----------------   
+  // ----------------
   // RkIntegrationDriver() = delete;
   // RkIntegrationDriver( const RkIntegrationDriver& ) = delete;
   // ~RkIntegrationDriver() = delete;
 
   // template<typename Real_t, typename Vector3D>
   // Real_t GetCurvature(Vector3D const & dir, float const charge, float const momentum) const;
-
 
   // Propagate the track along the numerical solution of the ODE by the requested length
   //   Inputs: current position, current direction, some particle properties, max # of steps
@@ -48,92 +47,69 @@ public:
   //
   //   Note: care needed to 'tune' max number of steps - compromise between getting work done & divergence
   //
-  // Versions: 
+  // Versions:
   //   1. Vector3D version
   // template <class Stepper_t, class Equation_t, class MagField_t>
   template <int Verbose = 1>
-  static inline __host__ __device__ bool Advance(vecgeom::Vector3D<Real_t>  & position,
-                                                 vecgeom::Vector3D<Real_t>  & momentumVec,
-                                                 Int_t  const &charge,
+  static inline __host__ __device__ bool Advance(vecgeom::Vector3D<Real_t> &position,
+                                                 vecgeom::Vector3D<Real_t> &momentumVec, Int_t const &charge,
                                                  // Real_t const &momentum,
-                                                 Real_t const &step,
-                                                 MagField_t const &magField,
-                                                 Real_t        &htry,         // Suggested integration step -- from previous stages
-                                                 Real_t  dydx_next[],          // dy_ds[Nvar] at final point (return only !! )
-                                                 Real_t  &lengthDone,
-                                                 unsigned int &totalTrials,
-                                                 unsigned int maxTrials = 5
-                                             ) ;                                                    
+                                                 Real_t const &step, MagField_t const &magField,
+                                                 Real_t &htry, // Suggested integration step -- from previous stages
+                                                 Real_t dydx_next[], // dy_ds[Nvar] at final point (return only !! )
+                                                 Real_t &lengthDone, unsigned int &totalTrials,
+                                                 unsigned int maxTrials = 5);
   //   2.  per variable version
   // template <class Stepper_t, class Equation_t, class MagField_t>
-  static inline __host__ __device__ bool
-  Advance(Real_t const &posx, Real_t const &posy, Real_t const &posz,
-          Real_t const &dirx, Real_t const &diry, Real_t const &dirz,
-          Int_t const &charge, Real_t const &momentum, Real_t const &step,
-          MagField_t const &magField,
-          Real_t        &htry,         // Suggested integration step -- from previous stages
-          Real_t &newposx, Real_t &newposy, Real_t &newposz,
-          Real_t &newdirx, Real_t &newdiry, Real_t &newdirz,
-          Real_t  dydx_next[],            // dy_ds[] at final point (return only !! )
-          Real_t &lengthDone,
-          unsigned int &totalTrials,
-          unsigned int maxTrials = 5
-     ) ;
+  static inline __host__ __device__ bool Advance(
+      Real_t const &posx, Real_t const &posy, Real_t const &posz, Real_t const &dirx, Real_t const &diry,
+      Real_t const &dirz, Int_t const &charge, Real_t const &momentum, Real_t const &step, MagField_t const &magField,
+      Real_t &htry, // Suggested integration step -- from previous stages
+      Real_t &newposx, Real_t &newposy, Real_t &newposz, Real_t &newdirx, Real_t &newdiry, Real_t &newdirz,
+      Real_t dydx_next[], // dy_ds[] at final point (return only !! )
+      Real_t &lengthDone, unsigned int &totalTrials, unsigned int maxTrials = 5);
 
-  // Versions: 
+  // Versions:
   //   1. Original Vector3D version
   // template <class Stepper_t, class Equation_t, class MagField_t>
-  static inline __host__ __device__ bool
-  AdvanceV1(vecgeom::Vector3D<Real_t> const &position,
-            vecgeom::Vector3D<Real_t> const &direction,
-            Int_t  const &charge,
-            Real_t const &momentum,
-            Real_t const &step,
-            MagField_t const &magField,
-            Real_t        &htry,  // Suggested integration step, from previous stages
-            vecgeom::Vector3D<Real_t> &endPosition,
-            vecgeom::Vector3D<Real_t> &endDirection,
-            Real_t  dydx_next[],  // dy_ds[Nvar] at final point (return only !! )
-            Real_t  &lengthDone,
-            unsigned int &totalTrials,
-            unsigned int maxTrials = 5
-     ) ;
+  static inline __host__ __device__ bool AdvanceV1(
+      vecgeom::Vector3D<Real_t> const &position, vecgeom::Vector3D<Real_t> const &direction, Int_t const &charge,
+      Real_t const &momentum, Real_t const &step, MagField_t const &magField,
+      Real_t &htry, // Suggested integration step, from previous stages
+      vecgeom::Vector3D<Real_t> &endPosition, vecgeom::Vector3D<Real_t> &endDirection,
+      Real_t dydx_next[], // dy_ds[Nvar] at final point (return only !! )
+      Real_t &lengthDone, unsigned int &totalTrials, unsigned int maxTrials = 5);
 
   // Invariants
   // ----------
-  static constexpr int    Nvar = 6;             // For now, adequate to integrate over x, y, z, px, py, pz
+  static constexpr int Nvar                   = 6;      // For now, adequate to integrate over x, y, z, px, py, pz
   static constexpr Real_t fEpsilonRelativeMax = 1.0e-6; // For now .. to be a parameter
-  static constexpr Real_t fMinimumStep=  2.0e-4 * copcore::units::millimeter;
-  static constexpr Real_t kSmall = 1.0e-30; //  amount to add to vector magnitude to avoid div by zero
-  
+  static constexpr Real_t fMinimumStep        = 2.0e-4 * copcore::units::millimeter;
+  static constexpr Real_t kSmall              = 1.0e-30; //  amount to add to vector magnitude to avoid div by zero
+
   // Auxiliary methods
   // -----------------
   // static void SetMaxRelativeError( Real_t epsMax ) { fEpsilonRelativeMax = epsMax; }
-   
+
   // template <typename Real_t, typename Int_t, class Stepper_t, class Equation_t, class MagField_t>
-  
-  static inline __host__ __device__
-  void PrintStep( vecgeom::Vector3D<Real_t> const &startPosition,
-                  vecgeom::Vector3D<Real_t> const &startDirection,
-                  Int_t const &charge, Real_t const &momentum, Real_t const &step,
-                  vecgeom::Vector3D<Real_t> &endPosition, vecgeom::Vector3D<Real_t> &endDirection);
 
-  static inline __host__ __device__ bool
-  IntegrateStep( const Real_t yStart[],
-                 const Real_t dydx[],
-                 int      charge,
-                 Real_t & xCurrent,    // InOut
-                 Real_t   htry,
-                 MagField_t  magField,                 
-                 Real_t      yEnd[],       // Out - values
-                 Real_t      next_dydx[], //     - next derivative
-                 Real_t &    hnext );
+  static inline __host__ __device__ void PrintStep(vecgeom::Vector3D<Real_t> const &startPosition,
+                                                   vecgeom::Vector3D<Real_t> const &startDirection, Int_t const &charge,
+                                                   Real_t const &momentum, Real_t const &step,
+                                                   vecgeom::Vector3D<Real_t> &endPosition,
+                                                   vecgeom::Vector3D<Real_t> &endDirection);
 
+  static inline __host__ __device__ bool IntegrateStep(const Real_t yStart[], const Real_t dydx[], int charge,
+                                                       Real_t &xCurrent, // InOut
+                                                       Real_t htry, MagField_t magField,
+                                                       Real_t yEnd[],      // Out - values
+                                                       Real_t next_dydx[], //     - next derivative
+                                                       Real_t &hnext);
 
   // static inline __host__ __device__ EquationType() { return Equation_t; }
 
 protected:
-   // template <typename Real_t>
+  // template <typename Real_t>
   static inline __host__ __device__ bool CheckModulus(Real_t &newdirX_v, Real_t &newdirY_v, Real_t &newdirZ_v);
 
 }; // end class declaration
@@ -144,139 +120,125 @@ protected:
 #include <iomanip>
 
 template <class Stepper_t, typename Real_t, typename Int_t, class Equation_t, class MagField_t>
-template <int  Verbose>
-inline __host__ __device__ 
-bool RkIntegrationDriver<Stepper_t, Real_t, Int_t, Equation_t, MagField_t>
-::Advance( vecgeom::Vector3D<Real_t> & position,       //   In/Out
-           vecgeom::Vector3D<Real_t> & momentumVec,    //   In/Out
-           Int_t      const &chargeInt,
-           // Real_t     const &momentum,
-           Real_t     const &length,
-           MagField_t const &magField,
-           Real_t           &htry,         // Suggested integration step -- from previous stages
-           Real_t  dydx_next[Nvar],            // dy_ds[] at final point (return only !! )
-           Real_t &lenAdvanced,                     // how far it advanced           
-           unsigned int &totalTrials,     // total overall steps for this integration
-           unsigned int  maxTrials       // max to do now
-   )
+template <int Verbose>
+inline __host__ __device__ bool RkIntegrationDriver<Stepper_t, Real_t, Int_t, Equation_t, MagField_t>::Advance(
+    vecgeom::Vector3D<Real_t> &position,    //   In/Out
+    vecgeom::Vector3D<Real_t> &momentumVec, //   In/Out
+    Int_t const &chargeInt,
+    // Real_t     const &momentum,
+    Real_t const &length, MagField_t const &magField,
+    Real_t &htry,              // Suggested integration step -- from previous stages
+    Real_t dydx_next[Nvar],    // dy_ds[] at final point (return only !! )
+    Real_t &lenAdvanced,       // how far it advanced
+    unsigned int &totalTrials, // total overall steps for this integration
+    unsigned int maxTrials     // max to do now
+)
 {
   using vecgeom::Vector3D;
 
-  Real_t yStart[Nvar] = {    position[0],    position[1],    position[2],
-                          momentumVec[0], momentumVec[1], momentumVec[2] };
-                        
+  Real_t yStart[Nvar] = {position[0], position[1], position[2], momentumVec[0], momentumVec[1], momentumVec[2]};
+
   // vecgeom::Vector3D<Real_t> &B0fieldVal;
   // EvaluateField( position, B0fieldVal );
 
   Real_t dydx[Nvar];
-  Real_t yEnd[Nvar];  
+  Real_t yEnd[Nvar];
   // Real_t charge= Real_t( chargeInt );
-  
+
   // Stepper_t::EquationType ??? ToDO
-  Equation_t::EvaluateDerivatives( magField, yStart, chargeInt, dydx );
+  Equation_t::EvaluateDerivatives(magField, yStart, chargeInt, dydx);
 
   // std::cout << " RK: i 00 s= " << setw(10) << lenAdvanced;
   // PrintFieldVectors::PrintLineSixvecDyDx( yStart, charge, magFieldDummy, dydx );
-  
-  Real_t x = 0.0 ;
-  Real_t hgood = 0.0;  // Length possible with adequate accuracy -- could return this for next step!
 
-  if( htry <= 0.0 || htry >= length ){
-     htry = length;
+  Real_t x     = 0.0;
+  Real_t hgood = 0.0; // Length possible with adequate accuracy -- could return this for next step!
+
+  if (htry <= 0.0 || htry >= length) {
+    htry = length;
   }
-  
-  bool done= false;
-  int  numSteps = 0;
 
-  bool allFailed = true; // Have all steps until now failed 
-  bool goodStep= false;  // last step was good
-  do
-  {
-     Real_t hnext; // , hdid;
+  bool done    = false;
+  int numSteps = 0;
 
-     goodStep= IntegrateStep(yStart, dydx, chargeInt, x, htry, magField,
-                             yEnd,   dydx_next, hnext );
+  bool allFailed = true;  // Have all steps until now failed
+  bool goodStep  = false; // last step was good
+  do {
+    Real_t hnext; // , hdid;
 
-     Real_t hdid = goodStep ? htry : 0.0 ;
-     allFailed = allFailed && !goodStep;
-     
-     lenAdvanced += hdid;
-     done =  (x >= length );     
-     hgood= vecCore::Max( hnext, Real_t(fMinimumStep) );
+    goodStep = IntegrateStep(yStart, dydx, chargeInt, x, htry, magField, yEnd, dydx_next, hnext);
+
+    Real_t hdid = goodStep ? htry : 0.0;
+    allFailed   = allFailed && !goodStep;
+
+    lenAdvanced += hdid;
+    done  = (x >= length);
+    hgood = vecCore::Max(hnext, Real_t(fMinimumStep));
 
 #ifdef RK_VERBOSE
-     Real_t htryOld = htry;
+    Real_t htryOld = htry;
 #endif
-     htry = hgood;
-     if( goodStep && !done ) {
-       for( int i=0; i< Nvar; i++ ) {
-          yStart[i] = yEnd[i];
-          dydx[i] = dydx_next[i];  // Using FSAL property !
-       }
-       htry = vecCore::Min( hgood , length - x );
-     }
+    htry = hgood;
+    if (goodStep && !done) {
+      for (int i = 0; i < Nvar; i++) {
+        yStart[i] = yEnd[i];
+        dydx[i]   = dydx_next[i]; // Using FSAL property !
+      }
+      htry = vecCore::Min(hgood, length - x);
+    }
 #ifdef RK_VERBOSE
-     if( Verbose > 1 ) {        
-         printf( " n = %4d  x = %10.5f ltot = %10.5f ", numSteps, x, lenAdvanced );
-         printf( " h:   suggested (input try) = %10.7f good? %1s next= %10.7f \n",  // did= %10.7f  good= %10.7f 
-                 htryOld,  /* did, */ ( goodStep ? "Y" : "N" ), hnext  /* , good */ );
-     }
+    if (Verbose > 1) {
+      printf(" n = %4d  x = %10.5f ltot = %10.5f ", numSteps, x, lenAdvanced);
+      printf(" h:   suggested (input try) = %10.7f good? %1s next= %10.7f \n", // did= %10.7f  good= %10.7f
+             htryOld, /* did, */ (goodStep ? "Y" : "N"), hnext /* , good */);
+    }
 #endif
 
-     ++numSteps;
+    ++numSteps;
 
-  } while ( !done && numSteps < maxTrials );
+  } while (!done && numSteps < maxTrials);
 
   totalTrials += numSteps;
 
   //  In case of failed last step, we must not use it's 'yEnd' values !!
-  if( goodStep ) {
+  if (goodStep) {
     // Real_t invM = 1.0 / (momentum+kSmall);
-    position.Set(    yEnd[0], yEnd[1], yEnd[2] );
-    momentumVec.Set( yEnd[3], yEnd[4], yEnd[5] );
+    position.Set(yEnd[0], yEnd[1], yEnd[2]);
+    momentumVec.Set(yEnd[3], yEnd[4], yEnd[5]);
     // endDirection.Set( invM*yEnd[3], invM*yEnd[4], invM*yEnd[5] );
   } else {
-    if( !allFailed ) { // numSteps == maxTrials ){
-      position.Set(    yStart[0], yStart[1], yStart[2] );
-      momentumVec.Set( yStart[3], yStart[4], yStart[5] );
+    if (!allFailed) { // numSteps == maxTrials ){
+      position.Set(yStart[0], yStart[1], yStart[2]);
+      momentumVec.Set(yStart[3], yStart[4], yStart[5]);
     }
-  }  
+  }
 
   return done;
 }
 
 // ----------------------------------------------------------------------------------------
 
-  // Versions: 
-  //   1. Vector3D version
-  // template <class Stepper_t, class Equation_t, class MagField_t>
+// Versions:
+//   1. Vector3D version
+// template <class Stepper_t, class Equation_t, class MagField_t>
 
 template <class Stepper_t, typename Real_t, typename Int_t, class Equation_t, class MagField_t>
-inline __host__ __device__ bool
-RkIntegrationDriver<Stepper_t, Real_t, Int_t, Equation_t, MagField_t>::
- AdvanceV1( vecgeom::Vector3D<Real_t> const &startPosition,
-            vecgeom::Vector3D<Real_t> const &startDirection,
-            Int_t  const &charge,
-            Real_t const &momentum,
-            Real_t const &step,
-            MagField_t const &magField,
-            Real_t        &htry,         // Suggested integration step -- from previous stages
-            vecgeom::Vector3D<Real_t> &endPosition,
-            vecgeom::Vector3D<Real_t> &endDirection,
-            Real_t  dydx_next[],          // dy_ds[Nvar] at final point (return only !! )
-            Real_t  &lengthDone,
-            unsigned int &totalTrials,
-            unsigned int maxTrials
-    )
+inline __host__ __device__ bool RkIntegrationDriver<Stepper_t, Real_t, Int_t, Equation_t, MagField_t>::AdvanceV1(
+    vecgeom::Vector3D<Real_t> const &startPosition, vecgeom::Vector3D<Real_t> const &startDirection,
+    Int_t const &charge, Real_t const &momentum, Real_t const &step, MagField_t const &magField,
+    Real_t &htry, // Suggested integration step -- from previous stages
+    vecgeom::Vector3D<Real_t> &endPosition, vecgeom::Vector3D<Real_t> &endDirection,
+    Real_t dydx_next[], // dy_ds[Nvar] at final point (return only !! )
+    Real_t &lengthDone, unsigned int &totalTrials, unsigned int maxTrials)
 {
   vecgeom::Vector3D<Real_t> positionVec = startPosition;
   vecgeom::Vector3D<Real_t> momentumVec = momentum * startDirection;
-  bool done = 
-     Advance( positionVec, momentumVec, charge, step, magField, htry, dydx_next, lengthDone, totalTrials, maxTrials );
-   
-  Real_t invM = 1.0 / (momentum+kSmall);
+  bool done =
+      Advance(positionVec, momentumVec, charge, step, magField, htry, dydx_next, lengthDone, totalTrials, maxTrials);
+
+  Real_t invM  = 1.0 / (momentum + kSmall);
   endPosition  = positionVec;
-  endDirection =  invM * momentumVec;
+  endDirection = invM * momentumVec;
 
   return done;
 }
@@ -284,71 +246,60 @@ RkIntegrationDriver<Stepper_t, Real_t, Int_t, Equation_t, MagField_t>::
 // ----------------------------------------------------------------------------------------
 
 template <class Stepper_t, typename Real_t, typename Int_t, class Equation_t, class MagField_t>
-inline __host__ __device__ bool
-RkIntegrationDriver<Stepper_t, Real_t, Int_t, Equation_t, MagField_t>::
-  IntegrateStep( const Real_t yStart[],
-                 const Real_t dydx[],
-                 int         charge,
-                 Real_t &    xCurrent,    // InOut
-                 Real_t      htry,
-                 MagField_t  magField,
-                 // Real_t eps_rel_max,
-                 Real_t   yEnd[],       // Out - values
-                 Real_t   next_dydx[], //     - next derivative
-                 Real_t & hnext )
+inline __host__ __device__ bool RkIntegrationDriver<Stepper_t, Real_t, Int_t, Equation_t, MagField_t>::IntegrateStep(
+    const Real_t yStart[], const Real_t dydx[], int charge,
+    Real_t &xCurrent, // InOut
+    Real_t htry, MagField_t magField,
+    // Real_t eps_rel_max,
+    Real_t yEnd[],      // Out - values
+    Real_t next_dydx[], //     - next derivative
+    Real_t &hnext)
 {
-   constexpr Real_t safetyFactor= 0.9;
-   constexpr Real_t shrinkPower = -1.0 /  Real_t(Stepper_t::kMethodOrder);
-   constexpr Real_t growPower   = -1.0 / (Real_t(Stepper_t::kMethodOrder+1));
-   constexpr Real_t max_step_increase = 10.0; // Step size must not grow   more than 10x
-   constexpr Real_t max_step_decrease = 0.1;  // Step size must not shrink more than 10x   
-   // const     Real_t errcon = std::pow( max_step_increase / safetyFactor , 1.0/growPower );
+  constexpr Real_t safetyFactor      = 0.9;
+  constexpr Real_t shrinkPower       = -1.0 / Real_t(Stepper_t::kMethodOrder);
+  constexpr Real_t growPower         = -1.0 / (Real_t(Stepper_t::kMethodOrder + 1));
+  constexpr Real_t max_step_increase = 10.0; // Step size must not grow   more than 10x
+  constexpr Real_t max_step_decrease = 0.1;  // Step size must not shrink more than 10x
+  // const     Real_t errcon = std::pow( max_step_increase / safetyFactor , 1.0/growPower );
 
-   Real_t yErr[Nvar];
-   
-   // static constexpr iMom0 = 3;  // Momentum starts at [3]
-   // = Mag2 ( Vector3D<Real_v>( yStart[iMom0], yStart[imom0+1], yStart[iMom0+2]) );
-   Real_t magMomentumSq = yStart[3] * yStart[3] + yStart[4] * yStart[4] + yStart[5] * yStart[5];
-   
-   Stepper_t::StepWithErrorEstimate(magField,
-                                    yStart, 
-                                    dydx,   
-                                    charge,
-                                    htry,
-                                    yEnd,        // Output:  y values at end,
-                                    yErr,        //          estimated errors, 
-                                    next_dydx);  //          next value of dydx
+  Real_t yErr[Nvar];
 
-   ErrorEstimatorRK  errorEstimator(fEpsilonRelativeMax, fMinimumStep );
-   Real_t errmax_sq = errorEstimator.EstimateSquareError( yErr, htry, magMomentumSq );
+  // static constexpr iMom0 = 3;  // Momentum starts at [3]
+  // = Mag2 ( Vector3D<Real_v>( yStart[iMom0], yStart[imom0+1], yStart[iMom0+2]) );
+  Real_t magMomentumSq = yStart[3] * yStart[3] + yStart[4] * yStart[4] + yStart[5] * yStart[5];
 
-   bool goodStep = errmax_sq <= 1.0;
-   if ( goodStep )
-   {
-     xCurrent += htry;
-     // Store next_dydx ...
+  Stepper_t::StepWithErrorEstimate(magField, yStart, dydx, charge, htry,
+                                   yEnd,       // Output:  y values at end,
+                                   yErr,       //          estimated errors,
+                                   next_dydx); //          next value of dydx
+
+  ErrorEstimatorRK errorEstimator(fEpsilonRelativeMax, fMinimumStep);
+  Real_t errmax_sq = errorEstimator.EstimateSquareError(yErr, htry, magMomentumSq);
+
+  bool goodStep = errmax_sq <= 1.0;
+  if (goodStep) {
+    xCurrent += htry;
+    // Store next_dydx ...
 #if 1
-     // New code - all threads run the same code, even power ... 
-     hnext = htry * vecCore::Min( safetyFactor*vecCore::Pow(errmax_sq, Real_t(0.5)*growPower ), max_step_increase );
-#else     
-     // Compute size of next Step
-     hnext = ( errmax_sq > errcon*errcon ) ? h * safetyFactor*std::pow(errmax_sq, Real_t(0.5)*growPower )
-                                           : hnext = max_step_increase*h ;
+    // New code - all threads run the same code, even power ...
+    hnext = htry * vecCore::Min(safetyFactor * vecCore::Pow(errmax_sq, Real_t(0.5) * growPower), max_step_increase);
+#else
+    // Compute size of next Step
+    hnext = (errmax_sq > errcon * errcon) ? h * safetyFactor * std::pow(errmax_sq, Real_t(0.5) * growPower)
+                                          : hnext = max_step_increase * h;
 #endif
-   }
-   else
-   {
-     // Step failed; compute the size of retrial Step.
-     Real_t htemp = safetyFactor * htry * std::pow( errmax_sq, 0.5* shrinkPower );
-     hnext = vecCore::Max( htemp, max_step_decrease * htry );
-     // no more than than a factor of 10 smaller 
+  } else {
+    // Step failed; compute the size of retrial Step.
+    Real_t htemp = safetyFactor * htry * std::pow(errmax_sq, 0.5 * shrinkPower);
+    hnext        = vecCore::Max(htemp, max_step_decrease * htry);
+    // no more than than a factor of 10 smaller
 
-     if( xCurrent + hnext == xCurrent ) {
-        // Serious Problem --- under FLOW !!!   Report it ??????????????????????????
-        hnext = 2.0 * vecCore::math::Max( htemp, htry );
-     }
-   }
-   return goodStep;
+    if (xCurrent + hnext == xCurrent) {
+      // Serious Problem --- under FLOW !!!   Report it ??????????????????????????
+      hnext = 2.0 * vecCore::math::Max(htemp, htry);
+    }
+  }
+  return goodStep;
 }
 
 // ----------------------------------------------------------------------------------------
@@ -359,20 +310,13 @@ RkIntegrationDriver<Stepper_t, Real_t, Int_t, Equation_t, MagField_t>::
  * output: new position, new direction of particle
  */
 template <class Stepper_t, typename Real_t, typename Int_t, class Equation_t, class MagField_t>
-inline __host__ __device__ bool
-RkIntegrationDriver<Stepper_t, Real_t, Int_t, Equation_t, MagField_t>
-  ::Advance(Real_t const &x0, Real_t const &y0, Real_t const &z0,
-            Real_t const &dirX0, Real_t const &dirY0, Real_t const &dirZ0,
-            Int_t const &charge, Real_t const &momentum, Real_t const &step,
-            MagField_t const &magField,
-            Real_t        &htry,         // Suggested integration step -- from previous stages            
-            Real_t &x, Real_t &y, Real_t &z,
-            Real_t &dx, Real_t &dy, Real_t &dz,
-            Real_t dydx_next[Nvar],            
-            Real_t &lenAdvanced,                     // how far it advanced
-            unsigned int &totalTrials,
-            unsigned int maxTrials                                         
-   )
+inline __host__ __device__ bool RkIntegrationDriver<Stepper_t, Real_t, Int_t, Equation_t, MagField_t>::Advance(
+    Real_t const &x0, Real_t const &y0, Real_t const &z0, Real_t const &dirX0, Real_t const &dirY0, Real_t const &dirZ0,
+    Int_t const &charge, Real_t const &momentum, Real_t const &step, MagField_t const &magField,
+    Real_t &htry, // Suggested integration step -- from previous stages
+    Real_t &x, Real_t &y, Real_t &z, Real_t &dx, Real_t &dy, Real_t &dz, Real_t dydx_next[Nvar],
+    Real_t &lenAdvanced, // how far it advanced
+    unsigned int &totalTrials, unsigned int maxTrials)
 {
   vecgeom::Vector3D<Real_t> position(x0, y0, z0);
   vecgeom::Vector3D<Real_t> startDirection(dirX0, dirY0, dirZ0);
@@ -381,15 +325,14 @@ RkIntegrationDriver<Stepper_t, Real_t, Int_t, Equation_t, MagField_t>
   // position.Set( x0, y0, z0);
   // startDirection.Set( dirX0, dirY0, dirZ0);
 
-  bool done= 
-     Advance(position, startDirection, charge, momentum, step, magField, htry,
-             endPosition, endDirection, dydx_next, lenAdvanced, maxTrials, totalTrials);
-  x  = endPosition.x();
-  y  = endPosition.y();
-  z  = endPosition.z();
-  dx = endDirection.x();
-  dy = endDirection.y();
-  dz = endDirection.z();
+  bool done = Advance(position, startDirection, charge, momentum, step, magField, htry, endPosition, endDirection,
+                      dydx_next, lenAdvanced, maxTrials, totalTrials);
+  x         = endPosition.x();
+  y         = endPosition.y();
+  z         = endPosition.z();
+  dx        = endDirection.x();
+  dy        = endDirection.y();
+  dz        = endDirection.z();
 
   // PrintStep(position, startDirection, charge, momentum, step, endPosition, endDirection);
   return done;
@@ -398,7 +341,9 @@ RkIntegrationDriver<Stepper_t, Real_t, Int_t, Equation_t, MagField_t>
 // ----------------------------------------------------------------------------------------
 
 template <class Stepper_t, typename Real_t, typename Int_t, class Equation_t, class MagField_t>
-bool RkIntegrationDriver<Stepper_t, Real_t, Int_t, Equation_t, MagField_t>::CheckModulus(Real_t &newdirX, Real_t &newdirY, Real_t &newdirZ)
+bool RkIntegrationDriver<Stepper_t, Real_t, Int_t, Equation_t, MagField_t>::CheckModulus(Real_t &newdirX,
+                                                                                         Real_t &newdirY,
+                                                                                         Real_t &newdirZ)
 {
   constexpr float perMillion = 1.0e-6;
 
@@ -415,13 +360,10 @@ bool RkIntegrationDriver<Stepper_t, Real_t, Int_t, Equation_t, MagField_t>::Chec
 // ----------------------------------------------------------------------------------------
 
 template <class Stepper_t, typename Real_t, typename Int_t, class Equation_t, class MagField_t>
-inline __host__ __device__
-void RkIntegrationDriver<Stepper_t, Real_t, Int_t, Equation_t, MagField_t>::
-   PrintStep(vecgeom::Vector3D<Real_t> const &startPosition,
-             vecgeom::Vector3D<Real_t> const &startDirection, Int_t const &charge,
-             Real_t const &momentum, Real_t const &step,
-             vecgeom::Vector3D<Real_t> &endPosition,
-             vecgeom::Vector3D<Real_t> &endDirection)
+inline __host__ __device__ void RkIntegrationDriver<Stepper_t, Real_t, Int_t, Equation_t, MagField_t>::PrintStep(
+    vecgeom::Vector3D<Real_t> const &startPosition, vecgeom::Vector3D<Real_t> const &startDirection,
+    Int_t const &charge, Real_t const &momentum, Real_t const &step, vecgeom::Vector3D<Real_t> &endPosition,
+    vecgeom::Vector3D<Real_t> &endDirection)
 {
   // Debug printing of input & output
   printf(" HelixSteper::PrintStep \n");

--- a/include/AdePT/magneticfield/UniformMagneticField.h
+++ b/include/AdePT/magneticfield/UniformMagneticField.h
@@ -16,55 +16,50 @@ public:
   // static constexpr bool gFieldChangesEnergy = false;
 
   /** @brief Constructor providing the constant field value (cartesian) */
-  __host__ __device__   
-  UniformMagneticField(const vecgeom::Vector3D<float> &fieldVector) : fFieldComponents(fieldVector) {}
-    //:  VVectorField(gNumFieldComponents, gFieldChangesEnergy),
+  __host__ __device__ UniformMagneticField(const vecgeom::Vector3D<float> &fieldVector) : fFieldComponents(fieldVector)
+  {
+  }
+  //:  VVectorField(gNumFieldComponents, gFieldChangesEnergy),
 
   /** @brief Constructor providing the constant field value (spherical) */
-  __host__ __device__   
-  UniformMagneticField(char, double vField, double vTheta, double vPhi);
+  __host__ __device__ UniformMagneticField(char, double vField, double vTheta, double vPhi);
 
   /** @brief Destructor */
-  __host__ __device__   
-  ~UniformMagneticField() {}
+  __host__ __device__ ~UniformMagneticField() {}
 
   /** @brief Copy constructor */
-  __host__ __device__   
-  UniformMagneticField(const UniformMagneticField &p) : fFieldComponents(p.fFieldComponents) {}
-      // : VVectorField(gNumFieldComponents, gFieldChangesEnergy),
+  __host__ __device__ UniformMagneticField(const UniformMagneticField &p) : fFieldComponents(p.fFieldComponents) {}
+  // : VVectorField(gNumFieldComponents, gFieldChangesEnergy),
 
   /** Assignment operator */
-  __host__ __device__   
-  UniformMagneticField &operator=(const UniformMagneticField &p);
+  __host__ __device__ UniformMagneticField &operator=(const UniformMagneticField &p);
 
   /** @brief Templated field interface */
   template <typename Real_t>
-  __host__ __device__
-  void Evaluate(const vecgeom::Vector3D<Real_t> & /*position*/, vecgeom::Vector3D<Real_t> &fieldValue) const
+  __host__ __device__ void Evaluate(const vecgeom::Vector3D<Real_t> & /*position*/,
+                                    vecgeom::Vector3D<Real_t> &fieldValue) const
   {
     fieldValue.Set(Real_t(fFieldComponents.x()), Real_t(fFieldComponents.y()), Real_t(fFieldComponents.z()));
   }
 
   /** @brief Templated field interface */
   template <typename Real_tp1, typename Real_tp2>
-  __host__ __device__  
-  void Evaluate(Real_tp1 /*x*/, Real_tp1 /*y*/, Real_tp1 /*z*/, Real_tp2 &Bx, Real_tp2 &By, Real_tp2 &Bz ) const
+  __host__ __device__ void Evaluate(Real_tp1 /*x*/, Real_tp1 /*y*/, Real_tp1 /*z*/, Real_tp2 &Bx, Real_tp2 &By,
+                                    Real_tp2 &Bz) const
   {
-     Bx = Real_tp2(fFieldComponents.x());
-     By = Real_tp2(fFieldComponents.y());
-     Bz = Real_tp2(fFieldComponents.z());
+    Bx = Real_tp2(fFieldComponents.x());
+    By = Real_tp2(fFieldComponents.y());
+    Bz = Real_tp2(fFieldComponents.z());
   }
-   
+
   /** @brief Interface to evaluate field at location */
-  __host__ __device__   
-  void GetFieldValue(const vecgeom::Vector3D<float> &position, vecgeom::Vector3D<float> &fieldValue)
+  __host__ __device__ void GetFieldValue(const vecgeom::Vector3D<float> &position, vecgeom::Vector3D<float> &fieldValue)
   {
     Evaluate<float>(position, fieldValue);
   }
-  
-private:
-  vecgeom::Vector3D<float> fFieldComponents;  
 
+private:
+  vecgeom::Vector3D<float> fFieldComponents;
 };
 
 #endif

--- a/include/AdePT/magneticfield/fieldConstants.h
+++ b/include/AdePT/magneticfield/fieldConstants.h
@@ -8,14 +8,17 @@
 
 namespace fieldConstants {
 
-  static constexpr double kB2C = -0.299792458 * (copcore::units::GeV / (copcore::units::tesla * copcore::units::meter));
-   // 
-  static constexpr float  deltaIntersection = 1.0e-4 * copcore::units::millimeter;
-   // Accuracy required for intersection of curved trajectory with surface(s)
+static constexpr double kB2C = -0.299792458 * (copcore::units::GeV / (copcore::units::tesla * copcore::units::meter));
+//
+static constexpr float deltaIntersection = 1.0e-4 * copcore::units::millimeter;
+// Accuracy required for intersection of curved trajectory with surface(s)
 
-  static constexpr float  gEpsilonDeflect = 1.E-2 * copcore::units::cm;  // Allowable deflection during an integration step
-       // The difference between the endpoint and the projection of the straight-line path after such a step
-       // Used to ensure the accuracy of (intersecting with volumes) the curved path is well approximated by chords.
-};
+static constexpr float gEpsilonDeflect =
+    1.E-2 * copcore::units::cm; // Allowable deflection during an integration step
+                                // The difference between the endpoint and the projection of the straight-line path
+                                // after such a step Used to ensure the accuracy of (intersecting with volumes) the
+                                // curved path is well approximated by chords.
+
+}; // namespace fieldConstants
 
 #endif

--- a/include/AdePT/magneticfield/fieldPropagatorConstBany.h
+++ b/include/AdePT/magneticfield/fieldPropagatorConstBany.h
@@ -15,10 +15,9 @@ class fieldPropagatorConstBany {
   using Precision = vecgeom::Precision;
 
 public:
-  inline __host__ __device__
-  void stepInField(ConstFieldHelixStepper &helixAnyB, double kinE, double mass, int charge,
-                   Precision step, vecgeom::Vector3D<vecgeom::Precision> &position,
-                   vecgeom::Vector3D<vecgeom::Precision> &direction);
+  inline __host__ __device__ void stepInField(ConstFieldHelixStepper &helixAnyB, double kinE, double mass, int charge,
+                                              Precision step, vecgeom::Vector3D<vecgeom::Precision> &position,
+                                              vecgeom::Vector3D<vecgeom::Precision> &direction);
 };
 
 // ----------------------------------------------------------------------------
@@ -37,7 +36,7 @@ inline __host__ __device__ void fieldPropagatorConstBany::stepInField(ConstField
 
     vecgeom::Vector3D<Precision> endPosition  = position;
     vecgeom::Vector3D<Precision> endDirection = direction;
-    helixAnyB.DoStep<Precision,int>(position, direction, charge, momentumMag, step, endPosition, endDirection);
+    helixAnyB.DoStep<Precision, int>(position, direction, charge, momentumMag, step, endPosition, endDirection);
     position  = endPosition;
     direction = endDirection;
   } else {

--- a/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
+++ b/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
@@ -8,102 +8,74 @@
 
 #include <VecGeom/base/Vector3D.h>
 
-#include "fieldConstants.h"         // For kB2C factor with units
+#include "fieldConstants.h" // For kB2C factor with units
 
 #include "UniformMagneticField.h"
 #include <AdePT/magneticfield/RkIntegrationDriver.h>
 
-template<class Field_t, class RkDriver_t, typename Real_t, class Navigator>
+template <class Field_t, class RkDriver_t, typename Real_t, class Navigator>
 class fieldPropagatorRungeKutta {
 public:
-  static
-  inline __host__ __device__
-  void stepInField( Field_t const & magneticField,     
-                    Real_t kinE,
-                    Real_t mass,
-                    int charge,
-                    Real_t step,
-                    vecgeom::Vector3D<Real_t> &position,
-                    vecgeom::Vector3D<Real_t> &direction
-                    , int id // For debugging
-     );
+  static inline __host__ __device__ void stepInField(Field_t const &magneticField, Real_t kinE, Real_t mass, int charge,
+                                                     Real_t step, vecgeom::Vector3D<Real_t> &position,
+                                                     vecgeom::Vector3D<Real_t> &direction, int id // For debugging
+  );
 
-  static   
-  inline __host__ __device__
-  __host__ __device__ Real_t ComputeStepAndNextVolume(
-      Field_t const & magneticField,
-      double kinE, double mass, int charge, double physicsStep,
-      vecgeom::Vector3D<Real_t> &position,
-      vecgeom::Vector3D<Real_t> &direction,
-      vecgeom::NavStateIndex const &current_state,
-      vecgeom::NavStateIndex &next_state,
-      bool         &  propagated,
-      const Real_t &  /*safety*/,
-      const int max_iterations
-      , int & iterDone
-      , int   threadId
-     );
-   // Move the track,
-   //   updating 'position', 'direction', the next state and returning the length moved.
+  static inline __host__ __device__ __host__ __device__ Real_t ComputeStepAndNextVolume(
+      Field_t const &magneticField, double kinE, double mass, int charge, double physicsStep,
+      vecgeom::Vector3D<Real_t> &position, vecgeom::Vector3D<Real_t> &direction,
+      vecgeom::NavStateIndex const &current_state, vecgeom::NavStateIndex &next_state, bool &propagated,
+      const Real_t & /*safety*/, const int max_iterations, int &iterDone, int threadId);
+  // Move the track,
+  //   updating 'position', 'direction', the next state and returning the length moved.
 protected:
-   static inline __host__ __device__
-   void IntegrateTrackToEnd( Field_t const & magField,  // RkDriver_t &integrationDriverRK,
-                             vecgeom::Vector3D<Real_t> & position,  vecgeom::Vector3D<Real_t> & momentumVec,
-                             int charge,  Real_t stepLength
-                             , int  id               // Temporary - for debugging
-                             , bool verbose = true   //    >>2
-      );
+  static inline __host__ __device__ void IntegrateTrackToEnd(
+      Field_t const &magField, // RkDriver_t &integrationDriverRK,
+      vecgeom::Vector3D<Real_t> &position, vecgeom::Vector3D<Real_t> &momentumVec, int charge, Real_t stepLength,
+      int id // Temporary - for debugging
+      ,
+      bool verbose = true //    >>2
+  );
 
-   static inline __host__ __device__
-   bool IntegrateTrackForProgress( Field_t const & magField,  // RkDriver_t &integrationDriverRK,
-                                   vecgeom::Vector3D<Real_t> & position,
-                                   vecgeom::Vector3D<Real_t> & momentumVec,
-                                   int charge, 
-                                   Real_t & stepLength          //   In/Out - In = requested; Out = last trial / next value ??
-      // unsigned int & totalTrials
-      );
-   
-  static constexpr unsigned int fMaxTrials= 100;
-  static constexpr unsigned int Nvar = 6;       // For position (3) and momentum (3) -- invariant
+  static inline __host__ __device__ bool IntegrateTrackForProgress(
+      Field_t const &magField, // RkDriver_t &integrationDriverRK,
+      vecgeom::Vector3D<Real_t> &position, vecgeom::Vector3D<Real_t> &momentumVec, int charge,
+      Real_t &stepLength //   In/Out - In = requested; Out = last trial / next value ??
+                         // unsigned int & totalTrials
+  );
+
+  static constexpr unsigned int fMaxTrials = 100;
+  static constexpr unsigned int Nvar       = 6; // For position (3) and momentum (3) -- invariant
 
 #ifdef VECGEOM_FLOAT_PRECISION
   static constexpr Real_t kPush = 10 * vecgeom::kTolerance;
 #else
   static constexpr Real_t kPush = 0.;
 #endif
-   
+
   // Cannot change the energy (or momentum magnitude) -- currently usable only for pure magnetic fields
 };
 
-#define VERBOSE_STEP_IN_THREAD 1    // 2022.09.05  14:00 -- look for failed RK integration hAdvanced = 0.0
+#define VERBOSE_STEP_IN_THREAD 1 // 2022.09.05  14:00 -- look for failed RK integration hAdvanced = 0.0
 
 // ----------------------------------------------------------------------------
-template<class Field_t, class RkDriver_t, typename Real_t, class Navigator_t>
-inline __host__ __device__  // __host__ __device_
-void fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>
-   ::stepInField( Field_t const & magField,  // RkDriver_t &integrationDriverRK,
-                  Real_t kinE,
-                  Real_t mass,
-                  int charge,
-                  Real_t step,
-                  vecgeom::Vector3D<Real_t> &position,
-                  vecgeom::Vector3D<Real_t> &direction
-                  , int id // For debugging
-      )
+template <class Field_t, class RkDriver_t, typename Real_t, class Navigator_t>
+inline __host__ __device__ // __host__ __device_
+    void
+    fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>::stepInField(
+        Field_t const &magField, // RkDriver_t &integrationDriverRK,
+        Real_t kinE, Real_t mass, int charge, Real_t step, vecgeom::Vector3D<Real_t> &position,
+        vecgeom::Vector3D<Real_t> &direction, int id // For debugging
+    )
 {
-  Real_t momentumMag = sqrt(kinE * (kinE + 2.0 * mass));
+  Real_t momentumMag    = sqrt(kinE * (kinE + 2.0 * mass));
   Real_t invMomentumMag = 1.0 / momentumMag;
-   
-  // Only charged particles ( e-, e+, any .. ) can be propagated 
+
+  // Only charged particles ( e-, e+, any .. ) can be propagated
   vecgeom::Vector3D<Real_t> positionVec = position;
   vecgeom::Vector3D<Real_t> momentumVec = momentumMag * direction;
-  IntegrateTrackToEnd( magField,
-                       positionVec,
-                       momentumVec,
-                       charge,
-                       step
-                       , id, true  // For debugging
-     );
+  IntegrateTrackToEnd(magField, positionVec, momentumVec, charge, step, id, true // For debugging
+  );
   position  = positionVec;
   direction = invMomentumMag * momentumVec;
   // Deviation of magnitude of direction from unit indicates integration error
@@ -111,41 +83,34 @@ void fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>
 
 // ----------------------------------------------------------------------------
 
-template<class Field_t, class RkDriver_t, typename Real_t, class Navigator_t>
-inline __host__ __device__
-void fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>::IntegrateTrackToEnd(
-      // RkDriver_t & integrationDriverRK,
-      Field_t const & magField,
-      vecgeom::Vector3D<Real_t> & position,
-      vecgeom::Vector3D<Real_t> & momentumVec,
-      int charge,
-      Real_t stepLength
-      , int  id
-      , bool verbose
-   )
+template <class Field_t, class RkDriver_t, typename Real_t, class Navigator_t>
+inline __host__ __device__ void fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>::
+    IntegrateTrackToEnd(
+        // RkDriver_t & integrationDriverRK,
+        Field_t const &magField, vecgeom::Vector3D<Real_t> &position, vecgeom::Vector3D<Real_t> &momentumVec,
+        int charge, Real_t stepLength, int id, bool verbose)
 {
   // Version 1.  Finish the integration of lanes ...
   // Future alternative (ToDo):  return unfinished intergration, in order to interleave loading of other 'lanes'
 
-  const unsigned int trialsPerCall = vecCore::Min( 30U, fMaxTrials / 2) ;  // Parameter that can be tuned
-  unsigned int totalTrials=0;
-  static int callNum = 0; 
-  callNum ++;
+  const unsigned int trialsPerCall = vecCore::Min(30U, fMaxTrials / 2); // Parameter that can be tuned
+  unsigned int totalTrials         = 0;
+  static int callNum               = 0;
+  callNum++;
 
-  Real_t  lenRemains = stepLength;
+  Real_t lenRemains = stepLength;
 
-  Real_t  hTry = stepLength;    // suggested 'good' length per integration step
+  Real_t hTry     = stepLength; // suggested 'good' length per integration step
   bool unfinished = true;
 
-  Real_t  totLen = 0.0;
-  unsigned int loopCt=0;
+  Real_t totLen       = 0.0;
+  unsigned int loopCt = 0;
   do {
-    Real_t hAdvanced = 0;     //  length integrated this iteration (of do-while)
-    Real_t  dydx_end[Nvar];
-    
-    bool done=
-       RkDriver_t::Advance( position, momentumVec, charge, lenRemains, magField, hTry, dydx_end,
-                            hAdvanced, totalTrials,
+    Real_t hAdvanced = 0; //  length integrated this iteration (of do-while)
+    Real_t dydx_end[Nvar];
+
+    bool done =
+        RkDriver_t::Advance(position, momentumVec, charge, lenRemains, magField, hTry, dydx_end, hAdvanced, totalTrials,
                             // id,     // Temporary ?
                             trialsPerCall);
     //   Runge-Kutta single call ( number of steps <= trialsPerCall )
@@ -153,215 +118,201 @@ void fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>::Integr
     lenRemains -= hAdvanced;
     unfinished = lenRemains > 0.0; /// Was = !done  ... for debugging ????
 
-    totLen+= hAdvanced;
+    totLen += hAdvanced;
     loopCt++;
 
     // sumAdvanced += hAdvanced;  // Gravy ..
 
-  } while ( unfinished  && (totalTrials < fMaxTrials) );
+  } while (unfinished && (totalTrials < fMaxTrials));
 
-  
-  if( loopCt > 1 && verbose ) { printf( " fieldPropagatorRK: id %3d call %4d --- LoopCt reached %d ", id, callNum, loopCt );  }
-     
+  if (loopCt > 1 && verbose) {
+    printf(" fieldPropagatorRK: id %3d call %4d --- LoopCt reached %d ", id, callNum, loopCt);
+  }
 }
 
 // ----------------------------------------------------------------------------
 
-template<class Field_t, class RkDriver_t, typename Real_t, class Navigator_t>
-inline __host__ __device__
-bool fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>::IntegrateTrackForProgress(
-      Field_t const & magField, 
-      vecgeom::Vector3D<Real_t> & position,
-      vecgeom::Vector3D<Real_t> & momentumVec,
-      int charge,
-      Real_t & stepLength          //   In/Out - In = requested; Out = last trial / next value ??
-      // , unsigned int & totalTrials
-   )
+template <class Field_t, class RkDriver_t, typename Real_t, class Navigator_t>
+inline __host__ __device__ bool fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>::
+    IntegrateTrackForProgress(Field_t const &magField, vecgeom::Vector3D<Real_t> &position,
+                              vecgeom::Vector3D<Real_t> &momentumVec, int charge,
+                              Real_t &stepLength //   In/Out - In = requested; Out = last trial / next value ??
+                                                 // , unsigned int & totalTrials
+    )
 {
   // Version 2.  Try to get some progress in the integration of this threads - but not more than trialsPerCall ...
   // Future alternative (ToDo):  return unfinished intergration, in order to interleave loading of other 'lanes'
-  const unsigned int trialsPerCall = vecCore::Min( 6U, fMaxTrials / 2) ;  // Parameter that can be tuned
-  
-  Real_t  lenRemains = stepLength;
+  const unsigned int trialsPerCall = vecCore::Min(6U, fMaxTrials / 2); // Parameter that can be tuned
 
-  Real_t  hTry = stepLength;    // suggested 'good' length per integration step
-  bool    done= false;
+  Real_t lenRemains = stepLength;
 
-  int     totalTrials= 0;
-  Real_t  hAdvanced = 0;     //  length integrated this iteration (of do-while)  
+  Real_t hTry = stepLength; // suggested 'good' length per integration step
+  bool done   = false;
+
+  int totalTrials  = 0;
+  Real_t hAdvanced = 0; //  length integrated this iteration (of do-while)
   do {
 
-    Real_t  dydx_end[Nvar];
-    
-    done= RkDriver_t::Advance( position, momentumVec, charge, lenRemains, magField, 
-                               hTry, dydx_end, hAdvanced, totalTrials, trialsPerCall);
+    Real_t dydx_end[Nvar];
+
+    done = RkDriver_t::Advance(position, momentumVec, charge, lenRemains, magField, hTry, dydx_end, hAdvanced,
+                               totalTrials, trialsPerCall);
     //   Runge-Kutta one call for 1+ iterations ( number of steps <= trialsPerCall )
-    
+
     stepLength -= hAdvanced;
     // unfinished = !done;  // (lenRemains > 0.0);
 
-  } while ( hAdvanced == 0.0 && totalTrials < fMaxTrials );
+  } while (hAdvanced == 0.0 && totalTrials < fMaxTrials);
 
-  return done; 
+  return done;
 }
 
-template<typename Real_t>
-inline __host__ __device__ Real_t
-inverseCurvature(
-    vecgeom::Vector3D<Real_t> & momentumVec,
-    vecgeom::Vector3D<Real_t> & BfieldVec,
-    int charge
-   )
+template <typename Real_t>
+inline __host__ __device__ Real_t inverseCurvature(vecgeom::Vector3D<Real_t> &momentumVec,
+                                                   vecgeom::Vector3D<Real_t> &BfieldVec, int charge)
 {
-  Real_t bmag2 = BfieldVec.Mag2();
-  Real_t ratioOverFld = (bmag2>0) ? momentumVec.Dot(BfieldVec) / bmag2 : 0.0;
+  Real_t bmag2                      = BfieldVec.Mag2();
+  Real_t ratioOverFld               = (bmag2 > 0) ? momentumVec.Dot(BfieldVec) / bmag2 : 0.0;
   vecgeom::Vector3D<Real_t> PtransB = momentumVec - ratioOverFld * BfieldVec;
-  
-  Real_t bmag  = sqrt(bmag2);
-  
+
+  Real_t bmag = sqrt(bmag2);
+
   // Real_t curv = fabs(Track::kB2C * charge * bmag / ( PtransB.Mag() + tiny));
 
   // Calculate inverse curvature instead - save a division
-  Real_t inv_curv = fabs( PtransB.Mag()
-                          / ( fieldConstants::kB2C * Real_t(charge) * bmag + 1.0e-30)
-     );
+  Real_t inv_curv = fabs(PtransB.Mag() / (fieldConstants::kB2C * Real_t(charge) * bmag + 1.0e-30));
   return inv_curv;
 }
 
 // Determine the step along curved trajectory for charged particles in a field.
 //  ( Same name as as navigator method. )
 
-template<class Field_t, class RkDriver_t, typename Real_t, class Navigator_t>
+template <class Field_t, class RkDriver_t, typename Real_t, class Navigator_t>
 inline __host__ __device__ Real_t
-fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t> ::ComputeStepAndNextVolume(
-    Field_t const & magField,
-    double kinE, double mass, int charge, double physicsStep,
-    vecgeom::Vector3D<Real_t> & position,
-    vecgeom::Vector3D<Real_t> & direction,
-    vecgeom::NavStateIndex const & current_state,
-    vecgeom::NavStateIndex       & next_state,
-    bool         & propagated,
-    const Real_t & /*safety*/,  //  eventually In/Out ?
-    const int max_iterations
-    , int & itersDone           //  useful for now - to monitor and report -- unclear if needed later
-    , int   indx
-   )
+fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>::ComputeStepAndNextVolume(
+    Field_t const &magField, double kinE, double mass, int charge, double physicsStep,
+    vecgeom::Vector3D<Real_t> &position, vecgeom::Vector3D<Real_t> &direction,
+    vecgeom::NavStateIndex const &current_state, vecgeom::NavStateIndex &next_state, bool &propagated,
+    const Real_t & /*safety*/,               //  eventually In/Out ?
+    const int max_iterations, int &itersDone //  useful for now - to monitor and report -- unclear if needed later
+    ,
+    int indx)
 {
-   // using copcore::units::MeV;
-  
-  const Real_t momentumMag   = sqrt(kinE * (kinE + 2.0 * mass));
+  // using copcore::units::MeV;
+
+  const Real_t momentumMag              = sqrt(kinE * (kinE + 2.0 * mass));
   vecgeom::Vector3D<Real_t> momentumVec = momentumMag * direction;
 
-  vecgeom::Vector3D<Real_t>  B0fieldVec = { 0.0, 0.0, 0.0 };  // Field value at starting point
-  magField.Evaluate( position, B0fieldVec );
-  
-  Real_t inv_curv = inverseCurvature /*<Real_t>*/ ( momentumVec, B0fieldVec, charge );
-  
+  vecgeom::Vector3D<Real_t> B0fieldVec = {0.0, 0.0, 0.0}; // Field value at starting point
+  magField.Evaluate(position, B0fieldVec);
+
+  Real_t inv_curv = inverseCurvature /*<Real_t>*/ (momentumVec, B0fieldVec, charge);
+
   // acceptable lateral error from field ~ related to delta_chord sagital distance
-  const Real_t safeLength =
-     sqrt( Real_t(2.0) * fieldConstants::gEpsilonDeflect * inv_curv); // max length along curve for deflectionn
-                                        // = sqrt( 2.0 / ( invEpsD * curv) ); // Candidate for fast inv-sqrt
+  const Real_t safeLength = sqrt(Real_t(2.0) * fieldConstants::gEpsilonDeflect *
+                                 inv_curv); // max length along curve for deflectionn
+                                            // = sqrt( 2.0 / ( invEpsD * curv) ); // Candidate for fast inv-sqrt
 
   Precision maxNextSafeMove = safeLength; // It can be reduced if, at the start, a boundary is encountered
-  
+
   Real_t stepDone           = 0.0;
   Real_t remains            = physicsStep;
   const Real_t tiniest_step = 1.0e-7 * physicsStep; // Ignore remainder if < e_s * PhysicsStep
   int chordIters            = 0;
 
-  constexpr bool inZeroFieldRegion= false; // This could be a per-region flag ... - better depend on template parameter?
+  constexpr bool inZeroFieldRegion =
+      false; // This could be a per-region flag ... - better depend on template parameter?
   bool found_end = false;
 
-  if ( inZeroFieldRegion ) {
+  if (inZeroFieldRegion) {
     stepDone = Navigator_t::ComputeStepAndNextVolume(position, direction, remains, current_state, next_state, kPush);
     position += stepDone * direction;
   } else {
-    bool continueIteration = false;     
-    bool fullChord = false;
+    bool continueIteration = false;
+    bool fullChord         = false;
     // vecgeom::Vector3D<Real_t> momentumVec = momentumMag * direction;
-    const Real_t  inv_momentumMag = 1.0 / momentumMag;
+    const Real_t inv_momentumMag = 1.0 / momentumMag;
 
-    bool   lastWasZero = false;   // Debug only ?  JA 2022.09.05
-    
+    bool lastWasZero = false; // Debug only ?  JA 2022.09.05
+
     //  Locate the intersection of the curved trajectory and the boundaries of the current
     //    volume (including daughters).
     do {
       static constexpr Precision ReduceFactor = 0.1;
-      static constexpr int       ReduceIters  = 6;
+      static constexpr int ReduceIters        = 6;
 
       vecgeom::Vector3D<Real_t> endPosition    = position;
-      vecgeom::Vector3D<Real_t> endMomentumVec = momentumVec; // momentumMag * direction;
-      const Real_t safeArc = min(remains, maxNextSafeMove); // safeLength);
-      
-      IntegrateTrackToEnd( magField, endPosition, endMomentumVec, charge, safeArc, indx);
+      vecgeom::Vector3D<Real_t> endMomentumVec = momentumVec;                   // momentumMag * direction;
+      const Real_t safeArc                     = min(remains, maxNextSafeMove); // safeLength);
+
+      IntegrateTrackToEnd(magField, endPosition, endMomentumVec, charge, safeArc, indx);
       //-----------------
       vecgeom::Vector3D<Real_t> chordVec     = endPosition - position;
-      Real_t chordDist = chordVec.Length();     
+      Real_t chordDist                       = chordVec.Length();
       vecgeom::Vector3D<Real_t> endDirection = inv_momentumMag * endMomentumVec;
-      chordVec *= (1.0 / chordDist);  // Now the direction of the chord!
+      chordVec *= (1.0 / chordDist); // Now the direction of the chord!
 
       // Check Intersection
       //-- vecgeom::Vector3D<Real_t> ChordDir= (1.0/chordDist) * ChordVec;
-      Real_t linearStep = Navigator_t::ComputeStepAndNextVolume(position, chordVec, chordDist, current_state, next_state, kPush);
+      Real_t linearStep =
+          Navigator_t::ComputeStepAndNextVolume(position, chordVec, chordDist, current_state, next_state, kPush);
       Real_t curvedStep;
 
-      if( lastWasZero && chordIters >= ReduceIters ) {          
-         lastWasZero = false;         
+      if (lastWasZero && chordIters >= ReduceIters) {
+        lastWasZero = false;
       }
 
       fullChord = (linearStep == chordDist);
       if (fullChord) {
         position    = endPosition;
         momentumVec = endMomentumVec;
-        
+
         direction  = endDirection;
         curvedStep = safeArc;
 
-        maxNextSafeMove   = safeArc;  // Reset it, once a step succeeds!!
-        continueIteration = true;        
+        maxNextSafeMove   = safeArc; // Reset it, once a step succeeds!!
+        continueIteration = true;
       } else if (linearStep <= kPush + Navigator_t::kBoundaryPush && stepDone == 0) {
         // Cope with a track at a boundary that wants to bend back into the previous
         //   volume in the first step (by reducing the attempted distance.)
         // FIXME: Even for zero steps, the Navigator will return kPush + possibly
         // Navigator::kBoundaryPush instead of a real 0.
-        curvedStep = 0;
+        curvedStep  = 0;
         lastWasZero = true;
-        
+
         // Reduce the step attempted in the next iteration to navigate around
         // boundaries where the chord step may end in a volume we just left.
         maxNextSafeMove   = ReduceFactor * safeArc;
         continueIteration = chordIters < ReduceIters;
 
-        if( ! continueIteration ) {
-           // Let's move to the other side of this boundary -- this side we cannot progress !!
-           curvedStep = Navigator_t::kBoundaryPush;
+        if (!continueIteration) {
+          // Let's move to the other side of this boundary -- this side we cannot progress !!
+          curvedStep = Navigator_t::kBoundaryPush;
         }
-      }
-      else
-      {
-        assert( next_state.IsOnBoundary() );
+      } else {
+        assert(next_state.IsOnBoundary());
         // assert( linearStep == chordDist );
-        
+
         // USE the intersection point on the chord & surface as the 'solution', ie. instead
         //     of the (potential) true point on the intersection of the curve and the boundary.
         // ( This involves a bias -- typically important only for muons in trackers.
         //   Currently it's controlled/limited by the acceptable step size ie. 'safeLength' )
         Real_t fraction = chordDist > 0 ? linearStep / chordDist : 0.0;
-        curvedStep = fraction * safeArc;    
+        curvedStep      = fraction * safeArc;
 #ifndef ENDPOINT_ON_CURVE
-        // Primitive approximation of end direction and linearStep to the crossing point ...        
-        position = position + linearStep * chordVec;        
-        direction       = direction * (1.0 - fraction) + endDirection * fraction;
-        direction       = direction.Unit();
-        momentumVec     = momentumMag * direction;
+        // Primitive approximation of end direction and linearStep to the crossing point ...
+        position    = position + linearStep * chordVec;
+        direction   = direction * (1.0 - fraction) + endDirection * fraction;
+        direction   = direction.Unit();
+        momentumVec = momentumMag * direction;
         // safeArc is how much the track would have been moved if not hitting the boundary
         // We approximate the actual reduction along the curved trajectory to be the same
         // as the reduction of the full chord due to the boundary crossing.
 #else
         // Alternative approximation of end position & direction -- calling RK again
         //  Better accuracy (e.g. for comparing with Helix) -- but the point will not be on the surface !!
-        IntegrateTrackToEnd( magField, position, momentumVec, charge, curvedStep, indx);
-        direction = inv_momentumMag * momentumVec;   // momentumVec.Unit();
+        IntegrateTrackToEnd(magField, position, momentumVec, charge, curvedStep, indx);
+        direction = inv_momentumMag * momentumVec; // momentumVec.Unit();
 #endif
         continueIteration = false;
       }
@@ -370,15 +321,15 @@ fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t> ::ComputeSte
       remains -= curvedStep;
       chordIters++;
 
-      found_end = (  (curvedStep > 0) && next_state.IsOnBoundary() )      // Fix 2022.09.05 JA
-               || (remains <= tiniest_step);
+      found_end = ((curvedStep > 0) && next_state.IsOnBoundary()) // Fix 2022.09.05 JA
+                  || (remains <= tiniest_step);
 
-    } while ( !found_end && continueIteration && (chordIters < max_iterations) );
+    } while (!found_end && continueIteration && (chordIters < max_iterations));
   }
 
   propagated = found_end;
   itersDone += chordIters;
-       //  = (chordIters < max_iterations);  // ---> Misses success on the last step!
+  //  = (chordIters < max_iterations);  // ---> Misses success on the last step!
   return stepDone;
 }
 

--- a/src/AdePTConfigurationMessenger.cc
+++ b/src/AdePTConfigurationMessenger.cc
@@ -39,16 +39,20 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
   fSetVerbosityCmd->SetGuidance("Set verbosity level for the AdePT integration layer");
 
   fSetTransportBufferThresholdCmd = new G4UIcmdWithAnInteger("/adept/setTransportBufferThreshold", this);
-  fSetTransportBufferThresholdCmd->SetGuidance("Set number of particles to be buffered before triggering the transport on GPU");
+  fSetTransportBufferThresholdCmd->SetGuidance(
+      "Set number of particles to be buffered before triggering the transport on GPU");
 
   fSetMillionsOfTrackSlotsCmd = new G4UIcmdWithADouble("/adept/setMillionsOfTrackSlots", this);
-  fSetMillionsOfTrackSlotsCmd->SetGuidance("Set the total number of track slots that will be allocated on the GPU, in millions");
+  fSetMillionsOfTrackSlotsCmd->SetGuidance(
+      "Set the total number of track slots that will be allocated on the GPU, in millions");
 
   fSetMillionsOfHitSlotsCmd = new G4UIcmdWithADouble("/adept/setMillionsOfHitSlots", this);
-  fSetMillionsOfHitSlotsCmd->SetGuidance("Set the total number of hit slots that will be allocated on the GPU, in millions");
+  fSetMillionsOfHitSlotsCmd->SetGuidance(
+      "Set the total number of hit slots that will be allocated on the GPU, in millions");
 
   fSetHitBufferFlushThresholdCmd = new G4UIcmdWithADouble("/adept/setHitBufferThreshold", this);
-  fSetHitBufferFlushThresholdCmd->SetGuidance("Set the usage threshold at which the buffer of hits is copied back to the host from GPU");
+  fSetHitBufferFlushThresholdCmd->SetGuidance(
+      "Set the usage threshold at which the buffer of hits is copied back to the host from GPU");
   fSetHitBufferFlushThresholdCmd->SetParameterName("HitBufferThreshold", false);
   fSetHitBufferFlushThresholdCmd->SetRange("HitBufferThreshold>=0.&&HitBufferThreshold<=1.");
 
@@ -77,44 +81,25 @@ AdePTConfigurationMessenger::~AdePTConfigurationMessenger()
 void AdePTConfigurationMessenger::SetNewValue(G4UIcommand *command, G4String newValue)
 {
 
-  if(command == fSetSeedCmd)
-  {
+  if (command == fSetSeedCmd) {
     fAdePTConfiguration->SetRandomSeed(fSetSeedCmd->GetNewIntValue(newValue));
-  }
-  else if(command == fSetTrackInAllRegionsCmd)
-  {
+  } else if (command == fSetTrackInAllRegionsCmd) {
     fAdePTConfiguration->SetTrackInAllRegions(fSetTrackInAllRegionsCmd->GetNewBoolValue(newValue));
-  }
-  else if(command == fAddRegionCmd)
-  {
+  } else if (command == fAddRegionCmd) {
     fAdePTConfiguration->AddGPURegionName(newValue);
-  }
-  else if(command == fActivateAdePTCmd)
-  {
+  } else if (command == fActivateAdePTCmd) {
     fAdePTConfiguration->SetAdePTActivation(fActivateAdePTCmd->GetNewBoolValue(newValue));
-  }
-  else if(command == fSetVerbosityCmd)
-  {
+  } else if (command == fSetVerbosityCmd) {
     fAdePTConfiguration->SetVerbosity(fSetVerbosityCmd->GetNewIntValue(newValue));
-  }
-  else if(command == fSetTransportBufferThresholdCmd)
-  {
+  } else if (command == fSetTransportBufferThresholdCmd) {
     fAdePTConfiguration->SetTransportBufferThreshold(fSetTransportBufferThresholdCmd->GetNewIntValue(newValue));
-  }
-  else if(command == fSetMillionsOfTrackSlotsCmd)
-  {
+  } else if (command == fSetMillionsOfTrackSlotsCmd) {
     fAdePTConfiguration->SetMillionsOfTrackSlots(fSetMillionsOfTrackSlotsCmd->GetNewDoubleValue(newValue));
-  }
-  else if(command == fSetMillionsOfHitSlotsCmd)
-  {
+  } else if (command == fSetMillionsOfHitSlotsCmd) {
     fAdePTConfiguration->SetMillionsOfHitSlots(fSetMillionsOfHitSlotsCmd->GetNewDoubleValue(newValue));
-  }
-  else if(command == fSetHitBufferFlushThresholdCmd)
-  {
+  } else if (command == fSetHitBufferFlushThresholdCmd) {
     fAdePTConfiguration->SetHitBufferFlushThreshold(fSetHitBufferFlushThresholdCmd->GetNewDoubleValue(newValue));
-  }
-  else if(command == fSetGDMLCmd)
-  {
+  } else if (command == fSetGDMLCmd) {
     fAdePTConfiguration->SetVecGeomGDML(newValue);
   }
 }

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -40,19 +40,20 @@ void AdePTGeant4Integration::CreateVecGeomWorld(std::string filename)
 
 void AdePTGeant4Integration::CheckGeometry(G4HepEmState *hepEmState)
 {
-  const G4VPhysicalVolume *g4world = G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
+  const G4VPhysicalVolume *g4world =
+      G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
   const vecgeom::VPlacedVolume *vecgeomWorld = vecgeom::GeoManager::Instance().GetWorld();
-  const int *g4tohepmcindex = hepEmState->fData->fTheMatCutData->fG4MCIndexToHepEmMCIndex;
-  int nvolumes        = vecgeom::GeoManager::Instance().GetRegisteredVolumesCount();
-  
+  const int *g4tohepmcindex                  = hepEmState->fData->fTheMatCutData->fG4MCIndexToHepEmMCIndex;
+  int nvolumes                               = vecgeom::GeoManager::Instance().GetRegisteredVolumesCount();
+
   // recursive geometry visitor lambda matching one by one Geant4 and VecGeom logical volumes
   typedef std::function<void(G4VPhysicalVolume const *, vecgeom::VPlacedVolume const *)> func_t;
   func_t visitGeometry = [&](G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVolume const *vg_pvol) {
     const auto g4_lvol = g4_pvol->GetLogicalVolume();
     const auto vg_lvol = vg_pvol->GetLogicalVolume();
 
-    int nd             = g4_lvol->GetNoDaughters();
-    auto daughters     = vg_lvol->GetDaughters();
+    int nd         = g4_lvol->GetNoDaughters();
+    auto daughters = vg_lvol->GetDaughters();
 
     if (nd != daughters.size()) throw std::runtime_error("Fatal: CheckGeometry: Mismatch in number of daughters");
     // Check if transformations are matching
@@ -62,7 +63,7 @@ void AdePTGeant4Integration::CheckGeometry(G4HepEmState *hepEmState)
     auto vgtransformation  = vg_pvol->GetTransformation();
     constexpr double epsil = 1.e-8;
     for (int i = 0; i < 3; ++i) {
-        if (std::abs(g4trans[i] - vgtransformation->Translation(i)) > epsil)
+      if (std::abs(g4trans[i] - vgtransformation->Translation(i)) > epsil)
         throw std::runtime_error(
             std::string("Fatal: CheckGeometry: Mismatch between Geant4 translation for physical volume") +
             vg_pvol->GetName());
@@ -72,27 +73,26 @@ void AdePTGeant4Integration::CheckGeometry(G4HepEmState *hepEmState)
     // already checked placed volumes when re-visiting the same volumes in different branches
     if (!g4rot) g4rot = &idrot;
     for (int row = 0; row < 3; ++row) {
-        for (int col = 0; col < 3; ++col) {
+      for (int col = 0; col < 3; ++col) {
         int i = row + 3 * col;
         if (std::abs((*g4rot)(row, col) - vgtransformation->Rotation(i)) > epsil)
-            throw std::runtime_error(
-                std::string("Fatal: CheckGeometry: Mismatch between Geant4 rotation for physical volume") +
-                vg_pvol->GetName());
-        }
+          throw std::runtime_error(
+              std::string("Fatal: CheckGeometry: Mismatch between Geant4 rotation for physical volume") +
+              vg_pvol->GetName());
+      }
     }
 
     // Check the couples
     if (g4_lvol->GetMaterialCutsCouple() == nullptr)
-        throw std::runtime_error("Fatal: CheckGeometry: G4LogicalVolume " + std::string(g4_lvol->GetName()) +
-                                std::string(" has no material-cuts couple"));
+      throw std::runtime_error("Fatal: CheckGeometry: G4LogicalVolume " + std::string(g4_lvol->GetName()) +
+                               std::string(" has no material-cuts couple"));
     int g4mcindex    = g4_lvol->GetMaterialCutsCouple()->GetIndex();
     int hepemmcindex = g4tohepmcindex[g4mcindex];
     // Check consistency with G4HepEm data
     if (hepEmState->fData->fTheMatCutData->fMatCutData[hepemmcindex].fG4MatCutIndex != g4mcindex)
-        throw std::runtime_error(
-            "Fatal: CheckGeometry: Mismatch between Geant4 mcindex and corresponding G4HepEm index");
+      throw std::runtime_error("Fatal: CheckGeometry: Mismatch between Geant4 mcindex and corresponding G4HepEm index");
     if (vg_lvol->id() >= nvolumes)
-          throw std::runtime_error("Fatal: CheckGeometry: Volume id larger than number of volumes");
+      throw std::runtime_error("Fatal: CheckGeometry: Volume id larger than number of volumes");
 
     // Now do the daughters
     for (int id = 0; id < g4_lvol->GetNoDaughters(); ++id) {
@@ -114,16 +114,15 @@ void AdePTGeant4Integration::CheckGeometry(G4HepEmState *hepEmState)
 void AdePTGeant4Integration::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4HepEmState *hepEmState,
                                             bool trackInAllRegions, std::vector<std::string> *gpuRegionNames)
 {
-  const G4VPhysicalVolume *g4world = G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
+  const G4VPhysicalVolume *g4world =
+      G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
   const vecgeom::VPlacedVolume *vecgeomWorld = vecgeom::GeoManager::Instance().GetWorld();
-  const int *g4tohepmcindex = hepEmState->fData->fTheMatCutData->fG4MCIndexToHepEmMCIndex;
+  const int *g4tohepmcindex                  = hepEmState->fData->fTheMatCutData->fG4MCIndexToHepEmMCIndex;
 
   // We need to go from region names to G4Region
-  std::vector<G4Region*> gpuRegions{};
-  if(!trackInAllRegions)
-  {
-    for(std::string regionName: *(gpuRegionNames))
-    {
+  std::vector<G4Region *> gpuRegions{};
+  if (!trackInAllRegions) {
+    for (std::string regionName : *(gpuRegionNames)) {
       G4Region *region = G4RegionStore::GetInstance()->GetRegion(regionName);
       gpuRegions.push_back(region);
     }
@@ -135,32 +134,26 @@ void AdePTGeant4Integration::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4
     const auto g4_lvol = g4_pvol->GetLogicalVolume();
     const auto vg_lvol = vg_pvol->GetLogicalVolume();
     // Fill the MCC index in the array
-    int g4mcindex    = g4_lvol->GetMaterialCutsCouple()->GetIndex();
-    int hepemmcindex = g4tohepmcindex[g4mcindex];
+    int g4mcindex                      = g4_lvol->GetMaterialCutsCouple()->GetIndex();
+    int hepemmcindex                   = g4tohepmcindex[g4mcindex];
     volAuxData[vg_lvol->id()].fMCIndex = hepemmcindex;
 
     // Check if the volume belongs to a GPU region
-    if(!trackInAllRegions)
-    {
-      for(G4Region *gpuRegion: gpuRegions)
-      {
+    if (!trackInAllRegions) {
+      for (G4Region *gpuRegion : gpuRegions) {
         if (g4_lvol->GetRegion() == gpuRegion) {
           volAuxData[vg_lvol->id()].fGPUregion = 1;
         }
       }
-    }
-    else
-    {
+    } else {
       volAuxData[vg_lvol->id()].fGPUregion = 1;
     }
-    
+
     // Check if the logical volume is sensitive
     bool sens = false;
 
-    if (g4_lvol->GetSensitiveDetector() != nullptr)
-    {
-      if (volAuxData[vg_lvol->id()].fSensIndex < 0) 
-      {
+    if (g4_lvol->GetSensitiveDetector() != nullptr) {
+      if (volAuxData[vg_lvol->id()].fSensIndex < 0) {
         G4cout << "VecGeom: Making " << vg_lvol->GetName() << " sensitive" << G4endl;
       }
       volAuxData[vg_lvol->id()].fSensIndex = 1;
@@ -184,7 +177,8 @@ void AdePTGeant4Integration::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4
 
 void AdePTGeant4Integration::InitScoringData(adeptint::VolAuxData *volAuxData)
 {
-  const G4VPhysicalVolume *g4world = G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
+  const G4VPhysicalVolume *g4world =
+      G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
   const vecgeom::VPlacedVolume *vecgeomWorld = vecgeom::GeoManager::Instance().GetWorld();
 
   // Used to keep track of the current vecgeom history while visiting the tree
@@ -200,10 +194,9 @@ void AdePTGeant4Integration::InitScoringData(adeptint::VolAuxData *volAuxData)
 
     aCurrentVecgeomHistory.push_back(vg_pvol);
     aCurrentGeant4History.push_back(g4_pvol);
-    
+
     // If the volume is sensitive:
-    if(volAuxData[vg_lvol->id()].fSensIndex == 1)
-    {
+    if (volAuxData[vg_lvol->id()].fSensIndex == 1) {
       // Initialize mapping of Vecgeom sensitive PlacedVolume IDs to G4 PhysicalVolume IDs
       // In order to be able to reconstruct navigation histories based on a VecGeom Navigation State Index,
       // we need to map not only the sensitive volume, but also the ones leading up to here
@@ -222,8 +215,8 @@ void AdePTGeant4Integration::InitScoringData(adeptint::VolAuxData *volAuxData)
       // VecGeom does not strip pointers from logical volume names
       if (std::string(pvol_d->GetLogicalVolume()->GetName()).rfind(g4pvol_d->GetLogicalVolume()->GetName(), 0) != 0)
         throw std::runtime_error("Fatal: CheckGeometry: Volume names " +
-                                  std::string(pvol_d->GetLogicalVolume()->GetName()) + " and " +
-                                  std::string(g4pvol_d->GetLogicalVolume()->GetName()) + " mismatch");
+                                 std::string(pvol_d->GetLogicalVolume()->GetName()) + " and " +
+                                 std::string(g4pvol_d->GetLogicalVolume()->GetName()) + " mismatch");
       visitGeometry(g4pvol_d, pvol_d);
     }
     aCurrentVecgeomHistory.pop_back();
@@ -235,29 +228,29 @@ void AdePTGeant4Integration::InitScoringData(adeptint::VolAuxData *volAuxData)
 void AdePTGeant4Integration::ProcessGPUHits(HostScoring &aScoring, HostScoring::Stats &aStats)
 {
   // For sequential processing of hits we only need one instance of each object
-  G4NavigationHistory *fPreG4NavigationHistory = new G4NavigationHistory();
-  G4NavigationHistory *fPostG4NavigationHistory = new G4NavigationHistory();
-  G4Step *fG4Step                           = new G4Step();
-  G4TouchableHandle fPreG4TouchableHistoryHandle = new G4TouchableHistory();
+  G4NavigationHistory *fPreG4NavigationHistory    = new G4NavigationHistory();
+  G4NavigationHistory *fPostG4NavigationHistory   = new G4NavigationHistory();
+  G4Step *fG4Step                                 = new G4Step();
+  G4TouchableHandle fPreG4TouchableHistoryHandle  = new G4TouchableHistory();
   G4TouchableHandle fPostG4TouchableHistoryHandle = new G4TouchableHistory();
   fG4Step->SetPreStepPoint(new G4StepPoint());
   fG4Step->SetPostStepPoint(new G4StepPoint());
 
-  // We need the dynamic particle associated to the track to have the correct particle definition, however this can 
+  // We need the dynamic particle associated to the track to have the correct particle definition, however this can
   // only be set at construction time. Similarly, we can only set the dynamic particle for a track when creating it
   // For this reason we create one track per particle type, to be reused
   // We set position to nullptr and kinetic energy to 0 for the dynamic particle since they need to be updated per hit
   // The same goes for the G4Track global time and position
   G4ParticleDefinition *aG4ParticleDefinition;
-  G4Track *aElectronTrack = new G4Track(new G4DynamicParticle(G4ParticleTable::GetParticleTable()->FindParticle("e-"), G4ThreeVector(0,0,0), 0), 
-                                        0, 
-                                        G4ThreeVector(0,0,0));
-  G4Track *aPositronTrack = new G4Track(new G4DynamicParticle(G4ParticleTable::GetParticleTable()->FindParticle("e+"), G4ThreeVector(0,0,0), 0), 
-                                        0, 
-                                        G4ThreeVector(0,0,0));
-  G4Track *aGammaTrack = new G4Track(new G4DynamicParticle(G4ParticleTable::GetParticleTable()->FindParticle("gamma"), G4ThreeVector(0,0,0), 0), 
-                                      0, 
-                                      G4ThreeVector(0,0,0));
+  G4Track *aElectronTrack = new G4Track(
+      new G4DynamicParticle(G4ParticleTable::GetParticleTable()->FindParticle("e-"), G4ThreeVector(0, 0, 0), 0), 0,
+      G4ThreeVector(0, 0, 0));
+  G4Track *aPositronTrack = new G4Track(
+      new G4DynamicParticle(G4ParticleTable::GetParticleTable()->FindParticle("e+"), G4ThreeVector(0, 0, 0), 0), 0,
+      G4ThreeVector(0, 0, 0));
+  G4Track *aGammaTrack = new G4Track(
+      new G4DynamicParticle(G4ParticleTable::GetParticleTable()->FindParticle("gamma"), G4ThreeVector(0, 0, 0), 0), 0,
+      G4ThreeVector(0, 0, 0));
 
   // Reconstruct G4NavigationHistory and G4Step, and call the SD code for each hit
   for (size_t i = aStats.fBufferStart; i < aStats.fBufferStart + aStats.fUsedSlots; i++) {
@@ -275,25 +268,24 @@ void AdePTGeant4Integration::ProcessGPUHits(HostScoring &aScoring, HostScoring::
         ->UpdateYourself(fPostG4NavigationHistory->GetTopVolume(), fPostG4NavigationHistory);
 
     // Reconstruct G4Step
-    switch(aScoring.fGPUHitsBuffer_host[aHitIdx].fParticleType)
-    {
-      case 0:
-        fG4Step->SetTrack(aElectronTrack);
-        break;
-      case 1:
-        fG4Step->SetTrack(aPositronTrack);
-        break;
-      case 2:
-        fG4Step->SetTrack(aGammaTrack);
-        break;
+    switch (aScoring.fGPUHitsBuffer_host[aHitIdx].fParticleType) {
+    case 0:
+      fG4Step->SetTrack(aElectronTrack);
+      break;
+    case 1:
+      fG4Step->SetTrack(aPositronTrack);
+      break;
+    case 2:
+      fG4Step->SetTrack(aGammaTrack);
+      break;
     }
-    FillG4Step(&(aScoring.fGPUHitsBuffer_host[aHitIdx]), fG4Step, fPreG4TouchableHistoryHandle, fPostG4TouchableHistoryHandle);
+    FillG4Step(&(aScoring.fGPUHitsBuffer_host[aHitIdx]), fG4Step, fPreG4TouchableHistoryHandle,
+               fPostG4TouchableHistoryHandle);
 
     // Call SD code
-    G4VSensitiveDetector *aSensitiveDetector =
-            fPreG4NavigationHistory->GetVolume(fPreG4NavigationHistory->GetDepth())
-            ->GetLogicalVolume()
-            ->GetSensitiveDetector();
+    G4VSensitiveDetector *aSensitiveDetector = fPreG4NavigationHistory->GetVolume(fPreG4NavigationHistory->GetDepth())
+                                                   ->GetLogicalVolume()
+                                                   ->GetSensitiveDetector();
 
     // Double check, a nullptr here can indicate an issue reconstructing the navigation history
     assert(aSensitiveDetector != nullptr);
@@ -351,18 +343,16 @@ void AdePTGeant4Integration::FillG4NavigationHistory(unsigned int aNavIndex, G4N
   if (aG4HistoryDepth >= aLevel) aG4NavigationHistory->BackLevel(aG4HistoryDepth - aLevel);
 }
 
-void AdePTGeant4Integration::FillG4Step(GPUHit *aGPUHit, 
-                                  G4Step *aG4Step, 
-                                  G4TouchableHandle &aPreG4TouchableHandle,
-                                  G4TouchableHandle &aPostG4TouchableHandle)
+void AdePTGeant4Integration::FillG4Step(GPUHit *aGPUHit, G4Step *aG4Step, G4TouchableHandle &aPreG4TouchableHandle,
+                                        G4TouchableHandle &aPostG4TouchableHandle)
 {
   const G4ThreeVector *aPostStepPointMomentumDirection = new G4ThreeVector(aGPUHit->fPostStepPoint.fMomentumDirection);
-  const G4ThreeVector *aPostStepPointPolarization = new G4ThreeVector(aGPUHit->fPostStepPoint.fPolarization);
-  const G4ThreeVector *aPostStepPointPosition = new G4ThreeVector(aGPUHit->fPostStepPoint.fPosition);
+  const G4ThreeVector *aPostStepPointPolarization      = new G4ThreeVector(aGPUHit->fPostStepPoint.fPolarization);
+  const G4ThreeVector *aPostStepPointPosition          = new G4ThreeVector(aGPUHit->fPostStepPoint.fPosition);
 
   // G4Step
-  aG4Step->SetStepLength(aGPUHit->fStepLength);                    // Real data
-  aG4Step->SetTotalEnergyDeposit(aGPUHit->fTotalEnergyDeposit);    // Real data
+  aG4Step->SetStepLength(aGPUHit->fStepLength);                 // Real data
+  aG4Step->SetTotalEnergyDeposit(aGPUHit->fTotalEnergyDeposit); // Real data
   // aG4Step->SetNonIonizingEnergyDeposit(0);                      // Missing data
   // aG4Step->SetControlFlag(G4SteppingControl::NormalCondition);  // Missing data
   // aG4Step->SetFirstStepFlag();                                  // Missing data
@@ -374,7 +364,7 @@ void AdePTGeant4Integration::FillG4Step(GPUHit *aGPUHit,
   G4Track *aTrack = aG4Step->GetTrack();
   // aTrack->SetTrackID(0);                                                                   // Missing data
   // aTrack->SetParentID(0);                                                                  // Missing data
-  aTrack->SetPosition(*aPostStepPointPosition);                                               // Real data
+  aTrack->SetPosition(*aPostStepPointPosition); // Real data
   // aTrack->SetGlobalTime(0);                                                                // Missing data
   // aTrack->SetLocalTime(0);                                                                 // Missing data
   // aTrack->SetProperTime(0);                                                                // Missing data
@@ -382,14 +372,14 @@ void AdePTGeant4Integration::FillG4Step(GPUHit *aGPUHit,
   // aTrack->SetNextTouchableHandle(nullptr);                                                 // Missing data
   // aTrack->SetOriginTouchableHandle(nullptr);                                               // Missing data
   // aTrack->SetKineticEnergy(aGPUHit->fPostStepPoint.fEKin);                                 // Real data
-  aTrack->SetMomentumDirection(*aPostStepPointMomentumDirection);                             // Real data
+  aTrack->SetMomentumDirection(*aPostStepPointMomentumDirection); // Real data
   // aTrack->SetVelocity(0);                                                                  // Missing data
-  aTrack->SetPolarization(*aPostStepPointPolarization);                                       // Real data
+  aTrack->SetPolarization(*aPostStepPointPolarization); // Real data
   // aTrack->SetTrackStatus(G4TrackStatus::fAlive);                                           // Missing data
   // aTrack->SetBelowThresholdFlag(false);                                                    // Missing data
   // aTrack->SetGoodForTrackingFlag(false);                                                   // Missing data
-  aTrack->SetStep(aG4Step);                                                                   // Real data
-  aTrack->SetStepLength(aGPUHit->fStepLength);                                                // Real data
+  aTrack->SetStep(aG4Step);                    // Real data
+  aTrack->SetStepLength(aGPUHit->fStepLength); // Real data
   // aTrack->SetVertexPosition(G4ThreeVector(0, 0, 0));                                       // Missing data
   // aTrack->SetVertexMomentumDirection(G4ThreeVector(0, 0, 0));                              // Missing data
   // aTrack->SetVertexKineticEnergy(0);                                                       // Missing data
@@ -404,45 +394,45 @@ void AdePTGeant4Integration::FillG4Step(GPUHit *aGPUHit,
 
   // Pre-Step Point
   G4StepPoint *aPreStepPoint = aG4Step->GetPreStepPoint();
-  aPreStepPoint->SetPosition(G4ThreeVector(aGPUHit->fPreStepPoint.fPosition));                      // Real data
+  aPreStepPoint->SetPosition(G4ThreeVector(aGPUHit->fPreStepPoint.fPosition)); // Real data
   // aPreStepPoint->SetLocalTime(0);                                                                // Missing data
   // aPreStepPoint->SetGlobalTime(0);                                                               // Missing data
   // aPreStepPoint->SetProperTime(0);                                                               // Missing data
-  aPreStepPoint->SetMomentumDirection(G4ThreeVector(aGPUHit->fPreStepPoint.fMomentumDirection));    // Real data
-  aPreStepPoint->SetKineticEnergy(aGPUHit->fPreStepPoint.fEKin);                                    // Real data
+  aPreStepPoint->SetMomentumDirection(G4ThreeVector(aGPUHit->fPreStepPoint.fMomentumDirection)); // Real data
+  aPreStepPoint->SetKineticEnergy(aGPUHit->fPreStepPoint.fEKin);                                 // Real data
   // aPreStepPoint->SetVelocity(0);                                                                 // Missing data
-  aPreStepPoint->SetTouchableHandle(aPreG4TouchableHandle);                                         // Real data
-  aPreStepPoint->SetMaterial(aPreG4TouchableHandle->GetVolume()->GetLogicalVolume()->GetMaterial());// Real data
+  aPreStepPoint->SetTouchableHandle(aPreG4TouchableHandle);                                          // Real data
+  aPreStepPoint->SetMaterial(aPreG4TouchableHandle->GetVolume()->GetLogicalVolume()->GetMaterial()); // Real data
   // aPreStepPoint->SetMaterialCutsCouple(nullptr);                                                 // Missing data
   // aPreStepPoint->SetSensitiveDetector(nullptr);                                                  // Missing data
   // aPreStepPoint->SetSafety(0);                                                                   // Missing data
-  aPreStepPoint->SetPolarization(G4ThreeVector(aGPUHit->fPreStepPoint.fPolarization));              // Real data
+  aPreStepPoint->SetPolarization(G4ThreeVector(aGPUHit->fPreStepPoint.fPolarization)); // Real data
   // aPreStepPoint->SetStepStatus(G4StepStatus::fUndefined);                                        // Missing data
   // aPreStepPoint->SetProcessDefinedStep(nullptr);                                                 // Missing data
   // aPreStepPoint->SetMass(0);                                                                     // Missing data
-  aPreStepPoint->SetCharge(aGPUHit->fPreStepPoint.fCharge);                                         // Real data
+  aPreStepPoint->SetCharge(aGPUHit->fPreStepPoint.fCharge); // Real data
   // aPreStepPoint->SetMagneticMoment(0);                                                           // Missing data
   // aPreStepPoint->SetWeight(0);                                                                   // Missing data
 
   // Post-Step Point
   G4StepPoint *aPostStepPoint = aG4Step->GetPostStepPoint();
-  aPostStepPoint->SetPosition(*aPostStepPointPosition);                                               // Real data
+  aPostStepPoint->SetPosition(*aPostStepPointPosition); // Real data
   // aPostStepPoint->SetLocalTime(0);                                                                 // Missing data
   // aPostStepPoint->SetGlobalTime(0);                                                                // Missing data
   // aPostStepPoint->SetProperTime(0);                                                                // Missing data
-  aPostStepPoint->SetMomentumDirection(*aPostStepPointMomentumDirection);                             // Real data
-  aPostStepPoint->SetKineticEnergy(aGPUHit->fPostStepPoint.fEKin);                                    // Real data
+  aPostStepPoint->SetMomentumDirection(*aPostStepPointMomentumDirection); // Real data
+  aPostStepPoint->SetKineticEnergy(aGPUHit->fPostStepPoint.fEKin);        // Real data
   // aPostStepPoint->SetVelocity(0);                                                                  // Missing data
-  aPostStepPoint->SetTouchableHandle(aPostG4TouchableHandle);                                         // Real data
-  aPostStepPoint->SetMaterial(aPostG4TouchableHandle->GetVolume()->GetLogicalVolume()->GetMaterial());// Real data
+  aPostStepPoint->SetTouchableHandle(aPostG4TouchableHandle);                                          // Real data
+  aPostStepPoint->SetMaterial(aPostG4TouchableHandle->GetVolume()->GetLogicalVolume()->GetMaterial()); // Real data
   // aPostStepPoint->SetMaterialCutsCouple(nullptr);                                                  // Missing data
   // aPostStepPoint->SetSensitiveDetector(nullptr);                                                   // Missing data
   // aPostStepPoint->SetSafety(0);                                                                    // Missing data
-  aPostStepPoint->SetPolarization(*aPostStepPointPolarization);                                       // Real data
+  aPostStepPoint->SetPolarization(*aPostStepPointPolarization); // Real data
   // aPostStepPoint->SetStepStatus(G4StepStatus::fUndefined);                                         // Missing data
   // aPostStepPoint->SetProcessDefinedStep(nullptr);                                                  // Missing data
   // aPostStepPoint->SetMass(0);                                                                      // Missing data
-  aPostStepPoint->SetCharge(aGPUHit->fPostStepPoint.fCharge);                                         // Real data
+  aPostStepPoint->SetCharge(aGPUHit->fPostStepPoint.fCharge); // Real data
   // aPostStepPoint->SetMagneticMoment(0);                                                            // Missing data
   // aPostStepPoint->SetWeight(0);                                                                    // Missing data
 }
@@ -455,17 +445,17 @@ void AdePTGeant4Integration::ReturnTracks(std::vector<adeptint::TrackData> *trac
   }
 
   constexpr double tolerance = 10. * vecgeom::kTolerance;
-  int tid = GetThreadID();
+  int tid                    = GetThreadID();
 
   // Build the secondaries and put them back on the Geant4 stack
   int i = 0;
   for (auto const &track : *tracksFromDevice) {
     if (debugLevel > 1) {
       std::cout << "[" << tid << "] fromDevice[ " << i++ << "]: pdg " << track.pdg << " kinetic energy " << track.eKin
-             << " position " << track.position[0] << " " << track.position[1] << " " << track.position[2]
-             << " direction " << track.direction[0] << " " << track.direction[1] << " " << track.direction[2] 
-             << " global time, local time, proper time: " << "(" << track.globalTime << ", " << track.localTime 
-             << ", " << track.properTime << ")" << std::endl;
+                << " position " << track.position[0] << " " << track.position[1] << " " << track.position[2]
+                << " direction " << track.direction[0] << " " << track.direction[1] << " " << track.direction[2]
+                << " global time, local time, proper time: "
+                << "(" << track.globalTime << ", " << track.localTime << ", " << track.properTime << ")" << std::endl;
     }
     G4ParticleMomentum direction(track.direction[0], track.direction[1], track.direction[2]);
 

--- a/src/AdePTPhysics.cc
+++ b/src/AdePTPhysics.cc
@@ -9,12 +9,12 @@
 #include "G4PhysicsListHelper.hh"
 
 #include "G4ComptonScattering.hh"
-//#include "G4KleinNishinaModel.hh"  // by defult in G4ComptonScattering
+// #include "G4KleinNishinaModel.hh"  // by defult in G4ComptonScattering
 
 #include "G4GammaConversion.hh"
 #include "G4PhotoElectricEffect.hh"
 #include "G4LivermorePhotoElectricModel.hh"
-//#include "G4RayleighScattering.hh"
+// #include "G4RayleighScattering.hh"
 
 #include "G4eMultipleScattering.hh"
 #include "G4GoudsmitSaundersonMscModel.hh"
@@ -27,7 +27,7 @@
 
 #include "G4BuilderType.hh"
 #include "G4LossTableManager.hh"
-//#include "G4UAtomicDeexcitation.hh"
+// #include "G4UAtomicDeexcitation.hh"
 
 #include "G4SystemOfUnits.hh"
 
@@ -59,7 +59,7 @@ AdePTPhysics::AdePTPhysics(const G4String &name) : G4VPhysicsConstructor(name)
   SetPhysicsType(bUnknown);
 }
 
-AdePTPhysics::~AdePTPhysics() 
+AdePTPhysics::~AdePTPhysics()
 {
   delete fAdePTConfiguration;
   delete fTrackingManager;
@@ -77,7 +77,7 @@ void AdePTPhysics::ConstructProcess()
 
   // Setup tracking manager
   fTrackingManager->SetVerbosity(0);
-  
+
   // Create one instance of AdePTTransport per thread and set it up according to the user configuration
   AdePTTransport *aAdePTTransport = new AdePTTransport();
   aAdePTTransport->SetDebugLevel(0);
@@ -95,10 +95,10 @@ void AdePTPhysics::ConstructProcess()
   if (tid < 0) {
     // Load the VecGeom world in memory
     AdePTGeant4Integration::CreateVecGeomWorld(fAdePTConfiguration->GetVecGeomGDML());
-    
+
     // Track and Hit buffer capacities on GPU are split among threads
-    int num_threads = G4RunManager::GetRunManager()->GetNumberOfThreads();
-    int track_capacity    = 1024 * 1024 * fAdePTConfiguration->GetMillionsOfTrackSlots() / num_threads;
+    int num_threads    = G4RunManager::GetRunManager()->GetNumberOfThreads();
+    int track_capacity = 1024 * 1024 * fAdePTConfiguration->GetMillionsOfTrackSlots() / num_threads;
     G4cout << "AdePT Allocated track capacity: " << track_capacity << " tracks" << G4endl;
     AdePTTransport::SetTrackCapacity(track_capacity);
     int hit_buffer_capacity = 1024 * 1024 * fAdePTConfiguration->GetMillionsOfHitSlots() / num_threads;
@@ -108,8 +108,7 @@ void AdePTPhysics::ConstructProcess()
     // Initialize common data:
     // G4HepEM, Upload VecGeom geometry to GPU, Geometry check, Create volume auxiliary data
     aAdePTTransport->Initialize(true /*common_data*/);
-    if (sequential) 
-    {
+    if (sequential) {
       // Initialize per-thread data (When in sequential mode)
       aAdePTTransport->Initialize();
     }
@@ -117,11 +116,9 @@ void AdePTPhysics::ConstructProcess()
     // Initialize per-thread data
     aAdePTTransport->Initialize();
   }
-  
+
   // Give the custom tracking manager a pointer to the AdePTTransport instance
   fTrackingManager->SetAdePTTransport(aAdePTTransport);
 
   // Translate Region names to actual G4 Regions and give them to the custom tracking manager
-
-
 }

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -119,19 +119,14 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
     G4Region *region = aTrack->GetVolume()->GetLogicalVolume()->GetRegion();
     // Check if the particle is in a GPU region
     bool isGPURegion = false;
-    if(fAdept->GetTrackInAllRegions())
-    {
+    if (fAdept->GetTrackInAllRegions()) {
       isGPURegion = true;
-    }
-    else
-    {
-      for(G4Region *gpuRegion: fGPURegions)
-      {
-        if (region == gpuRegion)
-          isGPURegion = true;
+    } else {
+      for (G4Region *gpuRegion : fGPURegions) {
+        if (region == gpuRegion) isGPURegion = true;
       }
     }
-    
+
     if (isGPURegion) {
       // If the track is in a GPU region, hand it over to AdePT
 
@@ -145,7 +140,7 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
 
       fAdept->AddTrack(pdg, energy, particlePosition[0], particlePosition[1], particlePosition[2], particleDirection[0],
                        particleDirection[1], particleDirection[2], globalTime, localTime, properTime);
-      
+
       // The track dies from the point of view of Geant4
       aTrack->SetTrackStatus(fStopAndKill);
 
@@ -166,13 +161,13 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
   delete aTrack;
 }
 
-void AdePTTrackingManager::StepInHostRegion(G4Track *aTrack) 
+void AdePTTrackingManager::StepInHostRegion(G4Track *aTrack)
 {
   /* From G4 Example RE07 */
 
-  G4EventManager* eventManager = G4EventManager::GetEventManager();
-  G4TrackingManager* trackManager = eventManager->GetTrackingManager();
-  G4SteppingManager* steppingManager = trackManager->GetSteppingManager();
+  G4EventManager *eventManager       = G4EventManager::GetEventManager();
+  G4TrackingManager *trackManager    = eventManager->GetTrackingManager();
+  G4SteppingManager *steppingManager = trackManager->GetSteppingManager();
 
   // Track the particle Step-by-Step while it is alive and outside of a GPU region
   while ((aTrack->GetTrackStatus() == fAlive) || (aTrack->GetTrackStatus() == fStopButAlive)) {
@@ -183,12 +178,11 @@ void AdePTTrackingManager::StepInHostRegion(G4Track *aTrack)
       // Switch the touchable to update the volume, which is checked in the
       // condition below and at the call site.
       aTrack->SetTouchableHandle(aTrack->GetNextTouchableHandle());
-      G4Region* region = aTrack->GetVolume()->GetLogicalVolume()->GetRegion();
+      G4Region *region = aTrack->GetVolume()->GetLogicalVolume()->GetRegion();
       // This should never be true if this flag is set, as all particles would be sent to AdePT
       assert(fAdept->GetTrackInAllRegions() == false);
       // Check whether the particle has entered a GPU region
-      for(G4Region *gpuRegion: fGPURegions)
-      {
+      for (G4Region *gpuRegion : fGPURegions) {
         if (region == gpuRegion) {
           return;
         }

--- a/src/AdePTTransport.cpp
+++ b/src/AdePTTransport.cpp
@@ -141,8 +141,8 @@ void AdePTTransport::Shower(int event)
       std::cout << "[" << tid << "] toDevice[ " << itr++ << "]: pdg " << track.pdg << " kinetic energy " << track.eKin
                 << " position " << track.position[0] << " " << track.position[1] << " " << track.position[2]
                 << " direction " << track.direction[0] << " " << track.direction[1] << " " << track.direction[2]
-                << " global time, local time, proper time: " << "(" << track.globalTime << ", " << track.localTime 
-                << ", " << track.properTime << ")" << std::endl;
+                << " global time, local time, proper time: "
+                << "(" << track.globalTime << ", " << track.localTime << ", " << track.properTime << ")" << std::endl;
     }
   }
 

--- a/src/AdePTTransport.cu
+++ b/src/AdePTTransport.cu
@@ -31,8 +31,6 @@
 #include <numeric>
 #include <algorithm>
 
-
-
 __constant__ __device__ struct G4HepEmParameters g4HepEmPars;
 __constant__ __device__ struct G4HepEmData g4HepEmData;
 
@@ -62,7 +60,8 @@ static G4HepEmState *InitG4HepEm()
   InitG4HepEmState(state);
 
   G4HepEmMatCutData *cutData = state->fData->fTheMatCutData;
-  std::cout << "fNumG4MatCuts = " << cutData->fNumG4MatCuts << ", fNumMatCutData = " << cutData->fNumMatCutData << std::endl;
+  std::cout << "fNumG4MatCuts = " << cutData->fNumG4MatCuts << ", fNumMatCutData = " << cutData->fNumMatCutData
+            << std::endl;
 
   // Copy to GPU.
   CopyG4HepEmDataToGPU(state->fData);
@@ -114,7 +113,7 @@ __global__ void InitTracks(adeptint::TrackData *trackinfo, int ntracks, int star
 
     Track &track = trackmgr->NextTrack();
     track.rngState.SetSeed(1234567 * event + startTrack + i);
-    track.eKin       = trackinfo[i].eKin;
+    track.eKin         = trackinfo[i].eKin;
     track.numIALeft[0] = -1.0;
     track.numIALeft[1] = -1.0;
     track.numIALeft[2] = -1.0;
@@ -127,7 +126,7 @@ __global__ void InitTracks(adeptint::TrackData *trackinfo, int ntracks, int star
     track.dir = {trackinfo[i].direction[0], trackinfo[i].direction[1], trackinfo[i].direction[2]};
 
     track.globalTime = trackinfo->globalTime;
-    track.localTime = trackinfo->localTime;
+    track.localTime  = trackinfo->localTime;
     track.properTime = trackinfo->properTime;
 
     track.navState.Clear();
@@ -194,7 +193,7 @@ __global__ void ClearLeakedQueues(LeakedTracks all)
 bool AdePTTransport::InitializeGeometry(const vecgeom::cxx::VPlacedVolume *world)
 {
   // Try 16384 if debug mode is crashing
-  COPCORE_CUDA_CHECK(vecgeom::cxx::CudaDeviceSetStackLimit(8192*2));
+  COPCORE_CUDA_CHECK(vecgeom::cxx::CudaDeviceSetStackLimit(8192 * 2));
   // Upload geometry to GPU.
   auto &cudaManager = vecgeom::cxx::CudaManager::Instance();
   cudaManager.LoadGeometry(world);
@@ -309,8 +308,9 @@ void AdePTTransport::ShowerGPU(int event, TrackBuffer &buffer) // const &buffer)
                                      buffer.toDevice.size() * sizeof(adeptint::TrackData), cudaMemcpyHostToDevice,
                                      gpuState.stream));
   if (fDebugLevel > 0) {
-    std::cout << std::dec << std::endl << "GPU transporting event " << event << " for CPU thread "
-           << fIntegrationLayer.GetThreadID() << ": " << std::flush;
+    std::cout << std::dec << std::endl
+              << "GPU transporting event " << event << " for CPU thread " << fIntegrationLayer.GetThreadID() << ": "
+              << std::flush;
   }
 
   // Initialize AdePT tracks using the track buffer copied from CPU
@@ -427,7 +427,7 @@ void AdePTTransport::ShowerGPU(int event, TrackBuffer &buffer) // const &buffer)
     // Check if we need to flush the hits buffer
     if (fScoring->CheckAndFlush(gpuState.stats->hostscoring_stats, fScoring_dev, gpuState.stream)) {
       // Synchronize the stream used to copy back the hits
-      COPCORE_CUDA_CHECK(cudaStreamSynchronize(gpuState.stream)); 
+      COPCORE_CUDA_CHECK(cudaStreamSynchronize(gpuState.stream));
       // Process the hits on CPU
       fIntegrationLayer.ProcessGPUHits(*fScoring, gpuState.stats->hostscoring_stats);
     }
@@ -444,7 +444,7 @@ void AdePTTransport::ShowerGPU(int event, TrackBuffer &buffer) // const &buffer)
     } else {
       previousElectrons = numElectrons;
       previousPositrons = numPositrons;
-      previousGammas = numGammas;
+      previousGammas    = numGammas;
       loopingNo         = 0;
     }
 

--- a/src/HepEMPhysics.cc
+++ b/src/HepEMPhysics.cc
@@ -11,12 +11,12 @@
 #include "G4PhysicsListHelper.hh"
 
 #include "G4ComptonScattering.hh"
-//#include "G4KleinNishinaModel.hh"  // by defult in G4ComptonScattering
+// #include "G4KleinNishinaModel.hh"  // by defult in G4ComptonScattering
 
 #include "G4GammaConversion.hh"
 #include "G4PhotoElectricEffect.hh"
 #include "G4LivermorePhotoElectricModel.hh"
-//#include "G4RayleighScattering.hh"
+// #include "G4RayleighScattering.hh"
 
 #include "G4eMultipleScattering.hh"
 #include "G4GoudsmitSaundersonMscModel.hh"
@@ -29,7 +29,7 @@
 
 #include "G4BuilderType.hh"
 #include "G4LossTableManager.hh"
-//#include "G4UAtomicDeexcitation.hh"
+// #include "G4UAtomicDeexcitation.hh"
 
 #include "G4SystemOfUnits.hh"
 
@@ -41,8 +41,6 @@
 #include "G4hIonisation.hh"
 #include "G4ionIonisation.hh"
 #include "G4NuclearStopping.hh"
-
-
 
 HepEMPhysics::HepEMPhysics(const G4String &name) : G4VPhysicsConstructor(name)
 {
@@ -67,15 +65,15 @@ void HepEMPhysics::ConstructProcess()
   // from G4EmStandardPhysics
   G4EmBuilder::PrepareEMPhysics();
 
-  G4EmParameters* param = G4EmParameters::Instance();
+  G4EmParameters *param = G4EmParameters::Instance();
 
   // processes used by several particles
-  G4hMultipleScattering* hmsc = new G4hMultipleScattering("ionmsc");
+  G4hMultipleScattering *hmsc = new G4hMultipleScattering("ionmsc");
 
   // nuclear stopping is enabled if th eenergy limit above zero
   G4double nielEnergyLimit = param->MaxNIELEnergy();
-  G4NuclearStopping* pnuc = nullptr;
-  if(nielEnergyLimit > 0.0) {
+  G4NuclearStopping *pnuc  = nullptr;
+  if (nielEnergyLimit > 0.0) {
     pnuc = new G4NuclearStopping();
     pnuc->SetMaxKinEnergy(nielEnergyLimit);
   }
@@ -113,11 +111,13 @@ void HepEMPhysics::ConstructProcess()
   // from G4EmStandardPhysics
 
   // generic ion
-  G4ParticleDefinition* particle = G4GenericIon::GenericIon();
-  G4ionIonisation* ionIoni = new G4ionIonisation();
+  G4ParticleDefinition *particle = G4GenericIon::GenericIon();
+  G4ionIonisation *ionIoni       = new G4ionIonisation();
   ph->RegisterProcess(hmsc, particle);
   ph->RegisterProcess(ionIoni, particle);
-  if(nullptr != pnuc) { ph->RegisterProcess(pnuc, particle); }
+  if (nullptr != pnuc) {
+    ph->RegisterProcess(pnuc, particle);
+  }
 
   // muons, hadrons ions
   G4EmBuilder::ConstructCharged(hmsc, pnuc);
@@ -125,5 +125,5 @@ void HepEMPhysics::ConstructProcess()
   // extra configuration
   G4EmModelActivator mact(GetPhysicsName());
 
-  //end of G4EmStandardPhysics
+  // end of G4EmStandardPhysics
 }

--- a/test/TestEm3/TestEm3.cu
+++ b/test/TestEm3/TestEm3.cu
@@ -187,10 +187,10 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
 
   InitBVH();
 
-  #ifdef ADEPT_USE_SURF
+#ifdef ADEPT_USE_SURF
   auto &surfdata = vgbrep::SurfData<double>::Instance();
   vgbrep::BrepCudaManager<double>::Instance().TransferSurfData(surfdata);
-  #endif
+#endif
 
   G4HepEmState *state = InitG4HepEm();
 
@@ -321,7 +321,7 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
     int transportBlocks;
 
     int inFlight;
-    int loopingNo = 0;
+    int loopingNo         = 0;
     int previousElectrons = -1, previousPositrons = -1;
 
     do {
@@ -398,13 +398,13 @@ void TestEm3(const vecgeom::cxx::VPlacedVolume *world, int numParticles, double 
       // Check if only charged particles are left that are looping.
       numElectrons = stats->inFlight[ParticleType::Electron];
       numPositrons = stats->inFlight[ParticleType::Positron];
-      numGammas = stats->inFlight[ParticleType::Gamma];
+      numGammas    = stats->inFlight[ParticleType::Gamma];
       if (numElectrons == previousElectrons && numPositrons == previousPositrons && numGammas == 0) {
         loopingNo++;
       } else {
         previousElectrons = numElectrons;
         previousPositrons = numPositrons;
-        loopingNo = 0;
+        loopingNo         = 0;
       }
 
     } while (inFlight > 0 && loopingNo < 200);

--- a/test/TestEm3/TestEm3.cuh
+++ b/test/TestEm3/TestEm3.cuh
@@ -94,7 +94,9 @@ class ParticleGenerator {
 
 public:
   __host__ __device__ ParticleGenerator(Track *tracks, SlotManager *slotManager, adept::MParray *activeQueue)
-    : fTracks(tracks), fSlotManager(slotManager), fActiveQueue(activeQueue) {}
+      : fTracks(tracks), fSlotManager(slotManager), fActiveQueue(activeQueue)
+  {
+  }
 
   __host__ __device__ Track &NextTrack()
   {
@@ -114,14 +116,13 @@ struct Secondaries {
   ParticleGenerator gammas;
 };
 
-
 // Kernels in different TUs.
-__global__ void TransportElectrons(
-    Track *electrons, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
-    GlobalScoring *globalScoring, ScoringPerVolume *scoringPerVolume);
-__global__ void TransportPositrons(
-    Track *positrons, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
-    GlobalScoring *globalScoring, ScoringPerVolume *scoringPerVolume);
+__global__ void TransportElectrons(Track *electrons, const adept::MParray *active, Secondaries secondaries,
+                                   adept::MParray *activeQueue, GlobalScoring *globalScoring,
+                                   ScoringPerVolume *scoringPerVolume);
+__global__ void TransportPositrons(Track *positrons, const adept::MParray *active, Secondaries secondaries,
+                                   adept::MParray *activeQueue, GlobalScoring *globalScoring,
+                                   ScoringPerVolume *scoringPerVolume);
 
 __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries,
                                 adept::MParray *activeQueue, GlobalScoring *globalScoring,

--- a/test/testField/testField.cpp
+++ b/test/testField/testField.cpp
@@ -40,7 +40,7 @@ float *BzFieldValue_dev = nullptr;
 const G4VPhysicalVolume *InitGeant4(const std::string &gdml_file)
 {
   auto defaultRegion = new G4Region("DefaultRegionForTheWorld"); // deleted by store
-  auto pcuts = G4ProductionCutsTable::GetProductionCutsTable()->GetDefaultProductionCuts();
+  auto pcuts         = G4ProductionCutsTable::GetProductionCutsTable()->GetDefaultProductionCuts();
   pcuts->SetProductionCut(DefaultCut, "gamma");
   pcuts->SetProductionCut(DefaultCut, "e-");
   pcuts->SetProductionCut(DefaultCut, "e+");
@@ -190,7 +190,7 @@ int main(int argc, char *argv[])
   // Only outputs are the data file(s)
   // Separate for now, but will want to unify
   OPTION_STRING(gdml_file, "cms2018.gdml"); //  "trackML.gdml"); //  "cms2018.gdml");
-  OPTION_INT(cache_depth, 0); // 0 = full depth
+  OPTION_INT(cache_depth, 0);               // 0 = full depth
   OPTION_INT(particles, 100);
   OPTION_DOUBLE(energy, 10); // entered in GeV
   energy *= copcore::units::GeV;
@@ -200,17 +200,17 @@ int main(int argc, char *argv[])
   OPTION_DOUBLE(bzValue, -1.00); // entered in tesla
   BzFieldValue_host = bzValue * copcore::units::tesla;
 
-  std::cout << "INFO: Particles to simulate = " << particles << " \n";  
-  std::cout << "INFO: Bz field value = " << bzValue << " T (tesla) \n"; 
+  std::cout << "INFO: Particles to simulate = " << particles << " \n";
+  std::cout << "INFO: Bz field value = " << bzValue << " T (tesla) \n";
 
-  constexpr int stackLimit= 8 * 1024;  // 8192 
+  constexpr int stackLimit = 8 * 1024; // 8192
   printf("testField.cpp/main(): Setting Cuda Device Stack Limit to %6d \n", stackLimit);
   cudaError_t error = cudaDeviceSetLimit(cudaLimitStackSize, stackLimit);
   if (error != cudaSuccess) {
-     printf("cudaDeviceSetLimit failed with %d, line(%d)\n", error, __LINE__);
-     exit(EXIT_FAILURE);
+    printf("cudaDeviceSetLimit failed with %d, line(%d)\n", error, __LINE__);
+    exit(EXIT_FAILURE);
   }
-  
+
   vecgeom::Stopwatch timer;
   timer.Start();
 

--- a/test/testField/testField.cuh
+++ b/test/testField/testField.cuh
@@ -54,26 +54,24 @@ struct Track {
 
   __host__ __device__ void print(int id = -1, bool verbose = false) const
   {
-     using copcore::units::MeV;
-     using copcore::units::mm;
-     // static const char *particleName[3] = {"e-", "g", "e+"};
-     printf( " id= %3d Pos[mm]: "
-             "%10.7g, %10.7g, %10.7g "
-             " kE[MeV]= %10.5g  Dir: %9.6f %9.6f %9.6f "
-             " - intl= %6.3f %6.3f %6.3f r0= %10.5g\n",
-             id, pos[0] / mm, pos[1] / mm, pos[2] / mm ,              
-             energy / MeV, dir[0], dir[1], dir[2],
-             numIALeft[0] , numIALeft[1], numIALeft[2],
-             initialRange / mm );
+    using copcore::units::MeV;
+    using copcore::units::mm;
+    // static const char *particleName[3] = {"e-", "g", "e+"};
+    printf(" id= %3d Pos[mm]: "
+           "%10.7g, %10.7g, %10.7g "
+           " kE[MeV]= %10.5g  Dir: %9.6f %9.6f %9.6f "
+           " - intl= %6.3f %6.3f %6.3f r0= %10.5g\n",
+           id, pos[0] / mm, pos[1] / mm, pos[2] / mm, energy / MeV, dir[0], dir[1], dir[2], numIALeft[0], numIALeft[1],
+           numIALeft[2], initialRange / mm);
 
 #ifdef COPCORE_DEVICE_COMPILATION
-     if (verbose) {
-        auto currentLevel = navState.GetLevel();
-        auto currentIndex = navState.GetNavIndex(currentLevel);
-        printf("  id= %3d current: (lv= %3d  ind= %8u  bnd= %1d)  ", id, currentLevel, currentIndex,
-               (int) navState.IsOnBoundary() );
-        printf("\n");        
-     }
+    if (verbose) {
+      auto currentLevel = navState.GetLevel();
+      auto currentIndex = navState.GetNavIndex(currentLevel);
+      printf("  id= %3d current: (lv= %3d  ind= %8u  bnd= %1d)  ", id, currentLevel, currentIndex,
+             (int)navState.IsOnBoundary());
+      printf("\n");
+    }
 #endif
   }
 };
@@ -166,6 +164,6 @@ extern __constant__ __device__ int *MCIndex;
 extern float BzFieldValue_host; //   = 1.0 * copcore::units::tesla;
 extern /*__device__*/ float *BzFieldValue_dev;
 
-__global__ void SetBzFieldPtr( float* pBzFieldValue_dev );
+__global__ void SetBzFieldPtr(float *pBzFieldValue_dev);
 
 #endif

--- a/test/testField/testField.h
+++ b/test/testField/testField.h
@@ -28,6 +28,7 @@ struct ScoringPerVolume {
 
 // Interface between C++ and CUDA.
 void testField(int numParticles, double energy, int batch, const int *MCCindex, ScoringPerVolume *scoringPerVolume,
-               GlobalScoring *globalScoring, int numVolumes, int numPlaced, G4HepEmState *state, bool rotatingParticleGun);
+               GlobalScoring *globalScoring, int numVolumes, int numPlaced, G4HepEmState *state,
+               bool rotatingParticleGun);
 
 #endif

--- a/test/test_atomic.cu
+++ b/test/test_atomic.cu
@@ -16,11 +16,9 @@ struct SomeStruct {
   adept::Atomic_t<int> var_int;
   adept::Atomic_t<float> var_float;
 
-  __host__ __device__
-  SomeStruct() {}
+  __host__ __device__ SomeStruct() {}
 
-  __host__ __device__
-  static SomeStruct *MakeInstanceAt(void *addr)
+  __host__ __device__ static SomeStruct *MakeInstanceAt(void *addr)
   {
     SomeStruct *obj = new (addr) SomeStruct();
     return obj;

--- a/test/test_magfieldRK.cpp
+++ b/test/test_magfieldRK.cpp
@@ -19,16 +19,16 @@
 
 using Real_t = float;
 // using Real_t = double;
-using Field_t = UniformMagneticField;
-using MagFieldEquation_t= MagneticFieldEquation<Field_t>;
+using Field_t            = UniformMagneticField;
+using MagFieldEquation_t = MagneticFieldEquation<Field_t>;
 
 template <typename T>
 using Vector3D = vecgeom::Vector3D<T>;
 
 #include <iostream>
 
-using std::cout;
 using std::cerr;
+using std::cout;
 using std::endl;
 using std::setw;
 
@@ -40,24 +40,23 @@ using namespace vecCore::math;
 // CreateUniformField();
 
 template <typename Real_t, typename Field_t> // , typename Equation_t>
-bool TestEquation( Field_t const & magField);
+bool TestEquation(Field_t const &magField);
 
 constexpr unsigned int gNposmom = 6; // Position 3-vec + Momentum 3-vec
-
 
 int gVerbose = 1;
 
 template <typename Real_t, typename Field_t> // , typename Equation_t>
-bool TestEquation( Field_t const & magField)
+bool TestEquation(Field_t const &magField)
 {
   using Equation_t = MagneticFieldEquation<Field_t>;
-   
+
   const Real_t perMillion = Real_t(1e-6);
   bool hasError           = false; // Return value
   using Bool_v            = vecCore::Mask<Real_t>;
 
   //  1. Initialize meaningful state
-  // 
+  //
   Vector3D<Real_t> PositionVec(1., 2., 3.); // initial
   Vector3D<Real_t> MomentumVec(0., 0.1, 1.);
   Vector3D<Real_t> FieldVec(0., 0., 1.); // Magnetic field value (constant)
@@ -66,39 +65,39 @@ bool TestEquation( Field_t const & magField)
 
   //  2. Initialise object for Equation (of motion)
   //
-  Real_t PositionMomentum[gNposmom] = { PositionVec[0], PositionVec[1], PositionVec[2],
-                                        MomentumVec[0], MomentumVec[1],  MomentumVec[2] } ;
+  Real_t PositionMomentum[gNposmom] = {PositionVec[0], PositionVec[1], PositionVec[2],
+                                       MomentumVec[0], MomentumVec[1], MomentumVec[2]};
   Real_t dydx[gNposmom];
-  int charge = -1;  
+  int charge = -1;
 
   //  3. Evaluate RHS / ie Derivatives of Equation of motion
   //
-  
-  //  Option 3a)  use a field value 
+
+  //  Option 3a)  use a field value
   Equation_t::EvaluateDerivatives(PositionMomentum, FieldVec, charge, dydx);
   // ****************************
 
-  //  Option 3b)  use a magnetic field class 
+  //  Option 3b)  use a magnetic field class
   // Equation_t::EvaluateDerivatives(PositionMomentum, charge, magField, dydx);
   //-- - Better form of method:
   //-- Equation_t::EvaluateDerivatives(magField, PositionMomentum, charge, dydx);
-  
+
   // ****************************
 
-  Real_t FieldArr[3] = { FieldVec[0], FieldVec[1], FieldVec[2] };
+  Real_t FieldArr[3] = {FieldVec[0], FieldVec[1], FieldVec[2]};
   std::cout << " Values obtained: " << std::endl;
-  PrintFieldVectors::PrintSixvecAndDyDx( PositionMomentum, charge, FieldArr, dydx );
+  PrintFieldVectors::PrintSixvecAndDyDx(PositionMomentum, charge, FieldArr, dydx);
 
   //  4. Test output values
   //
   Vector3D<Real_t> dPos_ds(dydx[0], dydx[1], dydx[2]);
-  Real_t  mag = dPos_ds.Mag();
-  Real_t  magDiff =  fabs ( mag - 1.0 );
-  assert  ( magDiff < 1.0e-6 );
-  if( magDiff > 2.0e-7 ) {
-     std::cerr << "WARNING>  dPos_ps (direction) is not a unit vector.  | Mag - 1 | = " << magDiff << std::endl;
+  Real_t mag     = dPos_ds.Mag();
+  Real_t magDiff = fabs(mag - 1.0);
+  assert(magDiff < 1.0e-6);
+  if (magDiff > 2.0e-7) {
+    std::cerr << "WARNING>  dPos_ps (direction) is not a unit vector.  | Mag - 1 | = " << magDiff << std::endl;
   }
-  
+
   Vector3D<Real_t> ForceVec(dydx[3], dydx[4], dydx[5]);
 
   // Check result
@@ -160,40 +159,39 @@ bool TestEquation( Field_t const & magField)
 #include <AdePT/copcore/PhysicalConstants.h>
 
 template <typename Real_t, typename Field_t> // , typename Equation_t>
-bool TestStepper( Field_t const & magField)
+bool TestStepper(Field_t const &magField)
 //   -----------
 {
   constexpr unsigned int Nvar = 6; // Number of integration variables
-  using Equation_t = MagneticFieldEquation<Field_t>;
-  using Stepper_t  = DormandPrinceRK45<Equation_t, Field_t, Nvar, Real_t>;
+  using Equation_t            = MagneticFieldEquation<Field_t>;
+  using Stepper_t             = DormandPrinceRK45<Equation_t, Field_t, Nvar, Real_t>;
 
-  Real_t yPosMom[Nvar] = { 0, 1, 2,  //  PositionVec[0], PositionVec[1], PositionVec[2],
-              0, 0, 3.0 * copcore::units::GeV } ; // MomentumVec[0], MomentumVec[1],  MomentumVec[2] } ;
+  Real_t yPosMom[Nvar] = {0, 1, 2,                          //  PositionVec[0], PositionVec[1], PositionVec[2],
+                          0, 0, 3.0 * copcore::units::GeV}; // MomentumVec[0], MomentumVec[1],  MomentumVec[2] } ;
 
   Real_t dy_ds[Nvar];
 
-  Real_t yOut[Nvar];        // Output:  y values at end,
-  Real_t yerr[Nvar];        //          estimated errors, 
-  Real_t next_dyds[Nvar];  //          next value of dydx
+  Real_t yOut[Nvar];      // Output:  y values at end,
+  Real_t yerr[Nvar];      //          estimated errors,
+  Real_t next_dyds[Nvar]; //          next value of dydx
 
-  int   charge = -1;
-  Real_t  step = 0.1; 
-  
+  int charge  = -1;
+  Real_t step = 0.1;
+
   // Evaluate dy_ds
   // Equation_t::EvaluateDerivatives(magField, yPosMom, charge, dy_ds);
-  Vector3D<float> magFieldVec( 1, 2, 3);  
+  Vector3D<float> magFieldVec(1, 2, 3);
   Equation_t::EvaluateDerivativesReturnB(magField, yPosMom, charge, dy_ds, magFieldVec);
   std::cout << " magField = " << magFieldVec[0] << " , " << magFieldVec[1] << " , " << magFieldVec[2] << std::endl;
-  
+
   Stepper_t::StepWithErrorEstimate(magField, yPosMom, dy_ds, charge, step, yOut, yerr, next_dyds);
 
-  float  magFieldOut[3] = { magFieldVec[0], magFieldVec[1], magFieldVec[2] }; 
+  float magFieldOut[3] = {magFieldVec[0], magFieldVec[1], magFieldVec[2]};
 
-  PrintFieldVectors::PrintSixvecAndDyDx( yPosMom, charge, magFieldOut, dy_ds);
-  
+  PrintFieldVectors::PrintSixvecAndDyDx(yPosMom, charge, magFieldOut, dy_ds);
+
   return true;
 }
-
 
 #include <AdePT/magneticfield/RkIntegrationDriver.h>
 
@@ -203,101 +201,95 @@ bool TestStepper( Field_t const & magField)
 const unsigned int trialsPerCall = 6; //  Try 100 later
 
 template <typename Real_t, typename Field_t> // , typename Equation_t>
-bool TestDriverAdvance( Field_t const & magField,  Real_t hLength = 300 )
+bool TestDriverAdvance(Field_t const &magField, Real_t hLength = 300)
 //   -----------
 {
   constexpr unsigned int Nvar = 6; // Number of integration variables
-  using Equation_t = MagneticFieldEquation<Field_t>;
-  using Stepper_t  = DormandPrinceRK45<Equation_t, Field_t, Nvar, Real_t>;
-  using Driver_t   = RkIntegrationDriver<Stepper_t, Real_t, int, Equation_t, Field_t>;
+  using Equation_t            = MagneticFieldEquation<Field_t>;
+  using Stepper_t             = DormandPrinceRK45<Equation_t, Field_t, Nvar, Real_t>;
+  using Driver_t              = RkIntegrationDriver<Stepper_t, Real_t, int, Equation_t, Field_t>;
 
-  Vector3D<Real_t> Position =  { 0,   0.001,   0.002   };  //  PositionVec[0], PositionVec[1], PositionVec[2],
-  Vector3D<Real_t> Direction = { 0,   1.0, 0.0 }; 
-  Real_t momentumMag = 3.0 * copcore::units::GeV ;
+  Vector3D<Real_t> Position  = {0, 0.001, 0.002}; //  PositionVec[0], PositionVec[1], PositionVec[2],
+  Vector3D<Real_t> Direction = {0, 1.0, 0.0};
+  Real_t momentumMag         = 3.0 * copcore::units::GeV;
 
   Vector3D<Real_t> Momentum = momentumMag * Direction;
-  
-  Real_t dy_ds[Nvar];
-  Real_t yOut[Nvar];        // Output:  y values at end,
-  Real_t yerr[Nvar];        //          estimated errors, 
-  Real_t next_dyds[Nvar];  //          next value of dydx
 
-  int   charge = -1;
-  
-  Real_t yStart[Nvar] = { Position[0], Position[1], Position[2],
-                          Momentum[0], Momentum[1], Momentum[2] } ;
+  Real_t dy_ds[Nvar];
+  Real_t yOut[Nvar];      // Output:  y values at end,
+  Real_t yerr[Nvar];      //          estimated errors,
+  Real_t next_dyds[Nvar]; //          next value of dydx
+
+  int charge = -1;
+
+  Real_t yStart[Nvar] = {Position[0], Position[1], Position[2], Momentum[0], Momentum[1], Momentum[2]};
   // std::cout << "yStart: " << std::endl;
   // PrintFieldVectors::PrintSixvec( yStart );
-  
-  Vector3D<float> magFieldStart( 0, 0, 0);
+
+  Vector3D<float> magFieldStart(0, 0, 0);
   Equation_t::EvaluateDerivativesReturnB(magField, yStart, charge, dy_ds, magFieldStart);
-  // std::cout << " magField = " << magFieldStart[0] << " , " << magFieldStart[1] << " , " << magFieldStart[2] << std::endl;
-  
+  // std::cout << " magField = " << magFieldStart[0] << " , " << magFieldStart[1] << " , " << magFieldStart[2] <<
+  // std::endl;
+
   // Do a couple of steps
-  unsigned int totalTrials = 0; 
+  unsigned int totalTrials = 0;
 
   // Test the simple Advance method
-  bool verbose = false; 
+  bool verbose       = false;
   double sumAdvanced = 0.0;
-    
-  bool done=false;
-  Real_t  hTry = hLength;    // suggested 'good' length per integration step
-  Real_t  dydx_end[Nvar];
+
+  bool done   = false;
+  Real_t hTry = hLength; // suggested 'good' length per integration step
+  Real_t dydx_end[Nvar];
 
   std::cout << " t:   " << setw(3) << totalTrials << " s= " << setw(9) << sumAdvanced << " ";
-  Real_t magFieldStartArr[3] = { magFieldStart[0],   magFieldStart[1],   magFieldStart[2] };
-  PrintFieldVectors::PrintLineSixvecDyDx( yStart, charge, magFieldStartArr, dy_ds );
+  Real_t magFieldStartArr[3] = {magFieldStart[0], magFieldStart[1], magFieldStart[2]};
+  PrintFieldVectors::PrintLineSixvecDyDx(yStart, charge, magFieldStartArr, dy_ds);
 
   Vector3D<Real_t> momentumVec = momentumMag * Direction;
-  
+
   do {
-    Real_t  hAdvanced= 0.0;
-    
-    done =     
-       Driver_t::Advance( Position, momentumVec, charge, hLength,
-                          magField, hTry, dydx_end,
-                          hAdvanced, totalTrials, trialsPerCall);
+    Real_t hAdvanced = 0.0;
+
+    done = Driver_t::Advance(Position, momentumVec, charge, hLength, magField, hTry, dydx_end, hAdvanced, totalTrials,
+                             trialsPerCall);
     // Runge-Kutta single call
-    
-    std::cout << "Advanced returned:  done= " << ( done ? "Yes" : " No" )
-              << " hAdvanced = " << hAdvanced 
-              << " hNext = " << hTry
-              << std::endl;
-    
-    Real_t yPosMom[Nvar] = { Position[0], Position[1], Position[2],
-                             momentumVec[0], momentumVec[1], momentumVec[2] } ;    
+
+    std::cout << "Advanced returned:  done= " << (done ? "Yes" : " No") << " hAdvanced = " << hAdvanced
+              << " hNext = " << hTry << std::endl;
+
+    Real_t yPosMom[Nvar] = {Position[0], Position[1], Position[2], momentumVec[0], momentumVec[1], momentumVec[2]};
     sumAdvanced += hAdvanced;
-    
-    if( verbose ) 
-       std::cout << "- Trials:   max/call = " << trialsPerCall << "  total done = " << totalTrials
-                 <<  ( (totalTrials == trialsPerCall) ?  " MAXimum reached !! " :  " " )
-                 << std::endl;
+
+    if (verbose)
+      std::cout << "- Trials:   max/call = " << trialsPerCall << "  total done = " << totalTrials
+                << ((totalTrials == trialsPerCall) ? " MAXimum reached !! " : " ") << std::endl;
     else
-       std::cout << " t: " << setw(4) << totalTrials << " s= " << setw(9) << sumAdvanced << " ";
+      std::cout << " t: " << setw(4) << totalTrials << " s= " << setw(9) << sumAdvanced << " ";
 
     Vector3D<float> magFieldEnd;
-    Equation_t::EvaluateDerivativesReturnB(magField, yPosMom, charge, dy_ds, magFieldEnd);  
-    Real_t magFieldEndArr[3] = { magFieldEnd[0],   magFieldEnd[1],   magFieldEnd[2] };
+    Equation_t::EvaluateDerivativesReturnB(magField, yPosMom, charge, dy_ds, magFieldEnd);
+    Real_t magFieldEndArr[3] = {magFieldEnd[0], magFieldEnd[1], magFieldEnd[2]};
 
     //--- PrintFieldVectors::PrintSixvecAndDyDx(
-    PrintFieldVectors::PrintLineSixvecDyDx( yPosMom, charge, magFieldEndArr, // dydx_end );
-                                            dy_ds);
-    
+    PrintFieldVectors::PrintLineSixvecDyDx(yPosMom, charge, magFieldEndArr, // dydx_end );
+                                           dy_ds);
+
     hLength -= hAdvanced;
     done = (hLength <= 0.0);
 
-  } while ( ! done );
-  
-  Vector3D<Real_t>  magFieldEnd;
-  magField.Evaluate( Position,  magFieldEnd );
+  } while (!done);
 
-  std::cout << " Mag field at end = " << magFieldEnd[0] << " , " << magFieldEnd[1] << "  , " <<  magFieldEnd[2] << std::endl;
+  Vector3D<Real_t> magFieldEnd;
+  magField.Evaluate(Position, magFieldEnd);
+
+  std::cout << " Mag field at end = " << magFieldEnd[0] << " , " << magFieldEnd[1] << "  , " << magFieldEnd[2]
+            << std::endl;
 
   // Test the 'full' DoStep methodx
 
-  
   // Finish the integration ...
-  
+
   return true;
 }
 
@@ -309,137 +301,133 @@ bool TestDriverAdvance( Field_t const & magField,  Real_t hLength = 300 )
 //   -------------
 
 template <typename Real_t, typename Field_t> // , typename Equation_t>
-bool CheckDriverVsHelix( Field_t const & magField,  const Real_t stepLength = 300.0 )
+bool CheckDriverVsHelix(Field_t const &magField, const Real_t stepLength = 300.0)
 //   -----------
 {
   constexpr unsigned int Nvar = 6; // Number of integration variables
-  using Equation_t = MagneticFieldEquation<Field_t>;
-  using Stepper_t  = DormandPrinceRK45<Equation_t, Field_t, Nvar, Real_t>;
-  using Driver_t   = RkIntegrationDriver<Stepper_t, Real_t, int, Equation_t, Field_t>;
+  using Equation_t            = MagneticFieldEquation<Field_t>;
+  using Stepper_t             = DormandPrinceRK45<Equation_t, Field_t, Nvar, Real_t>;
+  using Driver_t              = RkIntegrationDriver<Stepper_t, Real_t, int, Equation_t, Field_t>;
 
-  Vector3D<Real_t> const startPosition =  { 0,   0.001,   0.002   };  //  PositionVec[0], PositionVec[1], PositionVec[2],
-  Vector3D<Real_t> const startDirection = { 0,   1.0, 0.0 };
-  const Real_t momentumMag = 30.0 * copcore::units::MeV;
+  Vector3D<Real_t> const startPosition  = {0, 0.001, 0.002}; //  PositionVec[0], PositionVec[1], PositionVec[2],
+  Vector3D<Real_t> const startDirection = {0, 1.0, 0.0};
+  const Real_t momentumMag              = 30.0 * copcore::units::MeV;
 
   Vector3D<Real_t> const startMomentum = momentumMag * startDirection;
-    
+
   Real_t dy_ds[Nvar];
-  Real_t yOut[Nvar];        // Output:  y values at end,
-  Real_t yerr[Nvar];        //          estimated errors, 
-  Real_t next_dyds[Nvar];  //          next value of dydx
+  Real_t yOut[Nvar];      // Output:  y values at end,
+  Real_t yerr[Nvar];      //          estimated errors,
+  Real_t next_dyds[Nvar]; //          next value of dydx
 
-  int   charge = -1;
-  
-  Vector3D<float> magFieldStart( 1, 2, 3);
-  Real_t yStart[Nvar] = { startPosition[0], startPosition[1], startPosition[2],
-                          startMomentum[0], startMomentum[1], startMomentum[2] } ;
+  int charge = -1;
+
+  Vector3D<float> magFieldStart(1, 2, 3);
+  Real_t yStart[Nvar] = {startPosition[0], startPosition[1], startPosition[2],
+                         startMomentum[0], startMomentum[1], startMomentum[2]};
   Equation_t::EvaluateDerivativesReturnB(magField, yStart, charge, dy_ds, magFieldStart);
-  // std::cout << " magField = " << magFieldStart[0] << " , " << magFieldStart[1] << " , " << magFieldStart[2] << std::endl;
+  // std::cout << " magField = " << magFieldStart[0] << " , " << magFieldStart[1] << " , " << magFieldStart[2] <<
+  // std::endl;
 
-  // For use by Runge Kutta 
-  Real_t hLength = stepLength;
-  Vector3D<Real_t> Position = startPosition;
-  Vector3D<Real_t> Direction= startDirection;
+  // For use by Runge Kutta
+  Real_t hLength             = stepLength;
+  Vector3D<Real_t> Position  = startPosition;
+  Vector3D<Real_t> Direction = startDirection;
 
   // -- Test the simple Advance method
-  unsigned int totalTrials = 0; 
-  bool verbose = false;
-  Real_t  dydx_end[Nvar];
+  unsigned int totalTrials = 0;
+  bool verbose             = false;
+  Real_t dydx_end[Nvar];
 
-  if( verbose ) {
+  if (verbose) {
     // std::cout << "yStart: " << std::endl;
     // PrintFieldVectors::PrintSixvec( yStart );
     std::cout << " t:   " << setw(3) << totalTrials << " s= " << setw(9) << 0.0 << " ";
-    Real_t magFieldStartArr[3] = { magFieldStart[0],   magFieldStart[1],   magFieldStart[2] };    
-    PrintFieldVectors::PrintLineSixvecDyDx( yStart, charge, magFieldStartArr, dy_ds );
-  }                            
+    Real_t magFieldStartArr[3] = {magFieldStart[0], magFieldStart[1], magFieldStart[2]};
+    PrintFieldVectors::PrintLineSixvecDyDx(yStart, charge, magFieldStartArr, dy_ds);
+  }
 
-  bool unfinished = true;
-  Real_t  hTry = hLength;    // suggested 'good' length per integration step
-  Real_t  sumAdvanced = 0;     //  length integrated
-  
+  bool unfinished    = true;
+  Real_t hTry        = hLength; // suggested 'good' length per integration step
+  Real_t sumAdvanced = 0;       //  length integrated
+
   constexpr int maxTrials = 500;
 
-  Vector3D<Real_t> momentumVec= momentumMag * Direction;
-  
+  Vector3D<Real_t> momentumVec = momentumMag * Direction;
+
   do {
-    Real_t hAdvanced = 0;     //  length integrated
+    Real_t hAdvanced = 0; //  length integrated
 
-    bool done = 
-       Driver_t::Advance( Position, momentumVec, charge, hLength, magField, hTry, dydx_end,
-                          hAdvanced, totalTrials, trialsPerCall);
+    bool done = Driver_t::Advance(Position, momentumVec, charge, hLength, magField, hTry, dydx_end, hAdvanced,
+                                  totalTrials, trialsPerCall);
     //   Runge-Kutta single call ( number of steps <= trialsPerCall )
-    
+
     hLength -= hAdvanced;
-    unfinished = !done;  // (hLength > 0.0);
+    unfinished = !done; // (hLength > 0.0);
 
-    sumAdvanced += hAdvanced;  // Gravy ..
+    sumAdvanced += hAdvanced; // Gravy ..
 
-  } while ( unfinished  && (totalTrials < maxTrials) );
+  } while (unfinished && (totalTrials < maxTrials));
   // Ensure that the 'lane' integration is done .... or at least we tried hard
 
   // Cast the solution into simple variables - for comparison
   Vector3D<Real_t> endPositionRK  = Position;
   Vector3D<Real_t> endDirectionRK = (1.0 / momentumMag) * momentumVec;
-  Real_t magDirectionRK = endDirectionRK.Mag();
+  Real_t magDirectionRK           = endDirectionRK.Mag();
 
-  // For use by Helix method ...  
+  // For use by Helix method ...
   Vector3D<Real_t> endPositionHx, endDirectionHx;
-  
-  ConstFieldHelixStepper  helixBvec( magFieldStart );
+
+  ConstFieldHelixStepper helixBvec(magFieldStart);
   //********************
 
   // Helix solution --- for comparison
-#if 1  
-  // fieldPropagatorConstBany fieldPropagatorBany;  
+#if 1
+  // fieldPropagatorConstBany fieldPropagatorBany;
   helixBvec.DoStep(startPosition, startDirection, charge, momentumMag, stepLength,
-  /**************/ endPositionHx, endDirectionHx);                  
-#else  
-  helixBvec.DoStep<Real_t,int>(startPosition, startDirection, charge, momentumMag,
-                               stepLength, endPositionHx, endDirectionHx );
+                   /**************/ endPositionHx, endDirectionHx);
+#else
+  helixBvec.DoStep<Real_t, int>(startPosition, startDirection, charge, momentumMag, stepLength, endPositionHx,
+                                endDirectionHx);
 #endif
 
   // Compare the results HERE
-  Vector3D<Real_t> shiftVec = ( endPositionRK - endPositionHx );
-  Vector3D<Real_t> deltaDir = ( endDirectionRK - endDirectionHx );
-  
-  if( verbose ) {
-     std::cout << "- Trials:  max/call= " << trialsPerCall
-               << "  total done = " << totalTrials
-               << ( (totalTrials == trialsPerCall) ? " MAXimum reached !!":" ")
-               << std::endl;
+  Vector3D<Real_t> shiftVec = (endPositionRK - endPositionHx);
+  Vector3D<Real_t> deltaDir = (endDirectionRK - endDirectionHx);
+
+  if (verbose) {
+    std::cout << "- Trials:  max/call= " << trialsPerCall << "  total done = " << totalTrials
+              << ((totalTrials == trialsPerCall) ? " MAXimum reached !!" : " ") << std::endl;
   } else {
-     std::cout << " t: " << setw(4) << totalTrials
-               << " s= " << setw(7) << sumAdvanced << " "
-               << " l= " << setw(7) << stepLength  << " "
-               << " d||*1e6 = " << setw(10) << 1.e6 * ( magDirectionRK - 1.0 ) << " | " ;
+    std::cout << " t: " << setw(4) << totalTrials << " s= " << setw(7) << sumAdvanced << " "
+              << " l= " << setw(7) << stepLength << " "
+              << " d||*1e6 = " << setw(10) << 1.e6 * (magDirectionRK - 1.0) << " | ";
   }
-  Real_t yPosMom[Nvar] = { endPositionHx[0], endPositionHx[1], endPositionHx[2],
-                             momentumVec[0],   momentumVec[1],   momentumVec[2]  } ;
+  Real_t yPosMom[Nvar] = {endPositionHx[0], endPositionHx[1], endPositionHx[2],
+                          momentumVec[0],   momentumVec[1],   momentumVec[2]};
   Vector3D<float> magFieldEnd;
-  Equation_t::EvaluateDerivativesReturnB(magField, yPosMom, charge, dy_ds, magFieldEnd );
-  Real_t magFieldEndArr[3] = { magFieldEnd[0],   magFieldEnd[1],   magFieldEnd[2] };
+  Equation_t::EvaluateDerivativesReturnB(magField, yPosMom, charge, dy_ds, magFieldEnd);
+  Real_t magFieldEndArr[3] = {magFieldEnd[0], magFieldEnd[1], magFieldEnd[2]};
 
-  constexpr Real_t magFactorPos= 1.0 / Driver_t::  // RkIntegrationDriver<>
-     fEpsilonRelativeMax; 
-  constexpr Real_t magFactorDir= magFactorPos ; // 1.0e+6; 
+  constexpr Real_t magFactorPos = 1.0 / Driver_t:: // RkIntegrationDriver<>
+                                  fEpsilonRelativeMax;
+  constexpr Real_t magFactorDir = magFactorPos; // 1.0e+6;
 
-  Real_t mulFactorPos = magFactorPos / stepLength;
-  Real_t deltaPosMom[Nvar]=
-     { mulFactorPos * shiftVec[0], mulFactorPos * shiftVec[1], mulFactorPos * shiftVec[2],
-       magFactorDir * deltaDir[0], magFactorDir * deltaDir[1], magFactorDir * deltaDir[2] } ;
+  Real_t mulFactorPos      = magFactorPos / stepLength;
+  Real_t deltaPosMom[Nvar] = {mulFactorPos * shiftVec[0], mulFactorPos * shiftVec[1], mulFactorPos * shiftVec[2],
+                              magFactorDir * deltaDir[0], magFactorDir * deltaDir[1], magFactorDir * deltaDir[2]};
 
   //--- PrintFieldVectors::PrintSixvecAndDyDx(
-  PrintFieldVectors::PrintLineSixvecDyDx( yPosMom, charge, magFieldEndArr, deltaPosMom );
-  
+  PrintFieldVectors::PrintLineSixvecDyDx(yPosMom, charge, magFieldEndArr, deltaPosMom);
+
   // magField.Evaluate( endPositionHx, magFieldEnd );
   // std::cout << " Mag field at end = " << magFieldEnd[0] << " , " << magFieldEnd[1]
   //           << "  , " <<  magFieldEnd[2] << std::endl;
 
   // Test the 'full' DoStep methodx
-  
+
   // Finish the integration ...
-  
+
   return true;
 }
 
@@ -447,76 +435,74 @@ bool CheckDriverVsHelix( Field_t const & magField,  const Real_t stepLength = 30
 
 int main(int argc, char **argv)
 {
-  using copcore::units::tesla;   
-  Vector3D<float> fieldValueZ(0.0, 0.0, 1.0*tesla);
+  using copcore::units::tesla;
+  Vector3D<float> fieldValueZ(0.0, 0.0, 1.0 * tesla);
   bool allStepGood;
-  
+
   UniformMagneticField *pConstantBfield = new UniformMagneticField(fieldValueZ);
-  UniformMagneticField Bx( Vector3D<float>(10.0*tesla, 0.0,       0.0)  );
-  UniformMagneticField By( Vector3D<float>(0.0,       10.0*tesla, 0.0)  );
-  UniformMagneticField Bz( Vector3D<float>(0.0,       0.0,       10.0*tesla) );
+  UniformMagneticField Bx(Vector3D<float>(10.0 * tesla, 0.0, 0.0));
+  UniformMagneticField By(Vector3D<float>(0.0, 10.0 * tesla, 0.0));
+  UniformMagneticField Bz(Vector3D<float>(0.0, 0.0, 10.0 * tesla));
 
   cout << " -- Testing mag-field equation with float.   " << endl;
-  cout << " ---------------------------------------------------------------------" << endl;  
+  cout << " ---------------------------------------------------------------------" << endl;
   bool okUniformFloat = TestEquation<float, UniformMagneticField>(*pConstantBfield);
   bool okBxFloat      = TestEquation<float, UniformMagneticField>(Bx);
   bool okByFloat      = TestEquation<float, UniformMagneticField>(By);
   bool okBzFloat      = TestEquation<float, UniformMagneticField>(Bz);
-  bool allEqGood = okUniformFloat && okBxFloat && okByFloat && okBzFloat;
+  bool allEqGood      = okUniformFloat && okBxFloat && okByFloat && okBzFloat;
   cout << endl;
-  
-  cout << " ---------------------------------------------------------------------" << endl;  
+
+  cout << " ---------------------------------------------------------------------" << endl;
   cout << " -- Testing Dormand-Prince stepper with magfield and equation (float).   " << endl;
-  cout << " ---------------------------------------------------------------------" << endl;  
-  bool okStep1Float =   TestStepper<float, UniformMagneticField>(*pConstantBfield);
-  allStepGood = okStep1Float;
-#ifdef MORE  
-  bool okStep2Float =   TestStepper<float, UniformMagneticField>(Bx);
-  bool okStep3Float =   TestStepper<float, UniformMagneticField>(By);
-  bool okStep4Float =   TestStepper<float, UniformMagneticField>(Bz);
-  allStepGood &&= okStep2Float && okStep3Float && okStep4Float ;
+  cout << " ---------------------------------------------------------------------" << endl;
+  bool okStep1Float = TestStepper<float, UniformMagneticField>(*pConstantBfield);
+  allStepGood       = okStep1Float;
+#ifdef MORE
+  bool okStep2Float = TestStepper<float, UniformMagneticField>(Bx);
+  bool okStep3Float = TestStepper<float, UniformMagneticField>(By);
+  bool okStep4Float = TestStepper<float, UniformMagneticField>(Bz);
+  allStepGood    && = okStep2Float && okStep3Float && okStep4Float;
 #endif
   cout << endl;
 
   // float lenInc= 250;
-  cout << " -------------------------------------------------------------------------------" << endl;  
+  cout << " -------------------------------------------------------------------------------" << endl;
   cout << " -- Testing Integration driver 'Advance' with Dormand-Prince stepper (float). --" << endl;
   cout << " -------------------------------------------------------------------------------" << endl;
 
   using copcore::units::millimeter;
-  bool okDoPri1Float =  TestDriverAdvance<float, UniformMagneticField>(*pConstantBfield, 1000.0 * millimeter);
+  bool okDoPri1Float = TestDriverAdvance<float, UniformMagneticField>(*pConstantBfield, 1000.0 * millimeter);
 
   bool allDoPriGood = okDoPri1Float;
-  for ( float len = 250; len < 5000 ; len *= 2.0 )
-  {
-     cout << " -- Bx field -- \n";
-     bool okDoPri2Float =  TestDriverAdvance<float, UniformMagneticField>(Bx, len);
+  for (float len = 250; len < 5000; len *= 2.0) {
+    cout << " -- Bx field -- \n";
+    bool okDoPri2Float = TestDriverAdvance<float, UniformMagneticField>(Bx, len);
 
-     cout << " -- By field -- \n";  
-     bool okDoPri3Float =  TestDriverAdvance<float, UniformMagneticField>(By, 2.0* len);
+    cout << " -- By field -- \n";
+    bool okDoPri3Float = TestDriverAdvance<float, UniformMagneticField>(By, 2.0 * len);
 
-     cout << " -- Bz field -- \n";  
-     bool okDoPri4Float =  TestDriverAdvance<float, UniformMagneticField>(Bz, 3.0* len);
+    cout << " -- Bz field -- \n";
+    bool okDoPri4Float = TestDriverAdvance<float, UniformMagneticField>(Bz, 3.0 * len);
 
-     allDoPriGood |= okDoPri1Float && okDoPri2Float && okDoPri3Float && okDoPri4Float;
+    allDoPriGood |= okDoPri1Float && okDoPri2Float && okDoPri3Float && okDoPri4Float;
   }
 
-  cout << " -------------------------------------------------------------------------------" << endl;  
+  cout << " -------------------------------------------------------------------------------" << endl;
   cout << " -- Testing Integration driver 'Advance' vs Helix stepper (float).            --" << endl;
   cout << " -------------------------------------------------------------------------------" << endl;
   bool allChecksGood = true;
 
-  for ( float len = 10 ; len < 1000000 ; len *= 2.0 ) { 
-    bool okCheck1= CheckDriverVsHelix( *pConstantBfield, len );
+  for (float len = 10; len < 1000000; len *= 2.0) {
+    bool okCheck1 = CheckDriverVsHelix(*pConstantBfield, len);
     allChecksGood = allChecksGood && okCheck1;
   }
-  cout << " Checks vs Helix result = " << ( allChecksGood ? " OK ! " : " Errors Found " ) << "\n";
+  cout << " Checks vs Helix result = " << (allChecksGood ? " OK ! " : " Errors Found ") << "\n";
 
-  for ( double len = 10 ; len < 1000000 ; len *= 2.0 ) { 
-    bool okCheck1= CheckDriverVsHelix<double, UniformMagneticField> ( *pConstantBfield, len );
+  for (double len = 10; len < 1000000; len *= 2.0) {
+    bool okCheck1 = CheckDriverVsHelix<double, UniformMagneticField>(*pConstantBfield, len);
     allChecksGood = allChecksGood && okCheck1;
   }
 
-  
-  return ! ( allStepGood && allDoPriGood && allChecksGood );
+  return !(allStepGood && allDoPriGood && allChecksGood);
 }


### PR DESCRIPTION
Another maintenance commit following the creation of the AdePT library structure, simply applying the current `clang-format` settings to all source code. Though it's a large commit, we can use Git's `blame.ignoreRevsFile` functionality:

- https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
- https://michaelheap.com/git-ignore-rev/

and locally using:

```
git config --global blame.ignoreRevsFile .git-blame-ignore-revs
git config --global blame.markIgnoredLines true
git config --global blame.markUnblamableLines true
```

to avoid later confusion when looking at changes. The needed `.git-blame-ignore-revs` file is best added in a new PR after this is merged as the commit hash to ignore may not be know until then.

This can be used in future when/if we change the style.