### PR TITLE
Improve handling of retrieved steps from the GPU in async mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,12 +42,6 @@ set(CMAKE_CUDA_STANDARD_REQUIRED ${CMAKE_CXX_STANDARD_REQUIRED})
 set(CMAKE_CUDA_EXTENSIONS OFF)
 set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
 
-# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer -g")
-# set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
-
-# Disable ASAN for CUDA
-# set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=-fno-sanitize=address")
-
 #----------------------------------------------------------------------------#
 # User options
 #----------------------------------------------------------------------------#

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ set(CMAKE_CUDA_STANDARD_REQUIRED ${CMAKE_CXX_STANDARD_REQUIRED})
 set(CMAKE_CUDA_EXTENSIONS OFF)
 set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread -fno-omit-frame-pointer -g")
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread -fno-omit-frame-pointer -g")
 # set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
 
 # Disable ASAN for CUDA

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,12 @@ set(CMAKE_CUDA_STANDARD_REQUIRED ${CMAKE_CXX_STANDARD_REQUIRED})
 set(CMAKE_CUDA_EXTENSIONS OFF)
 set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread -fno-omit-frame-pointer -g")
+# set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
+
+# Disable ASAN for CUDA
+# set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=-fno-sanitize=address")
+
 #----------------------------------------------------------------------------#
 # User options
 #----------------------------------------------------------------------------#

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ set(CMAKE_CUDA_STANDARD_REQUIRED ${CMAKE_CXX_STANDARD_REQUIRED})
 set(CMAKE_CUDA_EXTENSIONS OFF)
 set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
 
-# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread -fno-omit-frame-pointer -g")
+# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer -g")
 # set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
 
 # Disable ASAN for CUDA

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,9 +136,9 @@ def buildAndTest() {
     env | sort | sed 's/:/:?     /g' | tr '?' '\n'
     export CMAKE_BINARY_DIR=BUILD_ASYNC_ON
     export ExtraCMakeOptions="-DASYNC_MODE=ON"
-    ctest -V --output-on-failure -S AdePT/jenkins/adept-ctest.cmake,$MODEL
+    ctest -V --output-on-failure --timeout 2400 -S AdePT/jenkins/adept-ctest.cmake,$MODEL
     export CMAKE_BINARY_DIR=BUILD_ASYNC_OFF
     export ExtraCMakeOptions="-DASYNC_MODE=OFF"
-    ctest -V --output-on-failure -S AdePT/jenkins/adept-ctest.cmake,$MODEL
+    ctest -V --output-on-failure --timeout 2400 -S AdePT/jenkins/adept-ctest.cmake,$MODEL
   """
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,6 +134,11 @@ def buildAndTest() {
     set -x
     export CUDA_CAPABILITY=${CUDA_CAPABILITY}
     env | sort | sed 's/:/:?     /g' | tr '?' '\n'
+    export CMAKE_BINARY_DIR=BUILD_ASYNC_ON
+    export ExtraCMakeOptions="-DASYNC_MODE=ON"
+    ctest -V --output-on-failure -S AdePT/jenkins/adept-ctest.cmake,$MODEL
+    export CMAKE_BINARY_DIR=BUILD_ASYNC_OFF
+    export ExtraCMakeOptions="-DASYNC_MODE=OFF"
     ctest -V --output-on-failure -S AdePT/jenkins/adept-ctest.cmake,$MODEL
   """
 }

--- a/examples/IntegrationBenchmark/ci_tests/example_template.mac
+++ b/examples/IntegrationBenchmark/ci_tests/example_template.mac
@@ -46,7 +46,7 @@ $hepmc_part
 
 /gun/particle e-
 /gun/energy 10 GeV
-/gun/number 500
+/gun/number 100
 /gun/position -220 0 0 mm
 /gun/direction 1 0 0
 /gun/print true

--- a/examples/IntegrationBenchmark/ci_tests/reproducibility.sh
+++ b/examples/IntegrationBenchmark/ci_tests/reproducibility.sh
@@ -47,7 +47,7 @@ $CI_TEST_DIR/python_scripts/macro_generator.py \
 $ADEPT_EXECUTABLE --do_validation --accumulated_events -m ${CI_TEST_DIR}/reproducibility.mac --output_dir ${CI_TEST_DIR} --output_file cms_ttbar_run1
 $ADEPT_EXECUTABLE --do_validation --accumulated_events -m ${CI_TEST_DIR}/reproducibility.mac --output_dir ${CI_TEST_DIR} --output_file cms_ttbar_run2 
 
-# allow for small rounding error of 1e-7 due to summation per thread
+# allow for small rounding error of 1e-6 due to summation per thread
 $CI_TEST_DIR/python_scripts/check_reproducibility.py --file1 ${CI_TEST_DIR}/cms_ttbar_run1.csv \
                                                      --file2 ${CI_TEST_DIR}/cms_ttbar_run2.csv \
-                                                     --tol 1e-7
+                                                     --tol 1e-5

--- a/examples/IntegrationBenchmark/ci_tests/validation_testem3.sh
+++ b/examples/IntegrationBenchmark/ci_tests/validation_testem3.sh
@@ -35,9 +35,9 @@ $CI_TEST_DIR/python_scripts/macro_generator.py \
     --output ${CI_TEST_DIR}/validation_testem3.mac \
     --gdml_name ${PROJECT_SOURCE_DIR}/examples/data/testEm3.gdml \
     --num_threads 4 \
