### PR TITLE
Moving AdePT Initialization to AdePTTrackingManager::BuildPhysicsTable

### DIFF
--- a/examples/Example1/src/DetectorConstruction.cc
+++ b/examples/Example1/src/DetectorConstruction.cc
@@ -47,25 +47,6 @@ G4VPhysicalVolume *DetectorConstruction::Construct()
     return world;
   }
 
-  // - REGIONS
-  if (world->GetLogicalVolume()->GetRegion() == nullptr) {
-    // Add default region if none available
-    // constexpr double DefaultCut = 0.7 * mm;
-    auto defaultRegion = G4RegionStore::GetInstance()->GetRegion("DefaultRegionForTheWorld");
-
-    defaultRegion->AddRootLogicalVolume(world->GetLogicalVolume());
-  }
-
-  for (auto region : *G4RegionStore::GetInstance()) {
-    region->UsedInMassGeometry(true); // make sure all regions are marked as used
-    region->UpdateMaterialList();
-  }
-
-  // - UPDATE COUPLES
-  G4cout << "Updating material-cut couples based on " << G4RegionStore::GetInstance()->size() << " regions ...\n";
-  G4ProductionCutsTable *theCoupleTable = G4ProductionCutsTable::GetProductionCutsTable();
-  theCoupleTable->UpdateCoupleTable(world);
-
   fWorld = world;
 
   return world;

--- a/include/AdePT/core/AdePTConfiguration.hh
+++ b/include/AdePT/core/AdePTConfiguration.hh
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: 2024 CERN
 // SPDX-License-Identifier: Apache-2.0
 
+#ifndef ADEPT_CONFIGURATION_HH
+#define ADEPT_CONFIGURATION_HH
+
 #include <string>
 #include <vector>
 #include <AdePT/integration/AdePTConfigurationMessenger.hh>
@@ -49,3 +52,5 @@ private:
 
   AdePTConfigurationMessenger *fAdePTConfigurationMessenger;
 };
+
+#endif

--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -11,6 +11,7 @@
 #include <AdePT/core/AdePTTransport.h>
 #include "AdePT/copcore/SystemOfUnits.h"
 #include <AdePT/integration/AdePTGeant4Integration.hh>
+#include <AdePT/core/AdePTConfiguration.hh>
 
 #include <vector>
 
@@ -36,18 +37,9 @@ public:
   void SetAdePTTransport(AdePTTransport<AdePTGeant4Integration> *adeptTransport)
   {
     fAdeptTransport = adeptTransport;
-    if (!adeptTransport->GetTrackInAllRegions()) {
-      for (std::string regionName : *(adeptTransport->GetGPURegionNames())) {
-        G4cout << "AdePTTrackingManager: Marking " << regionName << " as a GPU Region" << G4endl;
-        G4Region *region = G4RegionStore::GetInstance()->GetRegion(regionName);
-        if (region != nullptr)
-          fGPURegions.push_back(region);
-        else
-          G4Exception("AdePTTrackingManager", "Invalid parameter", FatalErrorInArgument,
-                      ("Region given to /adept/addGPURegion: " + regionName + " Not found\n").c_str());
-      }
-    }
   }
+
+  void SetAdePTConfiguration(AdePTConfiguration *aAdePTConfiguration) { fAdePTConfiguration = aAdePTConfiguration; }
 
 private:
   /// @brief Steps a particle using the generic G4 tracking, until it dies or enters a user-defined
@@ -61,10 +53,13 @@ private:
   void StepInHostRegion(G4Track *aTrack);
 
   std::vector<G4Region *> fGPURegions{};
-  AdePTTransport<AdePTGeant4Integration> *fAdeptTransport;
   int fVerbosity{0};
   G4double ProductionCut = 0.7 * copcore::units::mm;
   int MCIndex[100];
+  
+  AdePTTransport<AdePTGeant4Integration> *fAdeptTransport;
+  AdePTConfiguration *fAdePTConfiguration;
+  bool fAdePTInitialized{false};
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -30,6 +30,8 @@ public:
 
   void FlushEvent() override;
 
