### PR TITLE
Storing the origin touchable of each track

### DIFF
--- a/include/AdePT/core/AdePTTransport.cuh
+++ b/include/AdePT/core/AdePTTransport.cuh
@@ -156,6 +156,9 @@ __global__ void InitTracks(adeptint::TrackData *trackinfo, int ntracks, int star
     track.localTime  = trackinfo[i].localTime;
     track.properTime = trackinfo[i].properTime;
 
+    track.originNavState.Clear();
+    track.originNavState = trackinfo[i].originNavState;
+
     // setting up the NavState
     track.navState.Clear();
     track.navState = trackinfo[i].navState;

--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -43,7 +43,7 @@ public:
   /// @brief Adds a track to the buffer
   void AddTrack(int pdg, int parentId, double energy, double x, double y, double z, double dirx, double diry,
                 double dirz, double globalTime, double localTime, double properTime, int threadId, unsigned int eventId,
-                unsigned int trackIndex, vecgeom::NavigationState &&state);
+                unsigned int trackIndex, vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState);
 
   void SetTrackCapacity(size_t capacity) { fCapacity = capacity; }
   /// @brief Get the track capacity on GPU

--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -72,10 +72,11 @@ void AdePTTransport<IntegrationLayer>::AddTrack(int pdg, int parent_id, double e
                                                 double dirx, double diry, double dirz, double globalTime,
                                                 double localTime, double properTime, int /*threadId*/,
                                                 unsigned int eventId, unsigned int /*trackIndex*/,
-                                                vecgeom::NavigationState &&state)
+                                                vecgeom::NavigationState &&state,
+                                                vecgeom::NavigationState &&originState)
 {
   fBuffer.toDevice.emplace_back(pdg, parent_id, energy, x, y, z, dirx, diry, dirz, globalTime, localTime, properTime,
-                                std::move(state));
+                                std::move(state), std::move(originState));
   if (pdg == 11)
     fBuffer.nelectrons++;
   else if (pdg == -11)

--- a/include/AdePT/core/AdePTTransportInterface.hh
+++ b/include/AdePT/core/AdePTTransportInterface.hh
@@ -19,7 +19,8 @@ public:
   /// @brief Adds a track to the buffer
   virtual void AddTrack(int pdg, int parentId, double energy, double x, double y, double z, double dirx, double diry,
                         double dirz, double globalTime, double localTime, double properTime, int threadId,
-                        unsigned int eventId, unsigned int trackIndex, vecgeom::NavigationState &&state) = 0;
+                        unsigned int eventId, unsigned int trackIndex, vecgeom::NavigationState &&state,
+                        vecgeom::NavigationState &&originState) = 0;
 
   /// @brief Set capacity of on-GPU track buffer.
   virtual void SetTrackCapacity(size_t capacity) = 0;

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -105,7 +105,8 @@ __global__ void InjectTracks(AsyncAdePT::TrackDataWithIDs *trackinfo, int ntrack
                                            static_cast<float>(trackInfo.properTime), trackInfo.position,
                                            trackInfo.direction, trackInfo.eventId, trackInfo.parentId, trackInfo.threadId);
     track.navState.Clear();
-    track.navState = trackinfo[i].navState;
+    track.navState       = trackinfo[i].navState;
+    track.originNavState = trackinfo[i].originNavState;
     toBeEnqueued->push_back(QueueIndexPair{slot, queueIndex});
 
     // FIXME KEEP OLD IMPLEMENTATION SINCE THIS HAS NOT BEEN TESTED THOROUGLY, THEN REMOVE
