### PR TITLE
Fix: Don't call flush for an empty buffer

### DIFF
--- a/examples/Example1/CMakeLists.txt
+++ b/examples/Example1/CMakeLists.txt
@@ -66,6 +66,7 @@ target_link_libraries(example1
 SET(GDML ${PROJECT_BINARY_DIR}/cms2018_sd.gdml)
 configure_file("macros/example1.mac.in" "${PROJECT_BINARY_DIR}/example1.mac")
 configure_file("macros/example1_ttbar.mac.in" "${PROJECT_BINARY_DIR}/example1_ttbar.mac")
+configure_file("macros/example1_ttbar_noadept.mac.in" "${PROJECT_BINARY_DIR}/example1_ttbar_noadept.mac")
 
 # Tests
 

--- a/examples/Example1/macros/example1_ttbar_noadept.mac.in
+++ b/examples/Example1/macros/example1_ttbar_noadept.mac.in
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2023 CERN
+# SPDX-License-Identifier: Apache-2.0
+#  example23.in
+#
+
+## =============================================================================
+## Geant4 macro for modelling simplified sampling calorimeters
+## =============================================================================
+##
+/run/numberOfThreads 1
+/control/verbose 0
+/run/verbose 0
+/process/verbose 0
+/tracking/verbose 0
+/event/verbose 0
+
+/detector/filename cms2018_sd.gdml
+
+## -----------------------------------------------------------------------------
+## Optionally, set a constant magnetic filed:
+## -----------------------------------------------------------------------------
+/detector/setField 0 0 0 tesla
+#/detector/setField 0 0 3.8 tesla
+
+## -----------------------------------------------------------------------------
+## Set secondary production threshold, init. the run and set primary properties
+## -----------------------------------------------------------------------------
+/run/setCut 0.7 mm
+/run/initialize
+
+## User-defined Event verbosity: 1 = total edep, 2 = energy deposit per placed sensitive volume
+/eventAction/verbose 2
+
+/gun/hepmc
+/generator/hepmcAscii/maxevents 256
+/generator/hepmcAscii/firstevent 0
+/generator/hepmcAscii/open ppttbar.hepmc3
+/generator/hepmcAscii/verbose 0
+
+## -----------------------------------------------------------------------------
+## Run the simulation with the given number of events and print list of processes
+## -----------------------------------------------------------------------------
+
+# run events with parametrised simulation
+# by default all created models are active
+/run/beamOn 8
+

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -149,12 +149,11 @@ void AdePTTrackingManager::HandOverOneTrack(G4Track *aTrack)
 
 void AdePTTrackingManager::FlushEvent()
 {
-
   if (fVerbosity > 0)
     G4cout << "No more particles on the stack, triggering shower to flush the AdePT buffer with "
            << fAdeptTransport->GetNtoDevice() << " particles left." << G4endl;
-
-  fAdeptTransport->Shower(G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID());
+  if(fAdeptTransport->GetNtoDevice() > 0)
+    fAdeptTransport->Shower(G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID());
 }
 
 void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)


### PR DESCRIPTION
- Avoids calling the AdePT Shower function during the event flush if there are no particles in the AdePT buffer. The time spent in this extra call is specially noticeable when using small events.
- Adds a macro file to use with the `--noadept` option in `example1`
