### PR TITLE
Unify common part of RecordHit

### DIFF
--- a/include/AdePT/core/AdePTScoringTemplate.cuh
+++ b/include/AdePT/core/AdePTScoringTemplate.cuh
@@ -18,13 +18,13 @@ void FreeGPU(Scoring *scoring, Scoring *scoring_dev);
 
 template <typename Scoring>
 __device__ void RecordHit(Scoring *scoring_dev, int aParentID, char aParticleType, double aStepLength,
-                          double aTotalEnergyDeposit, vecgeom::NavigationState const *aPreState,
-                          vecgeom::Vector3D<Precision> const *aPrePosition,
-                          vecgeom::Vector3D<Precision> const *aPreMomentumDirection,
-                          vecgeom::Vector3D<Precision> const *aPrePolarization, double aPreEKin, double aPreCharge,
-                          vecgeom::NavigationState const *aPostState, vecgeom::Vector3D<Precision> const *aPostPosition,
-                          vecgeom::Vector3D<Precision> const *aPostMomentumDirection,
-                          vecgeom::Vector3D<Precision> const *aPostPolarization, double aPostEKin, double aPostCharge,
+                          double aTotalEnergyDeposit, vecgeom::NavigationState const &aPreState,
+                          vecgeom::Vector3D<Precision> const &aPrePosition,
+                          vecgeom::Vector3D<Precision> const &aPreMomentumDirection,
+                          double aPreEKin, double aPreCharge,
+                          vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
+                          vecgeom::Vector3D<Precision> const &aPostMomentumDirection,
+                          double aPostEKin, double aPostCharge,
                           unsigned int eventId, short threadId);
 
 template <typename Scoring>

--- a/include/AdePT/core/AdePTScoringTemplate.cuh
+++ b/include/AdePT/core/AdePTScoringTemplate.cuh
@@ -20,12 +20,10 @@ template <typename Scoring>
 __device__ void RecordHit(Scoring *scoring_dev, int aParentID, char aParticleType, double aStepLength,
                           double aTotalEnergyDeposit, vecgeom::NavigationState const &aPreState,
                           vecgeom::Vector3D<Precision> const &aPrePosition,
-                          vecgeom::Vector3D<Precision> const &aPreMomentumDirection,
-                          double aPreEKin, double aPreCharge,
+                          vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin, double aPreCharge,
                           vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
-                          vecgeom::Vector3D<Precision> const &aPostMomentumDirection,
-                          double aPostEKin, double aPostCharge,
-                          unsigned int eventId, short threadId);
+                          vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
+                          double aPostCharge, unsigned int eventId, short threadId);
 
 template <typename Scoring>
 __device__ void AccountProduced(Scoring *scoring_dev, int num_ele, int num_pos, int num_gam);

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -322,9 +322,6 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
 
   if (tracks.empty()) {
     async_adept_impl::FlushScoring(fScoring[threadId]);
-
-    // TODO: Most likely this needs to go to AsyncAdePTTransport in a function that
-    // we will forward-declare here (Otherwise AdePTScoring is undefined)
     fEventStates[threadId].store(EventState::ScoringRetrieved, std::memory_order_release);
   }
 