@@ -202,19 +203,21 @@ __global__ void FillFromDeviceBuffer(AllLeaked all, AsyncAdePT::TrackDataWithIDs
       // No space to transfer it out
       leakedTracks->fLeakedQueueNext->push_back(trackSlot);
     } else {
-      fromDevice[i].position[0]  = track->pos[0];
-      fromDevice[i].position[1]  = track->pos[1];
-      fromDevice[i].position[2]  = track->pos[2];
-      fromDevice[i].direction[0] = track->dir[0];
-      fromDevice[i].direction[1] = track->dir[1];
-      fromDevice[i].direction[2] = track->dir[2];
-      fromDevice[i].eKin         = track->eKin;
-      fromDevice[i].globalTime   = track->globalTime;
-      fromDevice[i].localTime    = track->localTime;
-      fromDevice[i].properTime   = track->properTime;
-      fromDevice[i].pdg          = pdg;
-      fromDevice[i].eventId      = track->eventId;
-      fromDevice[i].threadId     = track->threadId;
+      fromDevice[i].position[0]    = track->pos[0];
+      fromDevice[i].position[1]    = track->pos[1];
+      fromDevice[i].position[2]    = track->pos[2];
+      fromDevice[i].direction[0]   = track->dir[0];
+      fromDevice[i].direction[1]   = track->dir[1];
+      fromDevice[i].direction[2]   = track->dir[2];
+      fromDevice[i].eKin           = track->eKin;
+      fromDevice[i].globalTime     = track->globalTime;
+      fromDevice[i].localTime      = track->localTime;
+      fromDevice[i].properTime     = track->properTime;
+      fromDevice[i].pdg            = pdg;
+      fromDevice[i].eventId        = track->eventId;
+      fromDevice[i].threadId       = track->threadId;
+      fromDevice[i].navState       = track->navState;
+      fromDevice[i].originNavState = track->originNavState;
 
       leakedTracks->fSlotManager->MarkSlotForFreeing(trackSlot);
     }

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -73,7 +73,8 @@ public:
   /// @brief Adds a track to the buffer
   void AddTrack(int pdg, int parentId, double energy, double x, double y, double z, double dirx, double diry,
                 double dirz, double globalTime, double localTime, double properTime, int threadId, unsigned int eventId,
-                unsigned int trackIndex, vecgeom::NavigationState &&state) override;
+                unsigned int trackIndex, vecgeom::NavigationState &&state,
+                vecgeom::NavigationState &&originState) override;
   /// @brief Set track capacity on GPU
   void SetTrackCapacity(size_t capacity) override { fTrackCapacity = capacity; }
   /// @brief Set Hit buffer capacity on GPU and Host

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -105,7 +105,8 @@ void AsyncAdePTTransport<IntegrationLayer>::AddTrack(int pdg, int parentId, doub
                                                      double dirx, double diry, double dirz, double globalTime,
                                                      double localTime, double properTime, int threadId,
                                                      unsigned int eventId, unsigned int trackId,
-                                                     vecgeom::NavigationState &&state)
+                                                     vecgeom::NavigationState &&state,
+                                                     vecgeom::NavigationState &&originState)
 {
   if (pdg != 11 && pdg != -11 && pdg != 22) {
     G4cerr << __FILE__ << ":" << __LINE__ << ": Only supporting EM tracks. Got pdgID=" << pdg << "\n";
@@ -125,6 +126,7 @@ void AsyncAdePTTransport<IntegrationLayer>::AddTrack(int pdg, int parentId, doub
                          localTime,
                          properTime,
                          std::move(state),
+                         std::move(originState),
                          eventId,
                          trackId,
                          static_cast<short>(threadId)};

--- a/include/AdePT/core/CommonStruct.h
+++ b/include/AdePT/core/CommonStruct.h
@@ -106,8 +106,22 @@ struct TrackDataWithIDs : public adeptint::TrackData {
 
   TrackDataWithIDs(int pdg_id, int parentId, double ene, double x, double y, double z, double dirx, double diry,
                    double dirz, double gTime, double lTime, double pTime, vecgeom::NavigationState &&state,
-                   unsigned int eventId = 0, unsigned int trackId = 0, short threadId = -1)
-      : TrackData{pdg_id, parentId, ene, x, y, z, dirx, diry, dirz, gTime, lTime, pTime, std::move(state)},
+                   vecgeom::NavigationState &&originState, unsigned int eventId = 0, unsigned int trackId = 0,
+                   short threadId = -1)
+      : TrackData{pdg_id,
+                  parentId,
+                  ene,
+                  x,
+                  y,
+                  z,
+                  dirx,
+                  diry,
+                  dirz,
+                  gTime,
+                  lTime,
+                  pTime,
+                  std::move(state),
+                  std::move(originState)},
         eventId{eventId}, trackId{trackId}, threadId{threadId}
   {
   }

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -31,11 +31,12 @@ struct Track {
   float localTime{0.f};
   float properTime{0.f};
 
-  vecgeom::Vector3D<Precision> pos;   ///< track position
-  vecgeom::Vector3D<Precision> dir;   ///< track direction
-  vecgeom::Vector3D<float> safetyPos; ///< last position where the safety was computed
-  float safety{0.f};                  ///< last computed safety value
-  vecgeom::NavigationState navState;  ///< current navigation state
+  vecgeom::Vector3D<Precision> pos;        ///< track position
+  vecgeom::Vector3D<Precision> dir;        ///< track direction
+  vecgeom::Vector3D<float> safetyPos;      ///< last position where the safety was computed
+  float safety{0.f};                       ///< last computed safety value
+  vecgeom::NavigationState navState;       ///< current navigation state
+  vecgeom::NavigationState originNavState; ///< current navigation state
 
 #ifdef USE_SPLIT_KERNELS
   // Variables used to store track info needed for scoring
@@ -85,8 +86,8 @@ struct Track {
                    const vecgeom::Vector3D<Precision> &newDirection, const vecgeom::NavigationState &newNavState,
                    const Track &parentTrack)
       : rngState{rngState}, eKin{eKin}, globalTime{parentTrack.globalTime}, pos{parentPos}, dir{newDirection},
-        navState{newNavState}, eventId{parentTrack.eventId}, parentId{parentTrack.parentId},
-        threadId{parentTrack.threadId}
+        navState{newNavState}, originNavState{newNavState}, eventId{parentTrack.eventId},
+        parentId{parentTrack.parentId}, threadId{parentTrack.threadId}
   {
   }
 
@@ -135,6 +136,9 @@ struct Track {
     this->safety   = 0.0f;
     this->navState = parentNavState;
 
+    // Set the origin for this track
+    this->originNavState = parentNavState;
+
     // The global time is inherited from the parent
     this->globalTime = gTime;
     this->localTime  = 0.;
@@ -143,19 +147,20 @@ struct Track {
 
   __host__ __device__ void CopyTo(adeptint::TrackData &tdata, int pdg)
   {
-    tdata.pdg          = pdg;
-    tdata.parentId     = parentId;
-    tdata.position[0]  = pos[0];
-    tdata.position[1]  = pos[1];
-    tdata.position[2]  = pos[2];
-    tdata.direction[0] = dir[0];
-    tdata.direction[1] = dir[1];
-    tdata.direction[2] = dir[2];
-    tdata.eKin         = eKin;
-    tdata.globalTime   = globalTime;
-    tdata.localTime    = localTime;
-    tdata.properTime   = properTime;
-    // FIXME missing navState here
+    tdata.pdg            = pdg;
+    tdata.parentId       = parentId;
+    tdata.position[0]    = pos[0];
+    tdata.position[1]    = pos[1];
+    tdata.position[2]    = pos[2];
+    tdata.direction[0]   = dir[0];
+    tdata.direction[1]   = dir[1];
+    tdata.direction[2]   = dir[2];
+    tdata.eKin           = eKin;
+    tdata.globalTime     = globalTime;
+    tdata.localTime      = localTime;
+    tdata.properTime     = properTime;
+    tdata.navState       = navState;
+    tdata.originNavState = originNavState;
   }
 };
 #endif

--- a/include/AdePT/core/TrackData.h
+++ b/include/AdePT/core/TrackData.h
@@ -15,6 +15,7 @@ namespace adeptint {
 /// the destination, and used to reconstruct the track
 struct TrackData {
   vecgeom::NavigationState navState;
+  vecgeom::NavigationState originNavState;
   double position[3];
   double direction[3];
   double eKin{0};
@@ -26,9 +27,11 @@ struct TrackData {
 
   TrackData() = default;
   TrackData(int pdg_id, int parentId, double ene, double x, double y, double z, double dirx, double diry, double dirz,
-            double gTime, double lTime, double pTime, vecgeom::NavigationState &&state)
-      : navState{std::move(state)}, position{x, y, z}, direction{dirx, diry, dirz}, eKin{ene}, globalTime{gTime},
-        localTime{lTime}, properTime{pTime}, pdg{pdg_id}, parentId{parentId}
+            double gTime, double lTime, double pTime, vecgeom::NavigationState &&state,
+            vecgeom::NavigationState &&originState)
+      : navState{std::move(state)}, originNavState{std::move(originState)}, position{x, y, z},
+        direction{dirx, diry, dirz}, eKin{ene}, globalTime{gTime}, localTime{lTime}, properTime{pTime}, pdg{pdg_id},
+        parentId{parentId}
   {
   }
 

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -76,7 +76,7 @@ public:
 
 private:
   /// @brief Reconstruct G4TouchableHistory from a VecGeom Navigation index
-  void FillG4NavigationHistory(vecgeom::NavigationState aNavState, G4NavigationHistory *aG4NavigationHistory) const;
+  void FillG4NavigationHistory(vecgeom::NavigationState aNavState, G4NavigationHistory &aG4NavigationHistory) const;
 
   void FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step, G4TouchableHandle &aPreG4TouchableHandle,
                   G4TouchableHandle &aPostG4TouchableHandle) const;

--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -55,10 +55,17 @@ private:
   /// @brief Steps a track using the Generic G4TrackingManager until it enters a GPU region or stops
   void StepInHostRegion(G4Track *aTrack);
 
-  /// @brief Get the corresponding VecGeom NavigationState from the G4NavigationHistory
+  /// @brief Get the corresponding VecGeom NavigationState from the G4NavigationHistory. The boundary status will be set
+  /// to false by default
   /// @param aG4NavigationHistory the given G4NavigationHistory
   /// @return the corresponding vecgeom::NavigationState
-  const vecgeom::NavigationState GetVecGeomFromG4State(const G4Track *aG4Track);
+  const vecgeom::NavigationState GetVecGeomFromG4State(const G4NavigationHistory &aG4NavigationHistory);
+
+  /// @brief Get the corresponding VecGeom NavigationState from the track's G4NavigationHistory, and set the boundary
+  /// status based on the track's state
+  /// @param aG4Track The G4Track from which to extract the NavigationState
+  /// @return The corresponding vecgeom::NavigationState
+  const vecgeom::NavigationState GetVecGeomFromG4State(const G4Track &aG4Track);
 
   std::unique_ptr<G4HepEmTrackingManagerSpecialized> fHepEmTrackingManager;
   static inline int fNumThreads{0};

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -114,6 +114,9 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       currentTrack.properTime = properTime;
       currentTrack.navState   = navState;
 #ifdef ASYNC_MODE
+      // NOTE: When adapting the split kernels for async mode this won't
+      // work if we want to re-use slots on the fly. Directly copying to
+      // a trackdata struct would be better
       if (leak)
         leakedQueue->push_back(slot);
       else


### PR DESCRIPTION
This is part of the modifications required to run AdePT in ATLAS Athena. With this PR we keep track of the origin touchable of each track, as implemented [here](https://github.com/mnovak42/g4hepem/pull/108/commits/80340477d82b82fda678edf67c7081e5c7ba88f3) for the `G4HepEmTrackingManager`.

The main modifications needed for this are:
- Adding a new `NavigationState` field to AdePT tracks to store the origin touchable
- Convert the track's origin touchable to a VecGeom `NavigationState` when it goes into a GPU region
  -  When a primary track starts directly in a GPU region it's origin touchable is not set, so we take the track's current position
- The origin is set for particles generated during GPU transport
- When particles leak back to G4, reconstruct the origin touchable and add it to the track

It seems that in the case of Athena this information is needed for the russian roulette. In the future we may also reconstruct and set the touchable to the steps sent to scoring, but as this may affect performance it should only be done if this information is actually needed by the scoring code.

The result of a few short test runs doesn't show an impact on performance from this addition alone. The tests were done with GPU transport only in ECAL and HCAL, since the runs where we have leaks back to G4 are the most affected:

`CMS2018, 32 TTbar, 8 Threads, Transport on ECAL+HCAL`

|        | Sync    | Async   |
|--------|---------|---------|
| Master | 293.599 | 279.3   |
| New    | 293.869 | 278.292 |