-    --num_events 200 \
-    --num_trackslots 10 \
-    --num_hitslots 6 \
+    --num_events 1000 \
+    --num_trackslots 3 \
+    --num_hitslots 20 \
     --gun_type setDefault 
 
 

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -1110,9 +1110,9 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
 
 
 std::pair<GPUHit*, GPUHit*> GetGPUHitsFromBuffer(unsigned int threadId, unsigned int eventId, GPUstate &gpuState) {
-  HitInfo* hitinfo = gpuState.fHitScoring->GetNextHitsHandle(threadId);
-  if (hitinfo) {
-    return {hitinfo->begin, hitinfo->end};
+  HitQueueItem* hitItem = gpuState.fHitScoring->GetNextHitsHandle(threadId);
+  if (hitItem) {
+    return {hitItem->begin, hitItem->end};
   } else {
     return {nullptr, nullptr};
   }

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -1110,9 +1110,13 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
 
 
 std::pair<GPUHit*, GPUHit*> GetGPUHitsFromBuffer(unsigned int threadId, unsigned int eventId, GPUstate &gpuState) {
-  auto hitinfo = gpuState.fHitScoring->GetNextHitsHandle(threadId);
+  HitInfo* hitinfo = gpuState.fHitScoring->GetNextHitsHandle(threadId);
+  if (hitinfo) {
+    return {hitinfo->begin, hitinfo->end};
+  } else {
+    return {nullptr, nullptr};
+  }
 
-  return {hitinfo.begin, hitinfo.end};
   // if (!buffer) {
   //   return {nullptr, nullptr};
   // }

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -591,6 +591,7 @@ void HitProcessingLoop(HitProcessingContext *const context, GPUstate &gpuState,
     // Possible timing
     // auto start = std::chrono::high_resolution_clock::now();
     gpuState.fHitScoring->TransferHitsToHost(context->hitTransferStream);
+    cvG4Workers.notify_all(); // FIXME EXPERIMENTAL TO WAKE THEM UP BEFORE
     const bool haveNewHits = gpuState.fHitScoring->ProcessHits();
 
     // auto end = std::chrono::high_resolution_clock::now();

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -590,16 +590,16 @@ void HitProcessingLoop(HitProcessingContext *const context, GPUstate &gpuState,
 
     // FIXME: clean this after all works
     // Possible timing
-    // auto start = std::chrono::high_resolution_clock::now();
+    auto start = std::chrono::high_resolution_clock::now();
     gpuState.fHitScoring->TransferHitsToHost(context->hitTransferStream);
     const bool haveNewHits = gpuState.fHitScoring->ProcessHits(cvG4Workers); // FIXME pass cvG4Workers.notify_all(); down
 
-    // auto end = std::chrono::high_resolution_clock::now();
-    // std::chrono::duration<double> elapsed = end - start;
+    auto end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> elapsed = end - start;
 
-    // if (haveNewHits) {
-    //     std::cout << "HIT Processing time: " << elapsed.count() << " seconds" << std::endl;
-    // }
+    if (haveNewHits) {
+        std::cout << "HIT Processing time: " << elapsed.count() << " seconds" << std::endl;
+    }
 
     if (haveNewHits) {
       AdvanceEventStates(EventState::FlushingHits, EventState::HitsFlushed, eventStates);
@@ -978,8 +978,8 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
           // if (gpuState.stats->hitBufferOccupancy >= gpuState.fHitScoring->HitCapacity() / 2 ||
           //     gpuState.stats->hitBufferOccupancy >= 10000 ||
 
-          std::cout << " READY TO SWAP BEFORE SWAP??? " << gpuState.fHitScoring->ReadyToSwapBuffers() << " States " << std::endl;
-          gpuState.fHitScoring->PrintBufferStates();
+          // std::cout << " READY TO SWAP BEFORE SWAP??? " << gpuState.fHitScoring->ReadyToSwapBuffers() << " States " << std::endl;
+          // gpuState.fHitScoring->PrintBufferStates();
           if (gpuState.stats->hitBufferOccupancy >= gpuState.fHitScoring->HitCapacity() / 2 ||
               gpuState.stats->hitBufferOccupancy >= 10000 ||
               std::any_of(eventStates.begin(), eventStates.end(), [](const auto &state) {
@@ -1098,10 +1098,10 @@ std::pair<GPUHit*, GPUHit*> GetGPUHitsFromBuffer(unsigned int threadId, unsigned
   // return {range.first, range.second};
 
   // VERSION B FOR UNSORTED GPU HITS just return full buffer
-  std::cout << " Returning GPUhits : threadId " << threadId << " buffer->hitScoringInfo.fNSlot " << 
-  buffer->hitScoringInfo.fNSlot << " buffer->hostBufferCount[threadId] " << buffer->hostBufferCount[threadId] <<
-  " from " << buffer->hostBuffer + threadId * buffer->hitScoringInfo.fNSlot <<
-               " to " << buffer->hostBuffer + threadId * buffer->hitScoringInfo.fNSlot + buffer->hostBufferCount[threadId] << std::endl;
+  // std::cout << " Returning GPUhits : threadId " << threadId << " buffer->hitScoringInfo.fNSlot " << 
+  // buffer->hitScoringInfo.fNSlot << " buffer->hostBufferCount[threadId] " << buffer->hostBufferCount[threadId] <<
+  // " from " << buffer->hostBuffer + threadId * buffer->hitScoringInfo.fNSlot <<
+  //              " to " << buffer->hostBuffer + threadId * buffer->hitScoringInfo.fNSlot + buffer->hostBufferCount[threadId] << std::endl;
   return {buffer->hostBuffer + threadId * buffer->hitScoringInfo.fNSlot, 
           buffer->hostBuffer + threadId * buffer->hitScoringInfo.fNSlot + buffer->hostBufferCount[threadId]};
 }

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -1119,11 +1119,11 @@ std::pair<GPUHit*, GPUHit*> GetGPUHitsFromBuffer(unsigned int threadId, unsigned
     offset += buffer->hostBufferCount[i];
   }
 
-#define RED "\033[31m"
-#define RESET "\033[0m"
-#define BOLD_RED "\033[1;31m"
+// #define RED "\033[31m"
+// #define RESET "\033[0m"
+// #define BOLD_RED "\033[1;31m"
 
-  std::cout << BOLD_RED << "threadId " << threadId << " EventId " << eventId << " offset " << offset << " num hits to score " << buffer->hostBufferCount[threadId] << RESET << std::endl;
+//   std::cout << BOLD_RED << "threadId " << threadId << " EventId " << eventId << " offset " << offset << " num hits to score " << buffer->hostBufferCount[threadId] << RESET << std::endl;
 
   return {buffer->hostBuffer + offset, 
           buffer->hostBuffer + offset + buffer->hostBufferCount[threadId]};

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -1090,13 +1090,32 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
 //   return gpuState.fHitScoring->GetNextHitsVector(threadId);
 // }
 
+// #include <iostream>
+// #include <mutex>
+
+// std::mutex coutMutex;  // Global mutex to synchronize std::cout
+
+// void PrintThreadSafe(int threadId, int eventId, int offset, int numHits) {
+//     std::lock_guard<std::mutex> lock(coutMutex);  // Lock the mutex for this scope
+// #define RED "\033[31m"
+// #define RESET "\033[0m"
+// #define BOLD_RED "\033[1;31m"
+
+//     std::cout << BOLD_RED << "threadId " << threadId 
+//               << " EventId " << eventId 
+//               << " offset " << offset 
+//               << " num hits to score " << numHits 
+//               << RESET << std::endl;
+// }
+
 
 std::pair<GPUHit*, GPUHit*> GetGPUHitsFromBuffer(unsigned int threadId, unsigned int eventId, GPUstate &gpuState) {
-  auto buffer = gpuState.fHitScoring->GetNextHitsHandle(threadId);
+  auto hitinfo = gpuState.fHitScoring->GetNextHitsHandle(threadId);
 
-  if (!buffer) {
-    return {nullptr, nullptr};
-  }
+  return {hitinfo.begin, hitinfo.end};
+  // if (!buffer) {
+  //   return {nullptr, nullptr};
+  // }
     
   // VERSION A for SORTED GPU HITS
   // GPUHit dummy;
@@ -1114,19 +1133,20 @@ std::pair<GPUHit*, GPUHit*> GetGPUHitsFromBuffer(unsigned int threadId, unsigned
   // " from " << buffer->hostBuffer + threadId * buffer->hitScoringInfo.fNSlot <<
   //              " to " << buffer->hostBuffer + threadId * buffer->hitScoringInfo.fNSlot + buffer->hostBufferCount[threadId] << std::endl;
 
-  unsigned int offset = 0;
-  for (int i = 0; i < threadId; i++) {
-    offset += buffer->hostBufferCount[i];
-  }
+  // unsigned int offset = 0;
+  // for (int i = 0; i < threadId; i++) {
+  //   offset += buffer->hostBufferCount[i];
+  // }
 
 // #define RED "\033[31m"
 // #define RESET "\033[0m"
 // #define BOLD_RED "\033[1;31m"
 
 //   std::cout << BOLD_RED << "threadId " << threadId << " EventId " << eventId << " offset " << offset << " num hits to score " << buffer->hostBufferCount[threadId] << RESET << std::endl;
+// PrintThreadSafe(threadId, eventId, offset, buffer->hostBufferCount[threadId] );
 
-  return {buffer->hostBuffer + offset, 
-          buffer->hostBuffer + offset + buffer->hostBufferCount[threadId]};
+//   return {buffer->hostBuffer + offset, 
+//           buffer->hostBuffer + offset + buffer->hostBufferCount[threadId]};
 }
 
 void CloseGPUBuffer(unsigned int threadId, GPUstate &gpuState)

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -1109,8 +1109,8 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
 // }
 
 
-std::pair<GPUHit*, GPUHit*> GetGPUHitsFromBuffer(unsigned int threadId, unsigned int eventId, GPUstate &gpuState) {
-  HitQueueItem* hitItem = gpuState.fHitScoring->GetNextHitsHandle(threadId);
+std::pair<GPUHit*, GPUHit*> GetGPUHitsFromBuffer(unsigned int threadId, unsigned int eventId, GPUstate &gpuState, bool &dataOnBuffer) {
+  HitQueueItem* hitItem = gpuState.fHitScoring->GetNextHitsHandle(threadId, dataOnBuffer);
   if (hitItem) {
     return {hitItem->begin, hitItem->end};
   } else {
@@ -1153,9 +1153,9 @@ std::pair<GPUHit*, GPUHit*> GetGPUHitsFromBuffer(unsigned int threadId, unsigned
 //           buffer->hostBuffer + offset + buffer->hostBufferCount[threadId]};
 }
 
-void CloseGPUBuffer(unsigned int threadId, GPUstate &gpuState, GPUHit* begin)
+void CloseGPUBuffer(unsigned int threadId, GPUstate &gpuState, GPUHit* begin, const bool dataOnBuffer)
 {
-  gpuState.fHitScoring->CloseHitsHandle(threadId, begin);
+  gpuState.fHitScoring->CloseHitsHandle(threadId, begin, dataOnBuffer);
 }
 
 // TODO: Make it clear that this will initialize and return the GPUState or make a

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -268,9 +268,8 @@ __global__ void FinishIteration(AllParticleQueues all, Stats *stats, TracksAndSl
     //   gammaInteractions.queues[threadIdx.x]->clear();
     // }
     if (threadIdx.x == 0) {
-      stats->hitBufferOccupancy =
-          AsyncAdePT::gHitScoringBuffer_dev
-              .GetMaxSlotCount(); // FIXME for per thread counter AsyncAdePT::gHitScoringBuffer_dev.fSlotCounter;
+      // Note: hitBufferOccupancy gives the maximum occupancy of all threads combined
+      stats->hitBufferOccupancy = AsyncAdePT::gHitScoringBuffer_dev.GetMaxSlotCount();
     }
   }
 

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -590,16 +590,16 @@ void HitProcessingLoop(HitProcessingContext *const context, GPUstate &gpuState,
 
     // FIXME: clean this after all works
     // Possible timing
-    auto start = std::chrono::high_resolution_clock::now();
+    // auto start = std::chrono::high_resolution_clock::now();
     gpuState.fHitScoring->TransferHitsToHost(context->hitTransferStream);
     const bool haveNewHits = gpuState.fHitScoring->ProcessHits(cvG4Workers); // FIXME pass cvG4Workers.notify_all(); down
 
-    auto end = std::chrono::high_resolution_clock::now();
-    std::chrono::duration<double> elapsed = end - start;
+    // auto end = std::chrono::high_resolution_clock::now();
+    // std::chrono::duration<double> elapsed = end - start;
 
-    if (haveNewHits) {
-        std::cout << "HIT Processing time: " << elapsed.count() << " seconds" << std::endl;
-    }
+    // if (haveNewHits) {
+    //     std::cout << "HIT Processing time: " << elapsed.count() << " seconds" << std::endl;
+    // }
 
     if (haveNewHits) {
       AdvanceEventStates(EventState::FlushingHits, EventState::HitsFlushed, eventStates);
@@ -1102,8 +1102,16 @@ std::pair<GPUHit*, GPUHit*> GetGPUHitsFromBuffer(unsigned int threadId, unsigned
   // buffer->hitScoringInfo.fNSlot << " buffer->hostBufferCount[threadId] " << buffer->hostBufferCount[threadId] <<
   // " from " << buffer->hostBuffer + threadId * buffer->hitScoringInfo.fNSlot <<
   //              " to " << buffer->hostBuffer + threadId * buffer->hitScoringInfo.fNSlot + buffer->hostBufferCount[threadId] << std::endl;
-  return {buffer->hostBuffer + threadId * buffer->hitScoringInfo.fNSlot, 
-          buffer->hostBuffer + threadId * buffer->hitScoringInfo.fNSlot + buffer->hostBufferCount[threadId]};
+
+  unsigned int offset = 0;
+  for (int i = 0; i < threadId; i++) {
+    offset += buffer->hostBufferCount[i];
+  }
+
+  // std::cout << "threadId " << threadId << " EventId " << eventId << " offset " << offset << " num hits to score " << buffer->hostBufferCount[threadId] << std::endl;
+
+  return {buffer->hostBuffer + offset, 
+          buffer->hostBuffer + offset + buffer->hostBufferCount[threadId]};
 }
 
 void CloseGPUBuffer(unsigned int threadId, GPUstate &gpuState)

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -1153,9 +1153,9 @@ std::pair<GPUHit*, GPUHit*> GetGPUHitsFromBuffer(unsigned int threadId, unsigned
 //           buffer->hostBuffer + offset + buffer->hostBufferCount[threadId]};
 }
 
-void CloseGPUBuffer(unsigned int threadId, GPUstate &gpuState)
+void CloseGPUBuffer(unsigned int threadId, GPUstate &gpuState, GPUHit* begin)
 {
-  gpuState.fHitScoring->CloseHitsHandle(threadId);
+  gpuState.fHitScoring->CloseHitsHandle(threadId, begin);
 }
 
 // TODO: Make it clear that this will initialize and return the GPUState or make a

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -262,10 +262,6 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
     std::pair<GPUHit *, GPUHit *> range;
     bool dataOnBuffer;
 
-#define RESET "\033[0m"
-#define BOLD_RED "\033[1;31m"
-#define BOLD_BLUE "\033[1;34m"
-
     {
       std::unique_lock lock{fMutex_G4Workers};
       fCV_G4Workers.wait(lock);
@@ -274,17 +270,15 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
     while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate, dataOnBuffer)).first !=
            nullptr) {
       for (auto it = range.first; it != range.second; ++it) {
+        // important sanity check: thread should only process its own hits and only from the current event
         if (it->threadId != threadId)
-          std::cout << BOLD_RED << "Error, threadId doesn't match it->threadId " << it->threadId << " threadId "
-                    << threadId << RESET << std::endl;
-        ;
+          std::err << "Error, threadId doesn't match it->threadId " << it->threadId << " threadId " << threadId
+                   << std::endl;
         if (it->fEventId != eventId) {
-          std::cout << BOLD_RED << "Error, eventId doesn't match it->fEventId " << it->fEventId << "eventId " << eventId
-                    << RESET << std::endl;
-          std::cout << " num hits to be processed " << (range.second - range.first) << " dataOnBuffer " << dataOnBuffer
-                    << std::endl;
-          std::cout << "state : " << static_cast<unsigned int>(fEventStates[threadId].load(std::memory_order_acquire))
-                    << std::endl;
+          std::err << "Error, eventId doesn't match it->fEventId " << it->fEventId << "eventId " << eventId
+                   << " num hits to be processed " << (range.second - range.first) << " dataOnBuffer " << dataOnBuffer
+                   << "state : " << static_cast<unsigned int>(fEventStates[threadId].load(std::memory_order_acquire))
+                   << std::endl;
         }
         integrationInstance.ProcessGPUHit(*it);
       }

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -288,6 +288,7 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
     // if ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) std::cout << " G4 WORKER WAKING UP TO DO SOME SCORING! " << async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate).first << std::endl;
     // while ((range = fGPUstate.fHitScoring->GetNextHitsHandle(threadId, eventId)).first != nullptr) {
     while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) {
+      // std::cout << " EventId " << eventId << " scoring from " <<  range.first->fTotalEnergyDeposit << " to " << (range.second-1)->fTotalEnergyDeposit << std::endl;
       for (auto it = range.first; it != range.second; ++it) {
         if (it->threadId == threadId) integrationInstance.ProcessGPUHit(*it);
       }

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -3,6 +3,8 @@
 
 #include <AdePT/core/AsyncAdePTTransport.hh>
 
+// #include <AdePT/core/PerEventScoringImpl.cuh>
+
 #include <AdePT/integration/AdePTGeant4Integration.hh>
 
 #include <VecGeom/management/BVHManager.h>
@@ -259,9 +261,23 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
       fCV_G4Workers.wait(lock);
     }
 
-    std::shared_ptr<const std::vector<GPUHit>> gpuHits;
-    while ((gpuHits = async_adept_impl::GetGPUHits(threadId, *fGPUstate)) != nullptr) {
-      for (auto it = gpuHits->begin(); it != gpuHits->end(); ++it) {
+    // std::shared_ptr<const std::vector<GPUHit>> gpuHits;
+    *AsyncAdePT::BufferHandle buffer_handle;
+    // while ((gpuHits = async_adept_impl::GetGPUHits(threadId, *fGPUstate)) != nullptr) {
+    // while ((gpuHits = gpuState.fHitScoring->GetNextHitsVector(threadId)) != nullptr) {
+    while ((buffer_handle = fGPUstate.fHitScoring->GetNextHitsHandle(threadId)) != nullptr) {
+
+      auto begin = buffer_handle.hostBuffer;
+      auto end   = buffer_handle.hostBuffer + buffer_handle.hitScoringInfo.fSlotCounter;
+
+      GPUHit dummy;
+      dummy.fEventId = eventId;
+      auto range     = std::equal_range(begin, end, dummy,
+                                        [](const GPUHit &lhs, const GPUHit &rhs) { return lhs.fEventId < rhs.fEventId; });
+      // auto range     = std::equal_range(gpuHits->begin(), gpuHits->end(), dummy,
+      //                                   [](const GPUHit &lhs, const GPUHit &rhs) { return lhs.fEventId < rhs.fEventId; });
+      for (auto it = range.first; it != range.second; ++it) {
+      // for (auto it = gpuHits->begin(); it != gpuHits->end(); ++it) {
         assert(it->threadId == threadId);
         integrationInstance.ProcessGPUHit(*it);
       }

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -270,10 +270,10 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
       for (auto it = range.first; it != range.second; ++it) {
         // important sanity check: thread should only process its own hits and only from the current event
         if (it->threadId != threadId)
-          std::err << "Error, threadId doesn't match it->threadId " << it->threadId << " threadId " << threadId
+          std::cerr << "Error, threadId doesn't match it->threadId " << it->threadId << " threadId " << threadId
                    << std::endl;
         if (it->fEventId != eventId) {
-          std::err << "Error, eventId doesn't match it->fEventId " << it->fEventId << "eventId " << eventId
+          std::cerr << "Error, eventId doesn't match it->fEventId " << it->fEventId << "eventId " << eventId
                    << " num hits to be processed " << (range.second - range.first) << " dataOnBuffer " << dataOnBuffer
                    << "state : " << static_cast<unsigned int>(fEventStates[threadId].load(std::memory_order_acquire))
                    << std::endl;

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -262,32 +262,26 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
     std::pair<GPUHit*, GPUHit*> range;
     bool dataOnBuffer;
 
-    // check first before going to sleep
-    while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate, dataOnBuffer)).first != nullptr) {
-      // std::cout << " G4 WORKER WAKING UP TO DO SOME SCORING! " << std::endl;
-      for (auto it = range.first; it != range.second; ++it) {
-        assert(it->threadId == threadId);
-        assert(it->fEventId == eventId);
-        if (it->threadId == threadId) integrationInstance.ProcessGPUHit(*it);
-      }
-      async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate, range.first, dataOnBuffer);
-    }
+#define RESET "\033[0m"
+#define BOLD_RED "\033[1;31m"
+#define BOLD_BLUE    "\033[1;34m"
 
     {
       std::unique_lock lock{fMutex_G4Workers};
       fCV_G4Workers.wait(lock);
     }
 
-    // ensure to check again when device is flushed
-    if (fEventStates[threadId].load(std::memory_order_acquire) == EventState::DeviceFlushed) {
-      while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate, dataOnBuffer)).first != nullptr) {
-        for (auto it = range.first; it != range.second; ++it) {
-          assert(it->threadId == threadId);
-          assert(it->fEventId == eventId);
-          if (it->threadId == threadId) integrationInstance.ProcessGPUHit(*it);
-        }
-        async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate, range.first, dataOnBuffer);
+    while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate, dataOnBuffer)).first != nullptr) {
+      for (auto it = range.first; it != range.second; ++it) {
+        if(it->threadId != threadId)  std::cout << BOLD_RED << "Error, threadId doesn't match it->threadId " << it->threadId << " threadId " << threadId << RESET << std::endl;;
+        if(it->fEventId != eventId) {
+        std::cout << BOLD_RED << "Error, eventId doesn't match it->fEventId " << it->fEventId  << "eventId " << eventId << RESET << std::endl;
+        std::cout << " num hits to be processed " << (range.second - range.first) << " dataOnBuffer " << dataOnBuffer << std::endl;
+        std::cout << "state : " << static_cast<unsigned int>(fEventStates[threadId].load(std::memory_order_acquire) ) << std::endl;
       }
+        integrationInstance.ProcessGPUHit(*it);
+      }
+      async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate, range.first, dataOnBuffer);
     }
   }
 

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -46,7 +46,7 @@ bool InitializeApplyCuts(bool applycuts);
 G4HepEmState *InitG4HepEm();
 void FlushScoring(AdePTScoring &);
 std::shared_ptr<const std::vector<GPUHit>> GetGPUHits(unsigned int, AsyncAdePT::GPUstate &);
-std::pair<GPUHit*, GPUHit*> GetGPUHitsFromBuffer(unsigned int, unsigned int, AsyncAdePT::GPUstate &, bool &);
+std::pair<GPUHit *, GPUHit *> GetGPUHitsFromBuffer(unsigned int, unsigned int, AsyncAdePT::GPUstate &, bool &);
 void CloseGPUBuffer(unsigned int, AsyncAdePT::GPUstate &, GPUHit *, const bool);
 std::thread LaunchGPUWorker(int, int, int, AsyncAdePT::TrackBuffer &, AsyncAdePT::GPUstate &,
                             std::vector<std::atomic<AsyncAdePT::EventState>> &, std::condition_variable &,
@@ -259,26 +259,33 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
 
   while (fEventStates[threadId].load(std::memory_order_acquire) < EventState::DeviceFlushed) {
 
-    std::pair<GPUHit*, GPUHit*> range;
+    std::pair<GPUHit *, GPUHit *> range;
     bool dataOnBuffer;
 
 #define RESET "\033[0m"
 #define BOLD_RED "\033[1;31m"
-#define BOLD_BLUE    "\033[1;34m"
+#define BOLD_BLUE "\033[1;34m"
 
     {
       std::unique_lock lock{fMutex_G4Workers};
       fCV_G4Workers.wait(lock);
     }
 
-    while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate, dataOnBuffer)).first != nullptr) {
+    while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate, dataOnBuffer)).first !=
+           nullptr) {
       for (auto it = range.first; it != range.second; ++it) {
-        if(it->threadId != threadId)  std::cout << BOLD_RED << "Error, threadId doesn't match it->threadId " << it->threadId << " threadId " << threadId << RESET << std::endl;;
-        if(it->fEventId != eventId) {
-        std::cout << BOLD_RED << "Error, eventId doesn't match it->fEventId " << it->fEventId  << "eventId " << eventId << RESET << std::endl;
-        std::cout << " num hits to be processed " << (range.second - range.first) << " dataOnBuffer " << dataOnBuffer << std::endl;
-        std::cout << "state : " << static_cast<unsigned int>(fEventStates[threadId].load(std::memory_order_acquire) ) << std::endl;
-      }
+        if (it->threadId != threadId)
+          std::cout << BOLD_RED << "Error, threadId doesn't match it->threadId " << it->threadId << " threadId "
+                    << threadId << RESET << std::endl;
+        ;
+        if (it->fEventId != eventId) {
+          std::cout << BOLD_RED << "Error, eventId doesn't match it->fEventId " << it->fEventId << "eventId " << eventId
+                    << RESET << std::endl;
+          std::cout << " num hits to be processed " << (range.second - range.first) << " dataOnBuffer " << dataOnBuffer
+                    << std::endl;
+          std::cout << "state : " << static_cast<unsigned int>(fEventStates[threadId].load(std::memory_order_acquire))
+                    << std::endl;
+        }
         integrationInstance.ProcessGPUHit(*it);
       }
       async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate, range.first, dataOnBuffer);

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -285,7 +285,7 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
     // }
 
     std::pair<GPUHit*, GPUHit*> range;
-    if ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) std::cout << " G4 WORKER WAKING UP TO DO SOME SCORING! " << async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate).first << std::endl;
+    // if ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) std::cout << " G4 WORKER WAKING UP TO DO SOME SCORING! " << async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate).first << std::endl;
     // while ((range = fGPUstate.fHitScoring->GetNextHitsHandle(threadId, eventId)).first != nullptr) {
     while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) {
       for (auto it = range.first; it != range.second; ++it) {

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -261,6 +261,7 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
 
     std::pair<GPUHit*, GPUHit*> range;
     while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) {
+      // std::cout << " G4 WORKER WAKING UP TO DO SOME SCORING! " << std::endl;
       for (auto it = range.first; it != range.second; ++it) {
         if (it->threadId == threadId) integrationInstance.ProcessGPUHit(*it);
       }

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -271,12 +271,12 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
         // important sanity check: thread should only process its own hits and only from the current event
         if (it->threadId != threadId)
           std::cerr << "Error, threadId doesn't match it->threadId " << it->threadId << " threadId " << threadId
-                   << std::endl;
+                    << std::endl;
         if (it->fEventId != eventId) {
           std::cerr << "Error, eventId doesn't match it->fEventId " << it->fEventId << "eventId " << eventId
-                   << " num hits to be processed " << (range.second - range.first) << " dataOnBuffer " << dataOnBuffer
-                   << "state : " << static_cast<unsigned int>(fEventStates[threadId].load(std::memory_order_acquire))
-                   << std::endl;
+                    << " num hits to be processed " << (range.second - range.first) << " dataOnBuffer " << dataOnBuffer
+                    << "state : " << static_cast<unsigned int>(fEventStates[threadId].load(std::memory_order_acquire))
+                    << std::endl;
         }
         integrationInstance.ProcessGPUHit(*it);
       }

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -258,6 +258,15 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
   AdePTGeant4Integration &integrationInstance = fIntegrationLayerObjects[threadId];
 
   while (fEventStates[threadId].load(std::memory_order_acquire) < EventState::DeviceFlushed) {
+
+    std::pair<GPUHit*, GPUHit*> range;
+    while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) {
+      for (auto it = range.first; it != range.second; ++it) {
+        if (it->threadId == threadId) integrationInstance.ProcessGPUHit(*it);
+      }
+      async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate); // decrement refcount in buffer and last worker sets to BufferStatus::Free
+    }
+
     {
       std::unique_lock lock{fMutex_G4Workers};
       fCV_G4Workers.wait(lock);
@@ -284,16 +293,16 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
     //   }
     // }
 
-    std::pair<GPUHit*, GPUHit*> range;
-    // if ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) std::cout << " G4 WORKER WAKING UP TO DO SOME SCORING! " << async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate).first << std::endl;
-    // while ((range = fGPUstate.fHitScoring->GetNextHitsHandle(threadId, eventId)).first != nullptr) {
-    while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) {
-      // std::cout << " EventId " << eventId << " scoring from " <<  range.first->fTotalEnergyDeposit << " to " << (range.second-1)->fTotalEnergyDeposit << std::endl;
-      for (auto it = range.first; it != range.second; ++it) {
-        if (it->threadId == threadId) integrationInstance.ProcessGPUHit(*it);
-      }
-      async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate); // decrement refcount in buffer and last worker sets to BufferStatus::Free
-    }
+    // std::pair<GPUHit*, GPUHit*> range;
+    // // if ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) std::cout << " G4 WORKER WAKING UP TO DO SOME SCORING! " << async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate).first << std::endl;
+    // // while ((range = fGPUstate.fHitScoring->GetNextHitsHandle(threadId, eventId)).first != nullptr) {
+    // while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) {
+    //   // std::cout << " EventId " << eventId << " scoring from " <<  range.first->fTotalEnergyDeposit << " to " << (range.second-1)->fTotalEnergyDeposit << std::endl;
+    //   for (auto it = range.first; it != range.second; ++it) {
+    //     if (it->threadId == threadId) integrationInstance.ProcessGPUHit(*it);
+    //   }
+    //   async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate); // decrement refcount in buffer and last worker sets to BufferStatus::Free
+    // }
   }
 
   // Now device should be flushed, so retrieve the tracks:

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -261,12 +261,16 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
 
     std::pair<GPUHit*, GPUHit*> range;
     bool dataOnBuffer;
