### PR TITLE
move InitializeApplyCuts

### DIFF
--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -99,6 +99,11 @@ void AdePTTrackingManager::BuildPhysicsTable(const G4ParticleDefinition &part)
     InitializeAdePT();
   }
 
+  if (fAdePTInitialized) {
+    // Set ApplyCuts flag on device since now G4 physics is initialized
+    fAdeptTransport->InitializeApplyCuts(G4EmParameters::Instance()->ApplyCuts());
+  }
+
   // Bulid PhysicsTable for G4HepEm
   fHepEmTrackingManager->BuildPhysicsTable(part);
 
@@ -109,12 +114,6 @@ void AdePTTrackingManager::BuildPhysicsTable(const G4ParticleDefinition &part)
 
 void AdePTTrackingManager::PreparePhysicsTable(const G4ParticleDefinition &part)
 {
-
-  if (fAdePTInitialized) {
-    // Set ApplyCuts flag on device since now G4 physics is initialized
-    fAdeptTransport->InitializeApplyCuts(G4EmParameters::Instance()->ApplyCuts());
-  }
-
   // Prepare PhysicsTable for G4HepEm
   fHepEmTrackingManager->PreparePhysicsTable(part);
 


### PR DESCRIPTION
This move the InitializeApplyCuts to the BuildPhysics, as in Gauss the ApplyCuts flag was set separately and not yet available at the stage of PreparePhysics.