### PR TITLE
Keeping track of original particle ID

### DIFF
--- a/examples/IntegrationBenchmark/src/TrackingAction.cc
+++ b/examples/IntegrationBenchmark/src/TrackingAction.cc
@@ -100,22 +100,6 @@ void TrackingAction::PostUserTrackingAction(const G4Track *aTrack)
       aTestManager->removeTimer(Run::timers::NONEM);
     }
   }
-
-  // skip tracks coming from AdePT
-  if (aTrack->GetParentID() == -99) return;
-
-  // increase nb of processed tracks
-  // count nb of steps of this track
-  G4int nbSteps   = aTrack->GetCurrentStepNumber();
-  G4double Trleng = aTrack->GetTrackLength();
-
-  if (aTrack->GetDefinition() == G4Gamma::Gamma()) {
-    dynamic_cast<EventAction *>(G4EventManager::GetEventManager()->GetUserEventAction())->number_gammas++;
-  } else if (aTrack->GetDefinition() == G4Electron::Electron()) {
-    dynamic_cast<EventAction *>(G4EventManager::GetEventManager()->GetUserEventAction())->number_electrons++;
-  } else if (aTrack->GetDefinition() == G4Positron::Positron()) {
-    dynamic_cast<EventAction *>(G4EventManager::GetEventManager()->GetUserEventAction())->number_positrons++;
-  }
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/include/AdePT/core/AdePTScoringTemplate.cuh
+++ b/include/AdePT/core/AdePTScoringTemplate.cuh
@@ -18,7 +18,7 @@ namespace adept_scoring
   void FreeGPU(Scoring *scoring, Scoring *scoring_dev){}
 
   template <typename Scoring>