+
+    // check first before going to sleep
     while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate, dataOnBuffer)).first != nullptr) {
       // std::cout << " G4 WORKER WAKING UP TO DO SOME SCORING! " << std::endl;
       for (auto it = range.first; it != range.second; ++it) {
+        assert(it->threadId == threadId);
+        assert(it->fEventId == eventId);
         if (it->threadId == threadId) integrationInstance.ProcessGPUHit(*it);
       }
-      async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate, range.first, dataOnBuffer); // decrement refcount in buffer and last worker sets to BufferStatus::Free
+      async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate, range.first, dataOnBuffer);
     }
 
     {
@@ -274,37 +278,17 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
       fCV_G4Workers.wait(lock);
     }
 
-    // std::shared_ptr<const std::vector<GPUHit>> gpuHits;
-    // while ((gpuHits = async_adept_impl::GetGPUHits(threadId, *fGPUstate)) != nullptr) {
-    // // while ((gpuHits = gpuState.fHitScoring->GetNextHitsVector(threadId)) != nullptr) {
-    // while ((buffer_handle = fGPUstate.fHitScoring->GetNextHitsHandle(threadId)) != nullptr) {
-
-    //   auto begin = buffer_handle.hostBuffer;
-    //   auto end   = buffer_handle.hostBuffer + buffer_handle.hitScoringInfo.fSlotCounter;
-
-    //   GPUHit dummy;
-    //   dummy.fEventId = eventId;
-    //   auto range     = std::equal_range(begin, end, dummy,
-    //                                     [](const GPUHit &lhs, const GPUHit &rhs) { return lhs.fEventId < rhs.fEventId; });
-    //   // auto range     = std::equal_range(gpuHits->begin(), gpuHits->end(), dummy,
-    //   //                                   [](const GPUHit &lhs, const GPUHit &rhs) { return lhs.fEventId < rhs.fEventId; });
-    //   for (auto it = range.first; it != range.second; ++it) {
-    //   // for (auto it = gpuHits->begin(); it != gpuHits->end(); ++it) {
-    //     assert(it->threadId == threadId);
-    //     integrationInstance.ProcessGPUHit(*it);
-    //   }
-    // }
-
-    // std::pair<GPUHit*, GPUHit*> range;
-    // // if ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) std::cout << " G4 WORKER WAKING UP TO DO SOME SCORING! " << async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate).first << std::endl;
-    // // while ((range = fGPUstate.fHitScoring->GetNextHitsHandle(threadId, eventId)).first != nullptr) {
-    // while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) {
-    //   // std::cout << " EventId " << eventId << " scoring from " <<  range.first->fTotalEnergyDeposit << " to " << (range.second-1)->fTotalEnergyDeposit << std::endl;
-    //   for (auto it = range.first; it != range.second; ++it) {
-    //     if (it->threadId == threadId) integrationInstance.ProcessGPUHit(*it);
-    //   }
-    //   async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate); // decrement refcount in buffer and last worker sets to BufferStatus::Free
-    // }
+    // ensure to check again when device is flushed
+    if (fEventStates[threadId].load(std::memory_order_acquire) == EventState::DeviceFlushed) {
+      while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate, dataOnBuffer)).first != nullptr) {
+        for (auto it = range.first; it != range.second; ++it) {
+          assert(it->threadId == threadId);
+          assert(it->fEventId == eventId);
+          if (it->threadId == threadId) integrationInstance.ProcessGPUHit(*it);
+        }
+        async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate, range.first, dataOnBuffer);
+      }
+    }
   }
 
   // Now device should be flushed, so retrieve the tracks:

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -285,7 +285,7 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
     // }
 
     std::pair<GPUHit*, GPUHit*> range;
