### PR TITLE
[mini] fix bug if next state was outside

### DIFF
--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -265,7 +265,6 @@ void AdePTGeant4Integration::InitScoringData(adeptint::VolAuxData *volAuxData)
     // Though we only record and reconstruct hits for sensitive volumes, this map needs to store every
     // volume in the geometry, as a step may begin in a sensitive volume and end in a non-sensitive one
     fglobal_vecgeom_to_g4_map.insert(std::pair<int, const G4VPhysicalVolume *>(vg_pvol->id(), g4_pvol));
-    std::cout << " creating fglobal_vecgeom_to_g4_map with pair and volume " << vg_pvol->id() << std::endl;
     // Now do the daughters
     for (int id = 0; id < g4_lvol->GetNoDaughters(); ++id) {
       auto g4pvol_d = g4_lvol->GetDaughter(id);


### PR DESCRIPTION
If a step was recorded at the edge of the world such that the NextState would be "outside"  the reconstruction algorithm would try to access a outside volume that doesn't exist in the lookup table. This would lead to a segfault.

This PR adds a safeguard against that case. The scenario is unrealistic in a real setup, but should be avoided for stability (and the error was observed in some small tests)