### PR TITLE
Use direct linking to vecgeom's CUDA target to match AdePT

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,7 +53,7 @@ if(VecGeom_SURF_FOUND)
   message(STATUS "${Magenta}Disabled g4vg when using VecGeom surface model${ColorReset}")
 else()
   add_executable(test_g4vg_link test_g4vg_link.cpp)
-  cuda_rdc_target_link_libraries(test_g4vg_link PRIVATE G4VG::g4vg)
+  target_link_libraries(test_g4vg_link PRIVATE G4VG::g4vg VecGeom::vecgeomcuda)
 endif()
 
 #----------------------------------------------------------------------------#


### PR DESCRIPTION
Reported by @SeverinDiederichs, trying to build AdePT with a static VecGeom results in a failure of the `test_g4vg_link` buildtime test. This wasn't spotted in the initial PR because my setup had used a _shared_ build of VecGeom. The underlying cause is likely a corner case in `cuda_rdc_target_link_libraries` not linking in everything from VecGeom in the right order, or failing to do a final device link in the static case. This does not affect linking of AdePT itself with VecGeom and G4VG, where the explicit links to the VecGeom libs are done in the same way as this fix.

Use direct call to target_link_libraries for the G4VG link test, explicitly linking to both G4VG and the Vecgeomcuda targets. This gives a correct link whether VecGeom was built with static or shared libs, and matches what is done elsewhere in AdePT.