### PR TITLE
add tracking cuts

### DIFF
--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -493,7 +493,6 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
         }
       }
       // Particles are killed by not enqueuing them into the new activeQueue.
-      // continue;
     }
 
     // Record the step. Edep includes the continuous energy loss and edep from secondaries which were cut


### PR DESCRIPTION
This PR adds the tracking cuts for electrons/positrons.

For this, the annihilation of stopped positrons is moved after the discrete interaction kernels. Then, particles in the discrete interaction below the tracking cut are also marked as `stopped`. The energy of electrons is deposited, positrons are annihilated similarly to those that are stopped from continuous energy loss.

It seems that the tracking cut does not have any impact on the performance in ttbar events or testEM3. Still, we should add it for consistency and it might have an impact for other settings.

ToDo: 
- [ ] high-statistics physics validation