### PR TITLE
Better use of safety.

### DIFF
--- a/include/AdePT/magneticfield/fieldPropagatorConstBz.h
+++ b/include/AdePT/magneticfield/fieldPropagatorConstBz.h
@@ -142,7 +142,12 @@ __host__ __device__ Precision fieldPropagatorConstBz::ComputeStepAndNextVolume(
     } else {
       Precision newSafety = 0;
       if (stepDone > 0) {
+#ifdef ADEPT_USE_SURF
+        // Use maximum accuracy only if safety is samller than physicalStepLength
+        newSafety = Navigator::ComputeSafety(position, current_state, remains);
+#else
         newSafety = Navigator::ComputeSafety(position, current_state);
+#endif
       }
       if (newSafety > chordLen) {
         move         = chordLen;

--- a/include/AdePT/navigation/SurfNavigator.h
+++ b/include/AdePT/navigation/SurfNavigator.h
@@ -49,10 +49,12 @@ public:
   /// @brief Computes the isotropic safety from the globalpoint.
   /// @param globalpoint Point in global coordinates
   /// @param state Path where to compute safety
+  /// @param limit Limit to which safety should be computed accurately
   /// @return Isotropic safe distance
-  __host__ __device__ static Precision ComputeSafety(Vector3D const &globalpoint, vecgeom::NavigationState const &state)
+  __host__ __device__ static Precision ComputeSafety(Vector3D const &globalpoint, vecgeom::NavigationState const &state,
+                                                     Precision limit = vecgeom::InfinityLength<Real_t>())
   {
-    auto safety = vgbrep::protonav::BVHSurfNavigator<Real_t>::ComputeSafety(globalpoint, state);
+    auto safety = vgbrep::protonav::BVHSurfNavigator<Real_t>::ComputeSafety(globalpoint, state, limit);
     return safety;
   }
 


### PR DESCRIPTION
Implementing two safety features:

1. Safety caching: the tracks hold the point where safety is computed, and the safety value in that point. When safety is needed in a different point, the method track.GetSafety(new_point) will subtract from the cached value and return the positive remainder or zero otherwise. The GetSafety method can take an accurate limit value, and when the remainder is smaller than this limit the returned safety is zero. It is the user responsibility to call track.SetSafety(pos, safety) whenever the safety is fully recomputed in a new position.

2. Safety calculation uses a new surface model feature only to compute safety accurately when close to boundaries, and only use the aligned bounding box safety when far away. The distance limit is passed as a third parameter to `AdePTNavigator::ComputeSafety`, and must be typically equal to the discrete interaction step.