-  __device__ void RecordHit(Scoring *scoring_dev, char aParticleType, double aStepLength, double aTotalEnergyDeposit,
+  __device__ void RecordHit(Scoring *scoring_dev, int aTrackID, char aParticleType, double aStepLength, double aTotalEnergyDeposit,
                           vecgeom::NavigationState const *aPreState, vecgeom::Vector3D<Precision> *aPrePosition,
                           vecgeom::Vector3D<Precision> *aPreMomentumDirection,
                           vecgeom::Vector3D<Precision> *aPrePolarization, double aPreEKin, double aPreCharge,

--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -43,7 +43,7 @@ public:
   int GetNfromDevice() const { return fBuffer.fromDevice.size(); }
 
   /// @brief Adds a track to the buffer
-  void AddTrack(int pdg, double energy, double x, double y, double z, double dirx, double diry, double dirz,
+  void AddTrack(int pdg, int id, double energy, double x, double y, double z, double dirx, double diry, double dirz,
                 double globalTime, double localTime, double properTime);
 
   void SetTrackCapacity(size_t capacity) { fCapacity = capacity; }
@@ -74,20 +74,20 @@ public:
   void Shower(int event);
 
 private:
-  static inline G4HepEmState *fg4hepem_state{nullptr};       ///< The HepEm state singleton
-  static inline int fCapacity{1024 * 1024};                  ///< Track container capacity on GPU
-  static inline int fHitBufferCapacity{1024 * 1024};         ///< Capacity of hit buffers
-  int fNthreads{0};                            ///< Number of cpu threads
-  int fMaxBatch{0};                            ///< Max batch size for allocating GPU memory
-  int fNumVolumes{0};                          ///< Total number of active logical volumes
-  int fNumSensitive{0};                        ///< Total number of sensitive volumes
-  int fBufferThreshold{20};                    ///< Buffer threshold for flushing AdePT transport buffer
-  int fDebugLevel{1};                          ///< Debug level
-  GPUstate *fGPUstate{nullptr};                ///< CUDA state placeholder
-  AdeptScoring *fScoring{nullptr};             ///< User scoring object
-  AdeptScoring *fScoring_dev{nullptr};         ///< Device ptr for scoring data
-  TrackBuffer fBuffer;                         ///< Vector of buffers of tracks to/from device (per thread)
-  std::vector<std::string> *fGPURegionNames{}; ///< Region to which applies
+  static inline G4HepEmState *fg4hepem_state{nullptr}; ///< The HepEm state singleton
+  static inline int fCapacity{1024 * 1024};            ///< Track container capacity on GPU
+  static inline int fHitBufferCapacity{1024 * 1024};   ///< Capacity of hit buffers
+  int fNthreads{0};                                    ///< Number of cpu threads
+  int fMaxBatch{0};                                    ///< Max batch size for allocating GPU memory
+  int fNumVolumes{0};                                  ///< Total number of active logical volumes
+  int fNumSensitive{0};                                ///< Total number of sensitive volumes
+  int fBufferThreshold{20};                            ///< Buffer threshold for flushing AdePT transport buffer
+  int fDebugLevel{1};                                  ///< Debug level
+  GPUstate *fGPUstate{nullptr};                        ///< CUDA state placeholder
+  AdeptScoring *fScoring{nullptr};                     ///< User scoring object
+  AdeptScoring *fScoring_dev{nullptr};                 ///< Device ptr for scoring data
+  TrackBuffer fBuffer;                                 ///< Vector of buffers of tracks to/from device (per thread)
+  std::vector<std::string> *fGPURegionNames{};         ///< Region to which applies
   IntegrationLayer fIntegrationLayer; ///< Provides functionality needed for integration with the simulation toolkit
   bool fInit{false};                  ///< Service initialized flag
   bool fTrackInAllRegions;            ///< Whether the whole geometry is a GPU region

--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -40,11 +40,11 @@ bool AdePTTransport<IntegrationLayer>::InitializeField(double bz)
 }
 
 template <typename IntegrationLayer>
-void AdePTTransport<IntegrationLayer>::AddTrack(int pdg, double energy, double x, double y, double z, double dirx,
-                                                double diry, double dirz, double globalTime, double localTime,
-                                                double properTime)
+void AdePTTransport<IntegrationLayer>::AddTrack(int pdg, int id, double energy, double x, double y, double z,
+                                                double dirx, double diry, double dirz, double globalTime,
+                                                double localTime, double properTime)
 {
-  fBuffer.toDevice.emplace_back(pdg, energy, x, y, z, dirx, diry, dirz, globalTime, localTime, properTime);
+  fBuffer.toDevice.emplace_back(pdg, id, energy, x, y, z, dirx, diry, dirz, globalTime, localTime, properTime);
   if (pdg == 11)
     fBuffer.nelectrons++;
   else if (pdg == -11)
@@ -139,10 +139,10 @@ void AdePTTransport<IntegrationLayer>::Initialize(bool common_data)
             << std::endl;
 
   // Initialize user scoring data on Host
-  fScoring     = new AdeptScoring(fHitBufferCapacity);
+  fScoring = new AdeptScoring(fHitBufferCapacity);
 
   // Initialize the transport engine for the current thread
-  fGPUstate = adept_impl::InitializeGPU(fBuffer, fCapacity, fMaxBatch);
+  fGPUstate    = adept_impl::InitializeGPU(fBuffer, fCapacity, fMaxBatch);
   fScoring_dev = adept_impl::InitializeScoringGPU(fScoring);
 
   fInit = true;

--- a/include/AdePT/core/HostScoringImpl.cuh
+++ b/include/AdePT/core/HostScoringImpl.cuh
@@ -151,8 +151,9 @@ namespace adept_scoring
 
   /// @brief Record a hit
   template <>
-  __device__ void RecordHit(HostScoring *hostScoring_dev, char aParticleType, double aStepLength, double aTotalEnergyDeposit,
-                          vecgeom::NavigationState const *aPreState, vecgeom::Vector3D<Precision> *aPrePosition,
+  __device__ void RecordHit(HostScoring *hostScoring_dev, int aTrackID, char aParticleType, double aStepLength,
+                          double aTotalEnergyDeposit, vecgeom::NavigationState const *aPreState,
+                          vecgeom::Vector3D<Precision> *aPrePosition,
                           vecgeom::Vector3D<Precision> *aPreMomentumDirection,
                           vecgeom::Vector3D<Precision> *aPrePolarization, double aPreEKin, double aPreCharge,
                           vecgeom::NavigationState const *aPostState, vecgeom::Vector3D<Precision> *aPostPosition,
@@ -163,6 +164,7 @@ namespace adept_scoring
     GPUHit *aGPUHit = GetNextFreeHit(hostScoring_dev);
 
     // Fill the required data
+    aGPUHit->fTrackID            = aTrackID;
     aGPUHit->fParticleType       = aParticleType;
     aGPUHit->fStepLength         = aStepLength;
     aGPUHit->fTotalEnergyDeposit = aTotalEnergyDeposit;

--- a/include/AdePT/core/HostScoringStruct.cuh
+++ b/include/AdePT/core/HostScoringStruct.cuh
@@ -21,6 +21,7 @@ struct GPUStepPoint {
 // Stores the necessary data to reconstruct GPU hits on the host , and
 // call the user-defined Geant4 sensitive detector code
 struct GPUHit {
+  int fTrackID{0}; // Track ID
   char fParticleType{0}; // Particle type ID
   // Data needed to reconstruct G4 Step
   double fStepLength{0};

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -15,6 +15,9 @@
 // by the queue and not stored in memory.
 struct Track {
   using Precision = vecgeom::Precision;
+
+  int id{0}; // Stores the track id of the initial particle given to AdePT
+
   RanluxppDouble rngState;
   double eKin;
   double numIALeft[3];
@@ -56,6 +59,7 @@ struct Track {
   __host__ __device__ void CopyTo(adeptint::TrackData &tdata, int pdg)
   {
     tdata.pdg          = pdg;
+    tdata.id           = id;
     tdata.position[0]  = pos[0];
     tdata.position[1]  = pos[1];
     tdata.position[2]  = pos[2];

--- a/include/AdePT/core/TrackData.h
+++ b/include/AdePT/core/TrackData.h
@@ -19,12 +19,13 @@ struct TrackData {
   double localTime{0};
   double properTime{0};
   int pdg{0};
+  int id{0};
 
   TrackData() = default;
-  TrackData(int pdg_id, double ene, double x, double y, double z, double dirx, double diry, double dirz, double gTime,
-            double lTime, double pTime)
+  TrackData(int pdg_id, int id, double ene, double x, double y, double z, double dirx, double diry, double dirz,
+            double gTime, double lTime, double pTime)
       : position{x, y, z}, direction{dirx, diry, dirz}, eKin{ene}, globalTime{gTime}, localTime{lTime},
-        properTime{pTime}, pdg{pdg_id}
+        properTime{pTime}, pdg{pdg_id}, id{id}
   {
   }
 

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -243,21 +243,22 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 
     if (auxData.fSensIndex >= 0)
       adept_scoring::RecordHit(userScoring,
-                             IsElectron ? 0 : 1,       // Particle type
-                             elTrack.GetPStepLength(), // Step length
-                             energyDeposit,            // Total Edep
-                             &navState,                // Pre-step point navstate
-                             &preStepPos,              // Pre-step point position
-                             &preStepDir,              // Pre-step point momentum direction
-                             nullptr,                  // Pre-step point polarization
-                             preStepEnergy,            // Pre-step point kinetic energy
-                             IsElectron ? -1 : 1,      // Pre-step point charge
-                             &nextState,               // Post-step point navstate
-                             &pos,                     // Post-step point position
-                             &dir,                     // Post-step point momentum direction
-                             nullptr,                  // Post-step point polarization
-                             eKin,                     // Post-step point kinetic energy
-                             IsElectron ? -1 : 1);     // Post-step point charge
+                               currentTrack.id,
+                               IsElectron ? 0 : 1,       // Particle type
+                               elTrack.GetPStepLength(), // Step length
+                               energyDeposit,            // Total Edep
+                               &navState,                // Pre-step point navstate
+                               &preStepPos,              // Pre-step point position
+                               &preStepDir,              // Pre-step point momentum direction
+                               nullptr,                  // Pre-step point polarization
+                               preStepEnergy,            // Pre-step point kinetic energy
+                               IsElectron ? -1 : 1,      // Pre-step point charge
+                               &nextState,               // Post-step point navstate
+                               &pos,                     // Post-step point position
+                               &dir,                     // Post-step point momentum direction
+                               nullptr,                  // Post-step point polarization
+                               eKin,                     // Post-step point kinetic energy
+                               IsElectron ? -1 : 1);     // Post-step point charge
 
     // Save the `number-of-interaction-left` in our track.
     for (int ip = 0; ip < 3; ++ip) {
@@ -282,12 +283,14 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 
         gamma1.InitAsSecondary(pos, navState, globalTime);
         newRNG.Advance();
+        gamma1.id       = currentTrack.id;
         gamma1.rngState = newRNG;
         gamma1.eKin     = copcore::units::kElectronMassC2;
         gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
 
         gamma2.InitAsSecondary(pos, navState, globalTime);
         // Reuse the RNG state of the dying track.
+        gamma2.id       = currentTrack.id;
         gamma2.rngState = currentTrack.rngState;
         gamma2.eKin     = copcore::units::kElectronMassC2;
         gamma2.dir      = -gamma1.dir;
@@ -365,6 +368,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 1, /*numPositrons*/ 0, /*numGammas*/ 0);
 
       secondary.InitAsSecondary(pos, navState, globalTime);
+      secondary.id       = currentTrack.id;
       secondary.rngState = newRNG;
       secondary.eKin     = deltaEkin;
       secondary.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
@@ -391,6 +395,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 0, /*numPositrons*/ 0, /*numGammas*/ 1);
 
       gamma.InitAsSecondary(pos, navState, globalTime);
+      gamma.id       = currentTrack.id;
       gamma.rngState = newRNG;
       gamma.eKin     = deltaEkin;
       gamma.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
@@ -413,12 +418,14 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 0, /*numPositrons*/ 0, /*numGammas*/ 2);
 
       gamma1.InitAsSecondary(pos, navState, globalTime);
+      gamma1.id       = currentTrack.id;
       gamma1.rngState = newRNG;
       gamma1.eKin     = theGamma1Ekin;
       gamma1.dir.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
 
       gamma2.InitAsSecondary(pos, navState, globalTime);
       // Reuse the RNG state of the dying track.
+      gamma2.id       = currentTrack.id;
       gamma2.rngState = currentTrack.rngState;
       gamma2.eKin     = theGamma2Ekin;
       gamma2.dir.Set(theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]);
@@ -443,4 +450,3 @@ __global__ void TransportPositrons(adept::TrackManager<Track> *positrons, Second
 {
   TransportElectrons</*IsElectron*/ false, Scoring>(positrons, secondaries, leakedQueue, userScoring, auxDataArray);
 }
-

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -180,12 +180,14 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 1, /*numPositrons*/ 1, /*numGammas*/ 0);
 
       electron.InitAsSecondary(pos, navState, globalTime);
+      electron.id       = currentTrack.id;
       electron.rngState = newRNG;
       electron.eKin     = elKinEnergy;
       electron.dir.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
 
       positron.InitAsSecondary(pos, navState, globalTime);
       // Reuse the RNG state of the dying track.
+      positron.id       = currentTrack.id;
       positron.rngState = currentTrack.rngState;
       positron.eKin     = posKinEnergy;
       positron.dir.Set(dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]);
@@ -213,28 +215,30 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 1, /*numPositrons*/ 0, /*numGammas*/ 0);
 
         electron.InitAsSecondary(pos, navState, globalTime);
+        electron.id       = currentTrack.id;
         electron.rngState = newRNG;
         electron.eKin     = energyEl;
         electron.dir      = eKin * dir - newEnergyGamma * newDirGamma;
         electron.dir.Normalize();
       } else {
         if (auxData.fSensIndex >= 0)
-          adept_scoring::RecordHit(userScoring, 
-                                 2,                  // Particle type
-                                 geometryStepLength, // Step length
-                                 0,                  // Total Edep
-                                 &navState,          // Pre-step point navstate
-                                 &preStepPos,        // Pre-step point position
-                                 &preStepDir,        // Pre-step point momentum direction
-                                 nullptr,            // Pre-step point polarization
-                                 preStepEnergy,      // Pre-step point kinetic energy
-                                 0,                  // Pre-step point charge
-                                 &nextState,         // Post-step point navstate
-                                 &pos,               // Post-step point position
-                                 &dir,               // Post-step point momentum direction
-                                 nullptr,            // Post-step point polarization
-                                 newEnergyGamma,     // Post-step point kinetic energy
-                                 0);                 // Post-step point charge
+          adept_scoring::RecordHit(userScoring,
+                                   currentTrack.id,    // Track ID
+                                   2,                  // Particle type
+                                   geometryStepLength, // Step length
+                                   0,                  // Total Edep
+                                   &navState,          // Pre-step point navstate
+                                   &preStepPos,        // Pre-step point position
+                                   &preStepDir,        // Pre-step point momentum direction
+                                   nullptr,            // Pre-step point polarization
+                                   preStepEnergy,      // Pre-step point kinetic energy
+                                   0,                  // Pre-step point charge
+                                   &nextState,         // Post-step point navstate
+                                   &pos,               // Post-step point position
+                                   &dir,               // Post-step point momentum direction
+                                   nullptr,            // Post-step point polarization
+                                   newEnergyGamma,     // Post-step point kinetic energy
+                                   0);                 // Post-step point charge
       }
 
       // Check the new gamma energy and deposit if below threshold.
@@ -244,22 +248,23 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         survive();
       } else {
         if (auxData.fSensIndex >= 0)
-          adept_scoring::RecordHit(userScoring, 
-                                 2,                  // Particle type
-                                 geometryStepLength, // Step length
-                                 0,                  // Total Edep
-                                 &navState,          // Pre-step point navstate
-                                 &preStepPos,        // Pre-step point position
-                                 &preStepDir,        // Pre-step point momentum direction
-                                 nullptr,            // Pre-step point polarization
-                                 preStepEnergy,      // Pre-step point kinetic energy
-                                 0,                  // Pre-step point charge
-                                 &nextState,         // Post-step point navstate
-                                 &pos,               // Post-step point position
-                                 &dir,               // Post-step point momentum direction
-                                 nullptr,            // Post-step point polarization
-                                 newEnergyGamma,     // Post-step point kinetic energy
-                                 0);                 // Post-step point charge
+          adept_scoring::RecordHit(userScoring,
+                                   currentTrack.id,    // Track ID
+                                   2,                  // Particle type
+                                   geometryStepLength, // Step length
+                                   0,                  // Total Edep
+                                   &navState,          // Pre-step point navstate
+                                   &preStepPos,        // Pre-step point position
+                                   &preStepDir,        // Pre-step point momentum direction
+                                   nullptr,            // Pre-step point polarization
+                                   preStepEnergy,      // Pre-step point kinetic energy
+                                   0,                  // Pre-step point charge
+                                   &nextState,         // Post-step point navstate
+                                   &pos,               // Post-step point position
+                                   &dir,               // Post-step point momentum direction
+                                   nullptr,            // Post-step point polarization
+                                   newEnergyGamma,     // Post-step point kinetic energy
+                                   0);                 // Post-step point charge
         // The current track is killed by not enqueuing into the next activeQueue.
       }
       break;
@@ -283,6 +288,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         G4HepEmGammaInteractionPhotoelectric::SamplePhotoElectronDirection(photoElecE, dirGamma, dirPhotoElec, &rnge);
 
         electron.InitAsSecondary(pos, navState, globalTime);
+        electron.id       = currentTrack.id;
         electron.rngState = newRNG;
         electron.eKin     = photoElecE;
         electron.dir.Set(dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]);
@@ -290,22 +296,23 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         edep = eKin;
       }
       if (auxData.fSensIndex >= 0)
-        adept_scoring::RecordHit(userScoring, 
-                               2,                  // Particle type
-                               geometryStepLength, // Step length
-                               edep,               // Total Edep
-                               &navState,          // Pre-step point navstate
-                               &preStepPos,        // Pre-step point position
-                               &preStepDir,        // Pre-step point momentum direction
-                               nullptr,            // Pre-step point polarization
-                               preStepEnergy,      // Pre-step point kinetic energy
-                               0,                  // Pre-step point charge
-                               &nextState,         // Post-step point navstate
-                               &pos,               // Post-step point position
-                               &dir,               // Post-step point momentum direction
-                               nullptr,            // Post-step point polarization
-                               0,                  // Post-step point kinetic energy
-                               0);                 // Post-step point charge
+        adept_scoring::RecordHit(userScoring,
+                                 currentTrack.id,    // Track ID
+                                 2,                  // Particle type
+                                 geometryStepLength, // Step length
+                                 edep,               // Total Edep
+                                 &navState,          // Pre-step point navstate
+                                 &preStepPos,        // Pre-step point position
+                                 &preStepDir,        // Pre-step point momentum direction
+                                 nullptr,            // Pre-step point polarization
+                                 preStepEnergy,      // Pre-step point kinetic energy
+                                 0,                  // Pre-step point charge
+                                 &nextState,         // Post-step point navstate
+                                 &pos,               // Post-step point position
+                                 &dir,               // Post-step point momentum direction
+                                 nullptr,            // Post-step point polarization
+                                 0,                  // Post-step point kinetic energy
+                                 0);                 // Post-step point charge
       // The current track is killed by not enqueuing into the next activeQueue.
       break;
     }

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -70,7 +70,7 @@ void visitGeometry(G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVolume cons
   const G4RotationMatrix *g4rot = g4_pvol->GetRotation();
   G4RotationMatrix idrot;
   const auto vgtransformation = vg_pvol->GetTransformation();
-  constexpr double epsil = 1.e-8;
+  constexpr double epsil      = 1.e-8;
   for (int i = 0; i < 3; ++i) {
     if (std::abs(g4trans[i] - vgtransformation->Translation(i)) > epsil)
       throw std::runtime_error(
@@ -381,7 +381,7 @@ void AdePTGeant4Integration::FillG4Step(GPUHit *aGPUHit, G4Step *aG4Step, G4Touc
 
   // G4Track
   G4Track *aTrack = aG4Step->GetTrack();
-  // aTrack->SetTrackID(0);                                                                   // Missing data
+  aTrack->SetTrackID(aGPUHit->fTrackID); // ID of the initial particle that entered AdePT
   // aTrack->SetParentID(0);                                                                  // Missing data
   aTrack->SetPosition(*aPostStepPointPosition); // Real data
   // aTrack->SetGlobalTime(0);                                                                // Missing data
@@ -470,10 +470,10 @@ void AdePTGeant4Integration::ReturnTracks(std::vector<adeptint::TrackData> *trac
   int i = 0;
   for (auto const &track : *tracksFromDevice) {
     if (debugLevel > 1) {
-      std::cout << "[" << tid << "] fromDevice[ " << i++ << "]: pdg " << track.pdg << " kinetic energy " << track.eKin
-                << " position " << track.position[0] << " " << track.position[1] << " " << track.position[2]
-                << " direction " << track.direction[0] << " " << track.direction[1] << " " << track.direction[2]
-                << " global time, local time, proper time: "
+      std::cout << "[" << tid << "] fromDevice[ " << i++ << "]: pdg " << track.pdg << " id " << track.id
+                << " kinetic energy " << track.eKin << " position " << track.position[0] << " " << track.position[1]
+                << " " << track.position[2] << " direction " << track.direction[0] << " " << track.direction[1] << " "
+                << track.direction[2] << " global time, local time, proper time: "
                 << "(" << track.globalTime << ", " << track.localTime << ", " << track.properTime << ")" << std::endl;
     }
     G4ParticleMomentum direction(track.direction[0], track.direction[1], track.direction[2]);
@@ -489,7 +489,7 @@ void AdePTGeant4Integration::ReturnTracks(std::vector<adeptint::TrackData> *trac
     G4Track *secondary = new G4Track(dynamique, track.globalTime, posi);
     secondary->SetLocalTime(track.localTime);
     secondary->SetProperTime(track.properTime);
-    secondary->SetParentID(-99);
+    secondary->SetParentID(track.id);
 
     G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(secondary);
   }

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -85,8 +85,7 @@ void AdePTTrackingManager::InitializeAdePT()
 
 void AdePTTrackingManager::BuildPhysicsTable(const G4ParticleDefinition &part)
 {
-  if (!fAdePTInitialized)
-  {
+  if (!fAdePTInitialized) {
     InitializeAdePT();
   }
 
@@ -184,7 +183,7 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
     if (fAdeptTransport->GetTrackInAllRegions()) {
       isGPURegion = true;
     } else {
-      if(fGPURegions.find(region) != fGPURegions.end()) {
+      if (fGPURegions.find(region) != fGPURegions.end()) {
         isGPURegion = true;
       }
     }
@@ -199,26 +198,24 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
       G4double localTime     = aTrack->GetLocalTime();
       G4double properTime    = aTrack->GetProperTime();
       auto pdg               = aTrack->GetParticleDefinition()->GetPDGEncoding();
+      int id                 = aTrack->GetTrackID();
 
-      fAdeptTransport->AddTrack(pdg, energy, particlePosition[0], particlePosition[1], particlePosition[2], particleDirection[0],
-                       particleDirection[1], particleDirection[2], globalTime, localTime, properTime);
+      fAdeptTransport->AddTrack(pdg, id, energy, particlePosition[0], particlePosition[1], particlePosition[2],
+                                particleDirection[0], particleDirection[1], particleDirection[2], globalTime, localTime,
+                                properTime);
 
       // The track dies from the point of view of Geant4
       aTrack->SetTrackStatus(fStopAndKill);
 
     } else {
       // If the particle is not in a GPU region, track it on CPU
-      if(fGPURegions.empty())
-      {
+      if (fGPURegions.empty()) {
         // If there are no GPU regions, track until the end in Geant4
         trackManager->ProcessOneTrack(aTrack);
         if (aTrack->GetTrackStatus() != fStopAndKill) {
-          G4Exception("AdePTTrackingManager::HandOverOneTrack", "NotStopped", FatalException,
-            "track was not stopped");
+          G4Exception("AdePTTrackingManager::HandOverOneTrack", "NotStopped", FatalException, "track was not stopped");
         }
-      }
-      else
-      {
+      } else {
         // Track the particle step by step until it dies or enters a GPU region
         StepInHostRegion(aTrack);
       }
@@ -257,11 +254,9 @@ void AdePTTrackingManager::StepInHostRegion(G4Track *aTrack)
       // This should never be true if this flag is set, as all particles would be sent to AdePT
       assert(fAdeptTransport->GetTrackInAllRegions() == false);
       // If the region changed, check whether the particle has entered a GPU region
-      if(region != previousRegion)
-      {
+      if (region != previousRegion) {
         previousRegion = region;
-        if(fGPURegions.find(region) != fGPURegions.end())
-        {
+        if (fGPURegions.find(region) != fGPURegions.end()) {
           return;
         }
       }


### PR DESCRIPTION
AdePT tracks were previously not storing any track ID. With this change we will propagate the ID of particles coming into AdePT to their secondaries. This ID is added to the hit information returned to Geant4.

In addition to the hits, the ID is also set as the mother for leaked particles.