### PR TITLE
Disabled g4vg when VecGeom is compiled with the surface model

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,15 +49,20 @@ target_include_directories(test_copcore_link PRIVATE ${PROJECT_SOURCE_DIR}/inclu
 target_link_libraries(test_copcore_link PRIVATE CopCore)
 
 # - Check G4VG links as expected 
-include(FetchContent)
-FetchContent_Declare(
-  g4vg
-  EXCLUDE_FROM_ALL
-  URL https://github.com/celeritas-project/g4vg/archive/e034ada099132f857866949ec9ce8eadf1ff2251.zip)
-FetchContent_MakeAvailable(g4vg)
+if(VecGeom_SURF_FOUND)
+  message(STATUS "Disabled g4vg when using VecGeom surface model")
+else()
+  message(STATUS "Fetching and compiling g4vg ...")
+  include(FetchContent)
+  FetchContent_Declare(
+    g4vg
+    EXCLUDE_FROM_ALL
+    URL https://github.com/celeritas-project/g4vg/archive/e034ada099132f857866949ec9ce8eadf1ff2251.zip)
+  FetchContent_MakeAvailable(g4vg)
 
-add_executable(test_g4vg_link test_g4vg_link.cpp)
-target_link_libraries(test_g4vg_link PRIVATE G4VG::g4vg)
+  add_executable(test_g4vg_link test_g4vg_link.cpp)
+  target_link_libraries(test_g4vg_link PRIVATE G4VG::g4vg)
+endif()
 
 #----------------------------------------------------------------------------#
 # Basic Unit Tests


### PR DESCRIPTION
This is needed because g4vg pulls in almost the full Celeritas library, which maintains an old version of the interfaces to the surface model, not compiling anymore.

Without this PR we cannot work on updating the integration of the VecGeom surface model.