### PR TITLE
upgrade to latest G4hepem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ endif()
 # Build Targets
 #----------------------------------------------------------------------------#
 set(ADEPT_G4_INTEGRATION_SRCS
+  src/G4HepEmTrackingManagerSpecialized.cc
   src/AdePTTrackingManager.cc
   src/AdePTTrackingManager.cu
   src/AdePTPhysics.cc

--- a/examples/Example1/example1.cpp
+++ b/examples/Example1/example1.cpp
@@ -48,8 +48,7 @@ int main(int argc, char **argv)
   }
 
   // Initialization of default Run manager
-  auto *runManager = G4RunManagerFactory::CreateRunManager(G4RunManagerType::Default);
-  // auto *runManager = G4RunManagerFactory::CreateRunManager(G4RunManagerType::Serial);
+  std::unique_ptr<G4RunManager> runManager(G4RunManagerFactory::CreateRunManager());
 
   // Detector geometry:
   auto detector = new DetectorConstruction(allSensitive);
@@ -83,8 +82,6 @@ int main(int argc, char **argv)
   // Free the store: user actions, physics_list and detector_description are
   //                 owned and deleted by the run manager, so they should not
   //                 be deleted in the main() program !
-
-  delete runManager;
 
   return err;
 }

--- a/examples/IntegrationBenchmark/include/ActionInitialisation.hh
+++ b/examples/IntegrationBenchmark/include/ActionInitialisation.hh
@@ -44,7 +44,7 @@ class DetectorConstruction;
 class ActionInitialisation : public G4VUserActionInitialization {
 public:
   ActionInitialisation(G4String aOutputDirectory, G4String aOutputFilename, bool aDoBenchmark, bool aDoValidation,
-                       bool aDoAccumulatdEvents);
+                       bool aDoAccumulatedEvents);
   ~ActionInitialisation();
   /// Create all user actions.
   virtual void Build() const final;

--- a/examples/IntegrationBenchmark/integrationBenchmark.cpp
+++ b/examples/IntegrationBenchmark/integrationBenchmark.cpp
@@ -78,8 +78,7 @@ int main(int argc, char **argv)
   }
 
   // Initialization of default Run manager
-  auto *runManager = G4RunManagerFactory::CreateRunManager(G4RunManagerType::Default);
-  // auto *runManager = G4RunManagerFactory::CreateRunManager(G4RunManagerType::Serial);
+  std::unique_ptr<G4RunManager> runManager(G4RunManagerFactory::CreateRunManager());
 
   // Detector geometry:
   auto detector = new DetectorConstruction(allSensitive);
@@ -114,8 +113,6 @@ int main(int argc, char **argv)
   // Free the store: user actions, physics_list and detector_description are
   //                 owned and deleted by the run manager, so they should not
   //                 be deleted in the main() program !
-
-  delete runManager;
 
   return err;
 }

--- a/examples/IntegrationBenchmark/integrationBenchmark.cpp
+++ b/examples/IntegrationBenchmark/integrationBenchmark.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv)
   G4String outputFilename   = "";
   bool doBenchmark          = false;
   bool doValidation         = false;
-  bool doAccumlatedEvents   = false; // whether the edep is accumulated across events in the validation csv file
+  bool doAccumulatedEvents  = false; // whether the edep is accumulated across events in the validation csv file
   G4bool useInteractiveMode = true;
   G4bool useAdePT           = true;
   G4bool allSensitive = false; // If set, ignores the sensitive detector flags in the GDML and marks all volumes as
@@ -53,7 +53,7 @@ int main(int argc, char **argv)
     } else if (argument == "--do_validation") {
       doValidation = true;
     } else if (argument == "--accumulated_events") {
-      doAccumlatedEvents = true;
+      doAccumulatedEvents = true;
     } else if (argument == "--noadept") {
       useAdePT = false;
     } else if (argument == "--allsensitive") {
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
   // UserAction classes
   //-------------------------------
   runManager->SetUserInitialization(
-      new ActionInitialisation(outputDirectory, outputFilename, doBenchmark, doValidation, doAccumlatedEvents));
+      new ActionInitialisation(outputDirectory, outputFilename, doBenchmark, doValidation, doAccumulatedEvents));
 
   G4UImanager *UImanager = G4UImanager::GetUIpointer();
   G4String command       = "/control/execute ";

--- a/examples/common/src/FTFP_BERT_AdePT.cc
+++ b/examples/common/src/FTFP_BERT_AdePT.cc
@@ -45,11 +45,11 @@ FTFP_BERT_AdePT::FTFP_BERT_AdePT(G4int ver)
   // RegisterPhysics(new HepEMPhysics(ver));
 
   // Register the AdePT physics
-  RegisterPhysics(new AdePTPhysics());
+  RegisterPhysics(new AdePTPhysics(ver));
 
   // Synchroton Radiation & GN Physics
   // comenting out to remove gamma- and lepto-nuclear processes
-  // RegisterPhysics( new G4EmExtraPhysics(ver) );
+  // RegisterPhysics(new G4EmExtraPhysics(ver));
 
   // Decays
   RegisterPhysics(new G4DecayPhysics(ver));

--- a/examples/common/src/FTFP_BERT_AdePT.cc
+++ b/examples/common/src/FTFP_BERT_AdePT.cc
@@ -39,7 +39,7 @@ FTFP_BERT_AdePT::FTFP_BERT_AdePT(G4int ver)
 
   // Register the EM physics to use for tracking on CPU
   // RegisterPhysics(new G4EmStandardPhysics());
-  RegisterPhysics(new HepEMPhysics());
+  RegisterPhysics(new HepEMPhysics(ver));
 
   // Register the AdePT physics
   RegisterPhysics(new AdePTPhysics());

--- a/examples/common/src/FTFP_BERT_AdePT.cc
+++ b/examples/common/src/FTFP_BERT_AdePT.cc
@@ -38,8 +38,11 @@ FTFP_BERT_AdePT::FTFP_BERT_AdePT(G4int ver)
   // EM Physics
 
   // Register the EM physics to use for tracking on CPU
+  // Note: The explicit registering of physics on CPU is not needed anymore:
+  // the AdePTTrackingManager takes care of all EM particles and, on CPU, hands them over to
+  // the specialized G4HepEmTrackingManager
   // RegisterPhysics(new G4EmStandardPhysics());
-  RegisterPhysics(new HepEMPhysics(ver));
+  // RegisterPhysics(new HepEMPhysics(ver));
 
   // Register the AdePT physics
   RegisterPhysics(new AdePTPhysics());

--- a/examples/common/src/FTFP_BERT_HepEm.cc
+++ b/examples/common/src/FTFP_BERT_HepEm.cc
@@ -40,7 +40,7 @@ FTFP_BERT_HepEm::FTFP_BERT_HepEm(G4int ver)
 
   // Synchroton Radiation & GN Physics
   // comenting out to remove gamma- and lepto-nuclear processes
-  // RegisterPhysics( new G4EmExtraPhysics(ver) );
+  // RegisterPhysics(new G4EmExtraPhysics(ver));
 
   // Decays
   RegisterPhysics(new G4DecayPhysics(ver));

--- a/examples/common/src/FTFP_BERT_HepEm.cc
+++ b/examples/common/src/FTFP_BERT_HepEm.cc
@@ -36,7 +36,7 @@ FTFP_BERT_HepEm::FTFP_BERT_HepEm(G4int ver)
 
   // EM Physics
   // RegisterPhysics( new G4EmStandardPhysics(ver));
-  RegisterPhysics(new HepEMPhysics());
+  RegisterPhysics(new HepEMPhysics(ver));
 
   // Synchroton Radiation & GN Physics
   // comenting out to remove gamma- and lepto-nuclear processes

--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -74,11 +74,6 @@ public:
   void Cleanup();
   /// @brief Interface for transporting a buffer of tracks in AdePT.
   void Shower(int event, int threadId);
-  /// @brief Gets the VecGeomToG4Map
-  std::unordered_map<size_t, const G4VPhysicalVolume *> GetVecGeomG4Map() const override
-  {
-    return fIntegrationLayer.GetVecGeomG4Map();
-  }
 
 private:
   static inline G4HepEmState *fg4hepem_state{nullptr}; ///< The HepEm state singleton

--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -44,7 +44,7 @@ public:
   /// @brief Adds a track to the buffer
   void AddTrack(int pdg, int parentID, double energy, double x, double y, double z, double dirx, double diry,
                 double dirz, double globalTime, double localTime, double properTime, int threadId, unsigned int eventId,
-                unsigned int trackIndex);
+                unsigned int trackIndex, vecgeom::NavigationState &&state);
 
   void SetTrackCapacity(size_t capacity) { fCapacity = capacity; }
   /// @brief Get the track capacity on GPU
@@ -74,6 +74,11 @@ public:
   void Cleanup();
   /// @brief Interface for transporting a buffer of tracks in AdePT.
   void Shower(int event, int threadId);
+  /// @brief Gets the VecGeomToG4Map
+  std::unordered_map<size_t, const G4VPhysicalVolume *> GetVecGeomG4Map() const override
+  {
+    return fIntegrationLayer.GetVecGeomG4Map();
+  }
 
 private:
   static inline G4HepEmState *fg4hepem_state{nullptr}; ///< The HepEm state singleton