-    // if ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) std::cout << " G4 WORKER WAKING UP TO DO SOME SCORING! " << async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate).first << std::endl;
+    if ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) std::cout << " G4 WORKER WAKING UP TO DO SOME SCORING! " << async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate).first << std::endl;
     // while ((range = fGPUstate.fHitScoring->GetNextHitsHandle(threadId, eventId)).first != nullptr) {
     while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) {
       for (auto it = range.first; it != range.second; ++it) {

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -286,10 +286,9 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
 
     std::pair<GPUHit*, GPUHit*> range;
     // if ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) std::cout << " G4 WORKER WAKING UP TO DO SOME SCORING! " << async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate).first << std::endl;
-    while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) {
     // while ((range = fGPUstate.fHitScoring->GetNextHitsHandle(threadId, eventId)).first != nullptr) {
+    while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) {
       for (auto it = range.first; it != range.second; ++it) {
-        assert(it->threadId == threadId);
         if (it->threadId == threadId) integrationInstance.ProcessGPUHit(*it);
       }
       async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate); // decrement refcount in buffer and last worker sets to BufferStatus::Free

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -46,8 +46,8 @@ bool InitializeApplyCuts(bool applycuts);
 G4HepEmState *InitG4HepEm();
 void FlushScoring(AdePTScoring &);
 std::shared_ptr<const std::vector<GPUHit>> GetGPUHits(unsigned int, AsyncAdePT::GPUstate &);
-std::pair<GPUHit*, GPUHit*> GetGPUHitsFromBuffer(unsigned int, unsigned int, AsyncAdePT::GPUstate &);
-void CloseGPUBuffer(unsigned int, AsyncAdePT::GPUstate &, GPUHit *);
+std::pair<GPUHit*, GPUHit*> GetGPUHitsFromBuffer(unsigned int, unsigned int, AsyncAdePT::GPUstate &, bool &);
+void CloseGPUBuffer(unsigned int, AsyncAdePT::GPUstate &, GPUHit *, const bool);
 std::thread LaunchGPUWorker(int, int, int, AsyncAdePT::TrackBuffer &, AsyncAdePT::GPUstate &,
                             std::vector<std::atomic<AsyncAdePT::EventState>> &, std::condition_variable &,
                             std::vector<AdePTScoring> &, int, int);
@@ -260,12 +260,13 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
   while (fEventStates[threadId].load(std::memory_order_acquire) < EventState::DeviceFlushed) {
 
     std::pair<GPUHit*, GPUHit*> range;
-    while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) {
+    bool dataOnBuffer;
+    while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate, dataOnBuffer)).first != nullptr) {
       // std::cout << " G4 WORKER WAKING UP TO DO SOME SCORING! " << std::endl;
       for (auto it = range.first; it != range.second; ++it) {
         if (it->threadId == threadId) integrationInstance.ProcessGPUHit(*it);
       }
-      async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate, range.first); // decrement refcount in buffer and last worker sets to BufferStatus::Free
+      async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate, range.first, dataOnBuffer); // decrement refcount in buffer and last worker sets to BufferStatus::Free
     }
 
     {

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -46,6 +46,8 @@ bool InitializeApplyCuts(bool applycuts);
 G4HepEmState *InitG4HepEm();
 void FlushScoring(AdePTScoring &);
 std::shared_ptr<const std::vector<GPUHit>> GetGPUHits(unsigned int, AsyncAdePT::GPUstate &);
+std::pair<GPUHit*, GPUHit*> GetGPUHitsFromBuffer(unsigned int, unsigned int, AsyncAdePT::GPUstate &);
+void CloseGPUBuffer(unsigned int, AsyncAdePT::GPUstate &);
 std::thread LaunchGPUWorker(int, int, int, AsyncAdePT::TrackBuffer &, AsyncAdePT::GPUstate &,
                             std::vector<std::atomic<AsyncAdePT::EventState>> &, std::condition_variable &,
                             std::vector<AdePTScoring> &, int, int);
@@ -262,25 +264,35 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
     }
 
     // std::shared_ptr<const std::vector<GPUHit>> gpuHits;
