### PR TITLE
Surface navigation now split in finding the frame and relocation

### DIFF
--- a/examples/Example1/include/SensitiveDetector.hh
+++ b/examples/Example1/include/SensitiveDetector.hh
@@ -33,6 +33,7 @@
 #include "SimpleHit.hh"
 
 #include "G4VSensitiveDetector.hh"
+#include <set>
 
 class G4HCofThisEvent;
 class G4TouchableHistory;

--- a/examples/IntegrationBenchmark/include/SensitiveDetector.hh
+++ b/examples/IntegrationBenchmark/include/SensitiveDetector.hh
@@ -34,6 +34,7 @@
 
 #include "G4VFastSimSensitiveDetector.hh"
 #include "G4VSensitiveDetector.hh"
+#include <set>
 
 class G4HCofThisEvent;
 class G4TouchableHistory;

--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -67,7 +67,7 @@ template <typename IntegrationLayer>
 bool AdePTTransport<IntegrationLayer>::InitializeGeometry(const vecgeom::cxx::VPlacedVolume *world)
 {
   auto &cudaManager = vecgeom::cxx::CudaManager::Instance();
-  bool success = true;
+  bool success      = true;
 #ifdef ADEPT_USE_SURF
 #ifdef ADEPT_USE_SURF_SINGLE
   using BrepHelper = vgbrep::BrepHelper<float>;
@@ -83,9 +83,10 @@ bool AdePTTransport<IntegrationLayer>::InitializeGeometry(const vecgeom::cxx::VP
   cudaManager.SynchronizeNavigationTable();
 #else
   // Upload solid geometry to GPU.
+  cudaDeviceSetLimit(cudaLimitStackSize, 1024 * 8);
   cudaManager.LoadGeometry(world);
   auto world_dev = cudaManager.Synchronize();
-  success = world_dev != nullptr;
+  success        = world_dev != nullptr;
 #endif
   // Initialize BVH
   InitBVH();

--- a/include/AdePT/core/HostScoringImpl.cuh
+++ b/include/AdePT/core/HostScoringImpl.cuh
@@ -169,14 +169,14 @@ namespace adept_scoring
     aGPUHit->fStepLength         = aStepLength;
     aGPUHit->fTotalEnergyDeposit = aTotalEnergyDeposit;
     // Pre step point
-    aGPUHit->fPreStepPoint.fNavigationStateIndex = aPreState->GetNavIndex();
+    aGPUHit->fPreStepPoint.fNavigationState = *aPreState;
     Copy3DVector(aPrePosition, &(aGPUHit->fPreStepPoint.fPosition));
     Copy3DVector(aPreMomentumDirection, &(aGPUHit->fPreStepPoint.fMomentumDirection));
     // Copy3DVector(aPrePolarization, aGPUHit.fPreStepPoint.fPolarization);
     aGPUHit->fPreStepPoint.fEKin   = aPreEKin;
     aGPUHit->fPreStepPoint.fCharge = aPreCharge;
     // Post step point
-    aGPUHit->fPostStepPoint.fNavigationStateIndex = aPostState->GetNavIndex();
+    aGPUHit->fPostStepPoint.fNavigationState = *aPostState;
     Copy3DVector(aPostPosition, &(aGPUHit->fPostStepPoint.fPosition));
     Copy3DVector(aPostMomentumDirection, &(aGPUHit->fPostStepPoint.fMomentumDirection));
     // Copy3DVector(aPostPolarization, aGPUHit.fPostStepPoint.fPolarization);

--- a/include/AdePT/core/HostScoringStruct.cuh
+++ b/include/AdePT/core/HostScoringStruct.cuh
@@ -15,7 +15,7 @@ struct GPUStepPoint {
   double fEKin;
   double fCharge;
   // Data needed to reconstruct G4 Touchable history
-  NavIndex_t fNavigationStateIndex{0}; // VecGeom navigation state index, used to identify the touchable
+  vecgeom::NavigationState fNavigationState{0}; // VecGeom navigation state, used to identify the touchable
 };
 
 // Stores the necessary data to reconstruct GPU hits on the host , and

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -63,7 +63,7 @@ public:
 
 private:
   /// @brief Reconstruct G4TouchableHistory from a VecGeom Navigation index
-  void FillG4NavigationHistory(unsigned int aNavIndex, G4NavigationHistory *aG4NavigationHistory);
+  void FillG4NavigationHistory(vecgeom::NavigationState aNavState, G4NavigationHistory *aG4NavigationHistory);
 
   void FillG4Step(GPUHit *aGPUHit, G4Step *aG4Step, G4TouchableHandle &aPreG4TouchableHandle,
                   G4TouchableHandle &aPostG4TouchableHandle);

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -313,7 +313,8 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       // Kill the particle if it left the world.
       if (!nextState.IsOutside()) {
 #ifdef ADEPT_USE_SURF
-        AdePTNavigator::RelocateToNextVolume(pos, dir, hitsurf_index, nextState); 
+        AdePTNavigator::RelocateToNextVolume(pos, dir, hitsurf_index, nextState);
+        if (nextState.IsOutside()) continue;
 #else
         AdePTNavigator::RelocateToNextVolume(pos, dir, nextState);
 #endif

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -131,6 +131,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       if (!nextState.IsOutside()) {
 #ifdef ADEPT_USE_SURF
         AdePTNavigator::RelocateToNextVolume(pos, dir, hitsurf_index, nextState); 
+        if (nextState.IsOutside()) continue;
 #else
         AdePTNavigator::RelocateToNextVolume(pos, dir, nextState);
 #endif

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -95,16 +95,18 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
 
     // Check if there's a volume boundary in between.
     vecgeom::NavigationState nextState;
+    double geometryStepLength;
 #ifdef ADEPT_USE_SURF
     long hitsurf_index = -1;
-    double geometryStepLength = AdePTNavigator::ComputeStepAndNextVolume(pos, dir, geometricalStepLengthFromPhysics,
-                                                                         navState, nextState, hitsurf_index, kPush);
+    geometryStepLength = AdePTNavigator::ComputeStepAndNextVolume(pos, dir, geometricalStepLengthFromPhysics, navState,
+                                                                  nextState, hitsurf_index, kPush);
 #else
-    double geometryStepLength = AdePTNavigator::ComputeStepAndNextVolume(pos, dir, geometricalStepLengthFromPhysics,
-                                                                         navState, nextState, kPush);
+    geometryStepLength = AdePTNavigator::ComputeStepAndNextVolume(pos, dir, geometricalStepLengthFromPhysics, navState,
+                                                                  nextState, kPush);
 #endif
-  //  printf("pvol=%d  step=%g  onboundary=%d  pos={%g, %g, %g}  dir={%g, %g, %g}\n", navState.TopId(), geometryStepLength,
-  //         nextState.IsOnBoundary(), pos[0], pos[1], pos[2], dir[0], dir[1], dir[2]);
+    //  printf("pvol=%d  step=%g  onboundary=%d  pos={%g, %g, %g}  dir={%g, %g, %g}\n", navState.TopId(),
+    //  geometryStepLength,
+    //         nextState.IsOnBoundary(), pos[0], pos[1], pos[2], dir[0], dir[1], dir[2]);
     pos += geometryStepLength * dir;
 
     // Set boundary state in navState so the next step and secondaries get the
@@ -130,15 +132,15 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       // Kill the particle if it left the world.
       if (!nextState.IsOutside()) {
 #ifdef ADEPT_USE_SURF
-        AdePTNavigator::RelocateToNextVolume(pos, dir, hitsurf_index, nextState); 
+        AdePTNavigator::RelocateToNextVolume(pos, dir, hitsurf_index, nextState);
         if (nextState.IsOutside()) continue;
 #else
         AdePTNavigator::RelocateToNextVolume(pos, dir, nextState);
 #endif
         // Move to the next boundary.
         navState = nextState;
-        //printf("  -> pvol=%d pos={%g, %g, %g} \n", navState.TopId(), pos[0], pos[1], pos[2]);
-        // Check if the next volume belongs to the GPU region and push it to the appropriate queue
+        // printf("  -> pvol=%d pos={%g, %g, %g} \n", navState.TopId(), pos[0], pos[1], pos[2]);
+        //  Check if the next volume belongs to the GPU region and push it to the appropriate queue
 #ifndef ADEPT_USE_SURF
         const int nextlvolID = navState.Top()->GetLogicalVolume()->id();
 #else

--- a/include/AdePT/navigation/SurfNavigator.h
+++ b/include/AdePT/navigation/SurfNavigator.h
@@ -65,17 +65,16 @@ public:
   __host__ __device__ static Precision ComputeStepAndNextVolume(Vector3D const &globalpoint, Vector3D const &globaldir,
                                                                 Precision step_limit,
                                                                 vecgeom::NavigationState const &in_state,
-                                                                vecgeom::NavigationState &out_state, Precision push = 0)
+                                                                vecgeom::NavigationState &out_state,
+                                                                long &hitsurf_index, Precision push = 0)
   {
     if (step_limit <= 0) {
       in_state.CopyTo(&out_state);
       out_state.SetBoundaryState(false);
       return step_limit;
     }
-
-    vgbrep::CrossedSurface crossed_surf;
-    auto step = vgbrep::protonav::BVHSurfNavigator<Real_t>::ComputeStepAndHit(globalpoint, globaldir, in_state,
-                                                                              out_state, crossed_surf, step_limit);
+    auto step = vgbrep::protonav::BVHSurfNavigator<Real_t>::ComputeStepAndNextSurface(
+        globalpoint, globaldir, in_state, out_state, hitsurf_index, step_limit);
     return step;
   }
 
@@ -88,16 +87,19 @@ public:
                                                                      Vector3D const &globaldir, Precision step_limit,
                                                                      vecgeom::NavigationState const &in_state,
                                                                      vecgeom::NavigationState &out_state,
-                                                                     Precision push = 0)
+                                                                     long &hitsurf_index, Precision push = 0)
   {
-    return ComputeStepAndNextVolume(globalpoint, globaldir, step_limit, in_state, out_state, push);
+    return ComputeStepAndNextVolume(globalpoint, globaldir, step_limit, in_state, out_state, hitsurf_index, push);
   }
 
   // Relocate a state that was returned from ComputeStepAndNextVolume: the surface
   // model does this computation within ComputeStepAndNextVolume, so the relocation does nothing
-  __host__ __device__ static void RelocateToNextVolume(Vector3D const & /*globalpoint*/, Vector3D const & /*globaldir*/,
-                                                       vecgeom::NavigationState & /*state*/)
+  __host__ __device__ static void RelocateToNextVolume(Vector3D const &globalpoint, Vector3D const &globaldir,
+                                                       long hitsurf_index, vecgeom::NavigationState &out_state)
   {
+    vgbrep::CrossedSurface crossed_surf;
+    vgbrep::protonav::BVHSurfNavigator<Real_t>::RelocateToNextVolume(globalpoint, globaldir, Precision(0),
+                                                                     hitsurf_index, out_state, crossed_surf);
   }
 };
 

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -278,17 +278,20 @@ void AdePTGeant4Integration::ProcessGPUHits(HostScoring &aScoring, HostScoring::
   // Reconstruct G4NavigationHistory and G4Step, and call the SD code for each hit
   for (size_t i = aStats.fBufferStart; i < aStats.fBufferStart + aStats.fUsedSlots; i++) {
     // Get Hit index (Circular buffer)
-    int aHitIdx = i % aScoring.fBufferCapacity;
-
-    vecgeom::NavigationState &aNavState = aScoring.fGPUHitsBuffer_host[aHitIdx].fPreStepPoint.fNavigationState;
+    int aHitIdx                           = i % aScoring.fBufferCapacity;
+    vecgeom::NavigationState &preNavState = aScoring.fGPUHitsBuffer_host[aHitIdx].fPreStepPoint.fNavigationState;
     // Reconstruct Pre-Step point G4NavigationHistory
-    FillG4NavigationHistory(aNavState, fPreG4NavigationHistory);
+    FillG4NavigationHistory(preNavState, fPreG4NavigationHistory);
     ((G4TouchableHistory *)fPreG4TouchableHistoryHandle())
         ->UpdateYourself(fPreG4NavigationHistory->GetTopVolume(), fPreG4NavigationHistory);
     // Reconstruct Post-Step point G4NavigationHistory
-    FillG4NavigationHistory(aNavState, fPostG4NavigationHistory);
-    ((G4TouchableHistory *)fPostG4TouchableHistoryHandle())
-        ->UpdateYourself(fPostG4NavigationHistory->GetTopVolume(), fPostG4NavigationHistory);
+    vecgeom::NavigationState &postNavState = aScoring.fGPUHitsBuffer_host[aHitIdx].fPostStepPoint.fNavigationState;
+    if (!postNavState
+             .IsOutside()) { // if it is outside, don't set anything and check for nullptr GetVolume in FillG4Step
+      FillG4NavigationHistory(postNavState, fPostG4NavigationHistory);
+      ((G4TouchableHistory *)fPostG4TouchableHistoryHandle())
+          ->UpdateYourself(fPostG4NavigationHistory->GetTopVolume(), fPostG4NavigationHistory);
+    }
 
     // Reconstruct G4Step
     switch (aScoring.fGPUHitsBuffer_host[aHitIdx].fParticleType) {
@@ -317,7 +320,8 @@ void AdePTGeant4Integration::ProcessGPUHits(HostScoring &aScoring, HostScoring::
   }
 }
 
-void AdePTGeant4Integration::FillG4NavigationHistory(vecgeom::NavigationState aNavState, G4NavigationHistory *aG4NavigationHistory)
+void AdePTGeant4Integration::FillG4NavigationHistory(vecgeom::NavigationState aNavState,
+                                                     G4NavigationHistory *aG4NavigationHistory)
 {
   // Get the current depth of the history (corresponding to the previous reconstructed touchable)
   auto aG4HistoryDepth = aG4NavigationHistory->GetDepth();
@@ -351,13 +355,10 @@ void AdePTGeant4Integration::FillG4NavigationHistory(vecgeom::NavigationState aN
       aG4HistoryDepth = aLevel;
     } else {
       // If the navigation state is deeper than the current history we need to add the new levels
-      if(aLevel)
-      { 
+      if (aLevel) {
         aG4NavigationHistory->NewLevel(pnewvol, kNormal, pnewvol->GetCopyNo());
         aG4HistoryDepth++;
-      }
-      else
-      {
+      } else {
         aG4NavigationHistory->SetFirstEntry(pnewvol);
       }
     }
@@ -369,15 +370,15 @@ void AdePTGeant4Integration::FillG4NavigationHistory(vecgeom::NavigationState aN
 void AdePTGeant4Integration::FillG4Step(GPUHit *aGPUHit, G4Step *aG4Step, G4TouchableHandle &aPreG4TouchableHandle,
                                         G4TouchableHandle &aPostG4TouchableHandle)
 {
-  const G4ThreeVector *aPostStepPointMomentumDirection = new G4ThreeVector(aGPUHit->fPostStepPoint.fMomentumDirection.x(),
-                                                                           aGPUHit->fPostStepPoint.fMomentumDirection.y(),
-                                                                           aGPUHit->fPostStepPoint.fMomentumDirection.z());
-  const G4ThreeVector *aPostStepPointPolarization      = new G4ThreeVector(aGPUHit->fPostStepPoint.fPolarization.x(),
-                                                                           aGPUHit->fPostStepPoint.fPolarization.y(),
-                                                                           aGPUHit->fPostStepPoint.fPolarization.z());
-  const G4ThreeVector *aPostStepPointPosition          = new G4ThreeVector(aGPUHit->fPostStepPoint.fPosition.x(),
-                                                                           aGPUHit->fPostStepPoint.fPosition.y(),
-                                                                           aGPUHit->fPostStepPoint.fPosition.z());
+  const G4ThreeVector *aPostStepPointMomentumDirection =
+      new G4ThreeVector(aGPUHit->fPostStepPoint.fMomentumDirection.x(), aGPUHit->fPostStepPoint.fMomentumDirection.y(),
+                        aGPUHit->fPostStepPoint.fMomentumDirection.z());
+  const G4ThreeVector *aPostStepPointPolarization =
+      new G4ThreeVector(aGPUHit->fPostStepPoint.fPolarization.x(), aGPUHit->fPostStepPoint.fPolarization.y(),
+                        aGPUHit->fPostStepPoint.fPolarization.z());
+  const G4ThreeVector *aPostStepPointPosition =
+      new G4ThreeVector(aGPUHit->fPostStepPoint.fPosition.x(), aGPUHit->fPostStepPoint.fPosition.y(),
+                        aGPUHit->fPostStepPoint.fPosition.z());
 
   // G4Step
   aG4Step->SetStepLength(aGPUHit->fStepLength);                 // Real data
@@ -391,8 +392,8 @@ void AdePTGeant4Integration::FillG4Step(GPUHit *aGPUHit, G4Step *aG4Step, G4Touc
 
   // G4Track
   G4Track *aTrack = aG4Step->GetTrack();
-  aTrack->SetTrackID(aGPUHit->fParentID);                                                                   // Missing data
-  aTrack->SetParentID(aGPUHit->fParentID); // ID of the initial particle that entered AdePT
+  aTrack->SetTrackID(aGPUHit->fParentID);       // Missing data
+  aTrack->SetParentID(aGPUHit->fParentID);      // ID of the initial particle that entered AdePT
   aTrack->SetPosition(*aPostStepPointPosition); // Real data
   // aTrack->SetGlobalTime(0);                                                                // Missing data
   // aTrack->SetLocalTime(0);                                                                 // Missing data
@@ -423,16 +424,15 @@ void AdePTGeant4Integration::FillG4Step(GPUHit *aGPUHit, G4Step *aG4Step, G4Touc
 
   // Pre-Step Point
   G4StepPoint *aPreStepPoint = aG4Step->GetPreStepPoint();
-  aPreStepPoint->SetPosition(G4ThreeVector(aGPUHit->fPreStepPoint.fPosition.x(),
-                                          aGPUHit->fPreStepPoint.fPosition.y(),
-                                          aGPUHit->fPreStepPoint.fPosition.z())); // Real data
+  aPreStepPoint->SetPosition(G4ThreeVector(aGPUHit->fPreStepPoint.fPosition.x(), aGPUHit->fPreStepPoint.fPosition.y(),
+                                           aGPUHit->fPreStepPoint.fPosition.z())); // Real data
   // aPreStepPoint->SetLocalTime(0);                                                                // Missing data
   // aPreStepPoint->SetGlobalTime(0);                                                               // Missing data
   // aPreStepPoint->SetProperTime(0);                                                               // Missing data
   aPreStepPoint->SetMomentumDirection(G4ThreeVector(aGPUHit->fPreStepPoint.fMomentumDirection.x(),
                                                     aGPUHit->fPreStepPoint.fMomentumDirection.y(),
                                                     aGPUHit->fPreStepPoint.fMomentumDirection.z())); // Real data
-  aPreStepPoint->SetKineticEnergy(aGPUHit->fPreStepPoint.fEKin);                                 // Real data
+  aPreStepPoint->SetKineticEnergy(aGPUHit->fPreStepPoint.fEKin);                                     // Real data
   // aPreStepPoint->SetVelocity(0);                                                                 // Missing data
   aPreStepPoint->SetTouchableHandle(aPreG4TouchableHandle);                                          // Real data
   aPreStepPoint->SetMaterial(aPreG4TouchableHandle->GetVolume()->GetLogicalVolume()->GetMaterial()); // Real data
@@ -440,8 +440,8 @@ void AdePTGeant4Integration::FillG4Step(GPUHit *aGPUHit, G4Step *aG4Step, G4Touc
   // aPreStepPoint->SetSensitiveDetector(nullptr);                                                  // Missing data
   // aPreStepPoint->SetSafety(0);                                                                   // Missing data
   aPreStepPoint->SetPolarization(G4ThreeVector(aGPUHit->fPreStepPoint.fPolarization.x(),
-                                              aGPUHit->fPreStepPoint.fPolarization.y(),
-                                              aGPUHit->fPreStepPoint.fPolarization.z())); // Real data
+                                               aGPUHit->fPreStepPoint.fPolarization.y(),
+                                               aGPUHit->fPreStepPoint.fPolarization.z())); // Real data
   // aPreStepPoint->SetStepStatus(G4StepStatus::fUndefined);                                        // Missing data
   // aPreStepPoint->SetProcessDefinedStep(nullptr);                                                 // Missing data
   // aPreStepPoint->SetMass(0);                                                                     // Missing data
@@ -458,9 +458,13 @@ void AdePTGeant4Integration::FillG4Step(GPUHit *aGPUHit, G4Step *aG4Step, G4Touc
   aPostStepPoint->SetMomentumDirection(*aPostStepPointMomentumDirection); // Real data
   aPostStepPoint->SetKineticEnergy(aGPUHit->fPostStepPoint.fEKin);        // Real data
   // aPostStepPoint->SetVelocity(0);                                                                  // Missing data
-  aPostStepPoint->SetTouchableHandle(aPostG4TouchableHandle);                                          // Real data
-  aPostStepPoint->SetMaterial(aPostG4TouchableHandle->GetVolume()->GetLogicalVolume()->GetMaterial()); // Real data
-  aPostStepPoint->SetMaterialCutsCouple(aPostG4TouchableHandle->GetVolume()->GetLogicalVolume()->GetMaterialCutsCouple());
+  if (fPostG4TouchableHistoryHandle->GetVolume()) { // protect against nullptr if postNavState is outside
+    aPostStepPoint->SetTouchableHandle(fPostG4TouchableHistoryHandle); // Real data
+    aPostStepPoint->SetMaterial(
+        fPostG4TouchableHistoryHandle->GetVolume()->GetLogicalVolume()->GetMaterial()); // Real data
+    aPostStepPoint->SetMaterialCutsCouple(
+        fPostG4TouchableHistoryHandle->GetVolume()->GetLogicalVolume()->GetMaterialCutsCouple());
+  }
   // aPostStepPoint->SetSensitiveDetector(nullptr);                                                   // Missing data
   // aPostStepPoint->SetSafety(0);                                                                    // Missing data
   aPostStepPoint->SetPolarization(*aPostStepPointPolarization); // Real data


### PR DESCRIPTION
The AdePT interfaces for navigation normally compute first the distance to the next hit volume, then relocates to find out the next path. The first interface for surface navigation did systematically step+relocation in one go, which is very inefficient in case of non-zero magnetic field, where the field propagator has to call the distance computation in several points along the trajectory.

The PR introduces the split: distance computation does not change the output state, but sets its boundary flag according to a surface being hit within the physics step, returning also the index of this surface. The relocation method used this index as input. Due to the addition of this index in the interfaces, currently, the calling interface of the surface navigator is for the moment different than the solid navigators.