### PR TITLE
Reverting base class of physics constructors

### DIFF
--- a/examples/common/src/FTFP_BERT_AdePT.cc
+++ b/examples/common/src/FTFP_BERT_AdePT.cc
@@ -38,13 +38,12 @@ FTFP_BERT_AdePT::FTFP_BERT_AdePT(G4int ver)
   // EM Physics
 
   // Register the EM physics to use for tracking on CPU
-  // Note: The explicit registering of physics on CPU is not needed anymore:
-  // the AdePTTrackingManager takes care of all EM particles and, on CPU, hands them over to
-  // the specialized G4HepEmTrackingManager
-  // RegisterPhysics(new G4EmStandardPhysics());
-  // RegisterPhysics(new HepEMPhysics(ver));
-
+  // Note: The EM processes for e-, e+ and gammas are registered, but not used as the 
+  // partices are tracked by the specialized tracking manager
+  RegisterPhysics(new G4EmStandardPhysics());
+  
   // Register the AdePT physics
+  // Note: The AdePT tracking manager uses the G4HepEM tracking manager outside of GPU regions
   RegisterPhysics(new AdePTPhysics(ver));
 
   // Synchroton Radiation & GN Physics

--- a/examples/common/src/FTFP_BERT_HepEm.cc
+++ b/examples/common/src/FTFP_BERT_HepEm.cc
@@ -35,7 +35,11 @@ FTFP_BERT_HepEm::FTFP_BERT_HepEm(G4int ver)
   SetVerboseLevel(ver);
 
   // EM Physics
-  // RegisterPhysics( new G4EmStandardPhysics(ver));
+  // Note: The EM processes for e-, e+ and gammas are registered, but not used as the 
+  // partices are tracked by the specialized tracking manager
+  RegisterPhysics( new G4EmStandardPhysics(ver));
+
+  // Register the HepEM physics
   RegisterPhysics(new HepEMPhysics(ver));
 
   // Synchroton Radiation & GN Physics

--- a/include/AdePT/integration/AdePTPhysics.hh
+++ b/include/AdePT/integration/AdePTPhysics.hh
@@ -6,12 +6,11 @@
 
 #include "G4VPhysicsConstructor.hh"
 #include "globals.hh"
-#include "G4EmStandardPhysics.hh"
 
 class AdePTTrackingManager;
 class AdePTConfiguration;
 
-class AdePTPhysics : public G4EmStandardPhysics { // public G4VPhysicsConstructor {
+class AdePTPhysics : public G4VPhysicsConstructor {
 public:
   AdePTPhysics(int ver = 1, const G4String &name = "AdePT-physics-list");
   ~AdePTPhysics();

--- a/include/AdePT/integration/HepEMPhysics.hh
+++ b/include/AdePT/integration/HepEMPhysics.hh
@@ -4,10 +4,10 @@
 #ifndef HepEMPhysics_h
 #define HepEMPhysics_h 1
 
-#include "G4EmStandardPhysics.hh"
+#include "G4VPhysicsConstructor.hh"
 #include "globals.hh"
 
-class HepEMPhysics : public G4EmStandardPhysics {
+class HepEMPhysics : public G4VPhysicsConstructor {
 public:
   HepEMPhysics(int ver = 1, const G4String &name = "G4HepEm-physics-list");
   ~HepEMPhysics();

--- a/src/AdePTPhysics.cc
+++ b/src/AdePTPhysics.cc
@@ -15,8 +15,7 @@
 #include "G4EmParameters.hh"
 #include "G4BuilderType.hh"
 
-AdePTPhysics::AdePTPhysics(int ver, const G4String &name)
-    : G4EmStandardPhysics(ver, name) // G4VPhysicsConstructor(name)
+AdePTPhysics::AdePTPhysics(int ver, const G4String &name) : G4VPhysicsConstructor(name)
 {
   fAdePTConfiguration = new AdePTConfiguration();
 
@@ -26,6 +25,8 @@ AdePTPhysics::AdePTPhysics(int ver, const G4String &name)
 
   // Range factor: (can be set from the G4 macro)
   // param->SetMscRangeFactor(0.04); // 0.04 is the default set by SetDefaults
+
+  SetPhysicsType(bUnknown);
 }
 
 AdePTPhysics::~AdePTPhysics()
@@ -37,9 +38,6 @@ AdePTPhysics::~AdePTPhysics()
 
 void AdePTPhysics::ConstructProcess()
 {
-
-  G4EmStandardPhysics::ConstructProcess();
-
   // Register custom tracking manager for e-/e+ and gammas.
   fTrackingManager = new AdePTTrackingManager();
   G4Electron::Definition()->SetTrackingManager(fTrackingManager);

--- a/src/HepEMPhysics.cc
+++ b/src/HepEMPhysics.cc
@@ -45,7 +45,7 @@
 #include "G4ionIonisation.hh"
 #include "G4NuclearStopping.hh"
 
-HepEMPhysics::HepEMPhysics(int ver, const G4String &name) : G4EmStandardPhysics(ver, name)
+HepEMPhysics::HepEMPhysics(int ver, const G4String &name) : G4VPhysicsConstructor(name)
 {
   G4EmParameters *param = G4EmParameters::Instance();
   param->SetDefaults();
@@ -59,9 +59,6 @@ HepEMPhysics::~HepEMPhysics() {}
 
 void HepEMPhysics::ConstructProcess()
 {
-
-  G4EmStandardPhysics::ConstructProcess();
-
   // Register custom tracking manager for e-/e+ and gammas.
   auto *trackingManager = new G4HepEmTrackingManager();
   G4Electron::Definition()->SetTrackingManager(trackingManager);


### PR DESCRIPTION
Reverting the base class for AdePTPhysics and HepEMPhysics to G4VPhysicsConstructor. The constructors were transparently constructing G4EmStandardPhysics, G4EMStandard is now registered on the physics list again.