--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -238,51 +238,23 @@ void PerEventScoring::CopyToHost(cudaStream_t cudaStream)
 
 namespace adept_scoring {
 
-/// @brief Utility function to copy a 3D vector, used for filling the Step Points
-__device__ __forceinline__ void Copy3DVector(vecgeom::Vector3D<Precision> const *source,
-                                             vecgeom::Vector3D<Precision> *destination)
-{
-  destination->x() = source->x();
-  destination->y() = source->y();
-  destination->z() = source->z();
-}
-
 /// @brief Record a hit
 template <>
 __device__ void RecordHit(AsyncAdePT::PerEventScoring * /*scoring*/, int aParentID, char aParticleType,
-                          double aStepLength, double aTotalEnergyDeposit, vecgeom::NavigationState const *aPreState,
-                          vecgeom::Vector3D<Precision> const *aPrePosition,
-                          vecgeom::Vector3D<Precision> const *aPreMomentumDirection,
-                          vecgeom::Vector3D<Precision> const * /*aPrePolarization*/, double aPreEKin, double aPreCharge,
-                          vecgeom::NavigationState const *aPostState, vecgeom::Vector3D<Precision> const *aPostPosition,
-                          vecgeom::Vector3D<Precision> const *aPostMomentumDirection,
-                          vecgeom::Vector3D<Precision> const * /*aPostPolarization*/, double aPostEKin,
+                          double aStepLength, double aTotalEnergyDeposit, vecgeom::NavigationState const &aPreState,
+                          vecgeom::Vector3D<Precision> const &aPrePosition,
+                          vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin, double aPreCharge,
+                          vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
+                          vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
                           double aPostCharge, unsigned int eventID, short threadID)
 {
   // Acquire a hit slot
-  GPUHit &aGPUHit  = AsyncAdePT::gHitScoringBuffer_dev.GetNextSlot();
-  aGPUHit.fEventId = eventID;
-  aGPUHit.threadId = threadID;
+  GPUHit &aGPUHit = AsyncAdePT::gHitScoringBuffer_dev.GetNextSlot();
 
   // Fill the required data
-  aGPUHit.fParentID           = aParentID;
-  aGPUHit.fParticleType       = aParticleType;
-  aGPUHit.fStepLength         = aStepLength;
-  aGPUHit.fTotalEnergyDeposit = aTotalEnergyDeposit;
-  // Pre step point
-  aGPUHit.fPreStepPoint.fNavigationState = *aPreState;
-  Copy3DVector(aPrePosition, &(aGPUHit.fPreStepPoint.fPosition));
-  Copy3DVector(aPreMomentumDirection, &(aGPUHit.fPreStepPoint.fMomentumDirection));
-  // Copy3DVector(aPrePolarization, aGPUHit.fPreStepPoint.fPolarization);
-  aGPUHit.fPreStepPoint.fEKin   = aPreEKin;
-  aGPUHit.fPreStepPoint.fCharge = aPreCharge;
-  // Post step point
-  aGPUHit.fPostStepPoint.fNavigationState = *aPostState;
-  Copy3DVector(aPostPosition, &(aGPUHit.fPostStepPoint.fPosition));
-  Copy3DVector(aPostMomentumDirection, &(aGPUHit.fPostStepPoint.fMomentumDirection));
-  // Copy3DVector(aPostPolarization, aGPUHit.fPostStepPoint.fPolarization);
-  aGPUHit.fPostStepPoint.fEKin   = aPostEKin;
-  aGPUHit.fPostStepPoint.fCharge = aPostCharge;
+  FillHit(aGPUHit, aParentID, aParticleType, aStepLength, aTotalEnergyDeposit, aPreState, aPrePosition,
+          aPreMomentumDirection, aPreEKin, aPreCharge, aPostState, aPostPosition, aPostMomentumDirection, aPostEKin,
+          aPostCharge, eventID, threadID);
 }
 
 /// @brief Account for the number of produced secondaries

--- a/include/AdePT/core/ScoringCommons.hh
+++ b/include/AdePT/core/ScoringCommons.hh
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2024 CERN
 // SPDX-License-Identifier: Apache-2.0
 
+// This file contains elements that can be shared between several scoring implementations
+
 #ifndef SCORING_COMMONS_HH
 #define SCORING_COMMONS_HH
 
@@ -53,6 +55,47 @@ struct GlobalCounters {
     printf("Global scoring: stpChg=%llu stpNeu=%llu hits=%llu numGam=%llu numEle=%llu numPos=%llu numKilled=%llu\n",
            chargedSteps, neutralSteps, hits, numGammas, numElectrons, numPositrons, numKilled);
   }
+};
+
+/// @brief Utility function to copy a 3D vector, used for filling the Step Points
+__device__ __forceinline__ void Copy3DVector(vecgeom::Vector3D<Precision> const &source,
+                                             vecgeom::Vector3D<Precision> &destination)
+{
+  destination.x() = source.x();
+  destination.y() = source.y();
+  destination.z() = source.z();
+};
+
+/// @brief Fill the provided hit with the given data
+__device__ __forceinline__ void FillHit(GPUHit &aGPUHit, int aParentID, char aParticleType, double aStepLength,
+                                        double aTotalEnergyDeposit, vecgeom::NavigationState const &aPreState,
+                                        vecgeom::Vector3D<Precision> const &aPrePosition,
+                                        vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin,
+                                        double aPreCharge, vecgeom::NavigationState const &aPostState,
+                                        vecgeom::Vector3D<Precision> const &aPostPosition,
+                                        vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
+                                        double aPostCharge, unsigned int eventID, short threadID)
+{
+  aGPUHit.fEventId = eventID;
+  aGPUHit.threadId = threadID;
+
+  // Fill the required data
+  aGPUHit.fParentID           = aParentID;
+  aGPUHit.fParticleType       = aParticleType;
+  aGPUHit.fStepLength         = aStepLength;
+  aGPUHit.fTotalEnergyDeposit = aTotalEnergyDeposit;
+  // Pre step point
+  aGPUHit.fPreStepPoint.fNavigationState = aPreState;
+  Copy3DVector(aPrePosition, aGPUHit.fPreStepPoint.fPosition);
+  Copy3DVector(aPreMomentumDirection, aGPUHit.fPreStepPoint.fMomentumDirection);
+  aGPUHit.fPreStepPoint.fEKin   = aPreEKin;
+  aGPUHit.fPreStepPoint.fCharge = aPreCharge;
+  // Post step point
+  aGPUHit.fPostStepPoint.fNavigationState = aPostState;
+  Copy3DVector(aPostPosition, aGPUHit.fPostStepPoint.fPosition);
+  Copy3DVector(aPostMomentumDirection, aGPUHit.fPostStepPoint.fMomentumDirection);
+  aGPUHit.fPostStepPoint.fEKin   = aPostEKin;
+  aGPUHit.fPostStepPoint.fCharge = aPostCharge;
 };
 
 #endif

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -10,7 +10,7 @@
 #define ADEPTGEANT4_INTEGRATION_H
 
 #include <AdePT/core/CommonStruct.h>
