### PR TITLE
Create a transport interface for switching between AdePT implementations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,11 +164,11 @@ endif()
 #----------------------------------------------------------------------------#
 set(ADEPT_G4_INTEGRATION_SRCS
   src/AdePTTrackingManager.cc
-  src/AdePTTrackingManager.cu
   src/AdePTPhysics.cc
   src/HepEMPhysics.cc
   src/AdePTGeant4Integration.cpp
   src/AdePTConfigurationMessenger.cc
+  src/AdePTConfiguration.cc
 )
 
 add_library(CopCore INTERFACE)
@@ -178,7 +178,11 @@ target_include_directories(CopCore
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/>
 )
 
-add_library(AdePT_G4_integration SHARED ${ADEPT_G4_INTEGRATION_SRCS})
+add_library(AdePT_G4_integration SHARED
+  ${ADEPT_G4_INTEGRATION_SRCS}
+  src/AdePTTransport.cc
+  src/AdePTTransport.cu
+)
 target_include_directories(AdePT_G4_integration
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/examples/Example1/CMakeLists.txt
+++ b/examples/Example1/CMakeLists.txt
@@ -51,17 +51,17 @@ endif()
 # example1
 add_executable(example1 example1.cpp ${sources_g4} ${sources_hepmc3})
 target_include_directories(example1
-  PRIVATE 
-    ${PROJECT_SOURCE_DIR}/examples/Example1/include 
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}/examples/Example1/include
     ${PROJECT_SOURCE_DIR}/examples/Example1
     ${PROJECT_SOURCE_DIR}/examples/common/include
     ${HEPMC3_INCLUDE_DIR}
 )
 target_link_libraries(example1
   PRIVATE
-    AdePT_G4_integration
-    ${HEPMC3_LIBRARIES} 
+    ${HEPMC3_LIBRARIES}
     ${HEPMC3_FIO_LIBRARIES}
+    AdePT_G4_integration
 )
 
 # Install macros and geometry file

--- a/examples/IntegrationBenchmark/CMakeLists.txt
+++ b/examples/IntegrationBenchmark/CMakeLists.txt
@@ -52,16 +52,16 @@ endif()
 # integrationBenchmark
 add_executable(integrationBenchmark integrationBenchmark.cpp ${sources_g4} ${sources_hepmc3})
 target_include_directories(integrationBenchmark
-  PRIVATE 
-    ${PROJECT_SOURCE_DIR}/examples/IntegrationBenchmark/include 
+  PRIVATE
+    ${PROJECT_SOURCE_DIR}/examples/IntegrationBenchmark/include
     ${PROJECT_SOURCE_DIR}/examples/IntegrationBenchmark
     ${PROJECT_SOURCE_DIR}/examples/common/include
     ${HEPMC3_INCLUDE_DIR}
 )
 target_link_libraries(integrationBenchmark
   PRIVATE
-    AdePT_G4_integration  
-    ${HEPMC3_LIBRARIES} 
+    AdePT_G4_integration
+    ${HEPMC3_LIBRARIES}
     ${HEPMC3_FIO_LIBRARIES}
 )
 

--- a/include/AdePT/benchmarking/TestManager.h
+++ b/include/AdePT/benchmarking/TestManager.h
@@ -33,6 +33,7 @@
 #include <iomanip>
 // Output files and directories
 #include <filesystem>
