### PR TITLE
Using G4VG's PlacedVolume map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ if(Geant4_FOUND)
     FetchContent_Declare(
       g4vg
       GIT_REPOSITORY https://github.com/celeritas-project/g4vg
-      GIT_TAG v1.0.1)
+      GIT_TAG 638c273b744c7ac0fa865ddb15c161b853a4029b)
     # G4VG builds static by default, so change this to shared to match current
     # way AdePT is built.
     # could also configure for PIC mode static.

--- a/examples/IntegrationBenchmark/ci_tests/example_template.mac
+++ b/examples/IntegrationBenchmark/ci_tests/example_template.mac
@@ -15,8 +15,6 @@
 /event/verbose 0
 
 /detector/filename $gdml_name
-# Temporary workaround since we don't have a G4 to VecGeom converter
-/adept/setVecGeomGDML $gdml_name
 /adept/setVerbosity 0
 ## Threshold for buffering tracks before sending to GPU
 /adept/setTransportBufferThreshold 250000

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -149,16 +149,13 @@ void AdePTGeant4Integration::CreateVecGeomWorld(G4VPhysicalVolume const *physvol
   }
 
   vecgeom::GeoManager::Instance().SetTransformationCacheDepth(0);
-  auto conversion = g4vg::convert(physvol);
+  g4vg::Options options;
+  options.reflection_factory = false;
+  auto conversion            = g4vg::convert(physvol, options);
   vecgeom::GeoManager::Instance().SetWorldAndClose(conversion.world);
 
   // Get the mapping of VecGeom volume IDs to Geant4 physical volumes from g4vg
-  // fglobal_vecgeom_to_g4_map = conversion.physical_volumes;
-
-  // TODO: We generate the volume map using a visitor since the one provided by the converter
-  // appears to have a small number of wrongly mapped IDs
-  // Generate the mapping of VecGeom volume IDs to Geant4 physical volumes
-  GetPhysicalVolumeMap(fglobal_vecgeom_to_g4_map);
+  fglobal_vecgeom_to_g4_map = conversion.physical_volumes;
 
   // EXPECT: we finish with a non-null VecGeom host geometry
   vecgeom::VPlacedVolume const *vecgeomWorld = vecgeom::GeoManager::Instance().GetWorld();


### PR DESCRIPTION
Enables the new G4VG option to avoid using VecGeom's reflection factory (https://github.com/celeritas-project/g4vg/pull/22), which solves the wrong mapping of the daughters of reflected volumes in G4VG's PlacedVolume ID to G4 physical volume map.

Note that since we don't build the map on AdePT side anymore this change is incompatible with any previous G4VG commits.