### PR TITLE
Surface navigation now split in finding the frame and relocation

### DIFF
--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -67,7 +67,7 @@ template <typename IntegrationLayer>
 bool AdePTTransport<IntegrationLayer>::InitializeGeometry(const vecgeom::cxx::VPlacedVolume *world)
 {
   auto &cudaManager = vecgeom::cxx::CudaManager::Instance();
-  bool success = true;
+  bool success      = true;
 #ifdef ADEPT_USE_SURF
 #ifdef ADEPT_USE_SURF_SINGLE
   using BrepHelper = vgbrep::BrepHelper<float>;
@@ -83,9 +83,10 @@ bool AdePTTransport<IntegrationLayer>::InitializeGeometry(const vecgeom::cxx::VP
   cudaManager.SynchronizeNavigationTable();
 #else
   // Upload solid geometry to GPU.
+  cudaDeviceSetLimit(cudaLimitStackSize, 1024 * 8);
   cudaManager.LoadGeometry(world);
   auto world_dev = cudaManager.Synchronize();
-  success = world_dev != nullptr;
+  success        = world_dev != nullptr;
 #endif
   // Initialize BVH
   InitBVH();

--- a/include/AdePT/navigation/SurfNavigator.h
+++ b/include/AdePT/navigation/SurfNavigator.h
@@ -65,17 +65,16 @@ public:
   __host__ __device__ static Precision ComputeStepAndNextVolume(Vector3D const &globalpoint, Vector3D const &globaldir,
                                                                 Precision step_limit,
                                                                 vecgeom::NavigationState const &in_state,
-                                                                vecgeom::NavigationState &out_state, Precision push = 0)
+                                                                vecgeom::NavigationState &out_state,
+                                                                long &hitsurf_index, Precision push = 0)
   {
     if (step_limit <= 0) {
       in_state.CopyTo(&out_state);
       out_state.SetBoundaryState(false);
       return step_limit;
     }
-
-    vgbrep::CrossedSurface crossed_surf;
-    auto step = vgbrep::protonav::BVHSurfNavigator<Real_t>::ComputeStepAndHit(globalpoint, globaldir, in_state,
-                                                                              out_state, crossed_surf, step_limit);
+    auto step = vgbrep::protonav::BVHSurfNavigator<Real_t>::ComputeStepAndNextSurface(
+        globalpoint, globaldir, in_state, out_state, hitsurf_index, step_limit);
     return step;
   }
 
@@ -88,16 +87,19 @@ public:
                                                                      Vector3D const &globaldir, Precision step_limit,
                                                                      vecgeom::NavigationState const &in_state,
                                                                      vecgeom::NavigationState &out_state,
-                                                                     Precision push = 0)
+                                                                     long &hitsurf_index, Precision push = 0)
   {
-    return ComputeStepAndNextVolume(globalpoint, globaldir, step_limit, in_state, out_state, push);
+    return ComputeStepAndNextVolume(globalpoint, globaldir, step_limit, in_state, out_state, hitsurf_index, push);
   }
 
   // Relocate a state that was returned from ComputeStepAndNextVolume: the surface
   // model does this computation within ComputeStepAndNextVolume, so the relocation does nothing
-  __host__ __device__ static void RelocateToNextVolume(Vector3D const & /*globalpoint*/, Vector3D const & /*globaldir*/,
-                                                       vecgeom::NavigationState & /*state*/)
+  __host__ __device__ static void RelocateToNextVolume(Vector3D const &globalpoint, Vector3D const &globaldir,
+                                                       long hitsurf_index, vecgeom::NavigationState &out_state)
   {
+    vgbrep::CrossedSurface crossed_surf;
+    vgbrep::protonav::BVHSurfNavigator<Real_t>::RelocateToNextVolume(globalpoint, globaldir, Precision(0),
+                                                                     hitsurf_index, out_state, crossed_surf);
   }
 };
 

--- a/test/testField/electrons.cu
+++ b/test/testField/electrons.cu
@@ -167,6 +167,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
 
     // Check if there's a volume boundary in between.
     bool propagated = true;
+    long hitsurf_index = -1;
     double geometryStepLength;
     vecgeom::NavigationState nextState;
 
@@ -199,7 +200,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       fieldPropagatorConstBz fieldPropagatorBz(BzFieldValue);
       Precision helixStepLength = fieldPropagatorBz.ComputeStepAndNextVolume<AdePTNavigator>(
           energy, Mass, Charge, geometricalStepLengthFromPhysics, positionHx, directionHx, navState, nextStateHx,
-          propagatedHx, safety, max_iterations);
+          hitsurf_index, propagatedHx, safety, max_iterations);
       // activeSize < 100 ? max_iterations : max_iters_tail );
       // End   Baseline reply
 #endif
@@ -207,7 +208,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       geometryStepLength =
           fieldPropagatorRungeKutta<Field_t, RkDriver_t, Precision, AdePTNavigator>::ComputeStepAndNextVolume(
               magneticFieldB, energy, Mass, Charge, geometricalStepLengthFromPhysics, pos, dir, navState, nextState,
-              propagated, /*lengthDone,*/ safety,
+              hitsurf_index, propagated, /*lengthDone,*/ safety,
               // activeSize < 100 ? max_iterations : max_iters_tail ), // Was
               max_iterations, iterDone, slot);
 #ifdef CHECK_RESULTS
@@ -249,8 +250,13 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       }
 #endif
     } else {
+#ifdef ADEPT_USE_SURF
+      geometryStepLength = AdePTNavigator::ComputeStepAndNextVolume(pos, dir, geometricalStepLengthFromPhysics,
+                                                                    navState, nextState, hitsurf_index, kPush);
+#else
       geometryStepLength = AdePTNavigator::ComputeStepAndNextVolume(pos, dir, geometricalStepLengthFromPhysics,
                                                                     navState, nextState, kPush);
+#endif
       pos += geometryStepLength * dir;
     }
 
@@ -356,8 +362,11 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
 
       // Kill the particle if it left the world.
       if (!nextState.IsOutside()) {
+#ifdef ADEPT_USE_SURF
+        AdePTNavigator::RelocateToNextVolume(pos, dir, hitsurf_index, nextState);
+#else
         AdePTNavigator::RelocateToNextVolume(pos, dir, nextState);
-
+#endif
         // Move to the next boundary.
         navState = nextState;
         survive();


### PR DESCRIPTION
The AdePT interfaces for navigation normally compute first the distance to the next hit volume, then relocates to find out the next path. The first interface for surface navigation did systematically step+relocation in one go, which is very inefficient in case of non-zero magnetic field, where the field propagator has to call the distance computation in several points along the trajectory.

The PR introduces the split: distance computation does not change the output state, but sets its boundary flag according to a surface being hit within the physics step, returning also the index of this surface. The relocation method used this index as input. Due to the addition of this index in the interfaces, currently, the calling interface of the surface navigator is for the moment different than the solid navigators. 