+#include <mutex>
 
 struct TimeInfo {
   std::chrono::time_point<CLOCK> start;                                 ///< Start timestamp

--- a/include/AdePT/core/AdePTConfiguration.hh
+++ b/include/AdePT/core/AdePTConfiguration.hh
@@ -4,14 +4,29 @@
 #ifndef ADEPT_CONFIGURATION_HH
 #define ADEPT_CONFIGURATION_HH
 
+#include <AdePT/integration/AdePTConfigurationMessenger.hh>
+#include <AdePT/core/AdePTTransportInterface.hh>
+
+#include <memory>
 #include <string>
 #include <vector>
-#include <AdePT/integration/AdePTConfigurationMessenger.hh>
 
+/// @brief Factory function to create AdePT instances.
+/// Every AdePT transport implementation needs to provide this function to create
+/// instances of the transport implementation. These might either be one instance
+/// per thread, or share one instance across many threads. This is up to the
+/// transport implementation.
+std::shared_ptr<AdePTTransportInterface> AdePTTransportFactory(unsigned int nThread, unsigned int nTrackSlot,
+                                                               unsigned int nHitSlot, int verbosity,
+                                                               std::vector<std::string> const *GPURegionNames,
+                                                               bool trackInAllRegions);
+
+/// @brief Create and configure instances of an AdePT transport implementation.
+///
 class AdePTConfiguration {
 public:
-  AdePTConfiguration() { fAdePTConfigurationMessenger = new AdePTConfigurationMessenger(this); }
-  ~AdePTConfiguration() { delete fAdePTConfigurationMessenger; }
+  AdePTConfiguration();
+  ~AdePTConfiguration();
   void SetRandomSeed(int randomSeed) { fRandomSeed = randomSeed; }
   void SetTrackInAllRegions(bool trackInAllRegions) { fTrackInAllRegions = trackInAllRegions; }
   void AddGPURegionName(std::string name) { fGPURegionNames.push_back(name); }
@@ -36,6 +51,8 @@ public:
   double GetMillionsOfHitSlots() { return fMillionsOfHitSlots; }
   std::vector<std::string> *GetGPURegionNames() { return &fGPURegionNames; }
 
+  std::shared_ptr<AdePTTransportInterface> CreateAdePTInstance(unsigned int nThread);
+
   // Temporary
   std::string GetVecGeomGDML() { return fVecGeomGDML; }
 
@@ -50,10 +67,10 @@ private:
   double fMillionsOfTrackSlots{1};
   double fMillionsOfHitSlots{1};
   std::vector<std::string> fGPURegionNames{};
+  int fNThread = -1;
 
   std::string fVecGeomGDML{""};
-
-  AdePTConfigurationMessenger *fAdePTConfigurationMessenger;
+  std::unique_ptr<AdePTConfigurationMessenger> fAdePTConfigurationMessenger;
 };
 
 #endif

--- a/include/AdePT/core/AdePTScoringTemplate.cuh
+++ b/include/AdePT/core/AdePTScoringTemplate.cuh
@@ -18,25 +18,30 @@ namespace adept_scoring
   void FreeGPU(Scoring *scoring, Scoring *scoring_dev){}
 
   template <typename Scoring>
-  __device__ void RecordHit(Scoring *scoring_dev, int aParentID, char aParticleType, double aStepLength, double aTotalEnergyDeposit,
-                          vecgeom::NavigationState const *aPreState, vecgeom::Vector3D<Precision> *aPrePosition,
-                          vecgeom::Vector3D<Precision> *aPreMomentumDirection,
-                          vecgeom::Vector3D<Precision> *aPrePolarization, double aPreEKin, double aPreCharge,
-                          vecgeom::NavigationState const *aPostState, vecgeom::Vector3D<Precision> *aPostPosition,
-                          vecgeom::Vector3D<Precision> *aPostMomentumDirection,
-                          vecgeom::Vector3D<Precision> *aPostPolarization, double aPostEKin, double aPostCharge){}
+  __device__ void RecordHit(Scoring *scoring_dev, int aParentID, char aParticleType, double aStepLength,
+                            double aTotalEnergyDeposit, vecgeom::NavigationState const *aPreState,
+                            vecgeom::Vector3D<Precision> const *aPrePosition,
+                            vecgeom::Vector3D<Precision> const *aPreMomentumDirection,
+                            vecgeom::Vector3D<Precision> const *aPrePolarization, double aPreEKin, double aPreCharge,
+                            vecgeom::NavigationState const *aPostState,
+                            vecgeom::Vector3D<Precision> const *aPostPosition,
+                            vecgeom::Vector3D<Precision> const *aPostMomentumDirection,
+                            vecgeom::Vector3D<Precision> const *aPostPolarization, double aPostEKin, double aPostCharge,
+                            unsigned int eventId, short threadId);
 
-template <typename Scoring>
-__device__ void AccountProduced(Scoring *scoring_dev, int num_ele, int num_pos, int num_gam);
+  template <typename Scoring>
+  __device__ void AccountProduced(Scoring *scoring_dev, int num_ele, int num_pos, int num_gam);
 
-template <typename Scoring>
-__device__ __forceinline__ void EndOfIterationGPU(Scoring *scoring_dev);
+  template <typename Scoring>
+  __device__ __forceinline__ void EndOfIterationGPU(Scoring *scoring_dev);
 
-template <typename Scoring, typename IntegrationLayer>
-inline void EndOfIteration(Scoring &scoring, Scoring *scoring_dev, cudaStream_t &stream, IntegrationLayer &integration);
+  template <typename Scoring, typename IntegrationLayer>
+  inline void EndOfIteration(Scoring &scoring, Scoring *scoring_dev, cudaStream_t &stream,
+                             IntegrationLayer &integration);
 
-template <typename Scoring, typename IntegrationLayer>
-inline void EndOfTransport(Scoring &scoring, Scoring *scoring_dev, cudaStream_t &stream, IntegrationLayer &integration);
+  template <typename Scoring, typename IntegrationLayer>
+  inline void EndOfTransport(Scoring &scoring, Scoring *scoring_dev, cudaStream_t &stream,
+                             IntegrationLayer &integration);
 }
 
 #endif