-#include <AdePT/core/HostScoringStruct.cuh>
+#include <AdePT/core/ScoringCommons.hh>
 
 #include <G4EventManager.hh>
 #include <G4Event.hh>

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -600,16 +600,14 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
                                static_cast<char>(IsElectron ? 0 : 1),        // Particle type
                                elTrack.GetPStepLength(),                     // Step length
                                energyDeposit,                                // Total Edep
-                               &navState,                                    // Pre-step point navstate
-                               &preStepPos,                                  // Pre-step point position
-                               &preStepDir,                                  // Pre-step point momentum direction
-                               nullptr,                                      // Pre-step point polarization
+                               navState,                                    // Pre-step point navstate
+                               preStepPos,                                  // Pre-step point position
+                               preStepDir,                                  // Pre-step point momentum direction
                                preStepEnergy,                                // Pre-step point kinetic energy
                                IsElectron ? -1 : 1,                          // Pre-step point charge
-                               &nextState,                                   // Post-step point navstate
-                               &pos,                                         // Post-step point position
-                               &dir,                                         // Post-step point momentum direction
-                               nullptr,                                      // Post-step point polarization
+                               nextState,                                   // Post-step point navstate
+                               pos,                                         // Post-step point position
+                               dir,                                         // Post-step point momentum direction
                                eKin,                                         // Post-step point kinetic energy
                                IsElectron ? -1 : 1,                          // Post-step point charge
                                currentTrack.eventId, currentTrack.threadId); // eventID and threadID (not needed here)

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -600,14 +600,14 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
                                static_cast<char>(IsElectron ? 0 : 1),        // Particle type
                                elTrack.GetPStepLength(),                     // Step length
                                energyDeposit,                                // Total Edep
