### PR TITLE
Improving GPU region check

### DIFF
--- a/examples/Example1/macros/example1_ttbar.mac.in
+++ b/examples/Example1/macros/example1_ttbar.mac.in
@@ -29,8 +29,8 @@
 # If true, particles are transported on the GPU across the whole geometry, GPU regions are ignored
 /adept/setTrackInAllRegions true
 # In order to do the GPU transport only in specific regions
-/adept/addGPURegion EcalRegion
-/adept/addGPURegion HcalRegion
+#/adept/addGPURegion EcalRegion
+#/adept/addGPURegion HcalRegion
 
 
 ## -----------------------------------------------------------------------------

--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -54,7 +54,7 @@ private:
   /// @brief Steps a track using the Generic G4TrackingManager until it enters a GPU region or stops
   void StepInHostRegion(G4Track *aTrack);
 
-  std::vector<G4Region *> fGPURegions{};
+  std::set<G4Region *> fGPURegions{};
   int fVerbosity{0};
   G4double ProductionCut = 0.7 * copcore::units::mm;
   int MCIndex[100];

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -184,8 +184,8 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
     if (fAdeptTransport->GetTrackInAllRegions()) {
       isGPURegion = true;
     } else {
-      for (G4Region *gpuRegion : fGPURegions) {
-        if (region == gpuRegion) isGPURegion = true;
+      if(fGPURegions.find(region) != fGPURegions.end()) {
+        isGPURegion = true;
       }
     }
 


### PR DESCRIPTION
- Improves the GPU region check while stepping a track by changing from a linear search to using a set
- Only check when the region changes
- If there are no GPU regions registered, give the track back to Geant4's default tracking manager