--- a/include/AdePT/core/AdePTTransport.cuh
+++ b/include/AdePT/core/AdePTTransport.cuh
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 
+#ifndef ADEPT_TRANSPORT_CUH
+#define ADEPT_TRANSPORT_CUH
+
 #include <AdePT/core/AdePTScoringTemplate.cuh>
 #include <AdePT/core/HostScoringStruct.cuh>
 #include <AdePT/core/HostScoringImpl.cuh>
@@ -48,6 +51,11 @@
 #include <algorithm>
 
 namespace adept_impl {
+inline __constant__ __device__ struct G4HepEmParameters g4HepEmPars;
+inline __constant__ __device__ struct G4HepEmData g4HepEmData;
+
+inline __constant__ __device__ adeptint::VolAuxData *gVolAuxData = nullptr;
+inline __constant__ __device__ double BzFieldValue               = 0;
 
 bool InitializeVolAuxArray(adeptint::VolAuxArray &array)
 {
@@ -75,7 +83,7 @@ G4HepEmState *InitG4HepEm()
 
   // Copy to GPU.
   CopyG4HepEmDataToGPU(state->fData);
-  COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(g4HepEmPars, state->fParameters, sizeof(G4HepEmParameters)));
+  COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(adept_impl::g4HepEmPars, state->fParameters, sizeof(G4HepEmParameters)));
 
   // Create G4HepEmData with the device pointers.
   G4HepEmData dataOnDevice;
@@ -552,3 +560,5 @@ void ShowerGPU(IntegrationLayer &integration, int event, adeptint::TrackBuffer &
   adept_scoring::EndOfTransport<IntegrationLayer>(*scoring, scoring_dev, gpuState.stream, integration);
 }
 } // namespace adept_impl
+
+#endif

--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -47,7 +47,8 @@ bool AdePTTransport<IntegrationLayer>::InitializeField(double bz)
 template <typename IntegrationLayer>
 void AdePTTransport<IntegrationLayer>::AddTrack(int pdg, int parent_id, double energy, double x, double y, double z,
                                                 double dirx, double diry, double dirz, double globalTime,
-                                                double localTime, double properTime)
+                                                double localTime, double properTime, int /*threadId*/, unsigned int eventId,
+                                                unsigned int /*trackIndex*/)
 {
   fBuffer.toDevice.emplace_back(pdg, parent_id, energy, x, y, z, dirx, diry, dirz, globalTime, localTime, properTime);
   if (pdg == 11)
@@ -60,7 +61,7 @@ void AdePTTransport<IntegrationLayer>::AddTrack(int pdg, int parent_id, double e
   if (fBuffer.toDevice.size() >= fBufferThreshold) {
     if (fDebugLevel > 0)
       std::cout << "Reached the threshold of " << fBufferThreshold << " triggering the shower" << std::endl;
-    this->Shower(fIntegrationLayer.GetEventID());
+    this->Shower(eventId, 0);
   }
 }
 
@@ -199,7 +200,7 @@ void AdePTTransport<IntegrationLayer>::Cleanup()
 }
 
 template <typename IntegrationLayer>