-                               navState,                                    // Pre-step point navstate
-                               preStepPos,                                  // Pre-step point position
-                               preStepDir,                                  // Pre-step point momentum direction
+                               navState,                                     // Pre-step point navstate
+                               preStepPos,                                   // Pre-step point position
+                               preStepDir,                                   // Pre-step point momentum direction
                                preStepEnergy,                                // Pre-step point kinetic energy
                                IsElectron ? -1 : 1,                          // Pre-step point charge
-                               nextState,                                   // Post-step point navstate
-                               pos,                                         // Post-step point position
-                               dir,                                         // Post-step point momentum direction
+                               nextState,                                    // Post-step point navstate
+                               pos,                                          // Post-step point position
+                               dir,                                          // Post-step point momentum direction
                                eKin,                                         // Post-step point kinetic energy
                                IsElectron ? -1 : 1,                          // Post-step point charge
                                currentTrack.eventId, currentTrack.threadId); // eventID and threadID (not needed here)

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -297,14 +297,14 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                    2,                      // Particle type
                                    geometryStepLength,     // Step length
                                    edep,                   // Total Edep
-                                   navState,              // Pre-step point navstate
-                                   preStepPos,            // Pre-step point position
-                                   preStepDir,            // Pre-step point momentum direction
+                                   navState,               // Pre-step point navstate
+                                   preStepPos,             // Pre-step point position
+                                   preStepDir,             // Pre-step point momentum direction
                                    preStepEnergy,          // Pre-step point kinetic energy
                                    0,                      // Pre-step point charge
-                                   nextState,             // Post-step point navstate
-                                   pos,                   // Post-step point position
-                                   dir,                   // Post-step point momentum direction
+                                   nextState,              // Post-step point navstate
+                                   pos,                    // Post-step point position
+                                   dir,                    // Post-step point momentum direction
                                    0,                      // Post-step point kinetic energy
                                    0,                      // Post-step point charge
                                    currentTrack.eventId,   // Event Id
@@ -379,14 +379,14 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                    2,                                            // Particle type
                                    geometryStepLength,                           // Step length
                                    edep,                                         // Total Edep
-                                   navState,                                    // Pre-step point navstate
-                                   preStepPos,                                  // Pre-step point position
-                                   preStepDir,                                  // Pre-step point momentum direction
+                                   navState,                                     // Pre-step point navstate
+                                   preStepPos,                                   // Pre-step point position
+                                   preStepDir,                                   // Pre-step point momentum direction
                                    preStepEnergy,                                // Pre-step point kinetic energy
                                    0,                                            // Pre-step point charge
-                                   nextState,                                   // Post-step point navstate
-                                   pos,                                         // Post-step point position
-                                   dir,                                         // Post-step point momentum direction
+                                   nextState,                                    // Post-step point navstate
+                                   pos,                                          // Post-step point position
+                                   dir,                                          // Post-step point momentum direction
                                    newEnergyGamma,                               // Post-step point kinetic energy
                                    0,                                            // Post-step point charge
                                    currentTrack.eventId, currentTrack.threadId); // event and thread ID
@@ -434,18 +434,18 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                  2,                                            // Particle type
                                  geometryStepLength,                           // Step length
                                  edep,                                         // Total Edep
-                                 navState,                                    // Pre-step point navstate
-                                 preStepPos,                                  // Pre-step point position
-                                 preStepDir,                                  // Pre-step point momentum direction
+                                 navState,                                     // Pre-step point navstate
+                                 preStepPos,                                   // Pre-step point position
+                                 preStepDir,                                   // Pre-step point momentum direction
                                  preStepEnergy,                                // Pre-step point kinetic energy
                                  0,                                            // Pre-step point charge
-                                 nextState,                                   // Post-step point navstate
-                                 pos,                                         // Post-step point position
-                                 dir,                                         // Post-step point momentum direction
+                                 nextState,                                    // Post-step point navstate
+                                 pos,                                          // Post-step point position
+                                 dir,                                          // Post-step point momentum direction
                                  0,                                            // Post-step point kinetic energy
                                  0,                                            // Post-step point charge
                                  currentTrack.eventId, currentTrack.threadId); // event and thread ID