+  void InitializeAdePT();
+
   /// Set verbosity for integration
   void SetVerbosity(int verbosity) { fVerbosity = verbosity; }
 

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -28,6 +28,63 @@ AdePTTrackingManager::~AdePTTrackingManager()
 
 void AdePTTrackingManager::BuildPhysicsTable(const G4ParticleDefinition &part)
 {
+  if (!fAdePTInitialized)
+  {
+    // AdePT needs to be initialized here, since we know all needed Geant4 initializations are already finished
+    fAdeptTransport->SetDebugLevel(0);
+    fAdeptTransport->SetBufferThreshold(fAdePTConfiguration->GetTransportBufferThreshold());
+    fAdeptTransport->SetMaxBatch(2 * fAdePTConfiguration->GetTransportBufferThreshold());
+    fAdeptTransport->SetTrackInAllRegions(fAdePTConfiguration->GetTrackInAllRegions());
+    fAdeptTransport->SetGPURegionNames(fAdePTConfiguration->GetGPURegionNames());
+
+    // Check if this is a sequential run
+    G4RunManager::RMType rmType = G4RunManager::GetRunManager()->GetRunManagerType();
+    bool sequential             = (rmType == G4RunManager::sequentialRM);
+
+    // One thread initializes common elements
+    auto tid = G4Threading::G4GetThreadId();
+    if (tid < 0) {
+      // Load the VecGeom world in memory
+      AdePTGeant4Integration::CreateVecGeomWorld(fAdePTConfiguration->GetVecGeomGDML());
+
+      // Track and Hit buffer capacities on GPU are split among threads
+      int num_threads    = G4RunManager::GetRunManager()->GetNumberOfThreads();
+      int track_capacity = 1024 * 1024 * fAdePTConfiguration->GetMillionsOfTrackSlots() / num_threads;
+      G4cout << "AdePT Allocated track capacity: " << track_capacity << " tracks" << G4endl;
+      fAdeptTransport->SetTrackCapacity(track_capacity);
+      int hit_buffer_capacity = 1024 * 1024 * fAdePTConfiguration->GetMillionsOfHitSlots() / num_threads;
+      G4cout << "AdePT Allocated hit buffer capacity: " << hit_buffer_capacity << " slots" << G4endl;
+      fAdeptTransport->SetHitBufferCapacity(hit_buffer_capacity);
+
+      // Initialize common data:
+      // G4HepEM, Upload VecGeom geometry to GPU, Geometry check, Create volume auxiliary data
+      fAdeptTransport->Initialize(true /*common_data*/);
+      if (sequential) {
+        // Initialize per-thread data (When in sequential mode)
+        fAdeptTransport->Initialize();
+      }
+    } else {
+      // Initialize per-thread data
+      fAdeptTransport->Initialize();
+    }
+
+    // Initialize the GPU region list
+
+    if (!fAdeptTransport->GetTrackInAllRegions()) {
+      for (std::string regionName : *(fAdeptTransport->GetGPURegionNames())) {
+        G4cout << "AdePTTrackingManager: Marking " << regionName << " as a GPU Region" << G4endl;
+        G4Region *region = G4RegionStore::GetInstance()->GetRegion(regionName);
+        if (region != nullptr)
+          fGPURegions.push_back(region);
+        else
+          G4Exception("AdePTTrackingManager", "Invalid parameter", FatalErrorInArgument,
+                      ("Region given to /adept/addGPURegion: " + regionName + " Not found\n").c_str());
+      }
+    }
+
+    fAdePTInitialized = true;
+  }
+
   // For tracking on CPU by Geant4, construct the physics tables for the processes of
   // particles taken by this tracking manager, since Geant4 won't do it anymore
   G4ProcessManager *pManager       = part.GetProcessManager();

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -24,65 +24,70 @@ AdePTTrackingManager::~AdePTTrackingManager()
   fAdeptTransport->Cleanup();
 }
 
