### PR TITLE
[mini] fix constructors for AdePTPhysics

### DIFF
--- a/include/AdePT/integration/AdePTPhysics.hh
+++ b/include/AdePT/integration/AdePTPhysics.hh
@@ -13,7 +13,7 @@ class AdePTConfiguration;
 
 class AdePTPhysics : public G4EmStandardPhysics { // public G4VPhysicsConstructor {
 public:
-  AdePTPhysics(int ver, const G4String &name = "AdePT-physics-list");
+  AdePTPhysics(int ver = 1, const G4String &name = "AdePT-physics-list");
   ~AdePTPhysics();
   AdePTTrackingManager *GetTrackingManager() { return fTrackingManager; }
 

--- a/include/AdePT/integration/HepEMPhysics.hh
+++ b/include/AdePT/integration/HepEMPhysics.hh
@@ -9,7 +9,7 @@
 
 class HepEMPhysics : public G4EmStandardPhysics {
 public:
-  HepEMPhysics(int ver, const G4String &name = "G4HepEm-physics-list");
+  HepEMPhysics(int ver = 1, const G4String &name = "G4HepEm-physics-list");
   ~HepEMPhysics();
 
 public:


### PR DESCRIPTION
This fixes the `AdePTPhysics` and `HepEmPhysics` in AdePT, to have the same default values as the class they are derived from: `G4EmStandardPhysics`. This allows for using a factory function and is required in Gauss for LHCb simulations.