--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -41,17 +41,17 @@ void ShowerGPU(IntegrationLayer &integration, int event, TrackBuffer &buffer, GP
 template <typename IntegrationLayer>
 AdePTTransport<IntegrationLayer>::AdePTTransport(AdePTConfiguration &configuration)
 {
-  fDebugLevel = 0;
-  fBufferThreshold = configuration.GetTransportBufferThreshold();
-  fMaxBatch = 2 * configuration.GetTransportBufferThreshold();
+  fDebugLevel        = 0;
+  fBufferThreshold   = configuration.GetTransportBufferThreshold();
+  fMaxBatch          = 2 * configuration.GetTransportBufferThreshold();
   fTrackInAllRegions = configuration.GetTrackInAllRegions();
-  fGPURegionNames = configuration.GetGPURegionNames();
-  fCUDAStackLimit = configuration.GetCUDAStackLimit();
-  fCapacity = 1024 * 1024 * configuration.GetMillionsOfTrackSlots() / configuration.GetNumThreads();
+  fGPURegionNames    = configuration.GetGPURegionNames();
+  fCUDAStackLimit    = configuration.GetCUDAStackLimit();
+  fCapacity          = 1024 * 1024 * configuration.GetMillionsOfTrackSlots() / configuration.GetNumThreads();
   fHitBufferCapacity = 1024 * 1024 * configuration.GetMillionsOfHitSlots() / configuration.GetNumThreads();
-  
-  printf( "AdePT Allocated track capacity: %d tracks\n", fCapacity);
-  printf( "AdePT Allocated step buffer capacity: %d tracks\n", fHitBufferCapacity);
+
+  printf("AdePT Allocated track capacity: %d tracks\n", fCapacity);
+  printf("AdePT Allocated step buffer capacity: %d tracks\n", fHitBufferCapacity);
 }
 
 template <typename IntegrationLayer>
@@ -63,10 +63,12 @@ bool AdePTTransport<IntegrationLayer>::InitializeField(double bz)
 template <typename IntegrationLayer>
 void AdePTTransport<IntegrationLayer>::AddTrack(int pdg, int parent_id, double energy, double x, double y, double z,
                                                 double dirx, double diry, double dirz, double globalTime,
-                                                double localTime, double properTime, int /*threadId*/, unsigned int eventId,
-                                                unsigned int /*trackIndex*/)
+                                                double localTime, double properTime, int /*threadId*/,
+                                                unsigned int eventId, unsigned int /*trackIndex*/,
+                                                vecgeom::NavigationState &&state)
 {
-  fBuffer.toDevice.emplace_back(pdg, parent_id, energy, x, y, z, dirx, diry, dirz, globalTime, localTime, properTime);
+  fBuffer.toDevice.emplace_back(pdg, parent_id, energy, x, y, z, dirx, diry, dirz, globalTime, localTime, properTime,
+                                state);
   if (pdg == 11)
     fBuffer.nelectrons++;
   else if (pdg == -11)
@@ -85,9 +87,8 @@ template <typename IntegrationLayer>
 bool AdePTTransport<IntegrationLayer>::InitializeGeometry(const vecgeom::cxx::VPlacedVolume *world)
 {
   auto &cudaManager = vecgeom::cxx::CudaManager::Instance();
-  if(fCUDAStackLimit > 0)
-  {
-    std::cout <<  "CUDA Device stack limit: " <<  fCUDAStackLimit << "\n";
+  if (fCUDAStackLimit > 0) {
+    std::cout << "CUDA Device stack limit: " << fCUDAStackLimit << "\n";
     cudaDeviceSetLimit(cudaLimitStackSize, fCUDAStackLimit);
   }
   bool success = true;
@@ -219,8 +220,9 @@ template <typename IntegrationLayer>
 void AdePTTransport<IntegrationLayer>::Shower(int event, int /*threadId*/)
 {
   int tid = fIntegrationLayer.GetThreadID();
-  if (fDebugLevel > 0 && fBuffer.toDevice.size() == 0) {
-    std::cout << "[" << tid << "] AdePTTransport<IntegrationLayer>::Shower: No more particles in buffer. Exiting.\n";
+  if (fBuffer.toDevice.size() == 0) {
+    if (fDebugLevel > 0)
+      std::cout << "[" << tid << "] AdePTTransport<IntegrationLayer>::Shower: No more particles in buffer. Exiting.\n";
     return;
   }
 

--- a/include/AdePT/core/AdePTTransportInterface.hh
+++ b/include/AdePT/core/AdePTTransportInterface.hh
@@ -44,8 +44,6 @@ public:
   /// @brief Interface for transporting a buffer of tracks in AdePT.
   virtual void Shower(int event, int threadId) = 0;
   virtual void Cleanup()                       = 0;
-  /// @brief Get VecGeom to G4 volume map
-  virtual std::unordered_map<size_t, const G4VPhysicalVolume *> GetVecGeomG4Map() const = 0;
 };
 
 #endif

--- a/include/AdePT/core/AdePTTransportInterface.hh
+++ b/include/AdePT/core/AdePTTransportInterface.hh
@@ -4,9 +4,13 @@
 #ifndef ADEPT_TRANSPORT_INTERFACE_H
 #define ADEPT_TRANSPORT_INTERFACE_H
 
+#include "G4VPhysicalVolume.hh"
+#include "VecGeom/navigation/NavigationState.h"
+
 #include <memory>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 class AdePTTransportInterface {
 public:
@@ -15,7 +19,7 @@ public:
   /// @brief Adds a track to the buffer
   virtual void AddTrack(int pdg, int parentID, double energy, double x, double y, double z, double dirx, double diry,
                         double dirz, double globalTime, double localTime, double properTime, int threadId,
-                        unsigned int eventId, unsigned int trackIndex) = 0;
+                        unsigned int eventId, unsigned int trackIndex, vecgeom::NavigationState &&state) = 0;
 
   /// @brief Set capacity of on-GPU track buffer.
   virtual void SetTrackCapacity(size_t capacity) = 0;
@@ -40,6 +44,8 @@ public:
   /// @brief Interface for transporting a buffer of tracks in AdePT.
   virtual void Shower(int event, int threadId) = 0;
   virtual void Cleanup()                       = 0;
+  /// @brief Get VecGeom to G4 volume map
+  virtual std::unordered_map<size_t, const G4VPhysicalVolume *> GetVecGeomG4Map() const = 0;
 };
 
 #endif

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -22,7 +22,7 @@ struct Track {
 
   RanluxppDouble rngState;
   double eKin;
-  double numIALeft[3];
+  double numIALeft[4];
   double initialRange;
   double dynamicRangeFactor;
   double tlimitMin;
@@ -59,7 +59,6 @@ struct Track {
   bool restrictedPhysicalStepLength{false};
   bool stopped{false};
 #endif
-
 
   __host__ __device__ double Uniform() { return rngState.Rndm(); }
 

--- a/include/AdePT/core/TrackData.h
+++ b/include/AdePT/core/TrackData.h
@@ -6,12 +6,15 @@
 
 #include <AdePT/base/MParray.h>
 
+#include "VecGeom/navigation/NavigationState.h"
+
 namespace adeptint {
 
 /// @brief Track data exchanged between Geant4 and AdePT
 /// @details This struct is initialised from an AdePT Track, either in GPU or CPU, copied to
 /// the destination, and used to reconstruct the track
 struct TrackData {
+  vecgeom::NavigationState navState;
   double position[3];
   double direction[3];
   double eKin{0};
@@ -23,12 +26,13 @@ struct TrackData {
 
   TrackData() = default;
   TrackData(int pdg_id, int parentID, double ene, double x, double y, double z, double dirx, double diry, double dirz,
-            double gTime, double lTime, double pTime)
-      : position{x, y, z}, direction{dirx, diry, dirz}, eKin{ene}, globalTime{gTime}, localTime{lTime},
+            double gTime, double lTime, double pTime, vecgeom::NavigationState state)
+      : navState{state}, position{x, y, z}, direction{dirx, diry, dirz}, eKin{ene}, globalTime{gTime}, localTime{lTime},
         properTime{pTime}, pdg{pdg_id}, parentID{parentID}
   {
   }
 
+  // fixme: add include navigation state in operators?
   friend bool operator==(TrackData const &a, TrackData const &b) { return !(a < b && b < a); }
   friend bool operator!=(TrackData const &a, TrackData const &b) { return !(a == b); }
   inline bool operator<(TrackData const &t) const

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -30,7 +30,7 @@ class AdePTGeant4Integration {
 public:
   static constexpr G4int kAdePTTrackID =
       std::numeric_limits<G4int>::min() + 2; // TrackID to signify that the track came from AdePT
-  AdePTGeant4Integration()  = default;
+  AdePTGeant4Integration() = default;
   ~AdePTGeant4Integration();
 
   /// @brief Initializes VecGeom geometry
@@ -70,6 +70,8 @@ public:
   int GetEventID() const { return G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID(); }
 
   int GetThreadID() const { return G4Threading::G4GetThreadId(); }
+
+  std::unordered_map<size_t, const G4VPhysicalVolume *> GetVecGeomG4Map() const { return fglobal_vecgeom_to_g4_map; }
 
 private:
   /// @brief Reconstruct G4TouchableHistory from a VecGeom Navigation index

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -71,8 +71,6 @@ public:
 
   int GetThreadID() const { return G4Threading::G4GetThreadId(); }
 
-  std::unordered_map<size_t, const G4VPhysicalVolume *> GetVecGeomG4Map() const { return fglobal_vecgeom_to_g4_map; }
-
 private:
   /// @brief Reconstruct G4TouchableHistory from a VecGeom Navigation index
   void FillG4NavigationHistory(vecgeom::NavigationState aNavState, G4NavigationHistory *aG4NavigationHistory) const;

--- a/include/AdePT/integration/AdePTPhysics.hh
+++ b/include/AdePT/integration/AdePTPhysics.hh
@@ -6,19 +6,20 @@
 
 #include "G4VPhysicsConstructor.hh"
 #include "globals.hh"
+#include "G4EmStandardPhysics.hh"
 
 class AdePTTrackingManager;
 class AdePTConfiguration;
 
-class AdePTPhysics : public G4VPhysicsConstructor {
+class AdePTPhysics : public G4EmStandardPhysics { // public G4VPhysicsConstructor {
 public:
-  AdePTPhysics(const G4String &name = "AdePT-physics-list");
+  AdePTPhysics(int ver, const G4String &name = "AdePT-physics-list");
   ~AdePTPhysics();
   AdePTTrackingManager *GetTrackingManager() { return fTrackingManager; }
 
 public:
   // This method is dummy for physics: particles are constructed in PhysicsList
-  void ConstructParticle() override{};
+  void ConstructParticle() override {};
 
   // This method will be invoked in the Construct() method.
   // each physics process will be instantiated and

--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -51,6 +51,11 @@ private:
   /// @brief Steps a track using the Generic G4TrackingManager until it enters a GPU region or stops
   void StepInHostRegion(G4Track *aTrack);
 
+  /// @brief Get the corresponding VecGeom NavigationState from the G4NavigationHistory
+  /// @param aG4NavigationHistory the given G4NavigationHistory
+  /// @return the corresponding vecgeom::NavigationState
+  const vecgeom::NavigationState GetVecGeomFromG4State(const G4Track *aG4Track);
+
   std::unique_ptr<G4HepEmTrackingManagerSpecialized> fHepEmTrackingManager;
   static inline int fNumThreads{0};
   std::set<G4Region const *> fGPURegions{};

--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -13,6 +13,7 @@
 #include "AdePT/copcore/SystemOfUnits.h"
 #include <AdePT/integration/AdePTGeant4Integration.hh>
 #include <AdePT/core/AdePTConfiguration.hh>
+#include <AdePT/integration/G4HepEmTrackingManagerSpecialized.hh>
 
 #include <memory>
 #include <vector>
@@ -50,6 +51,7 @@ private:
   /// @brief Steps a track using the Generic G4TrackingManager until it enters a GPU region or stops
   void StepInHostRegion(G4Track *aTrack);
 
+  std::unique_ptr<G4HepEmTrackingManagerSpecialized> fHepEmTrackingManager;
   static inline int fNumThreads{0};
   std::set<G4Region const *> fGPURegions{};
   int fVerbosity{0};

--- a/include/AdePT/integration/G4HepEmTrackingManagerSpecialized.hh
+++ b/include/AdePT/integration/G4HepEmTrackingManagerSpecialized.hh
@@ -1,0 +1,25 @@
+#ifndef G4HepEmTrackingManagerSpecialized_h
+#define G4HepEmTrackingManagerSpecialized_h
+
+#include "G4HepEmTrackingManager.hh"
+
+class G4HepEmTrackingManagerSpecialized : public G4HepEmTrackingManager {
+public:
+  G4HepEmTrackingManagerSpecialized();
+  ~G4HepEmTrackingManagerSpecialized();
+
+  void SetGPURegions(const std::set<G4Region const *> &gpuRegions) { fGPURegions = gpuRegions; }
+
+  // Implement HandOverTrack that returns the track if it ends up in the GPU region
+  void HandOverOneTrack(G4Track *aTrack) override;
+
+  // Implement the early tracking exit function
+  bool CheckEarlyTrackingExit(G4Track *track, G4EventManager *evtMgr, G4UserTrackingAction *userTrackingAction,
+                              G4TrackVector &secondaries) const override;
+
+private:
+  std::set<G4Region const *> fGPURegions{};
+  // G4Region const * fPreviousRegion = nullptr;
+};
+
+#endif // G4HepEmTrackingManagerSpecialized_h

--- a/include/AdePT/integration/G4HepEmTrackingManagerSpecialized.hh
+++ b/include/AdePT/integration/G4HepEmTrackingManagerSpecialized.hh
@@ -3,6 +3,10 @@
 
 #include "G4HepEmTrackingManager.hh"
 
+#ifndef G4HepEm_EARLY_TRACKING_EXIT
+#error "Build error: G4HepEm must be build with -DG4HepEm_EARLY_TRACKING_EXIT=ON"
+#endif
+
 class G4HepEmTrackingManagerSpecialized : public G4HepEmTrackingManager {
 public:
   G4HepEmTrackingManagerSpecialized();

--- a/include/AdePT/integration/G4HepEmTrackingManagerSpecialized.hh
+++ b/include/AdePT/integration/G4HepEmTrackingManagerSpecialized.hh
@@ -20,6 +20,9 @@ public:
   ~G4HepEmTrackingManagerSpecialized();
 
   void SetGPURegions(const std::set<G4Region const *> &gpuRegions) { fGPURegions = gpuRegions; }
+  /// @brief Set whether AdePT should transport particles across the whole geometry
+  void SetTrackInAllRegions(bool trackInAllRegions) { fTrackInAllRegions = trackInAllRegions; }
+  bool GetTrackInAllRegions() const { return fTrackInAllRegions; }
 
   // Implement HandOverTrack that returns the track if it ends up in the GPU region
   void HandOverOneTrack(G4Track *aTrack) override;
@@ -29,7 +32,9 @@ public:
                               G4TrackVector &secondaries) const override;
 
 private:
-  std::set<G4Region const *> fGPURegions{};
+  bool fTrackInAllRegions = false;          ///< Whether the whole geometry is a GPU region
+  std::set<G4Region const *> fGPURegions{}; ///< List of GPU regions
+
   // G4Region const * fPreviousRegion = nullptr;
 };
 

--- a/include/AdePT/integration/G4HepEmTrackingManagerSpecialized.hh
+++ b/include/AdePT/integration/G4HepEmTrackingManagerSpecialized.hh
@@ -1,3 +1,10 @@
+// SPDX-FileCopyrightText: 2024 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+///   4HepEmTrackingManagerSpecialized class:
+///   The derived class from G4HepEmTrackingManager must implement HandOverOneTrack and CheckEarlyTrackingExit to allow
+///   for an early exit of the tracking loop in the G4HepEmTrackingManager
+
 #ifndef G4HepEmTrackingManagerSpecialized_h
 #define G4HepEmTrackingManagerSpecialized_h
 

--- a/include/AdePT/integration/HepEMPhysics.hh
+++ b/include/AdePT/integration/HepEMPhysics.hh
@@ -4,17 +4,17 @@
 #ifndef HepEMPhysics_h
 #define HepEMPhysics_h 1
 
-#include "G4VPhysicsConstructor.hh"
+#include "G4EmStandardPhysics.hh"
 #include "globals.hh"
 
-class HepEMPhysics : public G4VPhysicsConstructor {
+class HepEMPhysics : public G4EmStandardPhysics {
 public:
-  HepEMPhysics(const G4String &name = "G4HepEm-physics-list");
+  HepEMPhysics(int ver, const G4String &name = "G4HepEm-physics-list");
   ~HepEMPhysics();
 
 public:
   // This method is dummy for physics: particles are constructed in PhysicsList
-  void ConstructParticle() override{};
+  void ConstructParticle() override {};
 
   // This method will be invoked in the Construct() method.
   // each physics process will be instantiated and

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -126,6 +126,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       if (numIALeft <= 0) {
         numIALeft = -std::log(currentTrack.Uniform());
       }
+      if (ip == 3) numIALeft = vecgeom::kInfLength; // suppress lepton nuclear by infinite length
       theTrack->SetNumIALeft(numIALeft, ip);
     }
 
@@ -173,8 +174,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     // Skip electron/positron-nuclear reaction that would need to be handled by G4 itself
     if (winnerProcessIndex == 3) {
       winnerProcessIndex = -1;
-      assert(0); // currently, the lepton-nuclear processes are not registered in the AdePTPhysicsList, so they should
-                 // never be hit.
+      // Note, this should not be hit at the moment due to the infinite length, this is just for safety
     }
 
     // Check if there's a volume boundary in between.

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -121,7 +121,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     G4HepEmRandomEngine rnge(&currentTrack.rngState);
 
     // Sample the `number-of-interaction-left` and put it into the track.
-    for (int ip = 0; ip < 3; ++ip) {
+    for (int ip = 0; ip < 4; ++ip) {
       double numIALeft = currentTrack.numIALeft[ip];
       if (numIALeft <= 0) {
         numIALeft = -std::log(currentTrack.Uniform());
@@ -169,6 +169,11 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     int winnerProcessIndex = theTrack->GetWinnerProcessIndex();
     // Leave the range and MFP inside the G4HepEmTrack. If we split kernels, we
     // also need to carry them over!
+
+    // Skip electron/positron-nuclear reaction that would need to be handled by G4 itself
+    if (winnerProcessIndex == 3) {
+      winnerProcessIndex = -1;
+    }
 
     // Check if there's a volume boundary in between.
     bool propagated    = true;
@@ -284,7 +289,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
                                0, -1);                   // eventID and threadID (not needed here)
 
     // Save the `number-of-interaction-left` in our track.
-    for (int ip = 0; ip < 3; ++ip) {
+    for (int ip = 0; ip < 4; ++ip) {
       double numIALeft           = theTrack->GetNumIALeft(ip);
       currentTrack.numIALeft[ip] = numIALeft;
     }

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -173,6 +173,8 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     // Skip electron/positron-nuclear reaction that would need to be handled by G4 itself
     if (winnerProcessIndex == 3) {
       winnerProcessIndex = -1;
+      assert(0); // currently, the lepton-nuclear processes are not registered in the AdePTPhysicsList, so they should
+                 // never be hit.
     }
 
     // Check if there's a volume boundary in between.

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -100,6 +100,8 @@ __global__ void ElectronHowFar(adept::TrackManager<Track> *electrons, G4HepEmEle
     // Skip electron/positron-nuclear reaction that would need to be handled by G4 itself
     if (theTrack->GetWinnerProcessIndex() == 3) {
       theTrack->SetWinnerProcessIndex(-1);
+      assert(0); // currently, the lepton-nuclear processes are not registered in the AdePTPhysicsList, so they should
+                 // never be hit.
     }
 
     currentTrack.restrictedPhysicalStepLength = false;
@@ -206,7 +208,8 @@ static __global__ void ElectronMSC(adept::TrackManager<Track> *electrons, G4HepE
     G4HepEmRandomEngine rnge(&currentTrack.rngState);
 
     // Apply continuous effects.
-    currentTrack.stopped = G4HepEmElectronManager::PerformContinuous(&adept_impl::g4HepEmData, &adept_impl::g4HepEmPars, &elTrack, &rnge);
+    currentTrack.stopped =
+        G4HepEmElectronManager::PerformContinuous(&adept_impl::g4HepEmData, &adept_impl::g4HepEmPars, &elTrack, &rnge);
 
     // Collect the direction change and displacement by MSC.
     const double *direction = theTrack->GetDirection();
@@ -461,11 +464,12 @@ static __global__ void ElectronInteractions(adept::TrackManager<Track> *electron
     case 1: {
       // Invoke model for Bremsstrahlung: either SB- or Rel-Brem.
       double logEnergy = std::log(currentTrack.eKin);
-      double deltaEkin = currentTrack.eKin < adept_impl::g4HepEmPars.fElectronBremModelLim
-                             ? G4HepEmElectronInteractionBrem::SampleETransferSB(
-                                   &adept_impl::g4HepEmData, currentTrack.eKin, logEnergy, auxData.fMCIndex, &rnge, IsElectron)
-                             : G4HepEmElectronInteractionBrem::SampleETransferRB(
-                                   &adept_impl::g4HepEmData, currentTrack.eKin, logEnergy, auxData.fMCIndex, &rnge, IsElectron);
+      double deltaEkin =
+          currentTrack.eKin < adept_impl::g4HepEmPars.fElectronBremModelLim
+              ? G4HepEmElectronInteractionBrem::SampleETransferSB(&adept_impl::g4HepEmData, currentTrack.eKin,
+                                                                  logEnergy, auxData.fMCIndex, &rnge, IsElectron)
+              : G4HepEmElectronInteractionBrem::SampleETransferRB(&adept_impl::g4HepEmData, currentTrack.eKin,
+                                                                  logEnergy, auxData.fMCIndex, &rnge, IsElectron);
 
       double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
       double dirSecondary[3];

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -92,6 +92,7 @@ __global__ void ElectronHowFar(adept::TrackManager<Track> *electrons, G4HepEmEle
       if (numIALeft <= 0) {
         numIALeft = -std::log(currentTrack.Uniform());
       }
+      if (ip == 3) numIALeft = vecgeom::kInfLength; // suppress lepton nuclear by infinite length
       theTrack->SetNumIALeft(numIALeft, ip);
     }
 
@@ -100,8 +101,7 @@ __global__ void ElectronHowFar(adept::TrackManager<Track> *electrons, G4HepEmEle
     // Skip electron/positron-nuclear reaction that would need to be handled by G4 itself
     if (theTrack->GetWinnerProcessIndex() == 3) {
       theTrack->SetWinnerProcessIndex(-1);
-      assert(0); // currently, the lepton-nuclear processes are not registered in the AdePTPhysicsList, so they should
-                 // never be hit.
+      // Note, this should not be hit at the moment due to the infinite length, this is just for safety
     }
 
     currentTrack.restrictedPhysicalStepLength = false;

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -87,7 +87,7 @@ __global__ void ElectronHowFar(adept::TrackManager<Track> *electrons, G4HepEmEle
     G4HepEmRandomEngine rnge(&currentTrack.rngState);
 
     // Sample the `number-of-interaction-left` and put it into the track.
-    for (int ip = 0; ip < 3; ++ip) {
+    for (int ip = 0; ip < 4; ++ip) {
       double numIALeft = currentTrack.numIALeft[ip];
       if (numIALeft <= 0) {
         numIALeft = -std::log(currentTrack.Uniform());
@@ -96,6 +96,11 @@ __global__ void ElectronHowFar(adept::TrackManager<Track> *electrons, G4HepEmEle
     }
 
     G4HepEmElectronManager::HowFarToDiscreteInteraction(&g4HepEmData, &g4HepEmPars, &elTrack);
+
+    // Skip electron/positron-nuclear reaction that would need to be handled by G4 itself
+    if (theTrack->GetWinnerProcessIndex() == 3) {
+      theTrack->SetWinnerProcessIndex(-1);
+    }
 
     currentTrack.restrictedPhysicalStepLength = false;
     if (BzFieldValue != 0) {
@@ -332,7 +337,7 @@ static __global__ void ElectronInteractions(adept::TrackManager<Track> *electron
                                IsElectron ? -1 : 1);          // Post-step point charge
 
     // Save the `number-of-interaction-left` in our track.
-    for (int ip = 0; ip < 3; ++ip) {
+    for (int ip = 0; ip < 4; ++ip) {
       double numIALeft           = theTrack->GetNumIALeft(ip);
       currentTrack.numIALeft[ip] = numIALeft;
     }

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -90,18 +90,9 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
     // avoid photo-nuclear reaction that would need to be handled by G4 itself
     if (winnerProcessIndex == 3) {
       winnerProcessIndex = -1;
-      // NOTE: re-drawing was found to change the physics slightly, thus, it is commented out for now
-      // // since we do an redundant step if gamma-nuclear is drawn, we redraw up to 3 times
-      // int trials_left = 3;
-      // do {
-      //   // reset `number-of-interaction-left` since it is always consumed by the previous call to SampleInteraction()
-      //   theTrack->SetNumIALeft(-std::log(currentTrack.Uniform()), 0);
-      //   G4HepEmGammaManager::SampleInteraction(&g4HepEmData, &gammaTrack, currentTrack.Uniform());
-      //   trials_left--;
-      // } while (theTrack->GetWinnerProcessIndex() == 3 && trials_left > 0);
-
-      // // Reset final WinnerProcessIndex
-      // winnerProcessIndex = (theTrack->GetWinnerProcessIndex() == 3) ? -1 : theTrack->GetWinnerProcessIndex();
+      // NOTE: no simple re-drawing is possible, since HowFar returns now smaller steps due to the gamma-nuclear
+      // reactions in comparison to without gamma-nuclear reactions. Thus, an empty step without a reaction is needed to
+      // compensate for the smaller step size returned by HowFar.
     }
 
     // Get result into variables.

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -126,7 +126,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
     G4HepEmGammaManager::UpdateNumIALeft(theTrack);
 
     // Save the `number-of-interaction-left` in our track.
-    // Use index 0 since numIALeft stores for gammas only the total macroscopic cross section
+    // Use index 0 since numIALeft for gammas is based only on the total macroscopic cross section
     double numIALeft          = theTrack->GetNumIALeft(0);
     currentTrack.numIALeft[0] = numIALeft;
 

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -89,17 +89,19 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
 
     // avoid photo-nuclear reaction that would need to be handled by G4 itself
     if (winnerProcessIndex == 3) {
-      // since we do an redundant step if gamma-nuclear is drawn, we redraw up to 3 times
-      int trials_left = 3;
-      do {
-        // reset `number-of-interaction-left` since it is always consumed by the previous call to SampleInteraction()
-        theTrack->SetNumIALeft(-std::log(currentTrack.Uniform()), 0);
-        G4HepEmGammaManager::SampleInteraction(&g4HepEmData, &gammaTrack, currentTrack.Uniform());
-        trials_left--;
-      } while (theTrack->GetWinnerProcessIndex() == 3 && trials_left > 0);
+      winnerProcessIndex = -1;
+      // NOTE: re-drawing was found to change the physics slightly, thus, it is commented out for now
+      // // since we do an redundant step if gamma-nuclear is drawn, we redraw up to 3 times
+      // int trials_left = 3;
+      // do {
+      //   // reset `number-of-interaction-left` since it is always consumed by the previous call to SampleInteraction()
+      //   theTrack->SetNumIALeft(-std::log(currentTrack.Uniform()), 0);
+      //   G4HepEmGammaManager::SampleInteraction(&g4HepEmData, &gammaTrack, currentTrack.Uniform());
+      //   trials_left--;
+      // } while (theTrack->GetWinnerProcessIndex() == 3 && trials_left > 0);
 
-      // Reset final WinnerProcessIndex
-      winnerProcessIndex = (theTrack->GetWinnerProcessIndex() == 3) ? -1 : theTrack->GetWinnerProcessIndex();
+      // // Reset final WinnerProcessIndex
+      // winnerProcessIndex = (theTrack->GetWinnerProcessIndex() == 3) ? -1 : theTrack->GetWinnerProcessIndex();
     }
 
     // Get result into variables.

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -93,6 +93,8 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
     // disable photo-nuclear reaction that would need to be handled by G4 itself
     if (winnerProcessIndex == 3) {
       winnerProcessIndex = -1;
+      assert(0); // currently, the gamma-nuclear processes are not registered in the AdePTPhysicsList, so they should
+                 // never be hit.
     }
 
     // Leave the range and MFP inside the G4HepEmTrack. If we split kernels, we

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -53,8 +53,8 @@ __global__ void GammaHowFar(adept::TrackManager<Track> *gammas, G4HepEmGammaTrac
     }
 
     // Call G4HepEm to compute the physics step limit.
-    G4HepEmGammaManager::HowFar(&g4HepEmData, &g4HepEmPars, &gammaTrack);
-    G4HepEmGammaManager::SampleInteraction(&g4HepEmData, &gammaTrack, currentTrack.Uniform());
+    G4HepEmGammaManager::HowFar(&adept_impl::g4HepEmData, &adept_impl::g4HepEmPars, &gammaTrack);
+    G4HepEmGammaManager::SampleInteraction(&adept_impl::g4HepEmData, &gammaTrack, currentTrack.Uniform());
 
     // Skip electron/positron-nuclear reaction that would need to be handled by G4 itself
     if (theTrack->GetWinnerProcessIndex() == 3) {
@@ -231,7 +231,7 @@ __global__ void GammaInteractions(adept::TrackManager<Track> *gammas, G4HepEmGam
 
       double logEnergy = std::log(currentTrack.eKin);
       double elKinEnergy, posKinEnergy;
-      G4HepEmGammaInteractionConversion::SampleKinEnergies(&g4HepEmData, currentTrack.eKin, logEnergy, auxData.fMCIndex,
+      G4HepEmGammaInteractionConversion::SampleKinEnergies(&adept_impl::g4HepEmData, currentTrack.eKin, logEnergy, auxData.fMCIndex,
                                                            elKinEnergy, posKinEnergy, &rnge);
 
       double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
@@ -303,7 +303,9 @@ __global__ void GammaInteractions(adept::TrackManager<Track> *gammas, G4HepEmGam
                                    &currentTrack.dir,               // Post-step point momentum direction
                                    nullptr,                         // Post-step point polarization
                                    newEnergyGamma,                  // Post-step point kinetic energy
-                                   0);                              // Post-step point charge
+                                   0,                               // Post-step point charge
+                                   0, -1);                          // eventID and threadID (not needed here)
+
       }
 
       // Check the new gamma energy and deposit if below threshold.
@@ -329,7 +331,9 @@ __global__ void GammaInteractions(adept::TrackManager<Track> *gammas, G4HepEmGam
                                    &currentTrack.dir,               // Post-step point momentum direction
                                    nullptr,                         // Post-step point polarization
                                    newEnergyGamma,                  // Post-step point kinetic energy
-                                   0);                              // Post-step point charge
+                                   0,                               // Post-step point charge
+                                   0, -1);                          // eventID and threadID (not needed here)
+
         // The current track is killed by not enqueuing into the next activeQueue.
       }
       break;
@@ -339,7 +343,7 @@ __global__ void GammaInteractions(adept::TrackManager<Track> *gammas, G4HepEmGam
       const double theLowEnergyThreshold = 1 * copcore::units::eV;
 
       const double bindingEnergy = G4HepEmGammaInteractionPhotoelectric::SelectElementBindingEnergy(
-          &g4HepEmData, auxData.fMCIndex, gammaTrack.GetPEmxSec(), currentTrack.eKin, &rnge);
+          &adept_impl::g4HepEmData, auxData.fMCIndex, gammaTrack.GetPEmxSec(), currentTrack.eKin, &rnge);
       double edep = bindingEnergy;
 
       const double photoElecE = currentTrack.eKin - edep;
@@ -378,7 +382,9 @@ __global__ void GammaInteractions(adept::TrackManager<Track> *gammas, G4HepEmGam
                                  &currentTrack.dir,               // Post-step point momentum direction
                                  nullptr,                         // Post-step point polarization
                                  0,                               // Post-step point kinetic energy
-                                 0);                              // Post-step point charge
+                                 0,                               // Post-step point charge
+                                 0, -1);                          // eventID and threadID (not needed here)
+
 
       // The current track is killed by not enqueuing into the next activeQueue.
       break;

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -58,13 +58,10 @@ __global__ void GammaHowFar(adept::TrackManager<Track> *gammas, G4HepEmGammaTrac
 
     // Skip photo-nuclear reaction that would need to be handled by G4 itself
     if (theTrack->GetWinnerProcessIndex() == 3) {
-      // since we do an redundant step if gamma-nuclear is drawn, we redraw up to 3 times
-      int trials_left = 3;
-      do {
-        G4HepEmGammaManager::SampleInteraction(&g4HepEmData, &gammaTrack, currentTrack.Uniform());
-        trials_left--;
-        if (theTrack->GetWinnerProcessIndex() == 3 && trials_left == 0) theTrack->SetWinnerProcessIndex(-1);
-      } while (theTrack->GetWinnerProcessIndex() == 3 && trials_left > 0);
+      theTrack->SetWinnerProcessIndex(-1);
+      // NOTE: no simple re-drawing is possible, since HowFar returns now smaller steps due to the gamma-nuclear
+      // reactions in comparison to without gamma-nuclear reactions. Thus, an empty step without a reaction is needed to
+      // compensate for the smaller step size returned by HowFar.
     }
   }
 }

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -59,6 +59,8 @@ __global__ void GammaHowFar(adept::TrackManager<Track> *gammas, G4HepEmGammaTrac
     // Skip electron/positron-nuclear reaction that would need to be handled by G4 itself
     if (theTrack->GetWinnerProcessIndex() == 3) {
       theTrack->SetWinnerProcessIndex(-1);
+      assert(0); // currently, the gamma-nuclear processes are not registered in the AdePTPhysicsList, so they should
+                 // never be hit.
     }
   }
 }
@@ -231,8 +233,8 @@ __global__ void GammaInteractions(adept::TrackManager<Track> *gammas, G4HepEmGam
 
       double logEnergy = std::log(currentTrack.eKin);
       double elKinEnergy, posKinEnergy;
-      G4HepEmGammaInteractionConversion::SampleKinEnergies(&adept_impl::g4HepEmData, currentTrack.eKin, logEnergy, auxData.fMCIndex,
-                                                           elKinEnergy, posKinEnergy, &rnge);
+      G4HepEmGammaInteractionConversion::SampleKinEnergies(&adept_impl::g4HepEmData, currentTrack.eKin, logEnergy,
+                                                           auxData.fMCIndex, elKinEnergy, posKinEnergy, &rnge);
 
       double dirPrimary[] = {currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z()};
       double dirSecondaryEl[3], dirSecondaryPos[3];
@@ -305,7 +307,6 @@ __global__ void GammaInteractions(adept::TrackManager<Track> *gammas, G4HepEmGam
                                    newEnergyGamma,                  // Post-step point kinetic energy
                                    0,                               // Post-step point charge
                                    0, -1);                          // eventID and threadID (not needed here)
-
       }
 
       // Check the new gamma energy and deposit if below threshold.
@@ -384,7 +385,6 @@ __global__ void GammaInteractions(adept::TrackManager<Track> *gammas, G4HepEmGam
                                  0,                               // Post-step point kinetic energy
                                  0,                               // Post-step point charge
                                  0, -1);                          // eventID and threadID (not needed here)
-
 
       // The current track is killed by not enqueuing into the next activeQueue.
       break;

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -47,16 +47,19 @@ __global__ void GammaHowFar(adept::TrackManager<Track> *gammas, G4HepEmGammaTrac
     theTrack->SetMCIndex(auxData.fMCIndex);
 
     // Sample the `number-of-interaction-left` and put it into the track.
-    for (int ip = 0; ip < 3; ++ip) {
-      double numIALeft = currentTrack.numIALeft[ip];
-      if (numIALeft <= 0) {
-        numIALeft = -std::log(currentTrack.Uniform());
-      }
-      theTrack->SetNumIALeft(numIALeft, ip);
+    // Use index 0 since numIALeft for gammas is based only on the total macroscopic cross section
+    if (theTrack->GetNumIALeft(0) <= 0.0) {
+      theTrack->SetNumIALeft(-std::log(currentTrack.Uniform()), 0);
     }
 
     // Call G4HepEm to compute the physics step limit.
     G4HepEmGammaManager::HowFar(&g4HepEmData, &g4HepEmPars, &gammaTrack);
+    G4HepEmGammaManager::SampleInteraction(&g4HepEmData, &gammaTrack, currentTrack.Uniform());
+
+    // Skip electron/positron-nuclear reaction that would need to be handled by G4 itself
+    if (theTrack->GetWinnerProcessIndex() == 3) {
+      theTrack->SetWinnerProcessIndex(-1);
+    }
   }
 }
 
@@ -106,10 +109,9 @@ __global__ void GammaPropagation(adept::TrackManager<Track> *gammas, G4HepEmGamm
     G4HepEmGammaManager::UpdateNumIALeft(theTrack);
 
     // Save the `number-of-interaction-left` in our track.
-    for (int ip = 0; ip < 3; ++ip) {
-      double numIALeft           = theTrack->GetNumIALeft(ip);
-      currentTrack.numIALeft[ip] = numIALeft;
-    }
+    // Use index 0 since numIALeft for gammas is based only on the total macroscopic cross section
+    double numIALeft          = theTrack->GetNumIALeft(0);
+    currentTrack.numIALeft[0] = numIALeft;
 
     // Update the flight times of the particle
     double deltaTime = theTrack->GetGStepLength() / copcore::units::kCLight;

--- a/src/AdePTPhysics.cc
+++ b/src/AdePTPhysics.cc
@@ -15,7 +15,8 @@
 #include "G4EmParameters.hh"
 #include "G4BuilderType.hh"
 
-AdePTPhysics::AdePTPhysics(const G4String &name) : G4VPhysicsConstructor(name)
+AdePTPhysics::AdePTPhysics(int ver, const G4String &name)
+    : G4EmStandardPhysics(ver, name) // G4VPhysicsConstructor(name)
 {
   fAdePTConfiguration = new AdePTConfiguration();
 
@@ -24,21 +25,21 @@ AdePTPhysics::AdePTPhysics(const G4String &name) : G4VPhysicsConstructor(name)
   param->SetVerbose(1);
 
   // Range factor: (can be set from the G4 macro)
-  // param->SetMscRangeFactor(0.04);
-  //
-
-  SetPhysicsType(bUnknown);
+  // param->SetMscRangeFactor(0.04); // 0.04 is the default set by SetDefaults
 }
 
 AdePTPhysics::~AdePTPhysics()
 {
   delete fAdePTConfiguration;
   // the delete below causes a crash with G4.10.7
-  //delete fTrackingManager;
+  // delete fTrackingManager;
 }
 
 void AdePTPhysics::ConstructProcess()
 {
+
+  G4EmStandardPhysics::ConstructProcess();
+
   // Register custom tracking manager for e-/e+ and gammas.
   fTrackingManager = new AdePTTrackingManager();
   G4Electron::Definition()->SetTrackingManager(fTrackingManager);

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -176,6 +176,9 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
         fTrackCounter   = 0;
       }
 
+      // Get VecGeom Navigation state from G4History
+      vecgeom::NavigationState converted = GetVecGeomFromG4State(aTrack); 
+
       fAdeptTransport->AddTrack(pdg, id, energy, particlePosition[0], particlePosition[1], particlePosition[2],
                                 particleDirection[0], particleDirection[1], particleDirection[2], globalTime, localTime,
                                 properTime, G4Threading::G4GetThreadId(), eventID, fTrackCounter++,

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -8,6 +8,7 @@
 #include "G4EventManager.hh"
 #include "G4Event.hh"
 #include "G4RunManager.hh"
+#include "G4TransportationManager.hh"
 
 #include "G4Electron.hh"
 #include "G4Gamma.hh"
@@ -17,7 +18,10 @@
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-AdePTTrackingManager::AdePTTrackingManager() {}
+AdePTTrackingManager::AdePTTrackingManager()
+{
+  fHepEmTrackingManager = std::make_unique<G4HepEmTrackingManagerSpecialized>();
+}
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
@@ -76,9 +80,11 @@ void AdePTTrackingManager::InitializeAdePT()
         G4Exception("AdePTTrackingManager", "Invalid parameter", FatalErrorInArgument,
                     ("Region given to /adept/addGPURegion: " + regionName + " Not found\n").c_str());
     }
+    fHepEmTrackingManager->SetTrackInAllRegions(false);
+  } else {
+    fHepEmTrackingManager->SetTrackInAllRegions(true);
   }
   // initialize special G4HepEmTrackingManager
-  fHepEmTrackingManager = std::make_unique<G4HepEmTrackingManagerSpecialized>();
   fHepEmTrackingManager->SetGPURegions(fGPURegions);
 
   fAdePTInitialized = true;
@@ -92,19 +98,8 @@ void AdePTTrackingManager::BuildPhysicsTable(const G4ParticleDefinition &part)
     InitializeAdePT();
   }
 
-  // For tracking on CPU by Geant4, construct the physics tables for the processes of
-  // particles taken by this tracking manager, since Geant4 won't do it anymore
-  G4ProcessManager *pManager       = part.GetProcessManager();
-  G4ProcessManager *pManagerShadow = part.GetMasterProcessManager();
-
-  G4ProcessVector *pVector = pManager->GetProcessList();
-  for (std::size_t j = 0; j < pVector->size(); ++j) {
-    if (pManagerShadow == pManager) {
-      (*pVector)[j]->BuildPhysicsTable(part);
-    } else {
-      (*pVector)[j]->BuildWorkerPhysicsTable(part);
-    }
-  }
+  // Bulid PhysicsTable for G4HepEm
+  fHepEmTrackingManager->BuildPhysicsTable(part);
 
   // For tracking on GPU by AdePT
 }
@@ -113,19 +108,9 @@ void AdePTTrackingManager::BuildPhysicsTable(const G4ParticleDefinition &part)
 
 void AdePTTrackingManager::PreparePhysicsTable(const G4ParticleDefinition &part)
 {
-  // For tracking on CPU by Geant4, prepare the physics tables for the processes of
-  // particles taken by this tracking manager, since Geant4 won't do it anymore
-  G4ProcessManager *pManager       = part.GetProcessManager();
-  G4ProcessManager *pManagerShadow = part.GetMasterProcessManager();
 
-  G4ProcessVector *pVector = pManager->GetProcessList();
-  for (std::size_t j = 0; j < pVector->size(); ++j) {
-    if (pManagerShadow == pManager) {
-      (*pVector)[j]->PreparePhysicsTable(part);
-    } else {
-      (*pVector)[j]->PrepareWorkerPhysicsTable(part);
-    }
-  }
+  // Prepare PhysicsTable for G4HepEm
+  fHepEmTrackingManager->PreparePhysicsTable(part);
 
   // For tracking on GPU by AdePT
 }
@@ -137,6 +122,12 @@ void AdePTTrackingManager::HandOverOneTrack(G4Track *aTrack)
   if (fGPURegions.empty() && !fAdeptTransport->GetTrackInAllRegions()) {
     // if no GPU regions, hand over directly to G4HepEmTrackingManager
     fHepEmTrackingManager->HandOverOneTrack(aTrack);
+    if (aTrack->GetTrackStatus() != fStopAndKill) {
+      throw std::logic_error(
+          "Error: Although there is no GPU region, the G4HepEmTrackingManager did not finish tracking.");
+    }
+    delete aTrack;
+    return;
   }
   ProcessTrack(aTrack);
 }
@@ -152,39 +143,18 @@ void AdePTTrackingManager::FlushEvent()
 
 void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
 {
-  /* From G4 Example RE07 */
 
   G4EventManager *eventManager       = G4EventManager::GetEventManager();
   G4TrackingManager *trackManager    = eventManager->GetTrackingManager();
   G4SteppingManager *steppingManager = trackManager->GetSteppingManager();
-  G4TrackVector *secondaries         = trackManager->GimmeSecondaries();
   const bool trackInAllRegions       = fAdeptTransport->GetTrackInAllRegions();
 
-  // Clear secondary particle vector
-  for (std::size_t itr = 0; itr < secondaries->size(); ++itr) {
-    delete (*secondaries)[itr];
-  }
-  secondaries->clear();
-
+  // setup touchable to be able to get region from GetNextVolume
   steppingManager->SetInitialStep(aTrack);
-
-  G4UserTrackingAction *userTrackingAction = trackManager->GetUserTrackingAction();
-  if (userTrackingAction != nullptr) {
-    userTrackingAction->PreUserTrackingAction(aTrack);
-  }
-
-  // Give SteppingManger the maxmimum number of processes
-  steppingManager->GetProcessNumber();
-
-  // Give track the pointer to the Step
-  aTrack->SetStep(steppingManager->GetStep());
-
-  // Inform beginning of tracking to physics processes
-  aTrack->GetDefinition()->GetProcessManager()->StartTracking(aTrack);
 
   // Track the particle Step-by-Step while it is alive
   while ((aTrack->GetTrackStatus() == fAlive) || (aTrack->GetTrackStatus() == fStopButAlive)) {
-    G4Region const *region = aTrack->GetVolume()->GetLogicalVolume()->GetRegion();
+    G4Region const *region = aTrack->GetNextVolume()->GetLogicalVolume()->GetRegion();
 
     // Check if the particle is in a GPU region
     const bool isGPURegion = trackInAllRegions || fGPURegions.find(region) != fGPURegions.end();
@@ -208,7 +178,8 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
 
       fAdeptTransport->AddTrack(pdg, id, energy, particlePosition[0], particlePosition[1], particlePosition[2],
                                 particleDirection[0], particleDirection[1], particleDirection[2], globalTime, localTime,
-                                properTime, G4Threading::G4GetThreadId(), eventID, fTrackCounter++);
+                                properTime, G4Threading::G4GetThreadId(), eventID, fTrackCounter++,
+                                std::move(converted));
 
       // The track dies from the point of view of Geant4
       aTrack->SetTrackStatus(fStopAndKill);
@@ -219,44 +190,61 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
       fHepEmTrackingManager->HandOverOneTrack(aTrack);
     }
   }
-  // Inform end of tracking to physics processes
-  aTrack->GetDefinition()->GetProcessManager()->EndTracking();
 
-  if (userTrackingAction != nullptr) {
-    userTrackingAction->PostUserTrackingAction(aTrack);
-  }
-
-  eventManager->StackTracks(secondaries);
+  // delete track after finishing offloading to AdePT or finished tracking in G4HepEmTrackingManager
   delete aTrack;
 }
 
-void AdePTTrackingManager::StepInHostRegion(G4Track *aTrack)
+const vecgeom::NavigationState AdePTTrackingManager::GetVecGeomFromG4State(const G4Track *aG4Track)
 {
-  /* From G4 Example RE07 */
 
-  G4EventManager *eventManager       = G4EventManager::GetEventManager();
-  G4TrackingManager *trackManager    = eventManager->GetTrackingManager();
-  G4SteppingManager *steppingManager = trackManager->GetSteppingManager();
-  G4Region const *previousRegion     = aTrack->GetVolume()->GetLogicalVolume()->GetRegion();
+  // get history and depth from track
+  auto aG4NavigationHistory = aG4Track->GetNextTouchableHandle()->GetHistory();
+  auto aG4HistoryDepth      = aG4NavigationHistory->GetDepth();
 
-  // Track the particle Step-by-Step while it is alive and outside of a GPU region
-  while ((aTrack->GetTrackStatus() == fAlive || aTrack->GetTrackStatus() == fStopButAlive)) {
-    aTrack->IncrementCurrentStepNumber();
-    steppingManager->Stepping();
+  // the VecGeom NavigationState to be filled
+  vecgeom::NavigationState aNavState;
 
-    if (aTrack->GetTrackStatus() != fStopAndKill) {
-      // Switch the touchable to update the volume, which is checked in the
-      // condition below and at the call site.
-      aTrack->SetTouchableHandle(aTrack->GetNextTouchableHandle());
-      G4Region const *region = aTrack->GetVolume()->GetLogicalVolume()->GetRegion();
+  auto vecgeom_to_g4_map = fAdeptTransport->GetVecGeomG4Map();
 
-      // If the region changed, check whether the particle has entered a GPU region
-      if (region != previousRegion) {
-        previousRegion = region;
-        if (fGPURegions.find(region) != fGPURegions.end()) {
-          return;
-        }
-      }
+  // Iterate through the levels of G4NavigationHistory
+  for (unsigned int level = 0; level <= aG4HistoryDepth; ++level) {
+    // Get the current G4 volume at this level
+    const G4VPhysicalVolume *g4Volume = aG4NavigationHistory->GetVolume(level);
+
+    if (!g4Volume) {
+      throw std::runtime_error("G4NavigationHistory contains a null volume at level " + std::to_string(level));
     }
+
+    // Look up the corresponding VecGeom volume using the map
+    auto it =
+        std::find_if(vecgeom_to_g4_map.begin(), vecgeom_to_g4_map.end(),
+                     [&](const std::pair<int, const G4VPhysicalVolume *> &pair) { return pair.second == g4Volume; });
+
+    if (it == vecgeom_to_g4_map.end()) {
+      throw std::runtime_error("G4 volume not found in VecGeom mapping for level " + std::to_string(level));
+    }
+
+    // Get the corresponding VecGeom volume
+    const vecgeom::VPlacedVolume *vgVolume = vecgeom::GeoManager::Instance().FindPlacedVolume(it->first);
+    if (!vgVolume) {
+      throw std::runtime_error("VecGeom volume not found for ID " + std::to_string(it->first));
+    }
+
+    // Push the VecGeom volume to the NavigationState
+    aNavState.Push(vgVolume);
   }
+
+  // Set boundary status
+  if (aG4Track->GetStep() != nullptr) { // at initialization, the G4Step is not set yet, then we put OnBoundary to false
+    if (aG4Track->GetStep()->GetPostStepPoint()->GetStepStatus() == fGeomBoundary) {
+      aNavState.SetBoundaryState(true);
+    } else {
+      aNavState.SetBoundaryState(false);
+    }
+  } else {
+    aNavState.SetBoundaryState(false);
+  }
+
+  return aNavState;
 }

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -177,7 +177,7 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
       }
 
       // Get VecGeom Navigation state from G4History
-      vecgeom::NavigationState converted = GetVecGeomFromG4State(aTrack); 
+      vecgeom::NavigationState converted = GetVecGeomFromG4State(aTrack);
 
       fAdeptTransport->AddTrack(pdg, id, energy, particlePosition[0], particlePosition[1], particlePosition[2],
                                 particleDirection[0], particleDirection[1], particleDirection[2], globalTime, localTime,
@@ -205,37 +205,40 @@ const vecgeom::NavigationState AdePTTrackingManager::GetVecGeomFromG4State(const
   auto aG4NavigationHistory = aG4Track->GetNextTouchableHandle()->GetHistory();
   auto aG4HistoryDepth      = aG4NavigationHistory->GetDepth();
 
-  // the VecGeom NavigationState to be filled
+  // Initialize the NavState to be filled and push the world to it
   vecgeom::NavigationState aNavState;
+  auto current_volume = vecgeom::GeoManager::Instance().GetWorld();
+  aNavState.Push(current_volume);
 
-  auto vecgeom_to_g4_map = fAdeptTransport->GetVecGeomG4Map();
+  bool found_volume;
+  // we pushed already the world, so we can start at level 1
+  for (unsigned int level = 1; level <= aG4HistoryDepth; ++level) {
 
-  // Iterate through the levels of G4NavigationHistory
-  for (unsigned int level = 0; level <= aG4HistoryDepth; ++level) {
-    // Get the current G4 volume at this level
-    const G4VPhysicalVolume *g4Volume = aG4NavigationHistory->GetVolume(level);
+    found_volume = false;
 
-    if (!g4Volume) {
-      throw std::runtime_error("G4NavigationHistory contains a null volume at level " + std::to_string(level));
+    // Get current G4 volume and parent volume.
+    const G4VPhysicalVolume *g4Volume_parent = aG4NavigationHistory->GetVolume(level - 1);
+    const G4VPhysicalVolume *g4Volume        = aG4NavigationHistory->GetVolume(level);
+
+    // The index of the VecGeom volume on this level (that we need to push the NavState to)
+    // is the same as the G4 volume. The index of the G4 volume is found by matching it against
+    // the daughters of the parent volume, since the G4 volume itself has no index.
+    for (int id = 0; id < g4Volume_parent->GetLogicalVolume()->GetNoDaughters(); ++id) {
+      if (g4Volume == g4Volume_parent->GetLogicalVolume()->GetDaughter(id)) {
+        auto daughter = current_volume->GetLogicalVolume()->GetDaughters()[id];
+        aNavState.Push(daughter);
+        current_volume = daughter;
+        found_volume   = true;
+        break;
+      }
     }
 
-    // Look up the corresponding VecGeom volume using the map
-    auto it =
-        std::find_if(vecgeom_to_g4_map.begin(), vecgeom_to_g4_map.end(),
-                     [&](const std::pair<int, const G4VPhysicalVolume *> &pair) { return pair.second == g4Volume; });
-
-    if (it == vecgeom_to_g4_map.end()) {
-      throw std::runtime_error("G4 volume not found in VecGeom mapping for level " + std::to_string(level));
+    if (!found_volume) {
+      throw std::runtime_error("Fatal: G4 To VecGeom Geometry matching failed: G4 Volume name " +
+                               std::string(g4Volume->GetLogicalVolume()->GetName()) +
+                               " was not found in VecGeom Parent volume " +
+                               std::string(current_volume->GetLogicalVolume()->GetName()));
     }
-
-    // Get the corresponding VecGeom volume
-    const vecgeom::VPlacedVolume *vgVolume = vecgeom::GeoManager::Instance().FindPlacedVolume(it->first);
-    if (!vgVolume) {
-      throw std::runtime_error("VecGeom volume not found for ID " + std::to_string(it->first));
-    }
-
-    // Push the VecGeom volume to the NavigationState
-    aNavState.Push(vgVolume);
   }
 
   // Set boundary status

--- a/src/G4HepEmTrackingManagerSpecialized.cc
+++ b/src/G4HepEmTrackingManagerSpecialized.cc
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 CERN
+// SPDX-FileCopyrightText: 2024 CERN
 // SPDX-License-Identifier: Apache-2.0
 
 #include <AdePT/integration/G4HepEmTrackingManagerSpecialized.hh>

--- a/src/G4HepEmTrackingManagerSpecialized.cc
+++ b/src/G4HepEmTrackingManagerSpecialized.cc
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2023 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include <AdePT/integration/G4HepEmTrackingManagerSpecialized.hh>
+
+#include "G4Electron.hh"
+#include "G4Gamma.hh"
+#include "G4Positron.hh"
+
+G4HepEmTrackingManagerSpecialized::G4HepEmTrackingManagerSpecialized() : G4HepEmTrackingManager() {}
+
+G4HepEmTrackingManagerSpecialized::~G4HepEmTrackingManagerSpecialized() {}
+
+/// @brief The function checks within the TrackElectron and TrackGamma calls in G4HepEmTracking manager, if a barrier is
+/// hit.
+// Here is the specialized AdePT G4HepEmTrackingManager implementation that if the track enters a GPU region, it is
+// stopped on CPU and subsequently tracked on GPU
+/// @param track a G4track to be checked
+/// @param evtMgr the G4EventManager to stack secondaries
+/// @param userTrackingAction the UserTrackingAction
+/// @return
+bool G4HepEmTrackingManagerSpecialized::CheckEarlyTrackingExit(G4Track *track, G4EventManager *evtMgr,
+                                                               G4UserTrackingAction *userTrackingAction,
+                                                               G4TrackVector &secondaries) const
+{
+
+  G4Region const *region = track->GetVolume()->GetLogicalVolume()->GetRegion();
+
+  // TODO: for more efficient use, we only have to check for region within GPURegions, if the region changed.
+  //       This can be checked from the pre- and post-steppoint
+
+  // Not in the GPU region, continue normal tracking with G4HepEmTrackingManager
+  if (fGPURegions.find(region) != fGPURegions.end()) {
+    return false; // Continue tracking with G4HepEmTrackingManager
+  } else {
+
+    // first: end tracking for previous particle
+
+    // FIXME ignoring FastSimProc for now
+    // Invoke the fast simulation manager process EndTracking interface (if any)
+    // if (fFastSimProc != nullptr) {
+    //   fFastSimProc->EndTracking();
+    // }
+
+    if (userTrackingAction) {
+      userTrackingAction->PostUserTrackingAction(track);
+    }
+
+    // FIXME ignore the trajectory for now
+    // // Delete the trajectory object (if the user set any)
+    // if (theTrajectory != nullptr) {
+    //   delete theTrajectory;
+    // }
+
+    evtMgr->StackTracks(&secondaries);
+
+    return true; // stop tracking to hand over to GPU
+  }
+}
+
+void G4HepEmTrackingManagerSpecialized::HandOverOneTrack(G4Track *aTrack)
+{
+  const G4ParticleDefinition *part = aTrack->GetParticleDefinition();
+
+  bool tracking_finished = true; // whether G4HepEm finishes the track itself
+  if (part == G4Electron::Definition() || part == G4Positron::Definition()) {
+    tracking_finished = TrackElectron(aTrack);
+  } else if (part == G4Gamma::Definition()) {
+    tracking_finished = TrackGamma(aTrack);
+  }
+
+  // if G4HepEm finished the track, it can be deleted, otherwise it is kept to be transported on GPU
+  if (tracking_finished) {
+    aTrack->SetTrackStatus(fStopAndKill);
+    delete aTrack;
+  }
+}

--- a/src/G4HepEmTrackingManagerSpecialized.cc
+++ b/src/G4HepEmTrackingManagerSpecialized.cc
@@ -34,27 +34,47 @@ bool G4HepEmTrackingManagerSpecialized::CheckEarlyTrackingExit(G4Track *track, G
     return false; // Continue tracking with G4HepEmTrackingManager
   } else {
 
-    // first: end tracking for previous particle
+    // Track entered a GPU region. Now, the track must be properly ended here in the same way as G4HepEm would,
+    // since G4HepEm exists the TrackElectron / TrackGamma function immediately after this function returns true.
+    // This includes Ending the tracking for fast simulation manager, calling the UserTrackingAction,
+    // deleting the trajectory, and stacking the secondaries
 
-    // FIXME ignoring FastSimProc for now
     // Invoke the fast simulation manager process EndTracking interface (if any)
-    // if (fFastSimProc != nullptr) {
-    //   fFastSimProc->EndTracking();
-    // }
+    const G4ParticleDefinition *part = track->GetParticleDefinition();
 
+    G4VProcess *fFastSimProc;
+    if (part == G4Electron::Definition()) {
+      fFastSimProc = fFastSimProcess[0];
+    } else if (part == G4Positron::Definition()) {
+      fFastSimProc = fFastSimProcess[1];
+    } else if (part == G4Gamma::Definition()) {
+      fFastSimProc = fFastSimProcess[2];
+    } else {
+      throw std::runtime_error("Unexpected particle type!");
+    }
+
+    if (fFastSimProc != nullptr) {
+      fFastSimProc->EndTracking();
+    }
+
+    // call PostUserTrackingAction
     if (userTrackingAction) {
       userTrackingAction->PostUserTrackingAction(track);
     }
 
-    // FIXME ignore the trajectory for now
     // // Delete the trajectory object (if the user set any)
-    // if (theTrajectory != nullptr) {
-    //   delete theTrajectory;
-    // }
+    G4VTrajectory *theTrajectory = evtMgr->GetTrackingManager()->GetStoreTrajectory() == 0
+                                       ? nullptr
+                                       : evtMgr->GetTrackingManager()->GimmeTrajectory();
+    if (theTrajectory != nullptr) {
+      delete theTrajectory;
+    }
 
+    // Push secondaries
     evtMgr->StackTracks(&secondaries);
 
-    return true; // stop tracking to hand over to GPU
+    // return true to stop tracking in G4HepEmTrackingManager to hand over to GPU
+    return true;
   }
 }
 
@@ -62,7 +82,8 @@ void G4HepEmTrackingManagerSpecialized::HandOverOneTrack(G4Track *aTrack)
 {
   const G4ParticleDefinition *part = aTrack->GetParticleDefinition();
 
-  bool tracking_finished = true; // whether G4HepEm finishes the track itself
+  // Do tracking with G4HepEm and check whether the track was finished
+  bool tracking_finished = true;
   if (part == G4Electron::Definition() || part == G4Positron::Definition()) {
     tracking_finished = TrackElectron(aTrack);
   } else if (part == G4Gamma::Definition()) {

--- a/src/HepEMPhysics.cc
+++ b/src/HepEMPhysics.cc
@@ -4,7 +4,10 @@
 #include <AdePT/integration/HepEMPhysics.hh>
 
 // include the G4HepEmProcess from the G4HepEm lib.
-#include "G4HepEmProcess.hh"
+// #include "G4HepEmProcess.hh"
+
+// Using the tracking manager approach
+#include "G4HepEmTrackingManager.hh"
 
 #include "G4ParticleDefinition.hh"
 #include "G4ProcessManager.hh"
@@ -42,7 +45,7 @@
 #include "G4ionIonisation.hh"
 #include "G4NuclearStopping.hh"
 
-HepEMPhysics::HepEMPhysics(const G4String &name) : G4VPhysicsConstructor(name)
+HepEMPhysics::HepEMPhysics(int ver, const G4String &name) : G4EmStandardPhysics(ver, name)
 {
   G4EmParameters *param = G4EmParameters::Instance();
   param->SetDefaults();
@@ -60,70 +63,13 @@ HepEMPhysics::~HepEMPhysics() {}
 void HepEMPhysics::ConstructProcess()
 {
 
-  G4PhysicsListHelper *ph = G4PhysicsListHelper::GetPhysicsListHelper();
+  G4EmStandardPhysics::ConstructProcess();
 
-  // from G4EmStandardPhysics
-  G4EmBuilder::PrepareEMPhysics();
+  // Register custom tracking manager for e-/e+ and gammas.
+  auto *trackingManager = new G4HepEmTrackingManager();
+  G4Electron::Definition()->SetTrackingManager(trackingManager);
+  G4Positron::Definition()->SetTrackingManager(trackingManager);
+  G4Gamma::Definition()->SetTrackingManager(trackingManager);
 
-  G4EmParameters *param = G4EmParameters::Instance();
-
-  // processes used by several particles
-  G4hMultipleScattering *hmsc = new G4hMultipleScattering("ionmsc");
-
-  // nuclear stopping is enabled if th eenergy limit above zero
-  G4double nielEnergyLimit = param->MaxNIELEnergy();
-  G4NuclearStopping *pnuc  = nullptr;
-  if (nielEnergyLimit > 0.0) {
-    pnuc = new G4NuclearStopping();
-    pnuc->SetMaxKinEnergy(nielEnergyLimit);
-  }
-  // end of G4EmStandardPhysics
-
-  // creae the only one G4HepEm process that will be assigned to e-/e+ and gamma
-  G4HepEmProcess *hepEmProcess = new G4HepEmProcess();
-
-  // Add standard EM Processes
-  //
-  auto aParticleIterator = GetParticleIterator();
-  aParticleIterator->reset();
-  while ((*aParticleIterator)()) {
-    G4ParticleDefinition *particle = aParticleIterator->value();
-    G4String particleName          = particle->GetParticleName();
-
-    if (particleName == "gamma") {
-
-      // Add G4HepEm process to gamma: includes Conversion, Compton and photoelectric effect.
-      particle->GetProcessManager()->AddProcess(hepEmProcess, -1, -1, 1);
-
-    } else if (particleName == "e-") {
-
-      // Add G4HepEm process to e-: includes Ionisation and Bremsstrahlung for e-
-      particle->GetProcessManager()->AddProcess(hepEmProcess, -1, -1, 1);
-
-    } else if (particleName == "e+") {
-
-      // Add G4HepEm process to e+: includes Ionisation, Bremsstrahlung and e+e-
-      // annihilation into 2 gamma interactions for e+
-      particle->GetProcessManager()->AddProcess(hepEmProcess, -1, -1, 1);
-    }
-  }
-
-  // from G4EmStandardPhysics
-
-  // generic ion
-  G4ParticleDefinition *particle = G4GenericIon::GenericIon();
-  G4ionIonisation *ionIoni       = new G4ionIonisation();
-  ph->RegisterProcess(hmsc, particle);
-  ph->RegisterProcess(ionIoni, particle);
-  if (nullptr != pnuc) {
-    ph->RegisterProcess(pnuc, particle);
-  }
-
-  // muons, hadrons ions
-  G4EmBuilder::ConstructCharged(hmsc, pnuc);
-
-  // extra configuration
-  G4EmModelActivator mact(GetPhysicsName());
-
-  // end of G4EmStandardPhysics
+  // end of HepEMPhysics
 }

--- a/src/HepEMPhysics.cc
+++ b/src/HepEMPhysics.cc
@@ -52,10 +52,7 @@ HepEMPhysics::HepEMPhysics(int ver, const G4String &name) : G4EmStandardPhysics(
   param->SetVerbose(1);
 
   // Range factor: (can be set from the G4 macro)
-  param->SetMscRangeFactor(0.04);
-  //
-
-  SetPhysicsType(bElectromagnetic);
+  // param->SetMscRangeFactor(0.04); // 0.04 is the default set by SetDefaults
 }
 
 HepEMPhysics::~HepEMPhysics() {}

--- a/test/testField/electrons.cu
+++ b/test/testField/electrons.cu
@@ -139,7 +139,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     G4HepEmRandomEngine rnge(&currentTrack.rngState);
 
     // Sample the `number-of-interaction-left` and put it into the track.
-    for (int ip = 0; ip < 3; ++ip) {
+    for (int ip = 0; ip < 4; ++ip) {
       double numIALeft = currentTrack.numIALeft[ip];
       if (numIALeft <= 0) {
         numIALeft = -std::log(currentTrack.Uniform());
@@ -165,6 +165,11 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     int winnerProcessIndex = theTrack->GetWinnerProcessIndex();
     // Leave the range and MFP inside the G4HepEmTrack. If we split kernels, we
     // also need to carry them over!
+
+    // Skip electron/positron-nuclear reaction that would need to be handled by G4 itself
+    if (winnerProcessIndex == 3) {
+      winnerProcessIndex = -1;
+    }
 
     // Check if there's a volume boundary in between.
     bool propagated = true;
@@ -322,7 +327,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     atomicAdd(&scoringPerVolume->energyDeposit[volumeID], energyDeposit);
 
     // Save the `number-of-interaction-left` in our track.
-    for (int ip = 0; ip < 3; ++ip) {
+    for (int ip = 0; ip < 4; ++ip) {
       double numIALeft           = theTrack->GetNumIALeft(ip);
       currentTrack.numIALeft[ip] = numIALeft;
     }

--- a/test/testField/gammas.cu
+++ b/test/testField/gammas.cu
@@ -59,20 +59,22 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     theTrack->SetMCIndex(theMCIndex);
 
     // Sample the `number-of-interaction-left` and put it into the track.
-    for (int ip = 0; ip < 3; ++ip) {
-      double numIALeft = currentTrack.numIALeft[ip];
-      if (numIALeft <= 0) {
-        numIALeft = -std::log(currentTrack.Uniform());
-      }
-      theTrack->SetNumIALeft(numIALeft, ip);
+    // Use index 0 since numIALeft for gammas is based only on the total macroscopic cross section
+    if (theTrack->GetNumIALeft(0) <= 0.0) {
+      theTrack->SetNumIALeft(-std::log(currentTrack.Uniform()), 0);
     }
 
     // Call G4HepEm to compute the physics step limit.
     G4HepEmGammaManager::HowFar(&g4HepEmData, &g4HepEmPars, &gammaTrack);
+    G4HepEmGammaManager::SampleInteraction(&g4HepEmData, &gammaTrack, currentTrack.Uniform());
 
     // Get result into variables.
     double geometricalStepLengthFromPhysics = theTrack->GetGStepLength();
     int winnerProcessIndex                  = theTrack->GetWinnerProcessIndex();
+        // disable photo-nuclear reaction that would need to be handled by G4 itself
+    if (winnerProcessIndex == 3) {
+      winnerProcessIndex = -1;
+    }
     // Leave the range and MFP inside the G4HepEmTrack. If we split kernels, we
     // also need to carry them over!
 
@@ -101,10 +103,9 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
     G4HepEmGammaManager::UpdateNumIALeft(theTrack);
 
     // Save the `number-of-interaction-left` in our track.
-    for (int ip = 0; ip < 3; ++ip) {
-      double numIALeft           = theTrack->GetNumIALeft(ip);
-      currentTrack.numIALeft[ip] = numIALeft;
-    }
+    // Use index 0 since numIALeft for gammas is based only on the total macroscopic cross section
+    double numIALeft          = theTrack->GetNumIALeft(0);
+    currentTrack.numIALeft[0] = numIALeft;
 
     if (nextState.IsOnBoundary()) {
       // For now, just count that we hit something.


### PR DESCRIPTION
This PR introduces the required changes needed to use the latest version of G4HepEm. In G4HepEm the representation for the cross sections changed in this [PR](https://github.com/mnovak42/g4hepem/pull/115). Additionally, the e-+/gamma-nuclear reactions were added in G4HepEm. 

This PR
1.  uses the new function `G4HepEmGammaManager::SampleInteraction` and fixes the numIALeft.
**_Note_**: that since we don't register the gamma/lepton nuclear processes in the physics list they are currently ignored by AdePT and G4HepEm.
2. adopts the TrackingManager approach by using a derived class of the G4HepEmTrackingManager. This supersedes #316. The G4HepEmTrackingManagerSpecialized is instantiated as a member of the AdePTTrackingmanager and it takes care of all CPU propagation and cleans up the propagation loop.
3. adds a direct conversion of the Geant4 NavigationHistory to a VecGeom NavigationState. This cleans up many problems at boundaries that can become costly for edges of GPU regions, where particles are frequently moved between CPU and GPU, or very tangent particles could get stuck. This reduces the run time for 1e6 10 GeV electrons being shot at testEm3 where all layers are GPU regions (but the calorimeter is not) from
Before: Run time: 1582.26
Now: Run time: 1281.32
4. cleans up the AdePT physics. Now `FTFP_BERT_AdePT` derives from `G4EmStandardPhysics`.

Currently, the gamma/lepton nuclear processes are not registered in the PhysicsList. However, if they are registered, G4HepEm treats them correctly, while AdePT just ignores them. For electrons, they are suppressed by an infinite interaction length, for gamma (since they are handled internally in G4HepEm), we simply do a empty step. There is a implementation commented out that re-draws in case a gamma-nuclear reaction is drawn. It re-draws up to 3 times and in the (unlikely, but possible) case that we still end up with gamma-nuclear, we do a redundant step limited by gamma-nuclear but not invoking any process. However, using this changes the physics by ~ 1 % at the tail, leading to worse agreement, therefore we for now accept the performance penalty of empty steps.

**Testing:**
For the testing, different variations with testEM3 where tested:
1. making everything a GPU region via `/adept/setTrackInAllRegions true`.
2. making all layers a GPU region (but not the encompassing `Calorimeter` region.
3. using 3 different regions that include various layers, without specific order
4. using no regions at all.

These settings were tested against running with the `--noadept` option, which uses the `FTFP_BERT_HepEm` physics list. All 4 configurations were tested with this PR and with the `master` branch.

**Outcome:**
This PR shows excellent agreement between AdePT and G4 with G4HepEm: (the plot is for making everything a GPU region)
<img width="577" alt="Screenshot 2025-01-01 at 16 58 52" src="https://github.com/user-attachments/assets/13688705-c99c-4714-b523-cb24128d097b" />

It is slightly improved to the `master` branch:
<img width="575" alt="Screenshot 2025-01-01 at 17 00 27" src="https://github.com/user-attachments/assets/265b61f6-df42-479a-8a56-1430b06a548a" />

No major differences are observed using 2. all layers being regions, 3. using only certain regions, and 4. using no regions. 
2. All layers GPU:
<img width="576" alt="Screenshot 2025-01-01 at 18 53 07" src="https://github.com/user-attachments/assets/8359ad1e-276d-43d6-8271-87691c128df1" />
3. Various GPU regions:
<img width="568" alt="Screenshot 2025-01-01 at 18 53 48" src="https://github.com/user-attachments/assets/6029fb71-8804-43b7-abcb-31088016db54" />
4. No GPU regions:
<img width="568" alt="Screenshot 2025-01-01 at 18 54 21" src="https://github.com/user-attachments/assets/7854d0e4-b048-4026-bd5c-82ba41bb88d0" />

In the `master`, 3. gets stuck and never finishes. It could still be off in the plot above, to be investigated with higher statistics. Since it didn't work at all in the `master` this is still a significant improvement.
The overall run time for G4 + HepEm in our example is improved using the tracking manager approach: From `Run time: 2842.99 s` (master) to `Run time: 2255.76 s` using this PR (16 threads, 1e6 10 GeV electrons being shot at testEm3)

Additionally the energy deposition of CMS was checked and found to be at good agreement. The run time for CMS is similar, maybe slightly improved using AdePT everywhere.

To Do:

- [x] Proper validation after #326 is  merged.
- [x] Validate run with CMS.
- [ ] After [this PR](https://github.com/mnovak42/g4hepem/pull/117) is merged in G4HepEm, tag that version of G4HepEm and update CI
- [x] implement changes also in split kernels
- [x] validate with split kernels (validate kernels give roughly the same result but not to machine precision anymore, however, before this PR it was not compiling anymore).


NOTE: These are breaking changes, as older versions of G4HepEm cannot be used anymore.