### PR TITLE
Using g4vg-style placed volume map when loading geometry from GDML

### DIFF
--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -186,8 +186,6 @@ void AdePTTransport<IntegrationLayer>::Initialize(bool common_data)
     return;
   }
 
-  fIntegrationLayer.InitScoringData();
-
   std::cout << "=== AdePTTransport: initializing transport engine for thread: " << fIntegrationLayer.GetThreadID()
             << std::endl;
 

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -48,8 +48,8 @@ public:
   static void InitVolAuxData(adeptint::VolAuxData *volAuxData, G4HepEmState *hepEmState, bool trackInAllRegions,
                              std::vector<std::string> const *gpuRegionNames);
 
-  /// @brief Initializes the mapping of VecGeom to G4 volumes for sensitive volumes and their parents
-  void InitScoringData();
+  /// @brief Returns a mapping of VecGeom placed volume IDs to Geant4 physical volumes
+  static void GetPhysicalVolumeMap(std::vector<G4VPhysicalVolume const *> &vecgeomToG4Map);
 
   /// @brief Reconstructs GPU hits on host and calls the user-defined sensitive detector code
   void ProcessGPUHit(GPUHit const &hit);
@@ -83,8 +83,7 @@ private:
 
   void ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex, int debugLevel) const;
 
-  std::unordered_map<size_t,
-                     const G4VPhysicalVolume *> fglobal_vecgeom_to_g4_map; ///< Maps Vecgeom PV IDs to G4 PV IDs
+  static std::vector<G4VPhysicalVolume const *> fglobal_vecgeom_to_g4_map;
   std::unique_ptr<AdePTGeant4Integration_detail::ScoringObjects, AdePTGeant4Integration_detail::Deleter>
       fScoringObjects{nullptr};
 };

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -56,9 +56,9 @@ void AdePTTrackingManager::InitializeAdePT()
     fAdePTConfiguration->SetNumThreads(fNumThreads);
 
     // Load the VecGeom world using G4VG if we don't have a GDML file, VGDML otherwise
-    if(fAdePTConfiguration->GetVecGeomGDML().empty()) {
-      auto* tman = G4TransportationManager::GetTransportationManager();
-      auto* world = tman->GetNavigatorForTracking()->GetWorldVolume();
+    if (fAdePTConfiguration->GetVecGeomGDML().empty()) {
+      auto *tman  = G4TransportationManager::GetTransportationManager();
+      auto *world = tman->GetNavigatorForTracking()->GetWorldVolume();
       AdePTGeant4Integration::CreateVecGeomWorld(world);
     } else {
       AdePTGeant4Integration::CreateVecGeomWorld(fAdePTConfiguration->GetVecGeomGDML());


### PR DESCRIPTION
For consistency, we now use a vector for mapping vecgeom PlacedVolume IDs to Geant4 Physical volumes, as provided by g4vg.

For the time being we also generate this mapping on AdePT side rather than using the G4VG-provided map as there are a small number of volumes with different mappings when using either method.