### PR TITLE
Storing vertex information

### DIFF
--- a/examples/IntegrationBenchmark/ci_tests/reproducibility.sh
+++ b/examples/IntegrationBenchmark/ci_tests/reproducibility.sh
@@ -37,7 +37,7 @@ $CI_TEST_DIR/python_scripts/macro_generator.py \
     --gdml_name ${PROJECT_SOURCE_DIR}/examples/data/cms2018_sd.gdml \
     --num_threads 4 \
     --num_events 8 \
-    --num_trackslots 10 \
+    --num_trackslots 8 \
     --num_hitslots 4 \
     --gun_type hepmc \
     --event_file ${PROJECT_BINARY_DIR}/ppttbar.hepmc3

--- a/include/AdePT/core/AdePTTransport.cuh
+++ b/include/AdePT/core/AdePTTransport.cuh
@@ -140,6 +140,7 @@ __global__ void InitTracks(adeptint::TrackData *trackinfo, int ntracks, int star
 
     track.rngState.SetSeed(1234567 * event + startTrack + i);
     track.eKin         = trackinfo[i].eKin;
+    track.vertexEkin   = trackinfo[i].vertexEkin;
     track.numIALeft[0] = -1.0;
     track.numIALeft[1] = -1.0;
     track.numIALeft[2] = -1.0;
@@ -149,8 +150,12 @@ __global__ void InitTracks(adeptint::TrackData *trackinfo, int ntracks, int star
     track.dynamicRangeFactor = -1.0;
     track.tlimitMin          = -1.0;
 
-    track.pos = {trackinfo[i].position[0], trackinfo[i].position[1], trackinfo[i].position[2]};
-    track.dir = {trackinfo[i].direction[0], trackinfo[i].direction[1], trackinfo[i].direction[2]};
+    track.pos                     = {trackinfo[i].position[0], trackinfo[i].position[1], trackinfo[i].position[2]};
+    track.dir                     = {trackinfo[i].direction[0], trackinfo[i].direction[1], trackinfo[i].direction[2]};
+    track.vertexPosition          = {trackinfo[i].vertexPosition[0], trackinfo[i].vertexPosition[1],
+                                     trackinfo[i].vertexPosition[2]};
+    track.vertexMomentumDirection = {trackinfo[i].vertexMomentumDirection[0], trackinfo[i].vertexMomentumDirection[1],
+                                     trackinfo[i].vertexMomentumDirection[2]};
 
     track.globalTime = trackinfo[i].globalTime;
     track.localTime  = trackinfo[i].localTime;

--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -41,9 +41,11 @@ public:
   int GetNfromDevice() const { return fBuffer.fromDevice.size(); }
 
   /// @brief Adds a track to the buffer
-  void AddTrack(int pdg, int parentId, double energy, double x, double y, double z, double dirx, double diry,
-                double dirz, double globalTime, double localTime, double properTime, int threadId, unsigned int eventId,
-                unsigned int trackIndex, vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState);
+  void AddTrack(int pdg, int parentId, double energy, double vertexEnergy, double x, double y, double z, double dirx,
+                double diry, double dirz, double vertexX, double vertexY, double vertexZ, double vertexDirx,
+                double vertexDiry, double vertexDirz, double globalTime, double localTime, double properTime,
+                int threadId, unsigned int eventId, unsigned int trackIndex, vecgeom::NavigationState &&state,
+                vecgeom::NavigationState &&originState);
 
   void SetTrackCapacity(size_t capacity) { fCapacity = capacity; }
   /// @brief Get the track capacity on GPU

--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -68,14 +68,14 @@ bool AdePTTransport<IntegrationLayer>::InitializeApplyCuts(bool applycuts)
 }
 
 template <typename IntegrationLayer>
-void AdePTTransport<IntegrationLayer>::AddTrack(int pdg, int parent_id, double energy, double x, double y, double z,
-                                                double dirx, double diry, double dirz, double globalTime,
-                                                double localTime, double properTime, int /*threadId*/,
-                                                unsigned int eventId, unsigned int /*trackIndex*/,
-                                                vecgeom::NavigationState &&state,
-                                                vecgeom::NavigationState &&originState)
+void AdePTTransport<IntegrationLayer>::AddTrack(
+    int pdg, int parent_id, double energy, double vertexEnergy, double x, double y, double z, double dirx, double diry,
+    double dirz, double vertexX, double vertexY, double vertexZ, double vertexDirx, double vertexDiry,
+    double vertexDirz, double globalTime, double localTime, double properTime, int /*threadId*/, unsigned int eventId,
+    unsigned int /*trackIndex*/, vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState)
 {
-  fBuffer.toDevice.emplace_back(pdg, parent_id, energy, x, y, z, dirx, diry, dirz, globalTime, localTime, properTime,
+  fBuffer.toDevice.emplace_back(pdg, parent_id, energy, vertexEnergy, x, y, z, dirx, diry, dirz, vertexX, vertexY,
+                                vertexZ, vertexDirx, vertexDiry, vertexDirz, globalTime, localTime, properTime,
                                 std::move(state), std::move(originState));
   if (pdg == 11)
     fBuffer.nelectrons++;

--- a/include/AdePT/core/AdePTTransportInterface.hh
+++ b/include/AdePT/core/AdePTTransportInterface.hh
@@ -17,10 +17,11 @@ public:
   virtual ~AdePTTransportInterface() {}
 
   /// @brief Adds a track to the buffer
-  virtual void AddTrack(int pdg, int parentId, double energy, double x, double y, double z, double dirx, double diry,
-                        double dirz, double globalTime, double localTime, double properTime, int threadId,
-                        unsigned int eventId, unsigned int trackIndex, vecgeom::NavigationState &&state,
-                        vecgeom::NavigationState &&originState) = 0;
+  virtual void AddTrack(int pdg, int parentId, double energy, double vertexEnergy, double x, double y, double z,
+                        double dirx, double diry, double dirz, double vertexX, double vertexY, double vertexZ,
+                        double vertexDirx, double vertexDiry, double vertexDirz, double globalTime, double localTime,
+                        double properTime, int threadId, unsigned int eventId, unsigned int trackIndex,
+                        vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState) = 0;
 
   /// @brief Set capacity of on-GPU track buffer.
   virtual void SetTrackCapacity(size_t capacity) = 0;

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -71,9 +71,10 @@ public:
   ~AsyncAdePTTransport();
 
   /// @brief Adds a track to the buffer
-  void AddTrack(int pdg, int parentId, double energy, double x, double y, double z, double dirx, double diry,
-                double dirz, double globalTime, double localTime, double properTime, int threadId, unsigned int eventId,
-                unsigned int trackIndex, vecgeom::NavigationState &&state,
+  void AddTrack(int pdg, int parentId, double energy, double vertexEnergy, double x, double y, double z, double dirx,
+                double diry, double dirz, double vertexX, double vertexY, double vertexZ, double vertexDirx,
+                double vertexDiry, double vertexDirz, double globalTime, double localTime, double properTime,
+                int threadId, unsigned int eventId, unsigned int trackIndex, vecgeom::NavigationState &&state,
                 vecgeom::NavigationState &&originState) override;
   /// @brief Set track capacity on GPU
   void SetTrackCapacity(size_t capacity) override { fTrackCapacity = capacity; }

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -103,12 +103,11 @@ AsyncAdePTTransport<IntegrationLayer>::~AsyncAdePTTransport()
 }
 
 template <typename IntegrationLayer>
-void AsyncAdePTTransport<IntegrationLayer>::AddTrack(int pdg, int parentId, double energy, double x, double y, double z,
-                                                     double dirx, double diry, double dirz, double globalTime,
-                                                     double localTime, double properTime, int threadId,
-                                                     unsigned int eventId, unsigned int trackId,
-                                                     vecgeom::NavigationState &&state,
-                                                     vecgeom::NavigationState &&originState)
+void AsyncAdePTTransport<IntegrationLayer>::AddTrack(
+    int pdg, int parentId, double energy, double vertexEnergy, double x, double y, double z, double dirx, double diry,
+    double dirz, double vertexX, double vertexY, double vertexZ, double vertexDirx, double vertexDiry,
+    double vertexDirz, double globalTime, double localTime, double properTime, int threadId, unsigned int eventId,
+    unsigned int trackId, vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState)
 {
   if (pdg != 11 && pdg != -11 && pdg != 22) {
     G4cerr << __FILE__ << ":" << __LINE__ << ": Only supporting EM tracks. Got pdgID=" << pdg << "\n";
@@ -118,12 +117,19 @@ void AsyncAdePTTransport<IntegrationLayer>::AddTrack(int pdg, int parentId, doub
   TrackDataWithIDs track{pdg,
                          parentId,
                          energy,
+                         vertexEnergy,
                          x,
                          y,
                          z,
                          dirx,
                          diry,
                          dirz,
+                         vertexX,
+                         vertexY,
+                         vertexZ,
+                         vertexDirx,
+                         vertexDiry,
+                         vertexDirz,
                          globalTime,
                          localTime,
                          properTime,

--- a/include/AdePT/core/CommonStruct.h
+++ b/include/AdePT/core/CommonStruct.h
@@ -104,19 +104,27 @@ struct TrackDataWithIDs : public adeptint::TrackData {
   unsigned int trackId{0};
   short threadId{-1};
 
-  TrackDataWithIDs(int pdg_id, int parentId, double ene, double x, double y, double z, double dirx, double diry,
-                   double dirz, double gTime, double lTime, double pTime, vecgeom::NavigationState &&state,
-                   vecgeom::NavigationState &&originState, unsigned int eventId = 0, unsigned int trackId = 0,
-                   short threadId = -1)
+  TrackDataWithIDs(int pdg_id, int parentId, double ene, double vertexEne, double x, double y, double z, double dirx,
+                   double diry, double dirz, double vertexX, double vertexY, double vertexZ, double vertexDirx,
+                   double vertexDiry, double vertexDirz, double gTime, double lTime, double pTime,
+                   vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState, unsigned int eventId = 0,
+                   unsigned int trackId = 0, short threadId = -1)
       : TrackData{pdg_id,
                   parentId,
                   ene,
+                  vertexEne,
                   x,
                   y,
                   z,
                   dirx,
                   diry,
                   dirz,
+                  vertexX,
+                  vertexY,
+                  vertexZ,
+                  vertexDirx,
+                  vertexDiry,
+                  vertexDirz,
                   gTime,
                   lTime,
                   pTime,

--- a/include/AdePT/core/TrackData.h
+++ b/include/AdePT/core/TrackData.h
@@ -17,8 +17,11 @@ struct TrackData {
   vecgeom::NavigationState navState;
   vecgeom::NavigationState originNavState;
   double position[3];
+  double vertexPosition[3];
   double direction[3];
+  double vertexMomentumDirection[3];
   double eKin{0};
+  double vertexEkin{0};
   double globalTime{0};
   double localTime{0};
   double properTime{0};
@@ -26,12 +29,14 @@ struct TrackData {
   int parentId{0};
 
   TrackData() = default;
-  TrackData(int pdg_id, int parentId, double ene, double x, double y, double z, double dirx, double diry, double dirz,
-            double gTime, double lTime, double pTime, vecgeom::NavigationState &&state,
-            vecgeom::NavigationState &&originState)
+  TrackData(int pdg_id, int parentId, double ene, double vertexEne, double x, double y, double z, double dirx,
+            double diry, double dirz, double vertexX, double vertexY, double vertexZ, double vertexDirx,
+            double vertexDiry, double vertexDirz, double gTime, double lTime, double pTime,
+            vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState)
       : navState{std::move(state)}, originNavState{std::move(originState)}, position{x, y, z},
-        direction{dirx, diry, dirz}, eKin{ene}, globalTime{gTime}, localTime{lTime}, properTime{pTime}, pdg{pdg_id},
-        parentId{parentId}
+        vertexPosition{vertexX, vertexY, vertexZ}, direction{dirx, diry, dirz},
+        vertexMomentumDirection{vertexDirx, vertexDiry, vertexDirz}, eKin{ene}, vertexEkin{vertexEne},
+        globalTime{gTime}, localTime{lTime}, properTime{pTime}, pdg{pdg_id}, parentId{parentId}
   {
   }
 

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -48,8 +48,10 @@ public:
   static void InitVolAuxData(adeptint::VolAuxData *volAuxData, G4HepEmState *hepEmState, bool trackInAllRegions,
                              std::vector<std::string> const *gpuRegionNames);
 
-  /// @brief Returns a mapping of VecGeom placed volume IDs to Geant4 physical volumes
-  static void GetPhysicalVolumeMap(std::vector<G4VPhysicalVolume const *> &vecgeomToG4Map);
+  /// @brief Returns a mapping of VecGeom placed volume IDs to Geant4 physical volumes and a mapping of VecGeom logical
+  /// volume IDs to Geant4 logical volumes
+  static void MapVecGeomToG4(std::vector<G4VPhysicalVolume const *> &vecgeomPvToG4Map,
+                             std::vector<G4LogicalVolume const *> &vecgeomLvToG4Map);
 
   /// @brief Reconstructs GPU hits on host and calls the user-defined sensitive detector code
   void ProcessGPUHit(GPUHit const &hit);
@@ -83,7 +85,8 @@ private:
 
   void ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex, int debugLevel) const;
 
-  static std::vector<G4VPhysicalVolume const *> fglobal_vecgeom_to_g4_map;
+  static std::vector<G4VPhysicalVolume const *> fglobal_vecgeom_pv_to_g4_map;
+  static std::vector<G4LogicalVolume const *> fglobal_vecgeom_lv_to_g4_map;
   std::unique_ptr<AdePTGeant4Integration_detail::ScoringObjects, AdePTGeant4Integration_detail::Deleter>
       fScoringObjects{nullptr};
 };

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -410,8 +410,9 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
             secondary.InitAsSecondary(pos, navState, globalTime);
             secondary.parentId = currentTrack.parentId;
             secondary.rngState = newRNG;
-            secondary.eKin     = deltaEkin;
+            secondary.eKin = secondary.vertexEkin = deltaEkin;
             secondary.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
+            secondary.vertexMomentumDirection.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
 #endif
           }
 
@@ -460,8 +461,10 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
             gamma.InitAsSecondary(pos, navState, globalTime);
             gamma.parentId = currentTrack.parentId;
             gamma.rngState = newRNG;
-            gamma.eKin     = deltaEkin;
+            gamma.eKin = gamma.vertexEkin = deltaEkin;
             gamma.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
+            gamma.vertexMomentumDirection.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
+
 #endif
           }
 
@@ -508,8 +511,9 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
             gamma1.InitAsSecondary(pos, navState, globalTime);
             gamma1.parentId = currentTrack.parentId;
             gamma1.rngState = newRNG;
-            gamma1.eKin     = theGamma1Ekin;
+            gamma1.eKin = gamma1.vertexEkin = theGamma1Ekin;
             gamma1.dir.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
+            gamma1.vertexMomentumDirection.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
 #endif
           }
           if (ApplyCuts && (theGamma2Ekin < theGammaCut)) {
@@ -529,8 +533,9 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
             // the state is not reused, but this shouldn't be an issue)
             gamma2.parentId = currentTrack.parentId;
             gamma2.rngState = currentTrack.rngState;
-            gamma2.eKin     = theGamma2Ekin;
+            gamma2.eKin = gamma2.vertexEkin = theGamma2Ekin;
             gamma2.dir.Set(theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]);
+            gamma2.vertexMomentumDirection.Set(theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]);
 #endif
           }
 
@@ -579,15 +584,17 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
           newRNG.Advance();
           gamma1.parentId = currentTrack.parentId;
           gamma1.rngState = newRNG;
-          gamma1.eKin     = copcore::units::kElectronMassC2;
+          gamma1.eKin = gamma1.vertexEkin = copcore::units::kElectronMassC2;
           gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
+          gamma1.vertexMomentumDirection.Set(sint * cosPhi, sint * sinPhi, cost);
 
           gamma2.InitAsSecondary(pos, navState, globalTime);
           // Reuse the RNG state of the dying track.
           gamma2.parentId = currentTrack.parentId;
           gamma2.rngState = currentTrack.rngState;
-          gamma2.eKin     = copcore::units::kElectronMassC2;
-          gamma2.dir      = -gamma1.dir;
+          gamma2.eKin = gamma2.vertexEkin = copcore::units::kElectronMassC2;
+          gamma2.dir                      = -gamma1.dir;
+          gamma2.vertexMomentumDirection  = -gamma1.dir;
 #endif
         }
       }

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -264,8 +264,9 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         electron.InitAsSecondary(pos, navState, globalTime);
         electron.parentId = currentTrack.parentId;
         electron.rngState = newRNG;
-        electron.eKin     = elKinEnergy;
+        electron.eKin = electron.vertexEkin = elKinEnergy;
         electron.dir.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
+        electron.vertexMomentumDirection.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
 #endif
       }
 
@@ -284,8 +285,9 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         // Reuse the RNG state of the dying track.
         positron.parentId = currentTrack.parentId;
         positron.rngState = currentTrack.rngState;
-        positron.eKin     = posKinEnergy;
+        positron.eKin = positron.vertexEkin = posKinEnergy;
         positron.dir.Set(dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]);