-void AdePTTransport<IntegrationLayer>::Shower(int event)
+void AdePTTransport<IntegrationLayer>::Shower(int event, int /*threadId*/)
 {
   int tid = fIntegrationLayer.GetThreadID();
   if (fDebugLevel > 0 && fBuffer.toDevice.size() == 0) {

--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -249,7 +249,7 @@ void AdePTTransport<IntegrationLayer>::Shower(int event)
     std::cout << "[" << tid << "] fromDevice: " << nelec << " elec, " << nposi << " posi, " << ngamma << " gamma\n";
   }
 
-  fIntegrationLayer.ReturnTracks(&(fBuffer.fromDevice), fDebugLevel);
+  fIntegrationLayer.ReturnTracks(fBuffer.fromDevice.begin(), fBuffer.fromDevice.end(), fDebugLevel);
 
   fBuffer.Clear();
 }

--- a/include/AdePT/core/AdePTTransportInterface.hh
+++ b/include/AdePT/core/AdePTTransportInterface.hh
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2022 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ADEPT_TRANSPORT_INTERFACE_H
+#define ADEPT_TRANSPORT_INTERFACE_H
+
+#include <memory>
+#include <string>
+#include <vector>
+
+class AdePTTransportInterface {
+public:
+  virtual ~AdePTTransportInterface() {}
+
+  /// @brief Adds a track to the buffer
+  virtual void AddTrack(int pdg, int id, double energy, double x, double y, double z, double dirx, double diry,
+                        double dirz, double globalTime, double localTime, double properTime, int threadId,
+                        unsigned int eventId, unsigned int trackIndex) = 0;
+
+  /// @brief Set capacity of on-GPU track buffer.
+  virtual void SetTrackCapacity(size_t capacity) = 0;
+  /// @brief Set Hit buffer capacity on GPU and Host
+  virtual void SetHitBufferCapacity(size_t capacity) = 0;
+  /// @brief Set maximum batch size
+  virtual void SetMaxBatch(int npart) = 0;
+  /// @brief Set buffer threshold
+  virtual void SetBufferThreshold(int limit) = 0;
+  /// @brief Set debug level for transport
+  virtual void SetDebugLevel(int level) = 0;
+  /// @brief Set whether AdePT should transport particles across the whole geometry
+  virtual void SetTrackInAllRegions(bool trackInAllRegions) = 0;
+  /// @brief Check whether AdePT should transport particles across the whole geometry
+  virtual bool GetTrackInAllRegions() const = 0;
+  /// @brief Set Geant4 region to which it applies
+  virtual void SetGPURegionNames(std::vector<std::string> const *regionNames) = 0;
+  virtual std::vector<std::string> const *GetGPURegionNames()                 = 0;
+  virtual void SetCUDAStackLimit(int limit)                                   = 0;
+  /// @brief Initialize service and copy geometry & physics data on device
+  virtual void Initialize(bool common_data = false) = 0;
+  /// @brief Interface for transporting a buffer of tracks in AdePT.
+  virtual void Shower(int event, int threadId) = 0;
+  virtual void Cleanup()                       = 0;
+};
+
+#endif

--- a/include/AdePT/core/AdePTTransportStruct.cuh
+++ b/include/AdePT/core/AdePTTransportStruct.cuh
@@ -102,21 +102,12 @@ struct GPUstate {
   Stats *stats{nullptr};              ///< statistics object pointer on host
 };
 
