### PR TITLE
fix uninitialized values

### DIFF
--- a/include/AdePT/core/AdePTTransport.cuh
+++ b/include/AdePT/core/AdePTTransport.cuh
@@ -136,6 +136,7 @@ __global__ void InitTracks(adeptint::TrackData *trackinfo, int ntracks, int star
     track.numIALeft[0] = -1.0;
     track.numIALeft[1] = -1.0;
     track.numIALeft[2] = -1.0;
+    track.numIALeft[3] = -1.0;
 
     track.initialRange       = -1.0;
     track.dynamicRangeFactor = -1.0;

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -69,6 +69,7 @@ struct Track {
     this->numIALeft[0] = -1.0;
     this->numIALeft[1] = -1.0;
     this->numIALeft[2] = -1.0;
+    this->numIALeft[3] = -1.0;
 
     this->initialRange       = -1.0;
     this->dynamicRangeFactor = -1.0;


### PR DESCRIPTION
Unfortunately #324 missed to add the initialization of the new component of `numIALeft` which led to non-reproducible results as soon the the circular buffer got around, found in a long discussion with @hahnjo.

To Do:
- [x] general physics validation
- [x] physics validation for alllayers, regions, noregions
- [x] ensure reproducibility in ttbar events
 
 Validation: 
`setTrackInAllRegions`:
![Screenshot from 2025-01-09 14-42-21](https://github.com/user-attachments/assets/cadf4a65-2b1d-43dd-abbe-96199b1845ae)

`alllayers`:
![Screenshot from 2025-01-09 16-29-33](https://github.com/user-attachments/assets/c9725eb1-a7ff-4858-88a5-4338cc7c4c95)

`regions`:
![Screenshot from 2025-01-09 16-30-09](https://github.com/user-attachments/assets/2f65f97e-3eea-47e6-a715-2702a45b8e76)

`noregions`
![Screenshot from 2025-01-09 16-30-36](https://github.com/user-attachments/assets/54f9e467-c3c2-430b-ae97-0a8438ca118a)
