### PR TITLE
Integrate G4VG for use of in-memory conversion of Geant4->VecGeom geometries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ if(Geant4_FOUND)
       g4vg
       GIT_REPOSITORY https://github.com/sethrj/g4vg 
       GIT_TAG 7e9f3224c57b97d665d885f3a6bccb8fee1eaf54)
+    set(BUILD_SHARED_LIBS ON)
     FetchContent_MakeAvailable(g4vg)
   endif()
 endif()
@@ -216,6 +217,7 @@ target_link_libraries(AdePT_G4_integration
     G4HepEm::g4HepEmData
     G4HepEm::g4HepEmInit
     G4HepEm::g4HepEmRun
+    G4VG::g4vg
     CUDA::cudart
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ if(Geant4_FOUND)
   FetchContent_Declare(
     g4vg
     GIT_REPOSITORY https://github.com/celeritas-project/g4vg
-    GIT_TAG d130d8a93de63db6b50e829e4c2da378170253c8)
+    GIT_TAG v1.0.1)
   # G4VG builds static by default, so change this to shared
   # could also configure for PIC mode static.
   set(BUILD_SHARED_LIBS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,20 +141,16 @@ endif()
 
 # Find G4VG, optional as requires Geant4
 if(Geant4_FOUND)
-  find_package(G4VG QUIET)
-  # Note that at present, an external install seems to have issues
-  if(G4VG_FOUND)
-    include(CudaRdcUtils)
-  else()
-    # Fetch it locally
-    include(FetchContent)
-    FetchContent_Declare(
-      g4vg
-      GIT_REPOSITORY https://github.com/sethrj/g4vg 
-      GIT_TAG 7e9f3224c57b97d665d885f3a6bccb8fee1eaf54)
-    set(BUILD_SHARED_LIBS ON)
-    FetchContent_MakeAvailable(g4vg)
-  endif()
+  # Fetch it locally for now
+  include(FetchContent)
+  FetchContent_Declare(
+    g4vg
+    GIT_REPOSITORY https://github.com/sethrj/g4vg
+    GIT_TAG 7e9f3224c57b97d665d885f3a6bccb8fee1eaf54)
+  # G4VG builds static by default, so change this to shared
+  # could also configure for PIC mode static.
+  set(BUILD_SHARED_LIBS ON)
+  FetchContent_MakeAvailable(g4vg)
 endif()
 
 # Set up debugging levels for CUDA:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,8 +145,8 @@ if(Geant4_FOUND)
   include(FetchContent)
   FetchContent_Declare(
     g4vg
-    GIT_REPOSITORY https://github.com/sethrj/g4vg
-    GIT_TAG 7e9f3224c57b97d665d885f3a6bccb8fee1eaf54)
+    GIT_REPOSITORY https://github.com/celeritas-project/g4vg
+    GIT_TAG d130d8a93de63db6b50e829e4c2da378170253c8)
   # G4VG builds static by default, so change this to shared
   # could also configure for PIC mode static.
   set(BUILD_SHARED_LIBS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,23 @@ if(HepMC3_FOUND)
   add_compile_definitions(HEPMC3_FOUND)
 endif()
 
+# Find G4VG, optional as requires Geant4
+if(Geant4_FOUND)
+  find_package(G4VG QUIET)
+  # Note that at present, an external install seems to have issues
+  if(G4VG_FOUND)
+    include(CudaRdcUtils)
+  else()
+    # Fetch it locally
+    include(FetchContent)
+    FetchContent_Declare(
+      g4vg
+      GIT_REPOSITORY https://github.com/sethrj/g4vg 
+      GIT_TAG 7e9f3224c57b97d665d885f3a6bccb8fee1eaf54)
+    FetchContent_MakeAvailable(g4vg)
+  endif()
+endif()
+
 # Set up debugging levels for CUDA:
 # - For RelWithDebInfo (the default), generate line info to enable profiling.
 add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:RelWithDebInfo>>:--generate-line-info>")

--- a/cmake/AdePTConfig.cmake.in
+++ b/cmake/AdePTConfig.cmake.in
@@ -32,5 +32,8 @@ if(G4HepEm_FOUND)
   message(STATUS "G4HepEm Found ${G4HepEm_INCLUDE_DIR}")
 endif()
 
+# We currently build/install G4VG ourselves, so we know exactly where it is
+find_dependency(G4VG NO_DEFAULT_PATH PATHS "${PACKAGE_PREFIX_DIR}")
+
 # Include the targets file
 include("${AdePT_CMAKE_DIR}/AdePTTargets.cmake")

--- a/examples/Example1/CMakeLists.txt
+++ b/examples/Example1/CMakeLists.txt
@@ -68,6 +68,7 @@ target_link_libraries(example1
 SET(GDML ${PROJECT_BINARY_DIR}/cms2018_sd.gdml)
 configure_file("macros/example1.mac.in" "${PROJECT_BINARY_DIR}/example1.mac")
 configure_file("macros/example1_large_stack.mac.in" "${PROJECT_BINARY_DIR}/example1_large_stack.mac")
+configure_file("macros/example1_large_stack_g4vg.mac.in" "${PROJECT_BINARY_DIR}/example1_large_stack_g4vg.mac")
 configure_file("macros/example1_ttbar.mac.in" "${PROJECT_BINARY_DIR}/example1_ttbar.mac")
 configure_file("macros/example1_ttbar_LHCb.mac.in" "${PROJECT_BINARY_DIR}/example1_ttbar_LHCb.mac")
 configure_file("macros/example1_ttbar_noadept.mac.in" "${PROJECT_BINARY_DIR}/example1_ttbar_noadept.mac")
@@ -77,4 +78,8 @@ configure_file("macros/async_mode.mac.in" "${PROJECT_BINARY_DIR}/async_mode.mac"
 
 add_test(NAME example1
   COMMAND $<TARGET_FILE:example1> -m ${PROJECT_BINARY_DIR}/example1_large_stack.mac
+)
+
+add_test(NAME example1-g4vg
+  COMMAND $<TARGET_FILE:example1> -m ${PROJECT_BINARY_DIR}/example1_large_stack_g4vg.mac
 )

--- a/examples/Example1/macros/example1_large_stack_g4vg.mac.in
+++ b/examples/Example1/macros/example1_large_stack_g4vg.mac.in
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2023 CERN
+# SPDX-License-Identifier: Apache-2.0
+#  example23.in
+#
+
+## =============================================================================
+## Geant4 macro for modelling simplified sampling calorimeters
+## =============================================================================
+##
+/run/numberOfThreads 1
+/control/verbose 0
+/run/verbose 0
+/process/verbose 0
+/tracking/verbose 0
+/event/verbose 0
+##
+
+/detector/filename @GDML@
+/adept/setVerbosity 0
+## Threshold for buffering tracks before sending to GPU
+/adept/setTransportBufferThreshold 2000
+## Total number of GPU track slots (not per thread)
+/adept/setMillionsOfTrackSlots 1
+/adept/setMillionsOfHitSlots 1
+/adept/setCUDAStackLimit 8192
+
+# If true, particles are transported on the GPU across the whole geometry, GPU regions are ignored
+/adept/setTrackInAllRegions true
+# In order to do the GPU transport only in specific regions
+/adept/addGPURegion EcalRegion
+/adept/addGPURegion HcalRegion
+
+
+## -----------------------------------------------------------------------------
+## Optionally, set a constant magnetic filed:
+## -----------------------------------------------------------------------------
+/detector/setField 0 0 0 tesla
+#/detector/setField 0 0 3.8 tesla
+
+## -----------------------------------------------------------------------------
+## Set secondary production threshold, init. the run and set primary properties
+## -----------------------------------------------------------------------------
+/run/setCut 0.7 mm
+/run/initialize
+
+## User-defined Event verbosity: 1 = total edep, 2 = energy deposit per placed sensitive volume
+/eventAction/verbose 2
+
+/gun/setDefault
+/gun/particle e-
+/gun/energy 10 GeV
+/gun/number 200
+/gun/position 0 0 0
+/gun/print true
+
+# If false, the following parameters are ignored
+/gun/randomizeGun true
+# Usage: /gun/addParticle type ["weight" weight] ["energy" energy unit]
+/gun/addParticle e- weight 1 energy 10 GeV
+/gun/addParticle proton weight 0 energy 10 GeV
+/gun/minPhi 0 deg
+/gun/maxPhi 360 deg
+/gun/minTheta 10 deg
+/gun/maxTheta 170 deg
+
+## -----------------------------------------------------------------------------
+## Run the simulation with the given number of events and print list of processes
+## -----------------------------------------------------------------------------
+
+
+# run events with parametrised simulation
+# by default all created models are active
+/run/beamOn 1
+

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -36,6 +36,11 @@ public:
   /// however ideally this function will call the G4 to VecGeom geometry converter
   static void CreateVecGeomWorld(/*Temporary parameter*/ std::string filename);
 
+  /// @brief Construct VecGeom geometry from Geant4 physical volume
+  /// @details This calls the G4VG converter
+  /// @throws std::runtime_error if input or output volumes are nullptr
+  static void CreateVecGeomWorld(G4VPhysicalVolume const *physvol);
+
   /// @brief This function compares G4 and VecGeom geometries and reports any differences
   static void CheckGeometry(G4HepEmState *hepEmState);
 

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -22,6 +22,8 @@
 #include <G4HepEmData.hh>
 #include <G4HepEmMatCutData.hh>
 
+#include <G4VG.hh>
+
 #include <new>
 #include <type_traits>
 
@@ -99,6 +101,24 @@ void AdePTGeant4Integration::CreateVecGeomWorld(std::string filename)
   if (vecgeomWorld == nullptr) {
     std::cerr << "GeoManager vecgeomWorld volume is nullptr" << G4endl;
     return;
+  }
+}
+
+void AdePTGeant4Integration::CreateVecGeomWorld(G4VPhysicalVolume const *physvol)
+{
+  // EXPECT: a non-null input volume
+  if (physvol == nullptr) {
+    throw std::runtime_error("AdePTGeant4Integration::CreateVecGeomWorld : Input Geant4 Physical Volume is nullptr");
+  }
+
+  vecgeom::GeoManager::Instance().SetTransformationCacheDepth(0);
+  auto conversion = g4vg::convert(physvol);
+  vecgeom::GeoManager::Instance().SetWorldAndClose(conversion.world);
+
+  // EXPECT: we finish with a non-null VecGeom host geometry
+  vecgeom::VPlacedVolume const *vecgeomWorld = vecgeom::GeoManager::Instance().GetWorld();
+  if (vecgeomWorld == nullptr) {
+    throw std::runtime_error("AdePTGeant4Integration::CreateVecGeomWorld : Output VecGeom Physical Volume is nullptr");
   }
 }
 

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -55,8 +55,14 @@ void AdePTTrackingManager::InitializeAdePT()
     fNumThreads = G4RunManager::GetRunManager()->GetNumberOfThreads();
     fAdePTConfiguration->SetNumThreads(fNumThreads);
 
-    // Load the VecGeom world in memory
-    AdePTGeant4Integration::CreateVecGeomWorld(fAdePTConfiguration->GetVecGeomGDML());
+    // Load the VecGeom world using G4VG if we don't have a GDML file, VGDML otherwise
+    if(fAdePTConfiguration->GetVecGeomGDML().empty()) {
+      auto* tman = G4TransportationManager::GetTransportationManager();
+      auto* world = tman->GetNavigatorForTracking()->GetWorldVolume();
+      AdePTGeant4Integration::CreateVecGeomWorld(world);
+    } else {
+      AdePTGeant4Integration::CreateVecGeomWorld(fAdePTConfiguration->GetVecGeomGDML());
+    }
 
 // Create an instance of an AdePT transport engine. This can either be one engine per thread or a shared engine for
 // all threads.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,16 +52,8 @@ target_link_libraries(test_copcore_link PRIVATE CopCore)
 if(VecGeom_SURF_FOUND)
   message(STATUS "${Magenta}Disabled g4vg when using VecGeom surface model${ColorReset}")
 else()
-  message(STATUS "Fetching and compiling g4vg ...")
-  include(FetchContent)
-  FetchContent_Declare(
-    g4vg
-    EXCLUDE_FROM_ALL
-    URL https://github.com/celeritas-project/g4vg/archive/e034ada099132f857866949ec9ce8eadf1ff2251.zip)
-  FetchContent_MakeAvailable(g4vg)
-
   add_executable(test_g4vg_link test_g4vg_link.cpp)
-  target_link_libraries(test_g4vg_link PRIVATE G4VG::g4vg)
+  cuda_rdc_target_link_libraries(test_g4vg_link PRIVATE G4VG::g4vg)
 endif()
 
 #----------------------------------------------------------------------------#


### PR DESCRIPTION
This supersedes #289 to integrate the now standalone celeritas-project/G4VG library into AdePT for in-memory geometry conversions without an intermediate GDML file. The as-submitted implementation is:

- G4VG is pulled in via CMake's `FetchContent` mechanism to build it as part of AdePT.
- It is linked in to the AdePT integration library
- `AdePTGeant4Integration::CreateVecGeomWorld(G4VPhysicalVolume const *physvol)` is implemented to use G4VG to do the in-memory conversion.
- `AdePTTrackingManager::InitializeAdePT()` is updated to use that function _if_ `AdePTConfiguration::fVecGeomGDML` is empty.
- An extra test of example1 is provided that is identical to the existing test, except for not setting `AdePTConfiguration::fVecGeomGDML`.
  - I've confirmed locally that this results in the in memory conversion being called, but there's no reproducibility check against the GDML-using version.

~~I'm marking as draft as there's a final merge to do upstream in G4VG to get a proper commit to use, however, I wanted to start things off to get some initial CI checks done and for initial comments.~~ That's done, so fully ready for review!