### PR TITLE
fix minor things for strict compiler settings

### DIFF
--- a/examples/Example1/src/EventAction.cc
+++ b/examples/Example1/src/EventAction.cc
@@ -50,8 +50,6 @@ EventAction::~EventAction() {}
 
 void EventAction::BeginOfEventAction(const G4Event *)
 {
-  auto eventId = G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID();
-
   fTimer.Start();
 }
 

--- a/examples/Example1/src/RunAction.cc
+++ b/examples/Example1/src/RunAction.cc
@@ -41,7 +41,6 @@ RunAction::~RunAction() {}
 void RunAction::BeginOfRunAction(const G4Run *)
 {
   fTimer.Start();
-  auto tid = G4Threading::G4GetThreadId();
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/examples/Example1/src/TrackingAction.cc
+++ b/examples/Example1/src/TrackingAction.cc
@@ -39,7 +39,7 @@ TrackingAction::TrackingAction() : G4UserTrackingAction() {}
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-void TrackingAction::PreUserTrackingAction(const G4Track *aTrack)
+void TrackingAction::PreUserTrackingAction(const G4Track *)
 {
   // Reset step counter
   fSteppingAction->SetNumSteps(0);
@@ -47,7 +47,7 @@ void TrackingAction::PreUserTrackingAction(const G4Track *aTrack)
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-void TrackingAction::PostUserTrackingAction(const G4Track *aTrack)
+void TrackingAction::PostUserTrackingAction(const G4Track *)
 {
   // Reset step counter
   fSteppingAction->SetNumSteps(0);

--- a/examples/IntegrationBenchmark/src/EventAction.cc
+++ b/examples/IntegrationBenchmark/src/EventAction.cc
@@ -55,8 +55,6 @@ EventAction::~EventAction() {}
 
 void EventAction::BeginOfEventAction(const G4Event *)
 {
-  auto eventId = G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID();
-
   fTimer.Start();
 
   // Get the Run object associated to this thread and start the timer for this event

--- a/examples/IntegrationBenchmark/src/Run.cc
+++ b/examples/IntegrationBenchmark/src/Run.cc
@@ -55,11 +55,11 @@ void Run::EndOfRunSummary(G4String aOutputDirectory, G4String aOutputFilename)
     double eventMean  = fTestManager->getAccumulator(accumulators::EVENT_SUM) / GetNumberOfEvent();
     double eventStdev = STDEV(GetNumberOfEvent(), eventMean, fTestManager->getAccumulator(accumulators::EVENT_SQ));
 
-    double nonEMMean  = fTestManager->getAccumulator(accumulators::NONEM_SUM) / GetNumberOfEvent();
-    double nonEMStdev = STDEV(GetNumberOfEvent(), nonEMMean, fTestManager->getAccumulator(accumulators::NONEM_SQ));
-
-    double ecalMean  = fTestManager->getAccumulator(accumulators::ECAL_SUM) / GetNumberOfEvent();
-    double ecalStdev = STDEV(GetNumberOfEvent(), ecalMean, fTestManager->getAccumulator(accumulators::ECAL_SQ));
+    // currently unused:
+    // double nonEMMean  = fTestManager->getAccumulator(accumulators::NONEM_SUM) / GetNumberOfEvent();
+    // double nonEMStdev = STDEV(GetNumberOfEvent(), nonEMMean, fTestManager->getAccumulator(accumulators::NONEM_SQ));
+    // double ecalMean  = fTestManager->getAccumulator(accumulators::ECAL_SUM) / GetNumberOfEvent();
+    // double ecalStdev = STDEV(GetNumberOfEvent(), ecalMean, fTestManager->getAccumulator(accumulators::ECAL_SQ));
 
     G4cout << "------------------------------------------------------------"
            << "\n";
@@ -75,16 +75,17 @@ void Run::EndOfRunSummary(G4String aOutputDirectory, G4String aOutputFilename)
   TestManager<std::string> aOutputTestManager;
 
   // aBenchmarkStates->size() should correspond to the number of events
-  for (int i = 0; i < aBenchmarkStates->size(); i++) {
+  for (size_t i = 0; i < aBenchmarkStates->size(); i++) {
     if (fRunAction->GetDoValidation()) {
       // If we are taking validation data, export it to the specified file
       // Each benchmark state contains one counter per LogicalVolume
       // Export one CSV containing a list of volume IDs and Edep per event
       // for (auto iter = (*aBenchmarkStates)[i].begin(); iter != (*aBenchmarkStates)[i].end(); ++iter) {
       //   if(iter->first >= Run::accumulators::NUM_ACCUMULATORS)
-      //     aOutputTestManager.setAccumulator(std::to_string(iter->first - Run::accumulators::NUM_ACCUMULATORS), iter->second);
+      //     aOutputTestManager.setAccumulator(std::to_string(iter->first - Run::accumulators::NUM_ACCUMULATORS),
+      //     iter->second);
       // }
-      
+
       // aOutputTestManager.setOutputDirectory(aOutputDirectory);
       // aOutputTestManager.setOutputFilename(aOutputFilename);
       // aOutputTestManager.exportCSV(false);

--- a/examples/IntegrationBenchmark/src/TrackingAction.cc
+++ b/examples/IntegrationBenchmark/src/TrackingAction.cc
@@ -39,7 +39,7 @@ TrackingAction::TrackingAction() : G4UserTrackingAction() {}
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-void TrackingAction::PreUserTrackingAction(const G4Track *aTrack)
+void TrackingAction::PreUserTrackingAction(const G4Track *)
 {
   // Reset step counter
   fSteppingAction->SetNumSteps(0);
@@ -47,7 +47,7 @@ void TrackingAction::PreUserTrackingAction(const G4Track *aTrack)
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-void TrackingAction::PostUserTrackingAction(const G4Track *aTrack)
+void TrackingAction::PostUserTrackingAction(const G4Track *)
 {
   // Reset step counter
   fSteppingAction->SetNumSteps(0);

--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -83,7 +83,7 @@ private:
   int fMaxBatch{0};                                    ///< Max batch size for allocating GPU memory
   int fNumVolumes{0};                                  ///< Total number of active logical volumes
   int fNumSensitive{0};                                ///< Total number of sensitive volumes
-  int fBufferThreshold{20};                            ///< Buffer threshold for flushing AdePT transport buffer
+  size_t fBufferThreshold{20};                         ///< Buffer threshold for flushing AdePT transport buffer
   int fDebugLevel{1};                                  ///< Debug level
   int fCUDAStackLimit{0};                              ///< CUDA device stack limit
   GPUstate *fGPUstate{nullptr};                        ///< CUDA state placeholder

--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -159,8 +159,6 @@ void AdePTTransport<IntegrationLayer>::Initialize(bool common_data)
 
     // Do the material-cut couple index mapping once
     // as well as set flags for sensitive volumes and region
-    // Also set the mappings from sensitive volumes to hits and VecGeom to G4 indices
-    int *sensitive_volumes = nullptr;
 
     // Check VecGeom geometry matches Geant4. Initialize auxiliary per-LV data. Initialize scoring map.
     fIntegrationLayer.CheckGeometry(fg4hepem_state);
@@ -181,7 +179,7 @@ void AdePTTransport<IntegrationLayer>::Initialize(bool common_data)
     return;
   }
 
-  fIntegrationLayer.InitScoringData(VolAuxArray::GetInstance().fAuxData);
+  fIntegrationLayer.InitScoringData();
 
   std::cout << "=== AdePTTransport: initializing transport engine for thread: " << fIntegrationLayer.GetThreadID()
             << std::endl;

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -46,7 +46,7 @@ public:
                              std::vector<std::string> const *gpuRegionNames);
 
   /// @brief Initializes the mapping of VecGeom to G4 volumes for sensitive volumes and their parents
-  void InitScoringData(adeptint::VolAuxData *volAuxData);
+  void InitScoringData();
 
   /// @brief Reconstructs GPU hits on host and calls the user-defined sensitive detector code
   void ProcessGPUHit(GPUHit const &hit);

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -223,7 +223,7 @@ const vecgeom::NavigationState AdePTTrackingManager::GetVecGeomFromG4State(const
     // The index of the VecGeom volume on this level (that we need to push the NavState to)
     // is the same as the G4 volume. The index of the G4 volume is found by matching it against
     // the daughters of the parent volume, since the G4 volume itself has no index.
-    for (int id = 0; id < g4Volume_parent->GetLogicalVolume()->GetNoDaughters(); ++id) {
+    for (size_t id = 0; id < g4Volume_parent->GetLogicalVolume()->GetNoDaughters(); ++id) {
       if (g4Volume == g4Volume_parent->GetLogicalVolume()->GetDaughter(id)) {
         auto daughter = current_volume->GetLogicalVolume()->GetDaughters()[id];
         aNavState.Push(daughter);

--- a/test/testField/testField.cpp
+++ b/test/testField/testField.cpp
@@ -123,15 +123,15 @@ int *CreateMCCindex(const G4VPhysicalVolume *g4world, const vecgeom::VPlacedVolu
   // - FIND vecgeom::LogicalVolume corresponding to each and every G4LogicalVolume
   int nphysical = 0;
 
-  int nvolumes   = vecgeom::GeoManager::Instance().GetRegisteredVolumesCount();
-  int *mcc_index = new int[nvolumes];
+  unsigned int nvolumes = vecgeom::GeoManager::Instance().GetRegisteredVolumesCount();
+  int *mcc_index        = new int[nvolumes];
   memset(mcc_index, 0, nvolumes * sizeof(int));
 
   // recursive geometry visitor lambda matching one by one Geant4 and VecGeom logical volumes
   // (we need to make sure we set the right MCC index to the right volume)
   typedef std::function<void(G4LogicalVolume const *, vecgeom::LogicalVolume const *)> func_t;
   func_t visitAndSetMCindex = [&](G4LogicalVolume const *g4vol, vecgeom::LogicalVolume const *vol) {
-    int nd         = g4vol->GetNoDaughters();
+    size_t nd      = g4vol->GetNoDaughters();
     auto daughters = vol->GetDaughters();
     if (nd != daughters.size()) throw std::runtime_error("Mismatch in number of daughters");
     // Check the couples
@@ -150,7 +150,7 @@ int *CreateMCCindex(const G4VPhysicalVolume *g4world, const vecgeom::VPlacedVolu
     nphysical++;
 
     // Now do the daughters
-    for (int id = 0; id < nd; ++id) {
+    for (size_t id = 0; id < nd; ++id) {
       auto g4pvol = g4vol->GetDaughter(id);
       auto pvol   = daughters[id];
       // VecGeom does not strip pointers from logical volume names


### PR DESCRIPTION
In the hunt for some ugly non-reproducibility bug, I used strict compiler settings with `add_compile_options(-Wall -Wextra -Werror -Wuninitialized)`

This PR cleans unused variables and incorrect types that don't have any effect but prevent the usage of strict compiler settings.