### PR TITLE
CPU integration of G4HepEM using the tracking manager

### DIFF
--- a/examples/Example1/example1.cpp
+++ b/examples/Example1/example1.cpp
@@ -48,7 +48,7 @@ int main(int argc, char **argv)
   }
 
   // Initialization of default Run manager
-  auto *runManager = G4RunManagerFactory::CreateRunManager(G4RunManagerType::Default);
+  std::unique_ptr<G4RunManager> runManager(G4RunManagerFactory::CreateRunManager());
   // auto *runManager = G4RunManagerFactory::CreateRunManager(G4RunManagerType::Serial);
 
   // Detector geometry:
@@ -83,8 +83,6 @@ int main(int argc, char **argv)
   // Free the store: user actions, physics_list and detector_description are
   //                 owned and deleted by the run manager, so they should not
   //                 be deleted in the main() program !
-
-  delete runManager;
 
   return err;
 }

--- a/examples/common/src/FTFP_BERT_AdePT.cc
+++ b/examples/common/src/FTFP_BERT_AdePT.cc
@@ -39,7 +39,7 @@ FTFP_BERT_AdePT::FTFP_BERT_AdePT(G4int ver)
 
   // Register the EM physics to use for tracking on CPU
   // RegisterPhysics(new G4EmStandardPhysics());
-  RegisterPhysics(new HepEMPhysics());
+  RegisterPhysics(new HepEMPhysics(ver));
 
   // Register the AdePT physics
   RegisterPhysics(new AdePTPhysics());

--- a/examples/common/src/FTFP_BERT_HepEm.cc
+++ b/examples/common/src/FTFP_BERT_HepEm.cc
@@ -36,7 +36,7 @@ FTFP_BERT_HepEm::FTFP_BERT_HepEm(G4int ver)
 
   // EM Physics
   // RegisterPhysics( new G4EmStandardPhysics(ver));
-  RegisterPhysics(new HepEMPhysics());
+  RegisterPhysics(new HepEMPhysics(ver));
 
   // Synchroton Radiation & GN Physics
   // comenting out to remove gamma- and lepto-nuclear processes

--- a/include/AdePT/integration/HepEMPhysics.hh
+++ b/include/AdePT/integration/HepEMPhysics.hh
@@ -4,12 +4,14 @@
 #ifndef HepEMPhysics_h
 #define HepEMPhysics_h 1
 
-#include "G4VPhysicsConstructor.hh"
+// #include "G4VPhysicsConstructor.hh"
+#include "G4EmStandardPhysics.hh"
 #include "globals.hh"
 