-// Constant data structures from G4HepEm accessed by the kernels.
-// (defined in TestEm3.cu)
-extern __constant__ __device__ struct G4HepEmParameters g4HepEmPars;
-extern __constant__ __device__ struct G4HepEmData g4HepEmData;
-
-// Pointer for array of volume auxiliary data on device
-extern __constant__ __device__ adeptint::VolAuxData *gVolAuxData;
-
-// constexpr float BzFieldValue = 0.1 * copcore::units::tesla;
-extern __constant__ __device__ double BzFieldValue;
+namespace adept_impl {
 constexpr double kPush = 1.e-8 * copcore::units::cm;
-__constant__ __device__ struct G4HepEmParameters g4HepEmPars;
-__constant__ __device__ struct G4HepEmData g4HepEmData;
+extern __constant__ struct G4HepEmParameters g4HepEmPars;
+extern __constant__ struct G4HepEmData g4HepEmData;
 
-__constant__ __device__ adeptint::VolAuxData *gVolAuxData = nullptr;
-__constant__ __device__ double BzFieldValue               = 0;
-
+extern __constant__ __device__ adeptint::VolAuxData *gVolAuxData;
+extern __constant__ __device__ double BzFieldValue;
+} // namespace adept_impl
 #endif

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -12,12 +12,12 @@
 #include <AdePT/core/CommonStruct.h>
 #include <AdePT/core/HostScoringStruct.cuh>
 
-#include <G4HepEmState.hh>
-
 #include <G4EventManager.hh>
 #include <G4Event.hh>
 
 #include <unordered_map>
+
+struct G4HepEmState;
 
 namespace AdePTGeant4Integration_detail {
 struct ScoringObjects;

--- a/include/AdePT/integration/AdePTPhysics.hh
+++ b/include/AdePT/integration/AdePTPhysics.hh
@@ -6,8 +6,9 @@
 
 #include "G4VPhysicsConstructor.hh"
 #include "globals.hh"
-#include <AdePT/integration/AdePTTrackingManager.hh>
-#include <AdePT/core/AdePTConfiguration.hh>
+
+class AdePTTrackingManager;
+class AdePTConfiguration;
 
 class AdePTPhysics : public G4VPhysicsConstructor {
 public:

--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -8,11 +8,12 @@
 #include "G4RegionStore.hh"
 
 #include "globals.hh"
-#include <AdePT/core/AdePTTransport.h>
+#include <AdePT/core/AdePTTransportInterface.hh>
 #include "AdePT/copcore/SystemOfUnits.h"
 #include <AdePT/integration/AdePTGeant4Integration.hh>
 #include <AdePT/core/AdePTConfiguration.hh>
 
+#include <memory>
 #include <vector>
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -35,12 +36,6 @@ public:
   /// Set verbosity for integration
   void SetVerbosity(int verbosity) { fVerbosity = verbosity; }
 
-  // Set the AdePTTransport instance, also initializes the GPU region list
-  void SetAdePTTransport(AdePTTransport<AdePTGeant4Integration> *adeptTransport)
-  {
-    fAdeptTransport = adeptTransport;
-  }
-
   void SetAdePTConfiguration(AdePTConfiguration *aAdePTConfiguration) { fAdePTConfiguration = aAdePTConfiguration; }
 
 private:
@@ -54,13 +49,13 @@ private:
   /// @brief Steps a track using the Generic G4TrackingManager until it enters a GPU region or stops
   void StepInHostRegion(G4Track *aTrack);
 
-  std::set<G4Region *> fGPURegions{};
+  std::set<G4Region const *> fGPURegions{};
   int fVerbosity{0};
-  G4double ProductionCut = 0.7 * copcore::units::mm;
-  int MCIndex[100];
-  
-  AdePTTransport<AdePTGeant4Integration> *fAdeptTransport;
+
+  std::shared_ptr<AdePTTransportInterface> fAdeptTransport;
   AdePTConfiguration *fAdePTConfiguration;
+  unsigned int fTrackCounter{0};
+  int fCurrentEventID{0};
   bool fAdePTInitialized{false};
 };
 

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -42,6 +42,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
                                                           Secondaries &secondaries, MParrayTracks *leakedQueue,
                                                           Scoring *userScoring, VolAuxData const *auxDataArray)
 {
+  using namespace adept_impl;
 #ifdef VECGEOM_FLOAT_PRECISION
   const Precision kPush = 10 * vecgeom::kTolerance;
 #else

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -279,7 +279,8 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
                                &dir,                     // Post-step point momentum direction
                                nullptr,                  // Post-step point polarization
                                eKin,                     // Post-step point kinetic energy
-                               IsElectron ? -1 : 1);     // Post-step point charge
+                               IsElectron ? -1 : 1,      // Post-step point charge
+                               0, -1);                   // eventID and threadID (not needed here)
 
     // Save the `number-of-interaction-left` in our track.
     for (int ip = 0; ip < 3; ++ip) {

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -24,6 +24,7 @@ template <typename Scoring>
 __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries secondaries, MParrayTracks *leakedQueue,
                                 Scoring *userScoring, VolAuxData const *auxDataArray)
 {
+  using namespace adept_impl;
 #ifdef VECGEOM_FLOAT_PRECISION
   const Precision kPush = 10 * vecgeom::kTolerance;
 #else

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -259,7 +259,8 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                    &dir,                  // Post-step point momentum direction
                                    nullptr,               // Post-step point polarization
                                    newEnergyGamma,        // Post-step point kinetic energy
-                                   0);                    // Post-step point charge
+                                   0,                     // Post-step point charge
+                                   0, -1);                // event and thread ID
       }
 
       // Check the new gamma energy and deposit if below threshold.