-    *AsyncAdePT::BufferHandle buffer_handle;
     // while ((gpuHits = async_adept_impl::GetGPUHits(threadId, *fGPUstate)) != nullptr) {
-    // while ((gpuHits = gpuState.fHitScoring->GetNextHitsVector(threadId)) != nullptr) {
-    while ((buffer_handle = fGPUstate.fHitScoring->GetNextHitsHandle(threadId)) != nullptr) {
+    // // while ((gpuHits = gpuState.fHitScoring->GetNextHitsVector(threadId)) != nullptr) {
+    // while ((buffer_handle = fGPUstate.fHitScoring->GetNextHitsHandle(threadId)) != nullptr) {
 
-      auto begin = buffer_handle.hostBuffer;
-      auto end   = buffer_handle.hostBuffer + buffer_handle.hitScoringInfo.fSlotCounter;
+    //   auto begin = buffer_handle.hostBuffer;
+    //   auto end   = buffer_handle.hostBuffer + buffer_handle.hitScoringInfo.fSlotCounter;
 
-      GPUHit dummy;
-      dummy.fEventId = eventId;
-      auto range     = std::equal_range(begin, end, dummy,
-                                        [](const GPUHit &lhs, const GPUHit &rhs) { return lhs.fEventId < rhs.fEventId; });
-      // auto range     = std::equal_range(gpuHits->begin(), gpuHits->end(), dummy,
-      //                                   [](const GPUHit &lhs, const GPUHit &rhs) { return lhs.fEventId < rhs.fEventId; });
+    //   GPUHit dummy;
+    //   dummy.fEventId = eventId;
+    //   auto range     = std::equal_range(begin, end, dummy,
+    //                                     [](const GPUHit &lhs, const GPUHit &rhs) { return lhs.fEventId < rhs.fEventId; });
+    //   // auto range     = std::equal_range(gpuHits->begin(), gpuHits->end(), dummy,
+    //   //                                   [](const GPUHit &lhs, const GPUHit &rhs) { return lhs.fEventId < rhs.fEventId; });
+    //   for (auto it = range.first; it != range.second; ++it) {
+    //   // for (auto it = gpuHits->begin(); it != gpuHits->end(); ++it) {
+    //     assert(it->threadId == threadId);
+    //     integrationInstance.ProcessGPUHit(*it);
+    //   }
+    // }
+
+    std::pair<GPUHit*, GPUHit*> range;
+    // if ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) std::cout << " G4 WORKER WAKING UP TO DO SOME SCORING! " << async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate).first << std::endl;
+    while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate)).first != nullptr) {
+    // while ((range = fGPUstate.fHitScoring->GetNextHitsHandle(threadId, eventId)).first != nullptr) {
       for (auto it = range.first; it != range.second; ++it) {
-      // for (auto it = gpuHits->begin(); it != gpuHits->end(); ++it) {
         assert(it->threadId == threadId);
-        integrationInstance.ProcessGPUHit(*it);
+        if (it->threadId == threadId) integrationInstance.ProcessGPUHit(*it);
       }
+      async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate); // decrement refcount in buffer and last worker sets to BufferStatus::Free
     }
   }
 

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -3,8 +3,6 @@
 
 #include <AdePT/core/AsyncAdePTTransport.hh>
 