-class HepEMPhysics : public G4VPhysicsConstructor {
+// class HepEMPhysics : public G4VPhysicsConstructor {
+class HepEMPhysics : public G4EmStandardPhysics {
 public:
-  HepEMPhysics(const G4String &name = "G4HepEm-physics-list");
+  HepEMPhysics(int ver, const G4String &name = "G4HepEm-physics-list");
   ~HepEMPhysics();
 
 public:

--- a/src/HepEMPhysics.cc
+++ b/src/HepEMPhysics.cc
@@ -5,6 +5,7 @@
 
 // include the G4HepEmProcess from the G4HepEm lib.
 #include "G4HepEmProcess.hh"
+#include "G4HepEmTrackingManager.hh"
 
 #include "G4ParticleDefinition.hh"
 #include "G4ProcessManager.hh"
@@ -59,71 +60,76 @@ HepEMPhysics::~HepEMPhysics() {}
 
 void HepEMPhysics::ConstructProcess()
 {
+  // Register custom tracking manager for e-/e+ and gammas.
+  auto trackingManager = new G4HepEmTrackingManager();
+  G4Electron::Definition()->SetTrackingManager(trackingManager);
+  G4Positron::Definition()->SetTrackingManager(trackingManager);
+  G4Gamma::Definition()->SetTrackingManager(trackingManager);
 
-  G4PhysicsListHelper *ph = G4PhysicsListHelper::GetPhysicsListHelper();
+  // G4PhysicsListHelper *ph = G4PhysicsListHelper::GetPhysicsListHelper();
 
-  // from G4EmStandardPhysics
-  G4EmBuilder::PrepareEMPhysics();
+  // // from G4EmStandardPhysics
+  // G4EmBuilder::PrepareEMPhysics();
 
-  G4EmParameters *param = G4EmParameters::Instance();
+  // G4EmParameters *param = G4EmParameters::Instance();
 
-  // processes used by several particles
-  G4hMultipleScattering *hmsc = new G4hMultipleScattering("ionmsc");
+  // // processes used by several particles
+  // G4hMultipleScattering *hmsc = new G4hMultipleScattering("ionmsc");
 
-  // nuclear stopping is enabled if th eenergy limit above zero
-  G4double nielEnergyLimit = param->MaxNIELEnergy();
-  G4NuclearStopping *pnuc  = nullptr;
-  if (nielEnergyLimit > 0.0) {
-    pnuc = new G4NuclearStopping();
-    pnuc->SetMaxKinEnergy(nielEnergyLimit);
-  }
-  // end of G4EmStandardPhysics
+  // // nuclear stopping is enabled if th eenergy limit above zero
+  // G4double nielEnergyLimit = param->MaxNIELEnergy();
+  // G4NuclearStopping *pnuc  = nullptr;
+  // if (nielEnergyLimit > 0.0) {
+  //   pnuc = new G4NuclearStopping();
+  //   pnuc->SetMaxKinEnergy(nielEnergyLimit);
+  // }
+  // // end of G4EmStandardPhysics
 
-  // creae the only one G4HepEm process that will be assigned to e-/e+ and gamma
-  G4HepEmProcess *hepEmProcess = new G4HepEmProcess();
+  // // creae the only one G4HepEm process that will be assigned to e-/e+ and gamma
+  // G4HepEmProcess *hepEmProcess = new G4HepEmProcess();
 
-  // Add standard EM Processes
-  //
-  auto aParticleIterator = GetParticleIterator();
-  aParticleIterator->reset();
-  while ((*aParticleIterator)()) {
-    G4ParticleDefinition *particle = aParticleIterator->value();
-    G4String particleName          = particle->GetParticleName();
+  // // Add standard EM Processes
+  // //
+  // auto aParticleIterator = GetParticleIterator();
+  // aParticleIterator->reset();
+  // while ((*aParticleIterator)()) {
+  //   G4ParticleDefinition *particle = aParticleIterator->value();
+  //   G4String particleName          = particle->GetParticleName();
 
-    if (particleName == "gamma") {
+  //   if (particleName == "gamma") {
 
-      // Add G4HepEm process to gamma: includes Conversion, Compton and photoelectric effect.
-      particle->GetProcessManager()->AddProcess(hepEmProcess, -1, -1, 1);
+  //     // Add G4HepEm process to gamma: includes Conversion, Compton and photoelectric effect.
+  //     particle->GetProcessManager()->AddProcess(hepEmProcess, -1, -1, 1);
 
-    } else if (particleName == "e-") {
+  //   } else if (particleName == "e-") {
 
-      // Add G4HepEm process to e-: includes Ionisation and Bremsstrahlung for e-
-      particle->GetProcessManager()->AddProcess(hepEmProcess, -1, -1, 1);
+  //     // Add G4HepEm process to e-: includes Ionisation and Bremsstrahlung for e-
+  //     particle->GetProcessManager()->AddProcess(hepEmProcess, -1, -1, 1);
 
-    } else if (particleName == "e+") {
+  //   } else if (particleName == "e+") {
 
-      // Add G4HepEm process to e+: includes Ionisation, Bremsstrahlung and e+e-
-      // annihilation into 2 gamma interactions for e+
-      particle->GetProcessManager()->AddProcess(hepEmProcess, -1, -1, 1);
-    }
-  }
+  //     // Add G4HepEm process to e+: includes Ionisation, Bremsstrahlung and e+e-
+  //     // annihilation into 2 gamma interactions for e+
+  //     particle->GetProcessManager()->AddProcess(hepEmProcess, -1, -1, 1);
+  //   }
+  // }
 
-  // from G4EmStandardPhysics
+  // // from G4EmStandardPhysics
 
-  // generic ion
-  G4ParticleDefinition *particle = G4GenericIon::GenericIon();
-  G4ionIonisation *ionIoni       = new G4ionIonisation();
-  ph->RegisterProcess(hmsc, particle);
-  ph->RegisterProcess(ionIoni, particle);
-  if (nullptr != pnuc) {
-    ph->RegisterProcess(pnuc, particle);
-  }
+  // // generic ion
+  // G4ParticleDefinition *particle = G4GenericIon::GenericIon();
+  // G4ionIonisation *ionIoni       = new G4ionIonisation();
+  // ph->RegisterProcess(hmsc, particle);
+  // ph->RegisterProcess(ionIoni, particle);
+  // if (nullptr != pnuc) {
+  //   ph->RegisterProcess(pnuc, particle);
+  // }
 
-  // muons, hadrons ions
-  G4EmBuilder::ConstructCharged(hmsc, pnuc);
+  // // muons, hadrons ions
+  // G4EmBuilder::ConstructCharged(hmsc, pnuc);
 
-  // extra configuration
-  G4EmModelActivator mact(GetPhysicsName());
+  // // extra configuration
+  // G4EmModelActivator mact(GetPhysicsName());
 
-  // end of G4EmStandardPhysics
+  // // end of G4EmStandardPhysics
 }

--- a/src/HepEMPhysics.cc
+++ b/src/HepEMPhysics.cc
@@ -60,80 +60,80 @@ HepEMPhysics::~HepEMPhysics() {}
 
 void HepEMPhysics::ConstructProcess()
 {
-  // G4EmStandardPhysics::ConstructProcess();
+  G4EmStandardPhysics::ConstructProcess();
   
-  // // Register custom tracking manager for e-/e+ and gammas.
-  // auto *trackingManager = new G4HepEmTrackingManager();
-  // G4Electron::Definition()->SetTrackingManager(trackingManager);
-  // G4Positron::Definition()->SetTrackingManager(trackingManager);
-  // G4Gamma::Definition()->SetTrackingManager(trackingManager);
+  // Register custom tracking manager for e-/e+ and gammas.
+  auto *trackingManager = new G4HepEmTrackingManager();
+  G4Electron::Definition()->SetTrackingManager(trackingManager);
+  G4Positron::Definition()->SetTrackingManager(trackingManager);
+  G4Gamma::Definition()->SetTrackingManager(trackingManager);
 
-  // Integration trough G4 process:
+  // // Integration trough G4 process:
 
-  G4PhysicsListHelper *ph = G4PhysicsListHelper::GetPhysicsListHelper();
+  // G4PhysicsListHelper *ph = G4PhysicsListHelper::GetPhysicsListHelper();
 
-  // from G4EmStandardPhysics
-  G4EmBuilder::PrepareEMPhysics();
+  // // from G4EmStandardPhysics
+  // G4EmBuilder::PrepareEMPhysics();
 
-  G4EmParameters *param = G4EmParameters::Instance();
+  // G4EmParameters *param = G4EmParameters::Instance();
 
-  // processes used by several particles
-  G4hMultipleScattering *hmsc = new G4hMultipleScattering("ionmsc");
+  // // processes used by several particles
+  // G4hMultipleScattering *hmsc = new G4hMultipleScattering("ionmsc");
 
-  // nuclear stopping is enabled if th eenergy limit above zero
-  G4double nielEnergyLimit = param->MaxNIELEnergy();
-  G4NuclearStopping *pnuc  = nullptr;
-  if (nielEnergyLimit > 0.0) {
-    pnuc = new G4NuclearStopping();
-    pnuc->SetMaxKinEnergy(nielEnergyLimit);
-  }
-  // end of G4EmStandardPhysics
+  // // nuclear stopping is enabled if th eenergy limit above zero
+  // G4double nielEnergyLimit = param->MaxNIELEnergy();
+  // G4NuclearStopping *pnuc  = nullptr;
+  // if (nielEnergyLimit > 0.0) {
+  //   pnuc = new G4NuclearStopping();
+  //   pnuc->SetMaxKinEnergy(nielEnergyLimit);
+  // }
+  // // end of G4EmStandardPhysics
 
-  // creae the only one G4HepEm process that will be assigned to e-/e+ and gamma
-  G4HepEmProcess *hepEmProcess = new G4HepEmProcess();
+  // // creae the only one G4HepEm process that will be assigned to e-/e+ and gamma
+  // G4HepEmProcess *hepEmProcess = new G4HepEmProcess();
 
-  // Add standard EM Processes
-  //
-  auto aParticleIterator = GetParticleIterator();
-  aParticleIterator->reset();
-  while ((*aParticleIterator)()) {
-    G4ParticleDefinition *particle = aParticleIterator->value();
-    G4String particleName          = particle->GetParticleName();
+  // // Add standard EM Processes
+  // //
+  // auto aParticleIterator = GetParticleIterator();
+  // aParticleIterator->reset();
+  // while ((*aParticleIterator)()) {
+  //   G4ParticleDefinition *particle = aParticleIterator->value();
+  //   G4String particleName          = particle->GetParticleName();
 
-    if (particleName == "gamma") {
+  //   if (particleName == "gamma") {
 
-      // Add G4HepEm process to gamma: includes Conversion, Compton and photoelectric effect.
-      particle->GetProcessManager()->AddProcess(hepEmProcess, -1, -1, 1);
+  //     // Add G4HepEm process to gamma: includes Conversion, Compton and photoelectric effect.
+  //     particle->GetProcessManager()->AddProcess(hepEmProcess, -1, -1, 1);
 
-    } else if (particleName == "e-") {
+  //   } else if (particleName == "e-") {
 
-      // Add G4HepEm process to e-: includes Ionisation and Bremsstrahlung for e-
-      particle->GetProcessManager()->AddProcess(hepEmProcess, -1, -1, 1);
+  //     // Add G4HepEm process to e-: includes Ionisation and Bremsstrahlung for e-
+  //     particle->GetProcessManager()->AddProcess(hepEmProcess, -1, -1, 1);
 
-    } else if (particleName == "e+") {
+  //   } else if (particleName == "e+") {
 
-      // Add G4HepEm process to e+: includes Ionisation, Bremsstrahlung and e+e-
-      // annihilation into 2 gamma interactions for e+
-      particle->GetProcessManager()->AddProcess(hepEmProcess, -1, -1, 1);
-    }
-  }
+  //     // Add G4HepEm process to e+: includes Ionisation, Bremsstrahlung and e+e-
+  //     // annihilation into 2 gamma interactions for e+
+  //     particle->GetProcessManager()->AddProcess(hepEmProcess, -1, -1, 1);
+  //   }
+  // }
 
-  // from G4EmStandardPhysics
+  // // from G4EmStandardPhysics
 
-  // generic ion
-  G4ParticleDefinition *particle = G4GenericIon::GenericIon();
-  G4ionIonisation *ionIoni       = new G4ionIonisation();
-  ph->RegisterProcess(hmsc, particle);
-  ph->RegisterProcess(ionIoni, particle);
-  if (nullptr != pnuc) {
-    ph->RegisterProcess(pnuc, particle);
-  }
+  // // generic ion
+  // G4ParticleDefinition *particle = G4GenericIon::GenericIon();
+  // G4ionIonisation *ionIoni       = new G4ionIonisation();
+  // ph->RegisterProcess(hmsc, particle);
+  // ph->RegisterProcess(ionIoni, particle);
+  // if (nullptr != pnuc) {
+  //   ph->RegisterProcess(pnuc, particle);
+  // }
 
-  // muons, hadrons ions
-  G4EmBuilder::ConstructCharged(hmsc, pnuc);
+  // // muons, hadrons ions
+  // G4EmBuilder::ConstructCharged(hmsc, pnuc);
 
-  // extra configuration
-  G4EmModelActivator mact(GetPhysicsName());
+  // // extra configuration
+  // G4EmModelActivator mact(GetPhysicsName());
 
-  // end of G4EmStandardPhysics
+  // // end of G4EmStandardPhysics
 }


### PR DESCRIPTION
This PR shows how to use G4HepEM through the TrackingManager instead of the G4 process. However, it can be used only to run on CPU, and will not work with AdePT since one TrackingManager will replace the other.

In order to be able to run G4HepEM with tracking manager on full CPU and CPU + AdePT modes we would need:
- Two separate physics constructors, one registering the G4HepEM tracking manager for full CPU mode, and one registering the G4HepEM process and the AdePT tracking manager
  - However there seems to be a discrepancy in the results from the G4HepEM tracking manager and G4 process
- To implement a hybrid AdePT/G4HepEM tracking manager, removing the need to register the G4HepEM process
  - The current AdePT tracking manager would remain in case the user wants to use something other than G4HepEM on CPU