@@ -285,7 +286,8 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                    &dir,                  // Post-step point momentum direction
                                    nullptr,               // Post-step point polarization
                                    newEnergyGamma,        // Post-step point kinetic energy
-                                   0);                    // Post-step point charge
+                                   0,                     // Post-step point charge
+                                   0, -1);                // event and thread ID
         // The current track is killed by not enqueuing into the next activeQueue.
       }
       break;
@@ -333,7 +335,8 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                  &dir,                  // Post-step point momentum direction
                                  nullptr,               // Post-step point polarization
                                  0,                     // Post-step point kinetic energy
-                                 0);                    // Post-step point charge
+                                 0,                     // Post-step point charge
+                                 0, -1);                // event and thread ID
       // The current track is killed by not enqueuing into the next activeQueue.
       break;
     }

--- a/src/AdePTConfiguration.cc
+++ b/src/AdePTConfiguration.cc
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2024 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include <AdePT/core/AdePTConfiguration.hh>
+
+#include <AdePT/integration/AdePTGeant4Integration.hh>
+
+AdePTConfiguration::AdePTConfiguration() : fAdePTConfigurationMessenger{new AdePTConfigurationMessenger(this)} {}
+
+AdePTConfiguration::~AdePTConfiguration() {}
+
+std::shared_ptr<AdePTTransportInterface> AdePTConfiguration::CreateAdePTInstance(unsigned int nThread)
+{
+  if (fNThread == -1) {
+    // The number of threads is only correct when the MTRunManager initialises AdePT.
+    // Once the workers start up, they claim that the number of threads is 1.
+    fNThread = nThread;
+  }
+
+  auto adept =
+      AdePTTransportFactory(fNThread, 1024 * 1024 * GetMillionsOfTrackSlots(), 1024 * 1024 * GetMillionsOfHitSlots(),
+                            GetVerbosity(), GetGPURegionNames(), GetTrackInAllRegions());
+
+  // AdePT needs to be initialized here, since we know all needed Geant4 initializations are already finished
+  adept->SetBufferThreshold(GetTransportBufferThreshold());
+  adept->SetMaxBatch(2 * GetTransportBufferThreshold());
+  adept->SetCUDAStackLimit(GetCUDAStackLimit());
+
+  return adept;
+}

--- a/src/AdePTPhysics.cc
+++ b/src/AdePTPhysics.cc
@@ -2,47 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <AdePT/integration/AdePTPhysics.hh>
+
 #include <AdePT/integration/AdePTGeant4Integration.hh>
+#include <AdePT/core/AdePTConfiguration.hh>
+#include <AdePT/core/AdePTTransportInterface.hh>
+#include <AdePT/integration/AdePTTrackingManager.hh>
 
 #include "G4ParticleDefinition.hh"
