### PR TITLE
Use VecGeom recommendations for device linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,19 +163,23 @@ target_link_libraries(AdePT_G4_integration
   PUBLIC 
     CopCore
     VecGeom::vecgeom
-    VecGeom::vecgeomcuda_static
-    VecGeom::vgdml
     ${Geant4_LIBRARIES}
     G4HepEm::g4HepEm
     G4HepEm::g4HepEmData
     G4HepEm::g4HepEmInit
     G4HepEm::g4HepEmRun
-)
+  PRIVATE
+    VecGeom::vecgeomcuda
+    VecGeom::vgdml
+    )
+target_link_options(AdePT_G4_integration
+  PRIVATE $<DEVICE_LINK:$<TARGET_FILE:VecGeom::vecgeomcuda_static>>)
 
 set_target_properties(AdePT_G4_integration
   PROPERTIES 
     CUDA_SEPARABLE_COMPILATION ON 
     CUDA_RESOLVE_DEVICE_SYMBOLS ON
+    CUDA_RUNTIME_LIBRARY Shared
 )
 
 # Optional library to activate NVTX annotations for profiling:

--- a/test/testField/CMakeLists.txt
+++ b/test/testField/CMakeLists.txt
@@ -34,17 +34,18 @@ target_include_directories(testField
 target_link_libraries(testField
   PRIVATE
     CopCore
-    VecGeom::vecgeom
-    VecGeom::vecgeomcuda_static
+    VecGeom::vecgeomcuda
     VecGeom::vgdml
     ${Geant4_LIBRARIES}
     ${G4HepEm_LIBRARIES}
-    CUDA::cudart
 )
+target_link_options(testField
+  PRIVATE $<DEVICE_LINK:$<TARGET_FILE:VecGeom::vecgeomcuda_static>>)
 set_target_properties(testField 
   PROPERTIES 
     CUDA_SEPARABLE_COMPILATION ON 
     CUDA_RESOLVE_DEVICE_SYMBOLS ON
+    CUDA_RUNTIME_LIBRARY Shared
 )
 
 # Tests


### PR DESCRIPTION
As outlined in VecGeom README and build scripts, we have to be _very_ careful about linking to its CUDA component when we ourselves use VecGeom's CUDA functions. This is a small update to AdePT to use these recommendations:

1. Linking to `vecgeomcuda` privately, adding `vecgeomcuda_static` to the device link step.
2. Use `CUDA_RUNTIME_LIBRARY` as "Shared" to link to same runtime as used by `vecgeomcuda`

The public link to `vecgeom` is retained currently due to `AdePT_G4_integration` still exposing some of VecGeom in its interfaces, which is fine for now.

This change is required to allow use of G4VG for in memory use of Geant4-VecGeom conversions, but I've submitted just the linking change in isolation first to cross-check if this exposes `as-needed` (it doesn't locally at least) or performance issues.