### PR TITLE
Provide option to select between G4VG via FetchContent or find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,9 @@ endif()
 # Find G4VG, optional as requires Geant4
 if(Geant4_FOUND)
   find_package(G4VG 1.0.1 QUIET)
-  if(NOT G4VG_FOUND)
+  if(G4VG_FOUND)
+    message(STATUS "G4VG found ${G4VG_DIR}")
+  else()
     # Fetch it locally
     include(FetchContent)
     FetchContent_Declare(
@@ -153,6 +155,7 @@ if(Geant4_FOUND)
     # could also configure for PIC mode static.
     set(BUILD_SHARED_LIBS ON)
     FetchContent_MakeAvailable(g4vg)
+    message(STATUS "Fetched G4VG locally")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,16 +141,19 @@ endif()
 
 # Find G4VG, optional as requires Geant4
 if(Geant4_FOUND)
-  # Fetch it locally for now
-  include(FetchContent)
-  FetchContent_Declare(
-    g4vg
-    GIT_REPOSITORY https://github.com/celeritas-project/g4vg
-    GIT_TAG v1.0.1)
-  # G4VG builds static by default, so change this to shared
-  # could also configure for PIC mode static.
-  set(BUILD_SHARED_LIBS ON)
-  FetchContent_MakeAvailable(g4vg)
+  find_package(G4VG 1.0.1 QUIET)
+  if(NOT G4VG_FOUND)
+    # Fetch it locally
+    include(FetchContent)
+    FetchContent_Declare(
+      g4vg
+      GIT_REPOSITORY https://github.com/celeritas-project/g4vg
+      GIT_TAG v1.0.1)
+    # G4VG builds static by default, so change this to shared
+    # could also configure for PIC mode static.
+    set(BUILD_SHARED_LIBS ON)
+    FetchContent_MakeAvailable(g4vg)
+  endif()
 endif()
 
 # Set up debugging levels for CUDA:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,21 +141,32 @@ endif()
 
 # Find G4VG, optional as requires Geant4
 if(Geant4_FOUND)
-  find_package(G4VG 1.0.1 QUIET)
-  if(G4VG_FOUND)
-    message(STATUS "G4VG found ${G4VG_DIR}")
-  else()
+  # Default to use FetchContent'd G4VG for current ease of use and until CI
+  # includes an install. Also allows easy testing of upstream patches until
+  # fully stable across projects.
+  # NB: Though the option can be switched in a given build directory after the initial
+  # build, if you have an install of G4VG that could/would be picked up, you may get
+  # CMake-generate time warnings about safe runtime paths. Generally, you should
+  # pick one way to pickup G4VG and stick with that throughout the lifetime of
+  # the build directory.
+  # The eventual fix for this will be to move to require an external G4VG only
+  option(ADEPT_USE_BUILTIN_G4VG "Fetch and build G4VG as part of AdePT" ON)
+  if(ADEPT_USE_BUILTIN_G4VG)
     # Fetch it locally
     include(FetchContent)
     FetchContent_Declare(
       g4vg
       GIT_REPOSITORY https://github.com/celeritas-project/g4vg
       GIT_TAG v1.0.1)
-    # G4VG builds static by default, so change this to shared
+    # G4VG builds static by default, so change this to shared to match current
+    # way AdePT is built.
     # could also configure for PIC mode static.
     set(BUILD_SHARED_LIBS ON)
     FetchContent_MakeAvailable(g4vg)
-    message(STATUS "Fetched G4VG locally")
+    message(STATUS "Using FetchContent to build G4VG as part of AdePT")
+  else()
+    find_package(G4VG 1.0.1 REQUIRED)
+    message(STATUS "Found G4VG: ${G4VG_DIR}")
   endif()
 endif()
 

--- a/cmake/AdePTConfig.cmake.in
+++ b/cmake/AdePTConfig.cmake.in
@@ -32,8 +32,7 @@ if(G4HepEm_FOUND)
   message(STATUS "G4HepEm Found ${G4HepEm_INCLUDE_DIR}")
 endif()
 
-# We currently build/install G4VG ourselves, so we know exactly where it is
-find_dependency(G4VG NO_DEFAULT_PATH PATHS "${PACKAGE_PREFIX_DIR}")
+find_dependency(G4VG 1.0.1 REQUIRED)
 
 # Include the targets file
 include("${AdePT_CMAKE_DIR}/AdePTTargets.cmake")


### PR DESCRIPTION
A small ease of use/integration enhancement to use an external install of G4VG by default, falling back to use of `FetchContent` otherwise.

This should allow easier integration in ATLAS/Athena as well as common integration with Celeritas so the same G4VG install is used without symbol clashes.