-#include "G4ProcessManager.hh"
-#include "G4PhysicsListHelper.hh"
-
-#include "G4ComptonScattering.hh"
-// #include "G4KleinNishinaModel.hh"  // by defult in G4ComptonScattering
-
-#include "G4GammaConversion.hh"
-#include "G4PhotoElectricEffect.hh"
-#include "G4LivermorePhotoElectricModel.hh"
-// #include "G4RayleighScattering.hh"
-
-#include "G4eMultipleScattering.hh"
-#include "G4GoudsmitSaundersonMscModel.hh"
-#include "G4eIonisation.hh"
-#include "G4eBremsstrahlung.hh"
-#include "G4eplusAnnihilation.hh"
-
+#include "G4Electron.hh"
+#include "G4Positron.hh"
+#include "G4Gamma.hh"
 #include "G4EmParameters.hh"
-#include "G4MscStepLimitType.hh"
-
 #include "G4BuilderType.hh"
-#include "G4LossTableManager.hh"
-// #include "G4UAtomicDeexcitation.hh"
-
-#include "G4SystemOfUnits.hh"
-
-// from G4EmStandardPhysics
-#include "G4GenericIon.hh"
-#include "G4EmModelActivator.hh"
-#include "G4EmBuilder.hh"
-#include "G4hMultipleScattering.hh"
-#include "G4hIonisation.hh"
-#include "G4ionIonisation.hh"
-#include "G4NuclearStopping.hh"
-#include "G4SDManager.hh"
-
-#include "G4GeometryManager.hh"
-#include "G4RunManager.hh"
 
 AdePTPhysics::AdePTPhysics(const G4String &name) : G4VPhysicsConstructor(name)
 {
@@ -68,8 +39,6 @@ AdePTPhysics::~AdePTPhysics()
 
 void AdePTPhysics::ConstructProcess()
 {
-  G4PhysicsListHelper *ph = G4PhysicsListHelper::GetPhysicsListHelper();
-
   // Register custom tracking manager for e-/e+ and gammas.
   fTrackingManager = new AdePTTrackingManager();
   G4Electron::Definition()->SetTrackingManager(fTrackingManager);
@@ -78,13 +47,5 @@ void AdePTPhysics::ConstructProcess()
 
   // Setup tracking manager
   fTrackingManager->SetVerbosity(0);
-
-  // Create one instance of AdePTTransport per thread
-  auto aAdePTTransport = new AdePTTransport<AdePTGeant4Integration>();
-
-  // Give the custom tracking manager a pointer to the AdePTTransport instance
-  fTrackingManager->SetAdePTTransport(aAdePTTransport);
   fTrackingManager->SetAdePTConfiguration(fAdePTConfiguration);
-
-  // Translate Region names to actual G4 Regions and give them to the custom tracking manager
 }

--- a/src/AdePTTransport.cc
+++ b/src/AdePTTransport.cc
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2023 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include <AdePT/core/AdePTTransport.h>
+#include <AdePT/integration/AdePTGeant4Integration.hh>
+#include <AdePT/core/AdePTConfiguration.hh>
+
+/// @brief Create one instance of the synchronous AdePTTransport implementation per call.
+/// @param nThread Number of threads (to compute memory usage per thread).
+/// @param nTrackSlot Number of track slots across all AdePT instances.
+/// @param nHitSlot
+/// @param verbosity
+/// @param GPURegionNames
+/// @param trackInAllRegions
+/// @return
+std::shared_ptr<AdePTTransportInterface> AdePTTransportFactory(unsigned int nThread, unsigned int nTrackSlot,
+                                                               unsigned int nHitSlot, int verbosity,
+                                                               std::vector<std::string> const *GPURegionNames,
+                                                               bool trackInAllRegions)
+{
+  auto adept = std::make_shared<AdePTTransport<AdePTGeant4Integration>>();
+
+  // AdePT needs to be initialized here, since we know all needed Geant4 initializations are already finished
+  adept->SetDebugLevel(verbosity);
+  adept->SetTrackInAllRegions(trackInAllRegions);
+  adept->SetGPURegionNames(GPURegionNames);
+
+  const auto track_capacity = nTrackSlot / nThread;
+  G4cout << "AdePT Allocated track capacity: " << track_capacity << " tracks" << G4endl;
+  adept->SetTrackCapacity(track_capacity);
+
+  const auto hit_buffer_capacity = nHitSlot / nThread;
+  G4cout << "AdePT Allocated hit buffer capacity: " << hit_buffer_capacity << " slots" << G4endl;
+  adept->SetHitBufferCapacity(hit_buffer_capacity);
+
+  return adept;
+}

--- a/src/AdePTTransport.cu
+++ b/src/AdePTTransport.cu
@@ -6,6 +6,6 @@
 
 // Explicit instantiation of the ShowerGPU<AdePTGeant4Integration> function
 namespace adept_impl {
-    template void ShowerGPU<AdePTGeant4Integration>(AdePTGeant4Integration&, int, adeptint::TrackBuffer&, GPUstate&, HostScoring*, HostScoring*);
-}
-
+template void ShowerGPU<AdePTGeant4Integration>(AdePTGeant4Integration &, int, adeptint::TrackBuffer &, GPUstate &,
+                                                HostScoring *, HostScoring *);
+} // namespace adept_impl

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,12 +43,12 @@ add_subdirectory(testField)
 #----------------------------------------------------------------------------#
 # Link/RDC tests
 #----------------------------------------------------------------------------#
