### PR TITLE
fix particle gun

### DIFF
--- a/examples/common/include/ParticleGun.hh
+++ b/examples/common/include/ParticleGun.hh
@@ -13,11 +13,11 @@
 class ParticleGunMessenger;
 class G4Event;
 
-class ParticleGun : public G4ParticleGun {
+class ParticleGun {
 public:
   ParticleGun();
   ~ParticleGun();
-  virtual void GeneratePrimaries(G4Event *) final;
+  void GeneratePrimaries(G4Event *);
   void GenerateRandomPrimaryVertex(G4Event *aEvent, G4double aMinPhi, G4double aMaxPhi, G4double aMinTheta,
                                    G4double aMaxTheta, std::vector<G4ParticleDefinition *> *aParticleList,
                                    std::vector<float> *aParticleWeights, std::vector<float> *aParticleEnergies);
@@ -38,6 +38,9 @@ public:
   void ReWeight();
 
 private:
+  // G4Particle gun that uses the default G4 gun commands such as /gun/position etc.
+  std::unique_ptr<G4ParticleGun> fG4ParticleGun;
+
   G4double fPrintGun = 0.;
   // Gun randomization
   bool fRandomizeGun = false;


### PR DESCRIPTION
This PR slightly re-designs the AdePT `ParticleGun`. Previously, it was derived from the `G4ParticleGun` and used its own `ParticleGunMessenger`. However, even if the `ParticleGunMessenger` was derived from the `G4ParticleGunMessenger` (currently it is derived from the `G4UImessenger`) this approach is flawed, since the original `G4ParticleGunMessenger` attached to the `G4ParticleGun` that is invoked when the derived AdePT `ParticleGun` is instantiated is *not* attached to the AdePT `ParticleGun`. That meant that the default commands such as `/gun/position` would not work and just be ignored.

This is fixed by instead of deriving the AdePT `ParticleGun` from the `G4ParticleGun`, it has a member `fG4ParticleGun`. This member has then attached the original `G4ParticleGunMessenger` that takes care of the default commands such as `/gun/position`. The old AdePT `ParticleGun` funciontality is unchanged, it just uses under the hood the `fG4ParticleGun`.