-        // The current track is killed by not enqueuing into the next activeQueue and the slot is released
+      // The current track is killed by not enqueuing into the next activeQueue and the slot is released
 #ifdef ASYNC_MODE
       slotManager.MarkSlotForFreeing(slot);
 #endif

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -297,16 +297,14 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                    2,                      // Particle type
                                    geometryStepLength,     // Step length
                                    edep,                   // Total Edep
-                                   &navState,              // Pre-step point navstate
-                                   &preStepPos,            // Pre-step point position
-                                   &preStepDir,            // Pre-step point momentum direction
-                                   nullptr,                // Pre-step point polarization
+                                   navState,              // Pre-step point navstate
+                                   preStepPos,            // Pre-step point position
+                                   preStepDir,            // Pre-step point momentum direction
                                    preStepEnergy,          // Pre-step point kinetic energy
                                    0,                      // Pre-step point charge
-                                   &nextState,             // Post-step point navstate
-                                   &pos,                   // Post-step point position
-                                   &dir,                   // Post-step point momentum direction
-                                   nullptr,                // Post-step point polarization
+                                   nextState,             // Post-step point navstate
+                                   pos,                   // Post-step point position
+                                   dir,                   // Post-step point momentum direction
                                    0,                      // Post-step point kinetic energy
                                    0,                      // Post-step point charge
                                    currentTrack.eventId,   // Event Id
@@ -381,16 +379,14 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                    2,                                            // Particle type
                                    geometryStepLength,                           // Step length
                                    edep,                                         // Total Edep
-                                   &navState,                                    // Pre-step point navstate
-                                   &preStepPos,                                  // Pre-step point position
-                                   &preStepDir,                                  // Pre-step point momentum direction
-                                   nullptr,                                      // Pre-step point polarization
+                                   navState,                                    // Pre-step point navstate
+                                   preStepPos,                                  // Pre-step point position
+                                   preStepDir,                                  // Pre-step point momentum direction
                                    preStepEnergy,                                // Pre-step point kinetic energy
                                    0,                                            // Pre-step point charge
-                                   &nextState,                                   // Post-step point navstate
-                                   &pos,                                         // Post-step point position
-                                   &dir,                                         // Post-step point momentum direction
-                                   nullptr,                                      // Post-step point polarization
+                                   nextState,                                   // Post-step point navstate
+                                   pos,                                         // Post-step point position
+                                   dir,                                         // Post-step point momentum direction
                                    newEnergyGamma,                               // Post-step point kinetic energy
                                    0,                                            // Post-step point charge
                                    currentTrack.eventId, currentTrack.threadId); // event and thread ID
@@ -438,16 +434,14 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                  2,                                            // Particle type
                                  geometryStepLength,                           // Step length
                                  edep,                                         // Total Edep
-                                 &navState,                                    // Pre-step point navstate
-                                 &preStepPos,                                  // Pre-step point position
-                                 &preStepDir,                                  // Pre-step point momentum direction
-                                 nullptr,                                      // Pre-step point polarization
+                                 navState,                                    // Pre-step point navstate
+                                 preStepPos,                                  // Pre-step point position
+                                 preStepDir,                                  // Pre-step point momentum direction
                                  preStepEnergy,                                // Pre-step point kinetic energy
                                  0,                                            // Pre-step point charge
-                                 &nextState,                                   // Post-step point navstate
-                                 &pos,                                         // Post-step point position
-                                 &dir,                                         // Post-step point momentum direction
-                                 nullptr,                                      // Post-step point polarization
+                                 nextState,                                   // Post-step point navstate
+                                 pos,                                         // Post-step point position
+                                 dir,                                         // Post-step point momentum direction
                                  0,                                            // Post-step point kinetic energy
                                  0,                                            // Post-step point charge
                                  currentTrack.eventId, currentTrack.threadId); // event and thread ID


### PR DESCRIPTION
The sync and async modes differ only on how the GPUHit slot is retrieved, this PR unifies the rest of the code in the `FillHit` call

Also, improve the RecordHit interface by passing references instead of pointers.