### PR TITLE
Original particle ID used as ParentID for the hits

### DIFF
--- a/include/AdePT/core/AdePTScoringTemplate.cuh
+++ b/include/AdePT/core/AdePTScoringTemplate.cuh
@@ -18,7 +18,7 @@ namespace adept_scoring
   void FreeGPU(Scoring *scoring, Scoring *scoring_dev){}
 
   template <typename Scoring>
-  __device__ void RecordHit(Scoring *scoring_dev, int aTrackID, char aParticleType, double aStepLength, double aTotalEnergyDeposit,
+  __device__ void RecordHit(Scoring *scoring_dev, int aParentID, char aParticleType, double aStepLength, double aTotalEnergyDeposit,
                           vecgeom::NavigationState const *aPreState, vecgeom::Vector3D<Precision> *aPrePosition,
                           vecgeom::Vector3D<Precision> *aPreMomentumDirection,
                           vecgeom::Vector3D<Precision> *aPrePolarization, double aPreEKin, double aPreCharge,

--- a/include/AdePT/core/AdePTTransport.cuh
+++ b/include/AdePT/core/AdePTTransport.cuh
@@ -108,8 +108,8 @@ __global__ void InitTracks(adeptint::TrackData *trackinfo, int ntracks, int star
     };
     assert(trackmgr != nullptr && "Unsupported pdg type");
 
-    Track &track = trackmgr->NextTrack();
-    track.id     = trackinfo[i].id;
+    Track &track    = trackmgr->NextTrack();
+    track.parentID  = trackinfo[i].parentID;
 
     track.rngState.SetSeed(1234567 * event + startTrack + i);
     track.eKin         = trackinfo[i].eKin;

--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -43,7 +43,7 @@ public:
   int GetNfromDevice() const { return fBuffer.fromDevice.size(); }
 
   /// @brief Adds a track to the buffer
-  void AddTrack(int pdg, int id, double energy, double x, double y, double z, double dirx, double diry, double dirz,
+  void AddTrack(int pdg, int parentID, double energy, double x, double y, double z, double dirx, double diry, double dirz,
                 double globalTime, double localTime, double properTime);
 
   void SetTrackCapacity(size_t capacity) { fCapacity = capacity; }

--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -40,11 +40,11 @@ bool AdePTTransport<IntegrationLayer>::InitializeField(double bz)
 }
 
 template <typename IntegrationLayer>
-void AdePTTransport<IntegrationLayer>::AddTrack(int pdg, int id, double energy, double x, double y, double z,
+void AdePTTransport<IntegrationLayer>::AddTrack(int pdg, int parent_id, double energy, double x, double y, double z,
                                                 double dirx, double diry, double dirz, double globalTime,
                                                 double localTime, double properTime)
 {
-  fBuffer.toDevice.emplace_back(pdg, id, energy, x, y, z, dirx, diry, dirz, globalTime, localTime, properTime);
+  fBuffer.toDevice.emplace_back(pdg, parent_id, energy, x, y, z, dirx, diry, dirz, globalTime, localTime, properTime);
   if (pdg == 11)
     fBuffer.nelectrons++;
   else if (pdg == -11)

--- a/include/AdePT/core/HostScoringImpl.cuh
+++ b/include/AdePT/core/HostScoringImpl.cuh
@@ -151,7 +151,7 @@ namespace adept_scoring
 
   /// @brief Record a hit
   template <>
-  __device__ void RecordHit(HostScoring *hostScoring_dev, int aTrackID, char aParticleType, double aStepLength,
+  __device__ void RecordHit(HostScoring *hostScoring_dev, int aParentID, char aParticleType, double aStepLength,
                           double aTotalEnergyDeposit, vecgeom::NavigationState const *aPreState,
                           vecgeom::Vector3D<Precision> *aPrePosition,
                           vecgeom::Vector3D<Precision> *aPreMomentumDirection,
@@ -164,7 +164,7 @@ namespace adept_scoring
     GPUHit *aGPUHit = GetNextFreeHit(hostScoring_dev);
 
     // Fill the required data
-    aGPUHit->fTrackID            = aTrackID;
+    aGPUHit->fParentID           = aParentID;
     aGPUHit->fParticleType       = aParticleType;
     aGPUHit->fStepLength         = aStepLength;
     aGPUHit->fTotalEnergyDeposit = aTotalEnergyDeposit;

--- a/include/AdePT/core/HostScoringStruct.cuh
+++ b/include/AdePT/core/HostScoringStruct.cuh
@@ -21,7 +21,7 @@ struct GPUStepPoint {
 // Stores the necessary data to reconstruct GPU hits on the host , and
 // call the user-defined Geant4 sensitive detector code
 struct GPUHit {
-  int fTrackID{0}; // Track ID
+  int fParentID{0}; // Track ID
   char fParticleType{0}; // Particle type ID
   // Data needed to reconstruct G4 Step
   double fStepLength{0};

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -16,7 +16,7 @@
 struct Track {
   using Precision = vecgeom::Precision;
 
-  int id{0}; // Stores the track id of the initial particle given to AdePT
+  int parentID{0}; // Stores the track id of the initial particle given to AdePT
 
   RanluxppDouble rngState;
   double eKin;
@@ -59,7 +59,7 @@ struct Track {
   __host__ __device__ void CopyTo(adeptint::TrackData &tdata, int pdg)
   {
     tdata.pdg          = pdg;
-    tdata.id           = id;
+    tdata.parentID     = parentID;
     tdata.position[0]  = pos[0];
     tdata.position[1]  = pos[1];
     tdata.position[2]  = pos[2];

--- a/include/AdePT/core/TrackData.h
+++ b/include/AdePT/core/TrackData.h
@@ -19,13 +19,13 @@ struct TrackData {
   double localTime{0};
   double properTime{0};
   int pdg{0};
-  int id{0};
+  int parentID{0};
 
   TrackData() = default;
-  TrackData(int pdg_id, int id, double ene, double x, double y, double z, double dirx, double diry, double dirz,
+  TrackData(int pdg_id, int parentID, double ene, double x, double y, double z, double dirx, double diry, double dirz,
             double gTime, double lTime, double pTime)
       : position{x, y, z}, direction{dirx, diry, dirz}, eKin{ene}, globalTime{gTime}, localTime{lTime},
-        properTime{pTime}, pdg{pdg_id}, id{id}
+        properTime{pTime}, pdg{pdg_id}, parentID{parentID}
   {
   }
 

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -242,8 +242,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     properTime += deltaTime * (restMass / eKin);
 
     if (auxData.fSensIndex >= 0)
-      adept_scoring::RecordHit(userScoring,
-                               currentTrack.id,
+      adept_scoring::RecordHit(userScoring, currentTrack.parentID,
                                IsElectron ? 0 : 1,       // Particle type
                                elTrack.GetPStepLength(), // Step length
                                energyDeposit,            // Total Edep
@@ -283,14 +282,14 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 
         gamma1.InitAsSecondary(pos, navState, globalTime);
         newRNG.Advance();
-        gamma1.id       = currentTrack.id;
+        gamma1.parentID = currentTrack.parentID;
         gamma1.rngState = newRNG;
         gamma1.eKin     = copcore::units::kElectronMassC2;
         gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
 
         gamma2.InitAsSecondary(pos, navState, globalTime);
         // Reuse the RNG state of the dying track.
-        gamma2.id       = currentTrack.id;
+        gamma2.parentID = currentTrack.parentID;
         gamma2.rngState = currentTrack.rngState;
         gamma2.eKin     = copcore::units::kElectronMassC2;
         gamma2.dir      = -gamma1.dir;
@@ -368,7 +367,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 1, /*numPositrons*/ 0, /*numGammas*/ 0);
 
       secondary.InitAsSecondary(pos, navState, globalTime);
-      secondary.id       = currentTrack.id;
+      secondary.parentID = currentTrack.parentID;
       secondary.rngState = newRNG;
       secondary.eKin     = deltaEkin;
       secondary.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
@@ -395,7 +394,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 0, /*numPositrons*/ 0, /*numGammas*/ 1);
 
       gamma.InitAsSecondary(pos, navState, globalTime);
-      gamma.id       = currentTrack.id;
+      gamma.parentID = currentTrack.parentID;
       gamma.rngState = newRNG;
       gamma.eKin     = deltaEkin;
       gamma.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
@@ -418,14 +417,14 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 0, /*numPositrons*/ 0, /*numGammas*/ 2);
 
       gamma1.InitAsSecondary(pos, navState, globalTime);
-      gamma1.id       = currentTrack.id;
+      gamma1.parentID = currentTrack.parentID;
       gamma1.rngState = newRNG;
       gamma1.eKin     = theGamma1Ekin;
       gamma1.dir.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
 
       gamma2.InitAsSecondary(pos, navState, globalTime);
       // Reuse the RNG state of the dying track.
-      gamma2.id       = currentTrack.id;
+      gamma2.parentID = currentTrack.parentID;
       gamma2.rngState = currentTrack.rngState;
       gamma2.eKin     = theGamma2Ekin;
       gamma2.dir.Set(theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]);

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -180,14 +180,14 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 1, /*numPositrons*/ 1, /*numGammas*/ 0);
 
       electron.InitAsSecondary(pos, navState, globalTime);
-      electron.id       = currentTrack.id;
+      electron.parentID = currentTrack.parentID;
       electron.rngState = newRNG;
       electron.eKin     = elKinEnergy;
       electron.dir.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
 
       positron.InitAsSecondary(pos, navState, globalTime);
       // Reuse the RNG state of the dying track.
-      positron.id       = currentTrack.id;
+      positron.parentID = currentTrack.parentID;
       positron.rngState = currentTrack.rngState;
       positron.eKin     = posKinEnergy;
       positron.dir.Set(dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]);
@@ -215,7 +215,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 1, /*numPositrons*/ 0, /*numGammas*/ 0);
 
         electron.InitAsSecondary(pos, navState, globalTime);
-        electron.id       = currentTrack.id;
+        electron.parentID = currentTrack.parentID;
         electron.rngState = newRNG;
         electron.eKin     = energyEl;
         electron.dir      = eKin * dir - newEnergyGamma * newDirGamma;
@@ -223,22 +223,22 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       } else {
         if (auxData.fSensIndex >= 0)
           adept_scoring::RecordHit(userScoring,
-                                   currentTrack.id,    // Track ID
-                                   2,                  // Particle type
-                                   geometryStepLength, // Step length
-                                   0,                  // Total Edep
-                                   &navState,          // Pre-step point navstate
-                                   &preStepPos,        // Pre-step point position
-                                   &preStepDir,        // Pre-step point momentum direction
-                                   nullptr,            // Pre-step point polarization
-                                   preStepEnergy,      // Pre-step point kinetic energy
-                                   0,                  // Pre-step point charge
-                                   &nextState,         // Post-step point navstate
-                                   &pos,               // Post-step point position
-                                   &dir,               // Post-step point momentum direction
-                                   nullptr,            // Post-step point polarization
-                                   newEnergyGamma,     // Post-step point kinetic energy
-                                   0);                 // Post-step point charge
+                                   currentTrack.parentID, // Track ID
+                                   2,                     // Particle type
+                                   geometryStepLength,    // Step length
+                                   0,                     // Total Edep
+                                   &navState,             // Pre-step point navstate
+                                   &preStepPos,           // Pre-step point position
+                                   &preStepDir,           // Pre-step point momentum direction
+                                   nullptr,               // Pre-step point polarization
+                                   preStepEnergy,         // Pre-step point kinetic energy
+                                   0,                     // Pre-step point charge
+                                   &nextState,            // Post-step point navstate
+                                   &pos,                  // Post-step point position
+                                   &dir,                  // Post-step point momentum direction
+                                   nullptr,               // Post-step point polarization
+                                   newEnergyGamma,        // Post-step point kinetic energy
+                                   0);                    // Post-step point charge
       }
 
       // Check the new gamma energy and deposit if below threshold.
@@ -249,22 +249,22 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       } else {
         if (auxData.fSensIndex >= 0)
           adept_scoring::RecordHit(userScoring,
-                                   currentTrack.id,    // Track ID
-                                   2,                  // Particle type
-                                   geometryStepLength, // Step length
-                                   0,                  // Total Edep
-                                   &navState,          // Pre-step point navstate
-                                   &preStepPos,        // Pre-step point position
-                                   &preStepDir,        // Pre-step point momentum direction
-                                   nullptr,            // Pre-step point polarization
-                                   preStepEnergy,      // Pre-step point kinetic energy
-                                   0,                  // Pre-step point charge
-                                   &nextState,         // Post-step point navstate
-                                   &pos,               // Post-step point position
-                                   &dir,               // Post-step point momentum direction
-                                   nullptr,            // Post-step point polarization
-                                   newEnergyGamma,     // Post-step point kinetic energy
-                                   0);                 // Post-step point charge
+                                   currentTrack.parentID, // Track ID
+                                   2,                     // Particle type
+                                   geometryStepLength,    // Step length
+                                   0,                     // Total Edep
+                                   &navState,             // Pre-step point navstate
+                                   &preStepPos,           // Pre-step point position
+                                   &preStepDir,           // Pre-step point momentum direction
+                                   nullptr,               // Pre-step point polarization
+                                   preStepEnergy,         // Pre-step point kinetic energy
+                                   0,                     // Pre-step point charge
+                                   &nextState,            // Post-step point navstate
+                                   &pos,                  // Post-step point position
+                                   &dir,                  // Post-step point momentum direction
+                                   nullptr,               // Post-step point polarization
+                                   newEnergyGamma,        // Post-step point kinetic energy
+                                   0);                    // Post-step point charge
         // The current track is killed by not enqueuing into the next activeQueue.
       }
       break;
@@ -288,7 +288,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         G4HepEmGammaInteractionPhotoelectric::SamplePhotoElectronDirection(photoElecE, dirGamma, dirPhotoElec, &rnge);
 
         electron.InitAsSecondary(pos, navState, globalTime);
-        electron.id       = currentTrack.id;
+        electron.parentID = currentTrack.parentID;
         electron.rngState = newRNG;
         electron.eKin     = photoElecE;
         electron.dir.Set(dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]);
@@ -297,22 +297,22 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       }
       if (auxData.fSensIndex >= 0)
         adept_scoring::RecordHit(userScoring,
-                                 currentTrack.id,    // Track ID
-                                 2,                  // Particle type
-                                 geometryStepLength, // Step length
-                                 edep,               // Total Edep
-                                 &navState,          // Pre-step point navstate
-                                 &preStepPos,        // Pre-step point position
-                                 &preStepDir,        // Pre-step point momentum direction
-                                 nullptr,            // Pre-step point polarization
-                                 preStepEnergy,      // Pre-step point kinetic energy
-                                 0,                  // Pre-step point charge
-                                 &nextState,         // Post-step point navstate
-                                 &pos,               // Post-step point position
-                                 &dir,               // Post-step point momentum direction
-                                 nullptr,            // Post-step point polarization
-                                 0,                  // Post-step point kinetic energy
-                                 0);                 // Post-step point charge
+                                 currentTrack.parentID, // Track ID
+                                 2,                     // Particle type
+                                 geometryStepLength,    // Step length
+                                 edep,                  // Total Edep
+                                 &navState,             // Pre-step point navstate
+                                 &preStepPos,           // Pre-step point position
+                                 &preStepDir,           // Pre-step point momentum direction
+                                 nullptr,               // Pre-step point polarization
+                                 preStepEnergy,         // Pre-step point kinetic energy
+                                 0,                     // Pre-step point charge
+                                 &nextState,            // Post-step point navstate
+                                 &pos,                  // Post-step point position
+                                 &dir,                  // Post-step point momentum direction
+                                 nullptr,               // Post-step point polarization
+                                 0,                     // Post-step point kinetic energy
+                                 0);                    // Post-step point charge
       // The current track is killed by not enqueuing into the next activeQueue.
       break;
     }

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -365,9 +365,15 @@ void AdePTGeant4Integration::FillG4NavigationHistory(unsigned int aNavIndex, G4N
 void AdePTGeant4Integration::FillG4Step(GPUHit *aGPUHit, G4Step *aG4Step, G4TouchableHandle &aPreG4TouchableHandle,
                                         G4TouchableHandle &aPostG4TouchableHandle)
 {
-  const G4ThreeVector *aPostStepPointMomentumDirection = new G4ThreeVector(aGPUHit->fPostStepPoint.fMomentumDirection);
-  const G4ThreeVector *aPostStepPointPolarization      = new G4ThreeVector(aGPUHit->fPostStepPoint.fPolarization);
-  const G4ThreeVector *aPostStepPointPosition          = new G4ThreeVector(aGPUHit->fPostStepPoint.fPosition);
+  const G4ThreeVector *aPostStepPointMomentumDirection = new G4ThreeVector(aGPUHit->fPostStepPoint.fMomentumDirection.x(),
+                                                                           aGPUHit->fPostStepPoint.fMomentumDirection.y(),
+                                                                           aGPUHit->fPostStepPoint.fMomentumDirection.z());
+  const G4ThreeVector *aPostStepPointPolarization      = new G4ThreeVector(aGPUHit->fPostStepPoint.fPolarization.x(),
+                                                                           aGPUHit->fPostStepPoint.fPolarization.y(),
+                                                                           aGPUHit->fPostStepPoint.fPolarization.z());
+  const G4ThreeVector *aPostStepPointPosition          = new G4ThreeVector(aGPUHit->fPostStepPoint.fPosition.x(),
+                                                                           aGPUHit->fPostStepPoint.fPosition.y(),
+                                                                           aGPUHit->fPostStepPoint.fPosition.z());
 
   // G4Step
   aG4Step->SetStepLength(aGPUHit->fStepLength);                 // Real data

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -381,8 +381,8 @@ void AdePTGeant4Integration::FillG4Step(GPUHit *aGPUHit, G4Step *aG4Step, G4Touc
 
   // G4Track
   G4Track *aTrack = aG4Step->GetTrack();
-  aTrack->SetTrackID(aGPUHit->fTrackID); // ID of the initial particle that entered AdePT
-  // aTrack->SetParentID(0);                                                                  // Missing data
+  // aTrack->SetTrackID(0);                                                                   // Missing data
+  aTrack->SetParentID(aGPUHit->fParentID); // ID of the initial particle that entered AdePT
   aTrack->SetPosition(*aPostStepPointPosition); // Real data
   // aTrack->SetGlobalTime(0);                                                                // Missing data
   // aTrack->SetLocalTime(0);                                                                 // Missing data
@@ -470,7 +470,7 @@ void AdePTGeant4Integration::ReturnTracks(std::vector<adeptint::TrackData> *trac
   int i = 0;
   for (auto const &track : *tracksFromDevice) {
     if (debugLevel > 1) {
-      std::cout << "[" << tid << "] fromDevice[ " << i++ << "]: pdg " << track.pdg << " id " << track.id
+      std::cout << "[" << tid << "] fromDevice[ " << i++ << "]: pdg " << track.pdg << " parent id " << track.parentID
                 << " kinetic energy " << track.eKin << " position " << track.position[0] << " " << track.position[1]
                 << " " << track.position[2] << " direction " << track.direction[0] << " " << track.direction[1] << " "
                 << track.direction[2] << " global time, local time, proper time: "
@@ -489,7 +489,10 @@ void AdePTGeant4Integration::ReturnTracks(std::vector<adeptint::TrackData> *trac
     G4Track *secondary = new G4Track(dynamique, track.globalTime, posi);
     secondary->SetLocalTime(track.localTime);
     secondary->SetProperTime(track.properTime);
-    secondary->SetParentID(track.id);
+    secondary->SetParentID(track.parentID);
+
+    printf("%d\n", secondary->GetParentID());
+
 
     G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(secondary);
   }


### PR DESCRIPTION
This changes PR [296](https://github.com/apt-sim/AdePT/pull/296) to pass the propagated primary ID as parentID for the hits generated by AdePT.

It also fixes an issue during track reconstruction on the CPU side where some vectors wouldn't be properly initialized