-// #include <AdePT/core/PerEventScoringImpl.cuh>
-
 #include <AdePT/integration/AdePTGeant4Integration.hh>
 
 #include <VecGeom/management/BVHManager.h>

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -47,7 +47,7 @@ G4HepEmState *InitG4HepEm();
 void FlushScoring(AdePTScoring &);
 std::shared_ptr<const std::vector<GPUHit>> GetGPUHits(unsigned int, AsyncAdePT::GPUstate &);
 std::pair<GPUHit*, GPUHit*> GetGPUHitsFromBuffer(unsigned int, unsigned int, AsyncAdePT::GPUstate &);
-void CloseGPUBuffer(unsigned int, AsyncAdePT::GPUstate &);
+void CloseGPUBuffer(unsigned int, AsyncAdePT::GPUstate &, GPUHit *);
 std::thread LaunchGPUWorker(int, int, int, AsyncAdePT::TrackBuffer &, AsyncAdePT::GPUstate &,
                             std::vector<std::atomic<AsyncAdePT::EventState>> &, std::condition_variable &,
                             std::vector<AdePTScoring> &, int, int);
@@ -265,7 +265,7 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
       for (auto it = range.first; it != range.second; ++it) {
         if (it->threadId == threadId) integrationInstance.ProcessGPUHit(*it);
       }