+        positron.vertexMomentumDirection.Set(dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]);
 #endif
       }
 
@@ -347,8 +349,8 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         electron.InitAsSecondary(pos, navState, globalTime);
         electron.parentId = currentTrack.parentId;
         electron.rngState = newRNG;
-        electron.eKin     = energyEl;
-        electron.dir      = eKin * dir - newEnergyGamma * newDirGamma;
+        electron.eKin = electron.vertexEkin = energyEl;
+        electron.dir = electron.vertexMomentumDirection = eKin * dir - newEnergyGamma * newDirGamma;
 #endif
 
         electron.dir.Normalize();
@@ -420,8 +422,9 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         electron.InitAsSecondary(pos, navState, globalTime);
         electron.parentId = currentTrack.parentId;
         electron.rngState = newRNG;
-        electron.eKin     = photoElecE;
+        electron.eKin = electron.vertexEkin = photoElecE;
         electron.dir.Set(dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]);
+        electron.vertexMomentumDirection.Set(dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]);
 #endif
 
       } else {

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -223,10 +223,27 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
         convertedOrigin = GetVecGeomFromG4State(*aTrack->GetOriginTouchableHandle()->GetHistory());
       }
 
-      fAdeptTransport->AddTrack(pdg, id, energy, particlePosition[0], particlePosition[1], particlePosition[2],
-                                particleDirection[0], particleDirection[1], particleDirection[2], globalTime, localTime,
-                                properTime, G4Threading::G4GetThreadId(), eventID, fTrackCounter++,
-                                std::move(converted), std::move(convertedOrigin));
+      // Get the vertex information
+      G4ThreeVector vertexPosition;
+      G4ThreeVector vertexDirection;
+      G4double vertexEnergy;
+      if (aTrack->GetCurrentStepNumber() == 0) {
+        // If it's the first step of the track these values are not set
+        vertexPosition  = aTrack->GetPosition();
+        vertexDirection = aTrack->GetMomentumDirection();
+        vertexEnergy    = aTrack->GetKineticEnergy();
+      } else {
+        vertexPosition  = aTrack->GetVertexPosition();
+        vertexDirection = aTrack->GetVertexMomentumDirection();
+        vertexEnergy    = aTrack->GetVertexKineticEnergy();
+      }
+
+      fAdeptTransport->AddTrack(pdg, id, energy, vertexEnergy, particlePosition[0], particlePosition[1],
+                                particlePosition[2], particleDirection[0], particleDirection[1], particleDirection[2],
+                                vertexPosition[0], vertexPosition[1], vertexPosition[2], vertexDirection[0],
+                                vertexDirection[1], vertexDirection[2], globalTime, localTime, properTime,
+                                G4Threading::G4GetThreadId(), eventID, fTrackCounter++, std::move(converted),
+                                std::move(convertedOrigin));
 
       // The track dies from the point of view of Geant4
       aTrack->SetTrackStatus(fStopAndKill);


### PR DESCRIPTION
As part of the modifications required to run AdePT in ATLAS Athena, with this PR we keep track of vertex information needed by some user codes in Athena, mirroring this change in the G4HepEM tracking manager: https://github.com/mnovak42/g4hepem/pull/108/commits/b3dc506679424e0814c67b75612863bd25e44aba

As in the previous Athena-related PR https://github.com/apt-sim/AdePT/pull/347, we don't pass this information for scoring yet, but this can be done if eventually needed.

Performance test for these additions:

`CMS2018, 32 TTbar, 8 Threads, Transport on ECAL+HCAL`

|        | Sync    | Async   |
|--------|---------|---------|
| Master | 305.363 | 284.428  |
| New    | 308.255 | 283.359 |

`TestEm3, 128 events, 100x10GeV e-`

|        | Sync    | Async   |
|--------|---------|---------|
| Master | 26.2131 | 17.5006  |
| New    | 26.0619 | 17.2154 |

Sync: 4M Track slots, 10M Hit slots
Async: 4M Track slots, 25M Hit slots

 