### PR TITLE
Adding option to set all volumes as sensitive

### DIFF
--- a/examples/Example1/include/DetectorConstruction.hh
+++ b/examples/Example1/include/DetectorConstruction.hh
@@ -30,7 +30,7 @@ class DetectorMessenger;
 
 class DetectorConstruction : public G4VUserDetectorConstruction {
 public:
-  DetectorConstruction();
+  DetectorConstruction(bool allSensitive = false);
   virtual ~DetectorConstruction();
 
   virtual G4VPhysicalVolume *Construct() final;
@@ -57,6 +57,7 @@ private:
   G4ThreeVector fMagFieldVector;
 
   G4GDMLParser fParser;
+  bool fAllSensitive;
 };
 
 #endif /* DETECTORCONSTRUCTION_H */


### PR DESCRIPTION
Adds the option `--allsensitive` for example 1 so that the SD information in the geometry will be ignored and all volumes marked as sensitive.

This mode is useful in order to quickly validate geometries which don't contain SD info.