-      async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate); // decrement refcount in buffer and last worker sets to BufferStatus::Free
+      async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate, range.first); // decrement refcount in buffer and last worker sets to BufferStatus::Free
     }
 
     {

--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -96,11 +96,11 @@ struct BufferHandle {
   std::atomic<short> refcount = 0;
 
   void reset() {
-    std::cout << "Resetting buffer handle: " << this 
-              << " | Refcount: " << refcount.load() 
-              << " | State: " << static_cast<int>(state.load())
-              << " | hitScoringInfo.fSlotCounter: " << (void*)hitScoringInfo.fSlotCounter
-              << std::endl;
+    // std::cout << "Resetting buffer handle: " << this 
+    //           << " | Refcount: " << refcount.load() 
+    //           << " | State: " << static_cast<int>(state.load())
+    //           << " | hitScoringInfo.fSlotCounter: " << (void*)hitScoringInfo.fSlotCounter
+    //           << std::endl;
 
     if (!hitScoringInfo.fSlotCounter) {
         std::cerr << "ERROR: fSlotCounter is NULL at reset!\n";
@@ -132,12 +132,12 @@ struct BufferHandle {
   void decrement(unsigned int threadId) {
 
     int prev = refcount.load();
-    std::cout << "Before decrement: " << prev << " | Thread: " << threadId << std::endl;
+    // std::cout << "Before decrement: " << prev << " | Thread: " << threadId << std::endl;
 
 
 
     refcount.fetch_sub(1, std::memory_order_acq_rel);
-    std::cout << "After decrement: " << refcount.load() << " | Thread: " << threadId << std::endl;
+    // std::cout << "After decrement: " << refcount.load() << " | Thread: " << threadId << std::endl;
 
     // if (refcount.fetch_sub(1, std::memory_order_acq_rel) == 1) {
       // Last worker, reset state for reuse
@@ -316,8 +316,8 @@ public:
 
   void SwapDeviceBuffers(cudaStream_t cudaStream)
   {
-    printf("CALLING SWAP printing states\n");
-    PrintBufferStates();
+    // printf("CALLING SWAP printing states\n");
+    // PrintBufferStates();
     // Ensure that host side has been processed:
     auto &currentBuffer = fBuffers[fActiveBuffer];
     if (currentBuffer.state != BufferHandle::State::OnDevice)
@@ -337,11 +337,11 @@ public:
     //                                    cudaMemcpyDeviceToDevice, cudaStream));
 
     // Execute the swap:
-    printf("Before Swap buffer 0: fSlotCounter = %p\n", fBuffers[0].hitScoringInfo.fSlotCounter);
-    printf("Before Swap buffer 1: fSlotCounter = %p\n", fBuffers[1].hitScoringInfo.fSlotCounter);
+    // printf("Before Swap buffer 0: fSlotCounter = %p\n", fBuffers[0].hitScoringInfo.fSlotCounter);
+    // printf("Before Swap buffer 1: fSlotCounter = %p\n", fBuffers[1].hitScoringInfo.fSlotCounter);
 
     fActiveBuffer          = (fActiveBuffer + 1) % fBuffers.size();
-    printf("After Swap: fSlotCounter = %p\n", fBuffers[fActiveBuffer].hitScoringInfo.fSlotCounter);
+    // printf("After Swap: fSlotCounter = %p\n", fBuffers[fActiveBuffer].hitScoringInfo.fSlotCounter);
     auto &nextDeviceBuffer = fBuffers[fActiveBuffer];
     while (nextDeviceBuffer.state != BufferHandle::State::Free) {
       std::cerr << __func__ << " Warning: Another thread should have processed the hits.\n";
@@ -373,19 +373,19 @@ public:
           haveNewHits = true;
 
           // Possible timing
-          // auto start = std::chrono::high_resolution_clock::now();
+          auto start = std::chrono::high_resolution_clock::now();
           ProcessBuffer(handle, cvG4Workers, lock);
-          // auto end = std::chrono::high_resolution_clock::now();
-          // std::chrono::duration<double> elapsed = end - start;
-          //     std::cout << "BUFFER Processing time: " << elapsed.count() << " seconds" << std::endl;
+          auto end = std::chrono::high_resolution_clock::now();
+          std::chrono::duration<double> elapsed = end - start;
+              std::cout << "BUFFER Processing time: " << elapsed.count() << " seconds" << std::endl;
 
           // lock.unlock();
         }
       }
     }
 
-      std::cout << " Finished ProcessBuffer, states :" << std::endl;
-      PrintBufferStates();
+      // std::cout << " Finished ProcessBuffer, states :" << std::endl;
+      // PrintBufferStates();
 
     return haveNewHits;
   }
@@ -443,6 +443,12 @@ public:
       COPCORE_CUDA_CHECK(cudaMemsetAsync(buffer.hitScoringInfo.fSlotCounter, 0, 
                                    sizeof(unsigned int) * buffer.hitScoringInfo.fNThreads, 
                                    cudaStreamForHitCopy));
+
+    // std::cout << " BUFFER HIT GROESSE  " << sizeof(GPUHit) * fHitCapacity / 1024. /1024. /1024. << std::endl;
+
+      // for (int i = 0; i < buffer.hitScoringInfo.fNThreads; i++) {
+        
+      // }
 
       COPCORE_CUDA_CHECK(cudaMemcpyAsync(buffer.hostBuffer, bufferBegin,
                                         //  sizeof(GPUHit) * buffer.hitScoringInfo.fSlotCounter, cudaMemcpyDefault,


### PR DESCRIPTION
This PR improves the handling of the retrieved steps from the GPU in the async mode.

Previously, the HitProcessingThread would always copy out the retrieved steps to a vector and a unique_ptr would be pushed to the HitQueue. When the G4 workers pop the item from the queue, the data would be released.
Unfortunately, the copying of GB of data could take significant time in certain settings and block the buffer for longer than the GPU would require to run out of HitSlots. This scenario would mostly appear in testEm3 when shooting electrons, since every step of the full shower would be recorded, leading to a vast amount of data to be copied.

This PR now changes the handling in the following way:

Now, there are still two buffers on device, but only one large circular buffer on the CPU. Whenever the device buffer swaps, the retrieved steps are copied into the circular host buffer. Then, the G4 workers are woken up to directly score inside the circular buffer. When they finished the scoring, the memory is released, i.e., the GPU can copy into it again. If the circular host buffer is filled to more than 50% (which indicates that the G4 workers are not scoring their hits, e.g., because they are doing hadronics) the hits will be copied out before. If the G4 workers are available, the copy can be prevented, and if the G4 workers are busy, the hits can be copied out (e.g., as needed for CMS ttbar events). 

This yields to greatly improved performance of the async mode for applications where EM is largely dominating, such as testEm3.

The table shows the run time for T number of threads and E number of events. The first rows denote testEm3 with 100 primary 10 GeV electrons per event, the last two rows are ttbar events in CMS (without magnetic field)

| Type    | Sync | Async master |  Async this PR |
|---------|------|--------------|-----|
| 1T 2E   | 1.9 | 1.27   |  1.2 |
| 2T 4E | 2.0 | 1.9 |  1.2 |
| 4T 16E | 4.16 | 5.0 |  2.6|
| 8T 32E | 4.6 | 10.1   | 2.8|
| 16T 64E | 6.6 |out of slots | 4.5 |
| 16T 256E | 24.1 | -  | 17.5 |
| 16T 1000E | 94.7 | - |70.2 |
| ttbar 8T 16E all sensitive | 79.6 | 72.4  | 70.3|
|ttbar 16T 64E | 134.126 | 118.461 | 115.5 |


This PR adds the async mode in the CI, now both are tested.
Also, this finally enabled physics validation in testEm3 with the async AdePT, and it yields the same results as the sync AdePT:
<img width="583" alt="Screenshot 2025-02-22 at 17 06 47" src="https://github.com/user-attachments/assets/0de4b38b-a5ab-4383-bd97-2e68c19642ce" />