-# - Check CopCore links as expected 
+# - Check CopCore links as expected
 add_executable(test_copcore_link test_copcore_link.cpp)
 target_include_directories(test_copcore_link PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(test_copcore_link PRIVATE CopCore)
 
-# - Check G4VG links as expected 
+# - Check G4VG links as expected
 if(VecGeom_SURF_FOUND)
   message(STATUS "${Magenta}Disabled g4vg when using VecGeom surface model${ColorReset}")
 else()


### PR DESCRIPTION
- Add an interface for switching between different AdePT backends. In this way, the AsyncAdePT implementation can share scoring and integration code with example1.
  - Split the transport from the integration-related parts by creating a
  new library.
  - Create a transport abstraction, so AdePTTrackingManager is independent
  of the transport implementation.
  - Add thread and event IDs to the transport interface. These are
  necessary for the async transport implementation.
  - Start to enumerate tracks in the tracking manager. This can be used to
  reproducibly seed the AdePT random sequences.
  - Add some const declarations for the default AdePT implementation.
  - Use a factory funciton to instantiate AdePT. Like this, different
  AdePT implementations can be used without changing code in the tracking
  manager or in AdePTPhysics.
  - Replace a few includes with forward declarations.
  - Fix device link errors that can show when using a symbol in multiple
  cuda translation units.
- Refactor the processing of hits.
  - Instead of processing hits by passing a pointer/reference to a HostScoring instance, a loop over iterators to hits is used. In this way, hit scoring is decoupled from the specific implementation of HostScoring, and all classes with the same interface as the original GPUHit can be used for scoring. This is done to facilitate hit scoring in the AsyncExample.
  - Move Geant4 objects into the .cpp to make the integration headers simpler.
  - Place temporary scoring objects into a struct to go around G4's pool allocators. This prevents a destruction order fiasco (where the pool is gone but the object isn't), and keeps the scoring objects closer in memory. Two objects need to leak, unfortunately, since they are allocated in G4 pools, and the handles don't support them being on a stack.
  - Improve const correctness in a few places.
  - Add information about threadID and eventID to the scoring template. This information is required for AsyncAdePT to score correctly, but is unused in example1 for now.


These two changes don't seem to impact the run times. Here is a diff of the full sorted output of example 1 with 8 ttbar events on 4 threads (including diffing the energy depositions):
```diff
@@ -5104,7 +5092,7 @@
               proton:         7 eKin (GeV):         1720.36 (total)         245.765 (avg)
 Reading cms2018_sd.gdml transiently on CPU for Geant4 ...
                       References : NIM A 506 (2003), 250-303
-Run time: 159.599
+Run time: 160.097
               sigma+:         1 eKin (GeV):         12.1624 (total)         12.1624 (avg)
               sigma-:         1 eKin (GeV):          21.225 (total)          21.225 (avg)
               sigma-:         2 eKin (GeV):          28.236 (total)          14.118 (avg)
```
