### PR TITLE
include set

### DIFF
--- a/examples/Example1/include/SensitiveDetector.hh
+++ b/examples/Example1/include/SensitiveDetector.hh
@@ -29,6 +29,7 @@
 #define SENSITIVEDETECTOR_HH
 
 #include <unordered_map>
+#include <set>
 #include "SimpleHit.hh"
 
 #include "G4VSensitiveDetector.hh"

--- a/examples/IntegrationBenchmark/include/SensitiveDetector.hh
+++ b/examples/IntegrationBenchmark/include/SensitiveDetector.hh
@@ -29,6 +29,7 @@
 #define SENSITIVEDETECTOR_HH
 
 #include <unordered_map>
+#include <set>
 #include "SimpleHit.hh"
 
 #include "G4VFastSimSensitiveDetector.hh"


### PR DESCRIPTION
With GCC 11.4 AdePT doesn't compile because it misses set in the `SensitiveDetector`