+void AdePTTrackingManager::InitializeAdePT()
+{
+  // AdePT needs to be initialized here, since we know all needed Geant4 initializations are already finished
+  fAdeptTransport->SetDebugLevel(0);
+  fAdeptTransport->SetBufferThreshold(fAdePTConfiguration->GetTransportBufferThreshold());
+  fAdeptTransport->SetMaxBatch(2 * fAdePTConfiguration->GetTransportBufferThreshold());
+  fAdeptTransport->SetTrackInAllRegions(fAdePTConfiguration->GetTrackInAllRegions());
+  fAdeptTransport->SetGPURegionNames(fAdePTConfiguration->GetGPURegionNames());
+
+  // Check if this is a sequential run
+  G4RunManager::RMType rmType = G4RunManager::GetRunManager()->GetRunManagerType();
+  bool sequential             = (rmType == G4RunManager::sequentialRM);
+
+  // One thread initializes common elements
+  auto tid = G4Threading::G4GetThreadId();
+  if (tid < 0) {
+    // Load the VecGeom world in memory
+    AdePTGeant4Integration::CreateVecGeomWorld(fAdePTConfiguration->GetVecGeomGDML());
+
+    // Track and Hit buffer capacities on GPU are split among threads
+    int num_threads    = G4RunManager::GetRunManager()->GetNumberOfThreads();
+    int track_capacity = 1024 * 1024 * fAdePTConfiguration->GetMillionsOfTrackSlots() / num_threads;
+    G4cout << "AdePT Allocated track capacity: " << track_capacity << " tracks" << G4endl;
+    fAdeptTransport->SetTrackCapacity(track_capacity);
+    int hit_buffer_capacity = 1024 * 1024 * fAdePTConfiguration->GetMillionsOfHitSlots() / num_threads;
+    G4cout << "AdePT Allocated hit buffer capacity: " << hit_buffer_capacity << " slots" << G4endl;
+    fAdeptTransport->SetHitBufferCapacity(hit_buffer_capacity);
+
+    // Initialize common data:
+    // G4HepEM, Upload VecGeom geometry to GPU, Geometry check, Create volume auxiliary data
+    fAdeptTransport->Initialize(true /*common_data*/);
+    if (sequential) {
+      // Initialize per-thread data (When in sequential mode)
+      fAdeptTransport->Initialize();
+    }
+  } else {
+    // Initialize per-thread data
+    fAdeptTransport->Initialize();
+  }
+
+  // Initialize the GPU region list
+
+  if (!fAdeptTransport->GetTrackInAllRegions()) {
+    for (std::string regionName : *(fAdeptTransport->GetGPURegionNames())) {
+      G4cout << "AdePTTrackingManager: Marking " << regionName << " as a GPU Region" << G4endl;
+      G4Region *region = G4RegionStore::GetInstance()->GetRegion(regionName);
+      if (region != nullptr)
+        fGPURegions.push_back(region);
+      else
+        G4Exception("AdePTTrackingManager", "Invalid parameter", FatalErrorInArgument,
+                    ("Region given to /adept/addGPURegion: " + regionName + " Not found\n").c_str());
+    }
+  }
+
+  fAdePTInitialized = true;
+}
+
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 void AdePTTrackingManager::BuildPhysicsTable(const G4ParticleDefinition &part)
 {
   if (!fAdePTInitialized)
   {
-    // AdePT needs to be initialized here, since we know all needed Geant4 initializations are already finished
-    fAdeptTransport->SetDebugLevel(0);
-    fAdeptTransport->SetBufferThreshold(fAdePTConfiguration->GetTransportBufferThreshold());
-    fAdeptTransport->SetMaxBatch(2 * fAdePTConfiguration->GetTransportBufferThreshold());
-    fAdeptTransport->SetTrackInAllRegions(fAdePTConfiguration->GetTrackInAllRegions());
-    fAdeptTransport->SetGPURegionNames(fAdePTConfiguration->GetGPURegionNames());
-
-    // Check if this is a sequential run
-    G4RunManager::RMType rmType = G4RunManager::GetRunManager()->GetRunManagerType();
-    bool sequential             = (rmType == G4RunManager::sequentialRM);
-
-    // One thread initializes common elements
-    auto tid = G4Threading::G4GetThreadId();
-    if (tid < 0) {
-      // Load the VecGeom world in memory
-      AdePTGeant4Integration::CreateVecGeomWorld(fAdePTConfiguration->GetVecGeomGDML());
-
-      // Track and Hit buffer capacities on GPU are split among threads
-      int num_threads    = G4RunManager::GetRunManager()->GetNumberOfThreads();
-      int track_capacity = 1024 * 1024 * fAdePTConfiguration->GetMillionsOfTrackSlots() / num_threads;
-      G4cout << "AdePT Allocated track capacity: " << track_capacity << " tracks" << G4endl;
-      fAdeptTransport->SetTrackCapacity(track_capacity);
-      int hit_buffer_capacity = 1024 * 1024 * fAdePTConfiguration->GetMillionsOfHitSlots() / num_threads;
-      G4cout << "AdePT Allocated hit buffer capacity: " << hit_buffer_capacity << " slots" << G4endl;
-      fAdeptTransport->SetHitBufferCapacity(hit_buffer_capacity);
-
-      // Initialize common data:
-      // G4HepEM, Upload VecGeom geometry to GPU, Geometry check, Create volume auxiliary data
-      fAdeptTransport->Initialize(true /*common_data*/);
-      if (sequential) {
-        // Initialize per-thread data (When in sequential mode)
-        fAdeptTransport->Initialize();
-      }
-    } else {
-      // Initialize per-thread data
-      fAdeptTransport->Initialize();
-    }
-
-    // Initialize the GPU region list
-
-    if (!fAdeptTransport->GetTrackInAllRegions()) {
-      for (std::string regionName : *(fAdeptTransport->GetGPURegionNames())) {
-        G4cout << "AdePTTrackingManager: Marking " << regionName << " as a GPU Region" << G4endl;
-        G4Region *region = G4RegionStore::GetInstance()->GetRegion(regionName);
-        if (region != nullptr)
-          fGPURegions.push_back(region);
-        else
-          G4Exception("AdePTTrackingManager", "Invalid parameter", FatalErrorInArgument,
-                      ("Region given to /adept/addGPURegion: " + regionName + " Not found\n").c_str());
-      }
-    }
-
-    fAdePTInitialized = true;
+    InitializeAdePT();
   }
 
   // For tracking on CPU by Geant4, construct the physics tables for the processes of


### PR DESCRIPTION
Previously AdePTTransport was initialized at AdePTPhysics::ConstructProcess. However at this point the material-cut couples are not yet initialized in Geant4, which means G4HepEM can't be initialized. The workaround was to manually initialize them in the user detector construction.

This PR delays the AdePT initialization until AdePTTrackingManager::BuildPhysicsTable, at which point we have all the information we need.

One downside of this approach is that now we have a pointer to AdePTConfiguration in AdePTTrackingManager, rather than AdePTPhysics being the only user of the configuration.