### PR TITLE
Handle converted G4VPVParameterised/G4PVReplica volumes from G4VG in geometry checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,8 @@ if(Geant4_FOUND)
     FetchContent_Declare(
       g4vg
       GIT_REPOSITORY https://github.com/celeritas-project/g4vg
-      GIT_TAG 638c273b744c7ac0fa865ddb15c161b853a4029b)
+      GIT_TAG f4308d392a502b7bd7468938f8d9a63198d3d866 # v1.0.3
+    )
     # G4VG builds static by default, so change this to shared to match current
     # way AdePT is built.
     # could also configure for PIC mode static.
@@ -165,7 +166,7 @@ if(Geant4_FOUND)
     FetchContent_MakeAvailable(g4vg)
     message(STATUS "Using FetchContent to build G4VG as part of AdePT")
   else()
-    find_package(G4VG 1.0.1 REQUIRED)
+    find_package(G4VG 1.0.3 REQUIRED)
     message(STATUS "Found G4VG: ${G4VG_DIR}")
   endif()
 endif()


### PR DESCRIPTION
The latest updates to G4VG allow Geant4 parametrised/replica volumes to be converted to a VecGeom representation by direct placements. The need for this comes from the Delta Assessment "B5" example that uses these structures and for which there is no direct VecGeom equivalent except by making a direct placement for each copy. That's supported as of [G4VG 1.0.3](https://github.com/celeritas-project/g4vg/releases/tag/v1.0.3), but using this in AdePT and trying out B5 still leads to errors from `AdePTG4Integration::visitGeometry`.

That's sort of expected as the translation between Geant4 and VecGeom means that there will be N VecGeom placements for each replicated volume, N corresponding to the total number of replicas. Consequently, the checks in `visitGeometry` fail as:

1. The number of daughters in a given LV may be larger
2. Volume transformations may not match up as the original "parent" volume in Geant4 is compared against some copy of the replicated volume in VecGeom
    
The changes here address this, at least as far as the B5 geometry is concerned:

1. The number of LV daughters on the Geant4 side are counted as the sum of daughter multiplicities
   - For ordinary volumes this should be identical
   - It should also work for a mix of daughters (some standard, some parametrised), but this is untested. 
2. The transformation problem is a bit hacky, though pretty much copies what is done on the G4VG side:
   - If the Geant4 PV provides a `G4VPVParametrisation`, use that to transform it using the copy number of the compared VecGeom PV before extracting the transform from the Geant4 PV
   - If the Geant4 PV is a `G4PVReplica` use a `G4ReplicaNavigation` to do the same as above.
   - The hacky bit here is that use of this method requires a `const_cast` on the Geant4 PV as the transform step is non-const...
   - This does modify the underlying PV, but I think that's o.k (?) as it's only relevant for the navigation stage.

Testing with a local build against B5 shows this to now run to completion without error, but full validation has not been done yet (that's probably best addressed separately).