### PR TITLE
Apply cut work in progress

### DIFF
--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -274,6 +274,9 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     bool reached_interaction = true;
     bool cross_boundary = false;
 
+    const double theElCut = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fSecElProdCutE;
+    const double theGammaCut = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fSecGamProdCutE;
+
     if (stopped) {
       if (!IsElectron) {
         // Annihilate the stopped positron into two gammas heading to opposite
@@ -289,19 +292,28 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
         double sinPhi, cosPhi;
         sincos(phi, &sinPhi, &cosPhi);
 
-        gamma1.InitAsSecondary(pos, navState, globalTime);
-        newRNG.Advance();
-        gamma1.parentID = currentTrack.parentID;
-        gamma1.rngState = newRNG;
-        gamma1.eKin     = copcore::units::kElectronMassC2;
-        gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
+        // Apply cuts
+        if (APPLY_CUTS && (copcore::units::kElectronMassC2 < theGammaCut)) {
+          // Deposit the energy here and kill the secondaries
+          energyDeposit += 2 * copcore::units::kElectronMassC2;
+          
+        }
+        else
+        {
+          gamma1.InitAsSecondary(pos, navState, globalTime);
+          newRNG.Advance();
+          gamma1.parentID = currentTrack.parentID;
+          gamma1.rngState = newRNG;
+          gamma1.eKin     = copcore::units::kElectronMassC2;
+          gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
 
-        gamma2.InitAsSecondary(pos, navState, globalTime);
-        // Reuse the RNG state of the dying track.
-        gamma2.parentID = currentTrack.parentID;
-        gamma2.rngState = currentTrack.rngState;
-        gamma2.eKin     = copcore::units::kElectronMassC2;
-        gamma2.dir      = -gamma1.dir;
+          gamma2.InitAsSecondary(pos, navState, globalTime);
+          // Reuse the RNG state of the dying track.
+          gamma2.parentID = currentTrack.parentID;
+          gamma2.rngState = currentTrack.rngState;
+          gamma2.eKin     = copcore::units::kElectronMassC2;
+          gamma2.dir      = -gamma1.dir;
+        }
       }
       // Particles are killed by not enqueuing them into the new activeQueue.
       // continue;
@@ -357,9 +369,6 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
         // numbers after MSC used up a fair share for sampling the displacement.
         currentTrack.rngState.Advance();
 
-        const double theElCut = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fSecElProdCutE;
-        const double theGammaCut = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fSecGamProdCutE;
-
         switch (winnerProcessIndex) {
         case 0: {
           // Invoke ionization (for e-/e+):
@@ -373,8 +382,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
           adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 1, /*numPositrons*/ 0, /*numGammas*/ 0);
 
           // Apply cuts
-          if (false) {
-          // if (APPLY_CUTS && (deltaEkin < theElCut)) {
+          if (APPLY_CUTS && (deltaEkin < theElCut)) {
             // Deposit the energy here and kill the secondary
             energyDeposit += deltaEkin;
 
@@ -410,8 +418,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
           adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 0, /*numPositrons*/ 0, /*numGammas*/ 1);
 
           // Apply cuts
-          if (false) {
-          // if (APPLY_CUTS && (deltaEkin < theGammaCut)) {
+          if (APPLY_CUTS && (deltaEkin < theGammaCut)) {
             // Deposit the energy here and kill the secondary
             energyDeposit += deltaEkin;
             
@@ -443,8 +450,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
           adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 0, /*numPositrons*/ 0, /*numGammas*/ 2);
           
           // Apply cuts
-          if (false) {
-          // if (APPLY_CUTS && (theGamma1Ekin < theGammaCut)) {
+          if (APPLY_CUTS && (theGamma1Ekin < theGammaCut)) {
             // Deposit the energy here and kill the secondaries
             energyDeposit += theGamma1Ekin;
             
@@ -458,8 +464,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
             gamma1.eKin     = theGamma1Ekin;
             gamma1.dir.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
           }
-          if (false) {
-          // if (APPLY_CUTS && (theGamma2Ekin < theGammaCut)) {
+          if (APPLY_CUTS && (theGamma2Ekin < theGammaCut)) {
             // Deposit the energy here and kill the secondaries
             energyDeposit += theGamma2Ekin;
             

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -206,8 +206,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       // Check the cuts and deposit energy in this volume if needed
       double edep=0;
 
-      if (false) {
-      // if (APPLY_CUTS && elKinEnergy < theElCut) {
+      if (APPLY_CUTS && elKinEnergy < theElCut) {
         // Deposit the energy here and kill the secondary
         edep += elKinEnergy;
       }
@@ -221,9 +220,8 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         electron.dir.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
       }
 
-      if (false) {
-      // if (APPLY_CUTS && 
-      //       (copcore::units::kElectronMassC2 < theGammaCut && posKinEnergy < theElCut)) {
+      if (APPLY_CUTS && 
+            (copcore::units::kElectronMassC2 < theGammaCut && posKinEnergy < theElCut)) {
         // Deposit: posKinEnergy + 2 * copcore::units::kElectronMassC2 and kill the secondary
         edep += posKinEnergy + 2 * copcore::units::kElectronMassC2;
       }
@@ -285,9 +283,8 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       // Check the cuts and deposit energy in this volume if needed
       double edep=0;
 
-      if (energyEl > LowEnergyThreshold) {
-      // if (energyEl > LowEnergyThreshold && 
-      //     (APPLY_CUTS && (energyEl > theElCut))) {
+      if (energyEl > LowEnergyThreshold && 
+          (APPLY_CUTS && (energyEl > theElCut))) {
         // Create a secondary electron and sample/compute directions.
         Track &electron = secondaries.electrons->NextTrack();
 
@@ -345,9 +342,8 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
 
       double edep             = bindingEnergy;
       const double photoElecE = eKin - edep;
-      if (photoElecE > theLowEnergyThreshold) {
-      // if (photoElecE > theLowEnergyThreshold && 
-      //     (APPLY_CUTS && (photoElecE > theElCut))) {
+      if (photoElecE > theLowEnergyThreshold && 
+          (APPLY_CUTS && (photoElecE > theElCut))) {
         // Create a secondary electron and sample directions.
         Track &electron = secondaries.electrons->NextTrack();
         adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 1, /*numPositrons*/ 0, /*numGammas*/ 0);

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -18,6 +18,8 @@
 #include <G4HepEmGammaInteractionConversion.icc>
 #include <G4HepEmGammaInteractionPhotoelectric.icc>
 
+#define APPLY_CUTS true
+
 using VolAuxData = adeptint::VolAuxData;
 
 template <typename Scoring>
@@ -177,12 +179,16 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
     // We might need one branched RNG state, prepare while threads are synchronized.
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 
+    const double theElCut = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fSecElProdCutE;
+    const double theGammaCut = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fSecGamProdCutE;
+
     switch (winnerProcessIndex) {
     case 0: {
       // Invoke gamma conversion to e-/e+ pairs, if the energy is above the threshold.
       if (eKin < 2 * copcore::units::kElectronMassC2) {
         survive();
-        continue;
+        // continue;
+        break;
       }
 
       double logEnergy = std::log(eKin);
@@ -195,24 +201,66 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       G4HepEmGammaInteractionConversion::SampleDirections(dirPrimary, dirSecondaryEl, dirSecondaryPos, elKinEnergy,
                                                           posKinEnergy, &rnge);
 
-      Track &electron = secondaries.electrons->NextTrack();
-      Track &positron = secondaries.positrons->NextTrack();
-
       adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 1, /*numPositrons*/ 1, /*numGammas*/ 0);
+      
+      // Check the cuts and deposit energy in this volume if needed
+      double edep=0;
 
-      electron.InitAsSecondary(pos, navState, globalTime);
-      electron.parentID = currentTrack.parentID;
-      electron.rngState = newRNG;
-      electron.eKin     = elKinEnergy;
-      electron.dir.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
+      if (false) {
+      // if (APPLY_CUTS && elKinEnergy < theElCut) {
+        // Deposit the energy here and kill the secondary
+        edep += elKinEnergy;
+      }
+      else
+      {
+        Track &electron = secondaries.electrons->NextTrack();
+        electron.InitAsSecondary(pos, navState, globalTime);
+        electron.parentID = currentTrack.parentID;
+        electron.rngState = newRNG;
+        electron.eKin     = elKinEnergy;
+        electron.dir.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
+      }
 
-      positron.InitAsSecondary(pos, navState, globalTime);
-      // Reuse the RNG state of the dying track.
-      positron.parentID = currentTrack.parentID;
-      positron.rngState = currentTrack.rngState;
-      positron.eKin     = posKinEnergy;
-      positron.dir.Set(dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]);
+      if (false) {
+      // if (APPLY_CUTS && 
+      //       (copcore::units::kElectronMassC2 < theGammaCut && posKinEnergy < theElCut)) {
+        // Deposit: posKinEnergy + 2 * copcore::units::kElectronMassC2 and kill the secondary
+        edep += posKinEnergy + 2 * copcore::units::kElectronMassC2;
+      }
+      else
+      {
+        Track &positron = secondaries.positrons->NextTrack();
+        positron.InitAsSecondary(pos, navState, globalTime);
+        // Reuse the RNG state of the dying track.
+        positron.parentID = currentTrack.parentID;
+        positron.rngState = currentTrack.rngState;
+        positron.eKin     = posKinEnergy;
+        positron.dir.Set(dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]);
+      }
 
+      // If there is some edep from cutting particles, record the step
+      if(edep > 0)
+      {
+        if (auxData.fSensIndex >= 0)
+          adept_scoring::RecordHit(userScoring,
+                                    currentTrack.parentID, // Track ID
+                                    2,                     // Particle type
+                                    geometryStepLength,    // Step length
+                                    edep,                     // Total Edep
+                                    &navState,             // Pre-step point navstate
+                                    &preStepPos,           // Pre-step point position
+                                    &preStepDir,           // Pre-step point momentum direction
+                                    nullptr,               // Pre-step point polarization
+                                    preStepEnergy,         // Pre-step point kinetic energy
+                                    0,                     // Pre-step point charge
+                                    &nextState,            // Post-step point navstate
+                                    &pos,                  // Post-step point position
+                                    &dir,                  // Post-step point momentum direction
+                                    nullptr,               // Post-step point polarization
+                                    0,                     // Post-step point kinetic energy
+                                    0);                    // Post-step point charge
+      }
+      
       // The current track is killed by not enqueuing into the next activeQueue.
       break;
     }
@@ -221,7 +269,8 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       constexpr double LowEnergyThreshold = 100 * copcore::units::eV;
       if (eKin < LowEnergyThreshold) {
         survive();
-        continue;
+        // continue;
+        break;
       }
       const double origDirPrimary[] = {dir.x(), dir.y(), dir.z()};
       double dirPrimary[3];
@@ -230,10 +279,17 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       vecgeom::Vector3D<double> newDirGamma(dirPrimary[0], dirPrimary[1], dirPrimary[2]);
 
       const double energyEl = eKin - newEnergyGamma;
+
+      adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 1, /*numPositrons*/ 0, /*numGammas*/ 0);
+
+      // Check the cuts and deposit energy in this volume if needed
+      double edep=0;
+
       if (energyEl > LowEnergyThreshold) {
+      // if (energyEl > LowEnergyThreshold && 
+      //     (APPLY_CUTS && (energyEl > theElCut))) {
         // Create a secondary electron and sample/compute directions.
         Track &electron = secondaries.electrons->NextTrack();
-        adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 1, /*numPositrons*/ 0, /*numGammas*/ 0);
 
         electron.InitAsSecondary(pos, navState, globalTime);
         electron.parentID = currentTrack.parentID;
@@ -242,51 +298,41 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         electron.dir      = eKin * dir - newEnergyGamma * newDirGamma;
         electron.dir.Normalize();
       } else {
-        if (auxData.fSensIndex >= 0)
-          adept_scoring::RecordHit(userScoring,
-                                   currentTrack.parentID, // Track ID
-                                   2,                     // Particle type
-                                   geometryStepLength,    // Step length
-                                   0,                     // Total Edep
-                                   &navState,             // Pre-step point navstate
-                                   &preStepPos,           // Pre-step point position
-                                   &preStepDir,           // Pre-step point momentum direction
-                                   nullptr,               // Pre-step point polarization
-                                   preStepEnergy,         // Pre-step point kinetic energy
-                                   0,                     // Pre-step point charge
-                                   &nextState,            // Post-step point navstate
-                                   &pos,                  // Post-step point position
-                                   &dir,                  // Post-step point momentum direction
-                                   nullptr,               // Post-step point polarization
-                                   newEnergyGamma,        // Post-step point kinetic energy
-                                   0);                    // Post-step point charge
+        edep += energyEl;
       }
 
       // Check the new gamma energy and deposit if below threshold.
+      // TODO: Why are we using this hardcoded cut here?
       if (newEnergyGamma > LowEnergyThreshold) {
         eKin = newEnergyGamma;
         dir  = newDirGamma;
         survive();
       } else {
+        edep += newEnergyGamma;
+        // The current track is killed by not enqueuing into the next activeQueue.
+      }
+
+      // If there is some edep from cutting particles, record the step
+      if(edep > 0)
+      {
         if (auxData.fSensIndex >= 0)
           adept_scoring::RecordHit(userScoring,
-                                   currentTrack.parentID, // Track ID
-                                   2,                     // Particle type
-                                   geometryStepLength,    // Step length
-                                   0,                     // Total Edep
-                                   &navState,             // Pre-step point navstate
-                                   &preStepPos,           // Pre-step point position
-                                   &preStepDir,           // Pre-step point momentum direction
-                                   nullptr,               // Pre-step point polarization
-                                   preStepEnergy,         // Pre-step point kinetic energy
-                                   0,                     // Pre-step point charge
-                                   &nextState,            // Post-step point navstate
-                                   &pos,                  // Post-step point position
-                                   &dir,                  // Post-step point momentum direction
-                                   nullptr,               // Post-step point polarization
-                                   newEnergyGamma,        // Post-step point kinetic energy
-                                   0);                    // Post-step point charge
-        // The current track is killed by not enqueuing into the next activeQueue.
+                                    currentTrack.parentID, // Track ID
+                                    2,                     // Particle type
+                                    geometryStepLength,    // Step length
+                                    edep,                     // Total Edep
+                                    &navState,             // Pre-step point navstate
+                                    &preStepPos,           // Pre-step point position
+                                    &preStepDir,           // Pre-step point momentum direction
+                                    nullptr,               // Pre-step point polarization
+                                    preStepEnergy,         // Pre-step point kinetic energy
+                                    0,                     // Pre-step point charge
+                                    &nextState,            // Post-step point navstate
+                                    &pos,                  // Post-step point position
+                                    &dir,                  // Post-step point momentum direction
+                                    nullptr,               // Post-step point polarization
+                                    newEnergyGamma,        // Post-step point kinetic energy
+                                    0);                    // Post-step point charge
       }
       break;
     }
@@ -300,6 +346,8 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       double edep             = bindingEnergy;
       const double photoElecE = eKin - edep;
       if (photoElecE > theLowEnergyThreshold) {
+      // if (photoElecE > theLowEnergyThreshold && 
+      //     (APPLY_CUTS && (photoElecE > theElCut))) {
         // Create a secondary electron and sample directions.
         Track &electron = secondaries.electrons->NextTrack();
         adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 1, /*numPositrons*/ 0, /*numGammas*/ 0);
@@ -314,6 +362,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         electron.eKin     = photoElecE;
         electron.dir.Set(dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]);
       } else {
+        // If the secondary electron is cut, deposit all the energy of the gamma in this volume
         edep = eKin;
       }
       if (auxData.fSensIndex >= 0)


### PR DESCRIPTION
Draft PR for implementing apply cut in AdePT

Main changes:

- Re-structured scoring:

In order to record the energy from cut secondaries, the steps are recorded at the end of the kernel for electrons, and the energy includes the continuous energy loss plus the energy of any cut secondaries.

For gammas, there is a new possibility to record a step after pair production when the secondaries are cut. In compton scattering, previously only a hardcoded low energy cut was applied, and energy from those secondaries was not recorded. Now that energy is recorded too, even when production cuts are disabled. This causes a small increase in edep for some events with respect to the previous version.

- Apply cut:

Now applying the cuts stored in `g4HepEmData.fTheMatCutData->fMatCutData` to the secondaries produced in all processes. Any secondaries with energy lower than the cut are not produced, and their energy is added to the edep of their primary in that step.

- Current status:
  - The re-structured scoring works as expected, there is no performance difference with the previous version, the energy deposition is slightly higher for some events, but this comes from recording the energy of very low energy particles that were previously cut and ignored.
  - When the cuts are active there are two main issues:
    - The edep is consistently lower for all events. In principle this shouldn't happen
    - For some events, the results are unstable between runs. It could be related to the cuts in positron annihilation or pair production.
