### PR TITLE
enable calling of UserSteppingAction and PostUserTrackingAction

### DIFF
--- a/include/AdePT/core/AdePTConfiguration.hh
+++ b/include/AdePT/core/AdePTConfiguration.hh
@@ -29,6 +29,7 @@ public:
   ~AdePTConfiguration() {}
   void SetNumThreads(int numThreads) { fNumThreads = numThreads; }
   void SetTrackInAllRegions(bool trackInAllRegions) { fTrackInAllRegions = trackInAllRegions; }
+  void SetCallUserSteppingAction(bool callUserSteppingAction) { fCallUserSteppingAction = callUserSteppingAction; }
   void AddGPURegionName(std::string name) { fGPURegionNames.push_back(name); }
   void SetAdePTActivation(bool activateAdePT) { fAdePTActivated = activateAdePT; }
   void SetVerbosity(int verbosity) { fVerbosity = verbosity; };
@@ -43,6 +44,7 @@ public:
   void SetVecGeomGDML(std::string filename) { fVecGeomGDML = filename; }
 
   bool GetTrackInAllRegions() { return fTrackInAllRegions; }
+  bool GetCallUserSteppingAction() { return fCallUserSteppingAction; }
   bool IsAdePTActivated() { return fAdePTActivated; }
   int GetNumThreads() { return fNumThreads; };
   int GetVerbosity() { return fVerbosity; };
@@ -59,6 +61,7 @@ public:
 
 private:
   bool fTrackInAllRegions{false};
+  bool fCallUserSteppingAction{false};
   bool fAdePTActivated{true};
   int fNumThreads;
   int fVerbosity{0};

--- a/include/AdePT/core/AdePTConfiguration.hh
+++ b/include/AdePT/core/AdePTConfiguration.hh
@@ -30,6 +30,10 @@ public:
   void SetNumThreads(int numThreads) { fNumThreads = numThreads; }
   void SetTrackInAllRegions(bool trackInAllRegions) { fTrackInAllRegions = trackInAllRegions; }
   void SetCallUserSteppingAction(bool callUserSteppingAction) { fCallUserSteppingAction = callUserSteppingAction; }
+  void SetCallPostUserTrackingAction(bool callPostUserTrackingAction)
+  {
+    fCallPostUserTrackingAction = callPostUserTrackingAction;
+  }
   void AddGPURegionName(std::string name) { fGPURegionNames.push_back(name); }
   void SetAdePTActivation(bool activateAdePT) { fAdePTActivated = activateAdePT; }
   void SetVerbosity(int verbosity) { fVerbosity = verbosity; };
@@ -45,6 +49,7 @@ public:
 
   bool GetTrackInAllRegions() { return fTrackInAllRegions; }
   bool GetCallUserSteppingAction() { return fCallUserSteppingAction; }
+  bool GetCallPostUserTrackingAction() { return fCallPostUserTrackingAction; }
   bool IsAdePTActivated() { return fAdePTActivated; }
   int GetNumThreads() { return fNumThreads; };
   int GetVerbosity() { return fVerbosity; };
@@ -62,6 +67,7 @@ public:
 private:
   bool fTrackInAllRegions{false};
   bool fCallUserSteppingAction{false};
+  bool fCallPostUserTrackingAction{false};
   bool fAdePTActivated{true};
   int fNumThreads;
   int fVerbosity{0};

--- a/include/AdePT/core/AdePTScoringTemplate.cuh
+++ b/include/AdePT/core/AdePTScoringTemplate.cuh
@@ -23,7 +23,7 @@ __device__ void RecordHit(Scoring *scoring_dev, int aParentID, char aParticleTyp
                           vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin, double aPreCharge,
                           vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
                           vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                          double aPostCharge, unsigned int eventId, short threadId);
+                          double aPostCharge, unsigned int eventId, short threadId, bool isLastStep);
 
 template <typename Scoring>
 __device__ void AccountProduced(Scoring *scoring_dev, int num_ele, int num_pos, int num_gam);

--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -107,7 +107,6 @@ private:
   bool InitializeField(double bz);
   bool InitializeGeometry(const vecgeom::cxx::VPlacedVolume *world);
   bool InitializePhysics();
-  void ProcessGPUHits();
 };
 
 #include "AdePTTransport.icc"

--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -78,6 +78,7 @@ public:
   void Cleanup();
   /// @brief Interface for transporting a buffer of tracks in AdePT.
   void Shower(int event, int threadId);
+  void ProcessGPUSteps(int, int) {};
 
 private:
   static inline G4HepEmState *fg4hepem_state{nullptr}; ///< The HepEm state singleton

--- a/include/AdePT/core/AdePTTransportInterface.hh
+++ b/include/AdePT/core/AdePTTransportInterface.hh
@@ -47,8 +47,9 @@ public:
   /// @brief Initialize the ApplyCuts flag on device
   virtual bool InitializeApplyCuts(bool applycuts) = 0;
   /// @brief Interface for transporting a buffer of tracks in AdePT.
-  virtual void Shower(int event, int threadId) = 0;
-  virtual void Cleanup()                       = 0;
+  virtual void Shower(int event, int threadId)            = 0;
+  virtual void Cleanup()                                  = 0;
+  virtual void ProcessGPUSteps(int threadId, int eventId) = 0;
 };
 
 #endif

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -616,7 +616,7 @@ void HitProcessingLoop(HitProcessingContext *const context, GPUstate &gpuState,
 
 void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, TrackBuffer &trackBuffer, GPUstate &gpuState,
                    std::vector<std::atomic<EventState>> &eventStates, std::condition_variable &cvG4Workers,
-                   std::vector<AdePTScoring> &scoring, int adeptSeed, int debugLevel)
+                   std::vector<AdePTScoring> &scoring, int adeptSeed, int debugLevel, bool returnAllSteps)
 {
   // NVTXTracer tracer{"TransportLoop"};
 
@@ -791,7 +791,7 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
         const auto [threads, blocks] = computeThreadsAndBlocks(particlesInFlight[ParticleType::Electron]);
         TransportElectrons<PerEventScoring><<<blocks, threads, 0, electrons.stream>>>(
             electrons.tracks, electrons.queues.currentlyActive, secondaries, electrons.queues.nextActive,
-            electrons.queues.leakedTracksCurrent, gpuState.fScoring_dev);
+            electrons.queues.leakedTracksCurrent, gpuState.fScoring_dev, returnAllSteps);
 
         COPCORE_CUDA_CHECK(cudaEventRecord(electrons.event, electrons.stream));
         COPCORE_CUDA_CHECK(cudaStreamWaitEvent(gpuState.stream, electrons.event, 0));
@@ -802,7 +802,7 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
         const auto [threads, blocks] = computeThreadsAndBlocks(particlesInFlight[ParticleType::Positron]);
         TransportPositrons<PerEventScoring><<<blocks, threads, 0, positrons.stream>>>(
             positrons.tracks, positrons.queues.currentlyActive, secondaries, positrons.queues.nextActive,
-            positrons.queues.leakedTracksCurrent, gpuState.fScoring_dev);
+            positrons.queues.leakedTracksCurrent, gpuState.fScoring_dev, returnAllSteps);
 
         COPCORE_CUDA_CHECK(cudaEventRecord(positrons.event, positrons.stream));
         COPCORE_CUDA_CHECK(cudaStreamWaitEvent(gpuState.stream, positrons.event, 0));
@@ -813,7 +813,7 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
         const auto [threads, blocks] = computeThreadsAndBlocks(particlesInFlight[ParticleType::Gamma]);
         TransportGammas<PerEventScoring><<<blocks, threads, 0, gammas.stream>>>(
             gammas.tracks, gammas.queues.currentlyActive, secondaries, gammas.queues.nextActive,
-            gammas.queues.leakedTracksCurrent, gpuState.fScoring_dev); //, gpuState.gammaInteractions);
+            gammas.queues.leakedTracksCurrent, gpuState.fScoring_dev, returnAllSteps); //, gpuState.gammaInteractions);
 
         // constexpr unsigned int intThreads = 128;
         // ApplyGammaInteractions<PerEventScoring><<<dim3(20, 3, 1), intThreads, 0, gammas.stream>>>(
@@ -1099,12 +1099,12 @@ void CloseGPUBuffer(unsigned int threadId, GPUstate &gpuState, GPUHit *begin, co
 std::thread LaunchGPUWorker(int trackCapacity, int scoringCapacity, int numThreads, TrackBuffer &trackBuffer,
                             GPUstate &gpuState, std::vector<std::atomic<EventState>> &eventStates,
                             std::condition_variable &cvG4Workers, std::vector<AdePTScoring> &scoring, int adeptSeed,
-                            int debugLevel)
+                            int debugLevel, bool returnAllSteps)
 {
   return std::thread{
       &TransportLoop,     trackCapacity,         scoringCapacity,       numThreads,        std::ref(trackBuffer),
       std::ref(gpuState), std::ref(eventStates), std::ref(cvG4Workers), std::ref(scoring), adeptSeed,
-      debugLevel};
+      debugLevel,         returnAllSteps};
 }
 
 void FreeGPU(std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> &gpuState, G4HepEmState &g4hepem_state,

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -59,9 +59,9 @@ private:
   std::vector<double> fGPUNetEnergy;
   bool fTrackInAllRegions = false;
   std::vector<std::string> const *fGPURegionNames;
-  ///< Flag for the kernels to return all steps, needed for UserSteppingAction or UserTrackingAction
-  bool fReturnAllSteps         = false;
-  bool fCallUserSteppingAction = false;
+  // Flags for the kernels to return the last or all steps, needed for PostUserTrackingAction or UserSteppingAction
+  bool fReturnAllSteps = false;
+  bool fReturnLastStep = false;
 
   void Initialize();
   void InitBVH();

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -59,6 +59,9 @@ private:
   std::vector<double> fGPUNetEnergy;
   bool fTrackInAllRegions = false;
   std::vector<std::string> const *fGPURegionNames;
+  ///< Flag for the kernels to return all steps, needed for UserSteppingAction or UserTrackingAction
+  bool fReturnAllSteps         = false;
+  bool fCallUserSteppingAction = false;
 
   void Initialize();
   void InitBVH();
@@ -105,6 +108,7 @@ public:
   void Shower(int event, int threadId) override { Flush(threadId, event); }
   /// Block until transport of the given event is done.
   void Flush(int threadId, int eventId);
+  void ProcessGPUSteps(int threadId, int eventId);
   void Cleanup() override {}
 };
 

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -108,7 +108,7 @@ public:
   void Shower(int event, int threadId) override { Flush(threadId, event); }
   /// Block until transport of the given event is done.
   void Flush(int threadId, int eventId);
-  void ProcessGPUSteps(int threadId, int eventId);
+  void ProcessGPUSteps(int threadId, int eventId) override;
   void Cleanup() override {}
 };
 

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -48,7 +48,7 @@ std::pair<GPUHit *, GPUHit *> GetGPUHitsFromBuffer(unsigned int, unsigned int, A
 void CloseGPUBuffer(unsigned int, AsyncAdePT::GPUstate &, GPUHit *, const bool);
 std::thread LaunchGPUWorker(int, int, int, AsyncAdePT::TrackBuffer &, AsyncAdePT::GPUstate &,
                             std::vector<std::atomic<AsyncAdePT::EventState>> &, std::condition_variable &,
-                            std::vector<AdePTScoring> &, int, int, bool);
+                            std::vector<AdePTScoring> &, int, int, bool, bool);
 std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> InitializeGPU(int trackCapacity, int scoringCapacity,
                                                                                  int numThreads,
                                                                                  AsyncAdePT::TrackBuffer &trackBuffer,
@@ -85,10 +85,8 @@ AsyncAdePTTransport<IntegrationLayer>::AsyncAdePTTransport(AdePTConfiguration &c
       fDebugLevel{configuration.GetVerbosity()}, fIntegrationLayerObjects(fNThread), fEventStates(fNThread),
       fGPUNetEnergy(fNThread, 0.0), fTrackInAllRegions{configuration.GetTrackInAllRegions()},
       fGPURegionNames{configuration.GetGPURegionNames()}, fCUDAStackLimit{configuration.GetCUDAStackLimit()},
-      fCUDAHeapLimit{configuration.GetCUDAHeapLimit()},
-      fCallUserSteppingAction{configuration.GetCallUserSteppingAction()},
-      fReturnAllSteps{configuration.GetCallUserSteppingAction()}
-// ReturnAllSteps will be set to CallUserSteppingAction || CallUserTrackingAction once implemented
+      fCUDAHeapLimit{configuration.GetCUDAHeapLimit()}, fReturnAllSteps{configuration.GetCallUserSteppingAction()},
+      fReturnLastStep{configuration.GetCallPostUserTrackingAction()}
 {
   if (fNThread > kMaxThreads)
     throw std::invalid_argument("AsyncAdePTTransport limited to " + std::to_string(kMaxThreads) + " threads");
@@ -245,10 +243,10 @@ void AsyncAdePTTransport<IntegrationLayer>::Initialize()
 
   assert(fBuffer != nullptr);
 
-  fGPUstate = async_adept_impl::InitializeGPU(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, fScoring);
-  fGPUWorker =
-      async_adept_impl::LaunchGPUWorker(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, *fGPUstate, fEventStates,
-                                        fCV_G4Workers, fScoring, fAdePTSeed, fDebugLevel, fReturnAllSteps);
+  fGPUstate  = async_adept_impl::InitializeGPU(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, fScoring);
+  fGPUWorker = async_adept_impl::LaunchGPUWorker(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, *fGPUstate,
+                                                 fEventStates, fCV_G4Workers, fScoring, fAdePTSeed, fDebugLevel,
+                                                 fReturnAllSteps, fReturnLastStep);
 }
 
 template <typename IntegrationLayer>
@@ -279,7 +277,7 @@ void AsyncAdePTTransport<IntegrationLayer>::ProcessGPUSteps(int threadId, int ev
                   << "state : " << static_cast<unsigned int>(fEventStates[threadId].load(std::memory_order_acquire))
                   << "\033[0m" << std::endl;
       }
-      integrationInstance.ProcessGPUHit(*it, fCallUserSteppingAction);
+      integrationInstance.ProcessGPUHit(*it, fReturnAllSteps, fReturnLastStep);
     }
     async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate, range.first, dataOnBuffer);
   }

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -88,7 +88,7 @@ AsyncAdePTTransport<IntegrationLayer>::AsyncAdePTTransport(AdePTConfiguration &c
       fCUDAHeapLimit{configuration.GetCUDAHeapLimit()},
       fCallUserSteppingAction{configuration.GetCallUserSteppingAction()},
       fReturnAllSteps{configuration.GetCallUserSteppingAction()}
-      // ReturnAllSteps will be set to CallUserSteppingAction || CallUserTrackingAction once implemented
+// ReturnAllSteps will be set to CallUserSteppingAction || CallUserTrackingAction once implemented
 {
   if (fNThread > kMaxThreads)
     throw std::invalid_argument("AsyncAdePTTransport limited to " + std::to_string(kMaxThreads) + " threads");

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -277,7 +277,7 @@ void AsyncAdePTTransport<IntegrationLayer>::ProcessGPUSteps(int threadId, int ev
                   << "state : " << static_cast<unsigned int>(fEventStates[threadId].load(std::memory_order_acquire))
                   << "\033[0m" << std::endl;
       }
-      integrationInstance.ProcessGPUHit(*it, fReturnAllSteps, fReturnLastStep);
+      integrationInstance.ProcessGPUStep(*it, fReturnAllSteps, fReturnLastStep);
     }
     async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate, range.first, dataOnBuffer);
   }

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -48,7 +48,7 @@ std::pair<GPUHit *, GPUHit *> GetGPUHitsFromBuffer(unsigned int, unsigned int, A
 void CloseGPUBuffer(unsigned int, AsyncAdePT::GPUstate &, GPUHit *, const bool);
 std::thread LaunchGPUWorker(int, int, int, AsyncAdePT::TrackBuffer &, AsyncAdePT::GPUstate &,
                             std::vector<std::atomic<AsyncAdePT::EventState>> &, std::condition_variable &,
-                            std::vector<AdePTScoring> &, int, int);
+                            std::vector<AdePTScoring> &, int, int, bool);
 std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> InitializeGPU(int trackCapacity, int scoringCapacity,
                                                                                  int numThreads,
                                                                                  AsyncAdePT::TrackBuffer &trackBuffer,
@@ -85,7 +85,10 @@ AsyncAdePTTransport<IntegrationLayer>::AsyncAdePTTransport(AdePTConfiguration &c
       fDebugLevel{configuration.GetVerbosity()}, fIntegrationLayerObjects(fNThread), fEventStates(fNThread),
       fGPUNetEnergy(fNThread, 0.0), fTrackInAllRegions{configuration.GetTrackInAllRegions()},
       fGPURegionNames{configuration.GetGPURegionNames()}, fCUDAStackLimit{configuration.GetCUDAStackLimit()},
-      fCUDAHeapLimit{configuration.GetCUDAHeapLimit()}
+      fCUDAHeapLimit{configuration.GetCUDAHeapLimit()},
+      fCallUserSteppingAction{configuration.GetCallUserSteppingAction()},
+      fReturnAllSteps{configuration.GetCallUserSteppingAction()}
+      // ReturnAllSteps will be set to CallUserSteppingAction || CallUserTrackingAction once implemented
 {
   if (fNThread > kMaxThreads)
     throw std::invalid_argument("AsyncAdePTTransport limited to " + std::to_string(kMaxThreads) + " threads");
@@ -242,9 +245,10 @@ void AsyncAdePTTransport<IntegrationLayer>::Initialize()
 
   assert(fBuffer != nullptr);
 
-  fGPUstate  = async_adept_impl::InitializeGPU(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, fScoring);
-  fGPUWorker = async_adept_impl::LaunchGPUWorker(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, *fGPUstate,
-                                                 fEventStates, fCV_G4Workers, fScoring, fAdePTSeed, fDebugLevel);
+  fGPUstate = async_adept_impl::InitializeGPU(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, fScoring);
+  fGPUWorker =
+      async_adept_impl::LaunchGPUWorker(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, *fGPUstate, fEventStates,
+                                        fCV_G4Workers, fScoring, fAdePTSeed, fDebugLevel, fReturnAllSteps);
 }
 
 template <typename IntegrationLayer>
@@ -252,6 +256,33 @@ void AsyncAdePTTransport<IntegrationLayer>::InitBVH()
 {
   vecgeom::cxx::BVHManager::Init();
   vecgeom::cxx::BVHManager::DeviceInit();
+}
+
+template <typename IntegrationLayer>
+void AsyncAdePTTransport<IntegrationLayer>::ProcessGPUSteps(int threadId, int eventId)
+{
+
+  AdePTGeant4Integration &integrationInstance = fIntegrationLayerObjects[threadId];
+  std::pair<GPUHit *, GPUHit *> range;
+  bool dataOnBuffer;
+
+  while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate, dataOnBuffer)).first !=
+         nullptr) {
+    for (auto it = range.first; it != range.second; ++it) {
+      // important sanity check: thread should only process its own hits and only from the current event
+      if (it->threadId != threadId)
+        std::cerr << "\033[1;31mError, threadId doesn't match it->threadId " << it->threadId << " threadId " << threadId
+                  << "\033[0m" << std::endl;
+      if (it->fEventId != eventId) {
+        std::cerr << "\033[1;31mError, eventId doesn't match it->fEventId " << it->fEventId << "eventId " << eventId
+                  << " num hits to be processed " << (range.second - range.first) << " dataOnBuffer " << dataOnBuffer
+                  << "state : " << static_cast<unsigned int>(fEventStates[threadId].load(std::memory_order_acquire))
+                  << "\033[0m" << std::endl;
+      }
+      integrationInstance.ProcessGPUHit(*it, fCallUserSteppingAction);
+    }
+    async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate, range.first, dataOnBuffer);
+  }
 }
 
 template <typename IntegrationLayer>
@@ -268,31 +299,12 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
 
   while (fEventStates[threadId].load(std::memory_order_acquire) < EventState::DeviceFlushed) {
 
-    std::pair<GPUHit *, GPUHit *> range;
-    bool dataOnBuffer;
-
     {
       std::unique_lock lock{fMutex_G4Workers};
       fCV_G4Workers.wait(lock);
     }
 
-    while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate, dataOnBuffer)).first !=
-           nullptr) {
-      for (auto it = range.first; it != range.second; ++it) {
-        // important sanity check: thread should only process its own hits and only from the current event
-        if (it->threadId != threadId)
-          std::cerr << "Error, threadId doesn't match it->threadId " << it->threadId << " threadId " << threadId
-                    << std::endl;
-        if (it->fEventId != eventId) {
-          std::cerr << "Error, eventId doesn't match it->fEventId " << it->fEventId << "eventId " << eventId
-                    << " num hits to be processed " << (range.second - range.first) << " dataOnBuffer " << dataOnBuffer
-                    << "state : " << static_cast<unsigned int>(fEventStates[threadId].load(std::memory_order_acquire))
-                    << std::endl;
-        }
-        integrationInstance.ProcessGPUHit(*it);
-      }
-      async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate, range.first, dataOnBuffer);
-    }
+    ProcessGPUSteps(threadId, eventId);
   }
 
   // Now device should be flushed, so retrieve the tracks:

--- a/include/AdePT/core/HostScoringImpl.cuh
+++ b/include/AdePT/core/HostScoringImpl.cuh
@@ -155,7 +155,7 @@ __device__ void RecordHit(HostScoring *hostScoring_dev, int aParentID, char aPar
                           vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin, double aPreCharge,
                           vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
                           vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                          double aPostCharge, unsigned int, short)
+                          double aPostCharge, unsigned int, short, bool)
 {
   // Acquire a hit slot
   GPUHit &aGPUHit = *GetNextFreeHit(hostScoring_dev);
@@ -163,7 +163,7 @@ __device__ void RecordHit(HostScoring *hostScoring_dev, int aParentID, char aPar
   // Fill the required data
   FillHit(aGPUHit, aParentID, aParticleType, aStepLength, aTotalEnergyDeposit, aPreState, aPrePosition,
           aPreMomentumDirection, aPreEKin, aPreCharge, aPostState, aPostPosition, aPostMomentumDirection, aPostEKin,
-          aPostCharge, 0, 0);
+          aPostCharge, 0, 0, false);
 }
 
 /// @brief Account for the number of produced secondaries

--- a/include/AdePT/core/HostScoringImpl.cuh
+++ b/include/AdePT/core/HostScoringImpl.cuh
@@ -202,7 +202,7 @@ inline void EndOfIteration(HostScoring &hostScoring, HostScoring *hostScoring_de
     COPCORE_CUDA_CHECK(cudaStreamSynchronize(stream));
     // Process the hits on CPU
     for (const auto &hit : hostScoring) {
-      integration.ProcessGPUHit(hit);
+      integration.ProcessGPUStep(hit);
     }
   }
 }
@@ -220,7 +220,7 @@ inline void EndOfTransport(HostScoring &hostScoring, HostScoring *hostScoring_de
   COPCORE_CUDA_CHECK(cudaStreamSynchronize(stream));
   // Process the last hits on CPU
   for (const auto &hit : hostScoring) {
-    integration.ProcessGPUHit(hit);
+    integration.ProcessGPUStep(hit);
   }
 }
 } // namespace adept_scoring

--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -674,7 +674,7 @@ __device__ void RecordHit(AsyncAdePT::PerEventScoring * /*scoring*/, int aParent
                           vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin, double aPreCharge,
                           vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
                           vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                          double aPostCharge, unsigned int eventID, short threadID)
+                          double aPostCharge, unsigned int eventID, short threadID, bool isLastStep)
 {
   // Acquire a hit slot
   GPUHit &aGPUHit = AsyncAdePT::gHitScoringBuffer_dev.GetNextSlot(threadID);
@@ -682,7 +682,7 @@ __device__ void RecordHit(AsyncAdePT::PerEventScoring * /*scoring*/, int aParent
   // Fill the required data
   FillHit(aGPUHit, aParentID, aParticleType, aStepLength, aTotalEnergyDeposit, aPreState, aPrePosition,
           aPreMomentumDirection, aPreEKin, aPreCharge, aPostState, aPostPosition, aPostMomentumDirection, aPostEKin,
-          aPostCharge, eventID, threadID);
+          aPostCharge, eventID, threadID, isLastStep);
 }
 
 /// @brief Account for the number of produced secondaries

--- a/include/AdePT/core/ScoringCommons.hh
+++ b/include/AdePT/core/ScoringCommons.hh
@@ -21,18 +21,18 @@ struct GPUStepPoint {
 // Stores the necessary data to reconstruct GPU hits on the host , and
 // call the user-defined Geant4 sensitive detector code
 struct GPUHit {
-  int fParentID{0}; // Track ID
+  // Data needed to reconstruct pre-post step points
+  GPUStepPoint fPreStepPoint;
+  GPUStepPoint fPostStepPoint;
   // Data needed to reconstruct G4 Step
   double fStepLength{0};
   double fTotalEnergyDeposit{0};
   double fNonIonizingEnergyDeposit{0};
-  // bool fFirstStepInVolume{false};
-  // bool fLastStepInVolume{false};
-  // Data needed to reconstruct pre-post step points
-  GPUStepPoint fPreStepPoint;
-  GPUStepPoint fPostStepPoint;
+  int fParentID{0}; // Track ID
   unsigned int fEventId{0};
   short threadId{-1};
+  // bool fFirstStepInVolume{false};
+  bool fLastStepOfTrack{false};
   char fParticleType{0}; // Particle type ID
 };
 
@@ -74,11 +74,12 @@ __device__ __forceinline__ void FillHit(GPUHit &aGPUHit, int aParentID, char aPa
                                         double aPreCharge, vecgeom::NavigationState const &aPostState,
                                         vecgeom::Vector3D<Precision> const &aPostPosition,
                                         vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                                        double aPostCharge, unsigned int eventID, short threadID)
+                                        double aPostCharge, unsigned int eventID, short threadID, bool isLastStep)
 {
   aGPUHit.fEventId = eventID;
   aGPUHit.threadId = threadID;
 
+  aGPUHit.fLastStepOfTrack = isLastStep;
   // Fill the required data
   aGPUHit.fParentID           = aParentID;
   aGPUHit.fParticleType       = aParticleType;

--- a/include/AdePT/integration/AdePTConfigurationMessenger.hh
+++ b/include/AdePT/integration/AdePTConfigurationMessenger.hh
@@ -37,6 +37,7 @@ private:
   G4UIcmdWithAnInteger *fSetCUDAHeapLimitCmd;
   G4UIcmdWithABool *fSetTrackInAllRegionsCmd;
   G4UIcmdWithABool *fSetCallUserSteppingActionCmd;
+  G4UIcmdWithABool *fSetCallPostUserTrackingActionCmd;
   G4UIcmdWithAString *fAddRegionCmd;
   G4UIcmdWithABool *fActivateAdePTCmd;
   G4UIcmdWithAnInteger *fSetVerbosityCmd;

--- a/include/AdePT/integration/AdePTConfigurationMessenger.hh
+++ b/include/AdePT/integration/AdePTConfigurationMessenger.hh
@@ -36,6 +36,7 @@ private:
   G4UIcmdWithAnInteger *fSetCUDAStackLimitCmd;
   G4UIcmdWithAnInteger *fSetCUDAHeapLimitCmd;
   G4UIcmdWithABool *fSetTrackInAllRegionsCmd;
+  G4UIcmdWithABool *fSetCallUserSteppingActionCmd;
   G4UIcmdWithAString *fAddRegionCmd;
   G4UIcmdWithABool *fActivateAdePTCmd;
   G4UIcmdWithAnInteger *fSetVerbosityCmd;

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -54,7 +54,7 @@ public:
                              std::vector<G4LogicalVolume const *> &vecgeomLvToG4Map);
 
   /// @brief Reconstructs GPU hits on host and calls the user-defined sensitive detector code
-  void ProcessGPUHit(GPUHit const &hit);
+  void ProcessGPUHit(GPUHit const &hit, bool const callUserSteppingAction = false);
 
   /// @brief Takes a range of tracks coming from the device and gives them back to Geant4
   template <typename Iterator>

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -54,8 +54,8 @@ public:
                              std::vector<G4LogicalVolume const *> &vecgeomLvToG4Map);
 
   /// @brief Reconstructs GPU hits on host and calls the user-defined sensitive detector code
-  void ProcessGPUHit(GPUHit const &hit, bool const callUserSteppingAction = false,
-                     bool const callPostUserTrackingaction = false);
+  void ProcessGPUStep(GPUHit const &hit, bool const callUserSteppingAction = false,
+                      bool const callPostUserTrackingaction = false);
 
   /// @brief Takes a range of tracks coming from the device and gives them back to Geant4
   template <typename Iterator>

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -54,7 +54,8 @@ public:
                              std::vector<G4LogicalVolume const *> &vecgeomLvToG4Map);
 
   /// @brief Reconstructs GPU hits on host and calls the user-defined sensitive detector code
-  void ProcessGPUHit(GPUHit const &hit, bool const callUserSteppingAction = false);
+  void ProcessGPUHit(GPUHit const &hit, bool const callUserSteppingAction = false,
+                     bool const callPostUserTrackingaction = false);
 
   /// @brief Takes a range of tracks coming from the device and gives them back to Geant4
   template <typename Iterator>

--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -83,6 +83,10 @@ private:
   bool fAdePTInitialized{false};
 };
 
+#ifdef ASYNC_MODE
+std::shared_ptr<AsyncAdePT::AsyncAdePTTransport<AdePTGeant4Integration>> GetAdePTInstance();
+#endif
+
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 #endif

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -74,7 +74,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
                                                           Scoring *userScoring, VolAuxData const *auxDataArray)
 {
   using namespace adept_impl;
-  constexpr returnAllSteps          = false;
+  constexpr bool returnAllSteps          = false;
   constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
   constexpr int Charge              = IsElectron ? -1 : 1;
   constexpr double restMass         = copcore::units::kElectronMassC2;

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -74,7 +74,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
                                                           Scoring *userScoring, VolAuxData const *auxDataArray)
 {
   using namespace adept_impl;
-  constexpr bool returnAllSteps          = false;
+  constexpr bool returnAllSteps     = false;
   constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
   constexpr int Charge              = IsElectron ? -1 : 1;
   constexpr double restMass         = copcore::units::kElectronMassC2;

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -43,7 +43,7 @@ template <bool IsElectron, typename Scoring>
 static __device__ __forceinline__ void TransportElectrons(Track *electrons, const adept::MParray *active,
                                                           Secondaries &secondaries, adept::MParray *activeQueue,
                                                           adept::MParray *leakedQueue, Scoring *userScoring,
-                                                          bool returnAllSteps)
+                                                          bool returnAllSteps, bool returnLastStep)
 {
   constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
   constexpr int Charge              = IsElectron ? -1 : 1;
@@ -75,6 +75,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 {
   using namespace adept_impl;
   constexpr bool returnAllSteps     = false;
+  bool returnLastStep               = false;
   constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
   constexpr int Charge              = IsElectron ? -1 : 1;
   constexpr double restMass         = copcore::units::kElectronMassC2;
@@ -108,6 +109,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     double properTime = currentTrack.properTime;
 
     auto survive = [&](bool leak = false) {
+      returnLastStep          = false; // track survived, do not force return of step
       currentTrack.eKin       = eKin;
       currentTrack.pos        = pos;
       currentTrack.dir        = dir;
@@ -346,8 +348,9 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
         // Kill the particle if it left the world.
         if (!nextState.IsOutside()) {
           // Mark the particle. We need to change its navigation state to the next volume before enqueuing it
-          // This will happen after recordinf the step
+          // This will happen after recording the step
           cross_boundary = true;
+          returnLastStep = false; // the track survives, do not force return of step
         } else {
           // Particle left the world, don't enqueue it and release the slot
 #ifdef ASYNC_MODE
@@ -607,24 +610,25 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     }
 
     // Record the step. Edep includes the continuous energy loss and edep from secondaries which were cut
-    if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps)
+    if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep)
       adept_scoring::RecordHit(userScoring, currentTrack.parentId,
-                               static_cast<char>(IsElectron ? 0 : 1),        // Particle type
-                               elTrack.GetPStepLength(),                     // Step length
-                               energyDeposit,                                // Total Edep
-                               navState,                                     // Pre-step point navstate
-                               preStepPos,                                   // Pre-step point position
-                               preStepDir,                                   // Pre-step point momentum direction
-                               preStepEnergy,                                // Pre-step point kinetic energy
-                               IsElectron ? -1 : 1,                          // Pre-step point charge
-                               nextState,                                    // Post-step point navstate
-                               pos,                                          // Post-step point position
-                               dir,                                          // Post-step point momentum direction
-                               eKin,                                         // Post-step point kinetic energy
-                               IsElectron ? -1 : 1,                          // Post-step point charge
-                               currentTrack.eventId, currentTrack.threadId); // eventID and threadID (not needed here)
+                               static_cast<char>(IsElectron ? 0 : 1),       // Particle type
+                               elTrack.GetPStepLength(),                    // Step length
+                               energyDeposit,                               // Total Edep
+                               navState,                                    // Pre-step point navstate
+                               preStepPos,                                  // Pre-step point position
+                               preStepDir,                                  // Pre-step point momentum direction
+                               preStepEnergy,                               // Pre-step point kinetic energy
+                               IsElectron ? -1 : 1,                         // Pre-step point charge
+                               nextState,                                   // Post-step point navstate
+                               pos,                                         // Post-step point position
+                               dir,                                         // Post-step point momentum direction
+                               eKin,                                        // Post-step point kinetic energy
+                               IsElectron ? -1 : 1,                         // Post-step point charge
+                               currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                               returnLastStep);                             // whether this was the last step
     if (cross_boundary) {
-      // Move to the next boundary.
+      // Move to the next boundary now that the Step is recorded
       navState = nextState;
       // Check if the next volume belongs to the GPU region and push it to the appropriate queue
 #ifndef ADEPT_USE_SURF
@@ -654,18 +658,18 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 template <typename Scoring>
 __global__ void TransportElectrons(Track *electrons, const adept::MParray *active, Secondaries secondaries,
                                    adept::MParray *activeQueue, adept::MParray *leakedQueue, Scoring *userScoring,
-                                   bool returnAllSteps)
+                                   bool returnAllSteps, bool returnLastStep)
 {
   TransportElectrons</*IsElectron*/ true, Scoring>(electrons, active, secondaries, activeQueue, leakedQueue,
-                                                   userScoring, returnAllSteps);
+                                                   userScoring, returnAllSteps, returnLastStep);
 }
 template <typename Scoring>
 __global__ void TransportPositrons(Track *positrons, const adept::MParray *active, Secondaries secondaries,
                                    adept::MParray *activeQueue, adept::MParray *leakedQueue, Scoring *userScoring,
-                                   bool returnAllSteps)
+                                   bool returnAllSteps, bool returnLastStep)
 {
   TransportElectrons</*IsElectron*/ false, Scoring>(positrons, active, secondaries, activeQueue, leakedQueue,
-                                                    userScoring, returnAllSteps);
+                                                    userScoring, returnAllSteps, returnLastStep);
 }
 #else
 template <typename Scoring>

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -49,7 +49,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                 Scoring *userScoring, VolAuxData const *auxDataArray)
 {
   using namespace adept_impl;
-  constexpr returnAllSteps          = false;
+  constexpr bool returnAllSteps          = false;
   constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
   constexpr int Pdg                 = 22;
   int activeSize                    = gammas->fActiveTracks->size();

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -25,7 +25,7 @@ namespace AsyncAdePT {
 template <typename Scoring>
 __global__ void __launch_bounds__(256, 1)
     TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
-                    adept::MParray *leakedQueue, Scoring *userScoring)
+                    adept::MParray *leakedQueue, Scoring *userScoring, bool returnAllSteps)
 {
   constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
   int activeSize                    = active->size();
@@ -49,6 +49,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                 Scoring *userScoring, VolAuxData const *auxDataArray)
 {
   using namespace adept_impl;
+  constexpr returnAllSteps          = false;
   constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
   constexpr int Pdg                 = 22;
   int activeSize                    = gammas->fActiveTracks->size();
@@ -205,6 +206,25 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         slotManager.MarkSlotForFreeing(slot);
 #endif
       }
+
+      if (returnAllSteps)
+        adept_scoring::RecordHit(userScoring,
+                                 currentTrack.parentId,                        // Track ID
+                                 2,                                            // Particle type
+                                 geometryStepLength,                           // Step length
+                                 0,                                            // Total Edep
+                                 navState,                                     // Pre-step point navstate
+                                 preStepPos,                                   // Pre-step point position
+                                 preStepDir,                                   // Pre-step point momentum direction
+                                 preStepEnergy,                                // Pre-step point kinetic energy
+                                 0,                                            // Pre-step point charge
+                                 nextState,                                    // Post-step point navstate
+                                 pos,                                          // Post-step point position
+                                 dir,                                          // Post-step point momentum direction
+                                 0,                                            // Post-step point kinetic energy
+                                 0,                                            // Post-step point charge
+                                 currentTrack.eventId, currentTrack.threadId); // event and thread ID
+
       continue;
     } else {
 
@@ -227,6 +247,9 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
     const double theElCut    = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fSecElProdCutE;
     const double theGammaCut = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fSecGamProdCutE;
 
+    double edep           = 0.;
+    double newEnergyGamma = 0.; // gamma energy after compton scattering
+
     switch (winnerProcessIndex) {
     case 0: {
       // Invoke gamma conversion to e-/e+ pairs, if the energy is above the threshold.
@@ -248,8 +271,6 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 1, /*numPositrons*/ 1, /*numGammas*/ 0);
 
       // Check the cuts and deposit energy in this volume if needed
-      double edep = 0;
-
       if (ApplyCuts && elKinEnergy < theElCut) {
         // Deposit the energy here and kill the secondary
         edep = elKinEnergy;
@@ -291,27 +312,6 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
 #endif
       }
 
-      // If there is some edep from cutting particles, record the step
-      if (edep > 0) {
-        if (auxData.fSensIndex >= 0)
-          adept_scoring::RecordHit(userScoring,
-                                   currentTrack.parentId,  // Track ID
-                                   2,                      // Particle type
-                                   geometryStepLength,     // Step length
-                                   edep,                   // Total Edep
-                                   navState,               // Pre-step point navstate
-                                   preStepPos,             // Pre-step point position
-                                   preStepDir,             // Pre-step point momentum direction
-                                   preStepEnergy,          // Pre-step point kinetic energy
-                                   0,                      // Pre-step point charge
-                                   nextState,              // Post-step point navstate
-                                   pos,                    // Post-step point position
-                                   dir,                    // Post-step point momentum direction
-                                   0,                      // Post-step point kinetic energy
-                                   0,                      // Post-step point charge
-                                   currentTrack.eventId,   // Event Id
-                                   currentTrack.threadId); // thread ID
-      }
       // The current track is killed by not enqueuing into the next activeQueue and the slot is released
 #ifdef ASYNC_MODE
       slotManager.MarkSlotForFreeing(slot);
@@ -327,7 +327,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       }
       const double origDirPrimary[] = {dir.x(), dir.y(), dir.z()};
       double dirPrimary[3];
-      double newEnergyGamma =
+      newEnergyGamma =
           G4HepEmGammaInteractionCompton::SamplePhotonEnergyAndDirection(eKin, dirPrimary, origDirPrimary, &rnge);
       vecgeom::Vector3D<double> newDirGamma(dirPrimary[0], dirPrimary[1], dirPrimary[2]);
 
@@ -336,8 +336,6 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 1, /*numPositrons*/ 0, /*numGammas*/ 0);
 
       // Check the cuts and deposit energy in this volume if needed
-      double edep = 0;
-
       if (ApplyCuts ? energyEl > theElCut : energyEl > LowEnergyThreshold) {
         // Create a secondary electron and sample/compute directions.
 #ifdef ASYNC_MODE
@@ -372,27 +370,6 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         slotManager.MarkSlotForFreeing(slot);
 #endif
       }
-
-      // If there is some edep from cutting particles, record the step
-      if (edep > 0) {
-        if (auxData.fSensIndex >= 0)
-          adept_scoring::RecordHit(userScoring,
-                                   currentTrack.parentId,                        // Track ID
-                                   2,                                            // Particle type
-                                   geometryStepLength,                           // Step length
-                                   edep,                                         // Total Edep
-                                   navState,                                     // Pre-step point navstate
-                                   preStepPos,                                   // Pre-step point position
-                                   preStepDir,                                   // Pre-step point momentum direction
-                                   preStepEnergy,                                // Pre-step point kinetic energy
-                                   0,                                            // Pre-step point charge
-                                   nextState,                                    // Post-step point navstate
-                                   pos,                                          // Post-step point position
-                                   dir,                                          // Post-step point momentum direction
-                                   newEnergyGamma,                               // Post-step point kinetic energy
-                                   0,                                            // Post-step point charge
-                                   currentTrack.eventId, currentTrack.threadId); // event and thread ID
-      }
       break;
     }
     case 2: {
@@ -402,7 +379,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       const double bindingEnergy = G4HepEmGammaInteractionPhotoelectric::SelectElementBindingEnergy(
           &g4HepEmData, auxData.fMCIndex, gammaTrack.GetPEmxSec(), eKin, &rnge);
 
-      double edep             = bindingEnergy;
+      edep                    = bindingEnergy;
       const double photoElecE = eKin - edep;
       if (ApplyCuts ? photoElecE > theElCut : photoElecE > theLowEnergyThreshold) {
 
@@ -431,23 +408,6 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         // If the secondary electron is cut, deposit all the energy of the gamma in this volume
         edep = eKin;
       }
-      if (auxData.fSensIndex >= 0)
-        adept_scoring::RecordHit(userScoring,
-                                 currentTrack.parentId,                        // Track ID
-                                 2,                                            // Particle type
-                                 geometryStepLength,                           // Step length
-                                 edep,                                         // Total Edep
-                                 navState,                                     // Pre-step point navstate
-                                 preStepPos,                                   // Pre-step point position
-                                 preStepDir,                                   // Pre-step point momentum direction
-                                 preStepEnergy,                                // Pre-step point kinetic energy
-                                 0,                                            // Pre-step point charge
-                                 nextState,                                    // Post-step point navstate
-                                 pos,                                          // Post-step point position
-                                 dir,                                          // Post-step point momentum direction
-                                 0,                                            // Post-step point kinetic energy
-                                 0,                                            // Post-step point charge
-                                 currentTrack.eventId, currentTrack.threadId); // event and thread ID
       // The current track is killed by not enqueuing into the next activeQueue and the slot is released
 #ifdef ASYNC_MODE
       slotManager.MarkSlotForFreeing(slot);
@@ -459,6 +419,25 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       // Just keep particle alive
       survive();
     }
+    }
+    // If there is some edep from cutting particles, record the step
+    if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps) {
+      adept_scoring::RecordHit(userScoring,
+                               currentTrack.parentId,                        // Track ID
+                               2,                                            // Particle type
+                               geometryStepLength,                           // Step length
+                               edep,                                         // Total Edep
+                               navState,                                     // Pre-step point navstate
+                               preStepPos,                                   // Pre-step point position
+                               preStepDir,                                   // Pre-step point momentum direction
+                               preStepEnergy,                                // Pre-step point kinetic energy
+                               0,                                            // Pre-step point charge
+                               nextState,                                    // Post-step point navstate
+                               pos,                                          // Post-step point position
+                               dir,                                          // Post-step point momentum direction
+                               newEnergyGamma,                               // Post-step point kinetic energy
+                               0,                                            // Post-step point charge
+                               currentTrack.eventId, currentTrack.threadId); // event and thread ID
     }
   }
 }

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -25,7 +25,7 @@ namespace AsyncAdePT {
 template <typename Scoring>
 __global__ void __launch_bounds__(256, 1)
     TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
-                    adept::MParray *leakedQueue, Scoring *userScoring, bool returnAllSteps)
+                    adept::MParray *leakedQueue, Scoring *userScoring, bool returnAllSteps, bool returnLastStep)
 {
   constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
   int activeSize                    = active->size();
@@ -50,6 +50,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
 {
   using namespace adept_impl;
   constexpr bool returnAllSteps     = false;
+  bool returnLastStep               = false;
   constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
   constexpr int Pdg                 = 22;
   int activeSize                    = gammas->fActiveTracks->size();
@@ -81,6 +82,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
 
     // Write local variables back into track and enqueue
     auto survive = [&](bool leak = false) {
+      returnLastStep          = false; // particle survived, do not force return of step
       currentTrack.eKin       = eKin;
       currentTrack.pos        = pos;
       currentTrack.dir        = dir;
@@ -176,6 +178,28 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
 #else
         AdePTNavigator::RelocateToNextVolume(pos, dir, nextState);
 #endif
+
+        // if all steps are returned, we need to record the hit here,
+        // as now the nextState is defined, but the navState is not yet replaced
+        if (returnAllSteps)
+          adept_scoring::RecordHit(userScoring,
+                                   currentTrack.parentId,                       // Track ID
+                                   2,                                           // Particle type
+                                   geometryStepLength,                          // Step length
+                                   0,                                           // Total Edep
+                                   navState,                                    // Pre-step point navstate
+                                   preStepPos,                                  // Pre-step point position
+                                   preStepDir,                                  // Pre-step point momentum direction
+                                   preStepEnergy,                               // Pre-step point kinetic energy
+                                   0,                                           // Pre-step point charge
+                                   nextState,                                   // Post-step point navstate
+                                   pos,                                         // Post-step point position
+                                   dir,                                         // Post-step point momentum direction
+                                   0,                                           // Post-step point kinetic energy
+                                   0,                                           // Post-step point charge
+                                   currentTrack.eventId, currentTrack.threadId, // event and thread ID
+                                   returnLastStep); // whether this is the last step of the track
+
         // Move to the next boundary.
         navState = nextState;
         // printf("  -> pvol=%d pos={%g, %g, %g} \n", navState.TopId(), pos[0], pos[1], pos[2]);
@@ -205,26 +229,27 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
 #ifdef ASYNC_MODE
         slotManager.MarkSlotForFreeing(slot);
 #endif
+
+        // particle has left the world, record hit if last or all steps are returned
+        if (returnAllSteps || returnLastStep)
+          adept_scoring::RecordHit(userScoring,
+                                   currentTrack.parentId,                       // Track ID
+                                   2,                                           // Particle type
+                                   geometryStepLength,                          // Step length
+                                   0,                                           // Total Edep
+                                   navState,                                    // Pre-step point navstate
+                                   preStepPos,                                  // Pre-step point position
+                                   preStepDir,                                  // Pre-step point momentum direction
+                                   preStepEnergy,                               // Pre-step point kinetic energy
+                                   0,                                           // Pre-step point charge
+                                   nextState,                                   // Post-step point navstate
+                                   pos,                                         // Post-step point position
+                                   dir,                                         // Post-step point momentum direction
+                                   0,                                           // Post-step point kinetic energy
+                                   0,                                           // Post-step point charge
+                                   currentTrack.eventId, currentTrack.threadId, // event and thread ID
+                                   returnLastStep); // whether this is the last step of the track
       }
-
-      if (returnAllSteps)
-        adept_scoring::RecordHit(userScoring,
-                                 currentTrack.parentId,                        // Track ID
-                                 2,                                            // Particle type
-                                 geometryStepLength,                           // Step length
-                                 0,                                            // Total Edep
-                                 navState,                                     // Pre-step point navstate
-                                 preStepPos,                                   // Pre-step point position
-                                 preStepDir,                                   // Pre-step point momentum direction
-                                 preStepEnergy,                                // Pre-step point kinetic energy
-                                 0,                                            // Pre-step point charge
-                                 nextState,                                    // Post-step point navstate
-                                 pos,                                          // Post-step point position
-                                 dir,                                          // Post-step point momentum direction
-                                 0,                                            // Post-step point kinetic energy
-                                 0,                                            // Post-step point charge
-                                 currentTrack.eventId, currentTrack.threadId); // event and thread ID
-
       continue;
     } else {
 
@@ -421,23 +446,24 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
     }
     }
     // If there is some edep from cutting particles, record the step
-    if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps) {
+    if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep) {
       adept_scoring::RecordHit(userScoring,
-                               currentTrack.parentId,                        // Track ID
-                               2,                                            // Particle type
-                               geometryStepLength,                           // Step length
-                               edep,                                         // Total Edep
-                               navState,                                     // Pre-step point navstate
-                               preStepPos,                                   // Pre-step point position
-                               preStepDir,                                   // Pre-step point momentum direction
-                               preStepEnergy,                                // Pre-step point kinetic energy
-                               0,                                            // Pre-step point charge
-                               nextState,                                    // Post-step point navstate
-                               pos,                                          // Post-step point position
-                               dir,                                          // Post-step point momentum direction
-                               newEnergyGamma,                               // Post-step point kinetic energy
-                               0,                                            // Post-step point charge
-                               currentTrack.eventId, currentTrack.threadId); // event and thread ID
+                               currentTrack.parentId,                       // Track ID
+                               2,                                           // Particle type
+                               geometryStepLength,                          // Step length
+                               edep,                                        // Total Edep
+                               navState,                                    // Pre-step point navstate
+                               preStepPos,                                  // Pre-step point position
+                               preStepDir,                                  // Pre-step point momentum direction
+                               preStepEnergy,                               // Pre-step point kinetic energy
+                               0,                                           // Pre-step point charge
+                               nextState,                                   // Post-step point navstate
+                               pos,                                         // Post-step point position
+                               dir,                                         // Post-step point momentum direction
+                               newEnergyGamma,                              // Post-step point kinetic energy
+                               0,                                           // Post-step point charge
+                               currentTrack.eventId, currentTrack.threadId, // event and thread ID
+                               returnLastStep); // whether this is the last step of the track
     }
   }
 }

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -49,7 +49,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                 Scoring *userScoring, VolAuxData const *auxDataArray)
 {
   using namespace adept_impl;
-  constexpr bool returnAllSteps          = false;
+  constexpr bool returnAllSteps     = false;
   constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
   constexpr int Pdg                 = 22;
   int activeSize                    = gammas->fActiveTracks->size();

--- a/src/AdePTConfigurationMessenger.cc
+++ b/src/AdePTConfigurationMessenger.cc
@@ -27,8 +27,11 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
   fSetTrackInAllRegionsCmd->SetGuidance("If true, particles are tracked on the GPU across the whole geometry");
 
   fSetCallUserSteppingActionCmd = new G4UIcmdWithABool("/adept/CallUserSteppingAction", this);
-  fSetCallUserSteppingActionCmd->SetGuidance("If true, the UserSteppingAction is called for on every step. NOTE: This "
-                                             "means that every single step is recorded on GPU and send back to CPU");
+  fSetCallUserSteppingActionCmd->SetGuidance(
+      "If true, the UserSteppingAction is called for on every step. WARNING: The steps are currently not sorted, that "
+      "means it is not guaranteed that the UserSteppingAction is called in order, i.e., it could get called on the "
+      "secondary before the primary has finished its track."
+      " NOTE: This means that every single step is recorded on GPU and send back to CPU, which can impact performance");
 
   fSetCallPostUserTrackingActionCmd = new G4UIcmdWithABool("/adept/CallPostUserTrackingAction", this);
   fSetCallPostUserTrackingActionCmd->SetGuidance(

--- a/src/AdePTConfigurationMessenger.cc
+++ b/src/AdePTConfigurationMessenger.cc
@@ -26,6 +26,10 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
   fSetTrackInAllRegionsCmd = new G4UIcmdWithABool("/adept/setTrackInAllRegions", this);
   fSetTrackInAllRegionsCmd->SetGuidance("If true, particles are tracked on the GPU across the whole geometry");
 
+  fSetCallUserSteppingActionCmd = new G4UIcmdWithABool("/adept/CallUserSteppingAction", this);
+  fSetCallUserSteppingActionCmd->SetGuidance("If true, the UserSteppingAction is called for on every step. NOTE: This "
+                                             "means that every single step is recorded on GPU and send back to CPU");
+
   fAddRegionCmd = new G4UIcmdWithAString("/adept/addGPURegion", this);
   fAddRegionCmd->SetGuidance("Add a region in which transport will be done on GPU");
 
@@ -70,6 +74,7 @@ AdePTConfigurationMessenger::~AdePTConfigurationMessenger()
   delete fSetCUDAStackLimitCmd;
   delete fSetCUDAHeapLimitCmd;
   delete fSetTrackInAllRegionsCmd;
+  delete fSetCallUserSteppingActionCmd;
   delete fAddRegionCmd;
   delete fActivateAdePTCmd;
   delete fSetVerbosityCmd;
@@ -86,6 +91,8 @@ void AdePTConfigurationMessenger::SetNewValue(G4UIcommand *command, G4String new
 
   if (command == fSetTrackInAllRegionsCmd) {
     fAdePTConfiguration->SetTrackInAllRegions(fSetTrackInAllRegionsCmd->GetNewBoolValue(newValue));
+  } else if (command == fSetCallUserSteppingActionCmd) {
+    fAdePTConfiguration->SetCallUserSteppingAction(newValue);
   } else if (command == fAddRegionCmd) {
     fAdePTConfiguration->AddGPURegionName(newValue);
   } else if (command == fActivateAdePTCmd) {

--- a/src/AdePTConfigurationMessenger.cc
+++ b/src/AdePTConfigurationMessenger.cc
@@ -30,6 +30,11 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
   fSetCallUserSteppingActionCmd->SetGuidance("If true, the UserSteppingAction is called for on every step. NOTE: This "
                                              "means that every single step is recorded on GPU and send back to CPU");
 
+  fSetCallPostUserTrackingActionCmd = new G4UIcmdWithABool("/adept/CallPostUserTrackingAction", this);
+  fSetCallPostUserTrackingActionCmd->SetGuidance(
+      "If true, the PostUserTrackingAction is called for on every track. NOTE: This "
+      "means that the last step of every track is recorded on GPU and send back to CPU");
+
   fAddRegionCmd = new G4UIcmdWithAString("/adept/addGPURegion", this);
   fAddRegionCmd->SetGuidance("Add a region in which transport will be done on GPU");
 
@@ -75,6 +80,7 @@ AdePTConfigurationMessenger::~AdePTConfigurationMessenger()
   delete fSetCUDAHeapLimitCmd;
   delete fSetTrackInAllRegionsCmd;
   delete fSetCallUserSteppingActionCmd;
+  delete fSetCallPostUserTrackingActionCmd;
   delete fAddRegionCmd;
   delete fActivateAdePTCmd;
   delete fSetVerbosityCmd;
@@ -93,6 +99,8 @@ void AdePTConfigurationMessenger::SetNewValue(G4UIcommand *command, G4String new
     fAdePTConfiguration->SetTrackInAllRegions(fSetTrackInAllRegionsCmd->GetNewBoolValue(newValue));
   } else if (command == fSetCallUserSteppingActionCmd) {
     fAdePTConfiguration->SetCallUserSteppingAction(newValue);
+  } else if (command == fSetCallPostUserTrackingActionCmd) {
+    fAdePTConfiguration->SetCallPostUserTrackingAction(newValue);
   } else if (command == fAddRegionCmd) {
     fAdePTConfiguration->AddGPURegionName(newValue);
   } else if (command == fActivateAdePTCmd) {

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -343,8 +343,8 @@ void AdePTGeant4Integration::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4
   visitGeometry(g4world, vecgeomWorld);
 }
 
-void AdePTGeant4Integration::ProcessGPUHit(GPUHit const &hit, bool const callUserSteppingAction,
-                                           bool const callPostUserTrackingAction)
+void AdePTGeant4Integration::ProcessGPUStep(GPUHit const &hit, bool const callUserSteppingAction,
+                                            bool const callPostUserTrackingAction)
 {
   if (!fScoringObjects) {
     fScoringObjects.reset(new AdePTGeant4Integration_detail::ScoringObjects());

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -343,7 +343,8 @@ void AdePTGeant4Integration::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4
   visitGeometry(g4world, vecgeomWorld);
 }
 
-void AdePTGeant4Integration::ProcessGPUHit(GPUHit const &hit, bool const callUserSteppingAction)
+void AdePTGeant4Integration::ProcessGPUHit(GPUHit const &hit, bool const callUserSteppingAction,
+                                           bool const callPostUserTrackingAction)
 {
   if (!fScoringObjects) {
     fScoringObjects.reset(new AdePTGeant4Integration_detail::ScoringObjects());
@@ -396,6 +397,13 @@ void AdePTGeant4Integration::ProcessGPUHit(GPUHit const &hit, bool const callUse
     auto *evtMgr             = G4EventManager::GetEventManager();
     auto *userSteppingAction = evtMgr->GetUserSteppingAction();
     if (userSteppingAction) userSteppingAction->UserSteppingAction(fScoringObjects->fG4Step);
+  }
+
+  // call UserSteppingAction if required
+  if (hit.fLastStepOfTrack && callPostUserTrackingAction) {
+    auto *evtMgr             = G4EventManager::GetEventManager();
+    auto *userTrackingAction = evtMgr->GetUserTrackingAction();
+    if (userTrackingAction) userTrackingAction->PostUserTrackingAction(fScoringObjects->fG4Step->GetTrack());
   }
 }
 

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -187,6 +187,12 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
   G4SteppingManager *steppingManager = trackManager->GetSteppingManager();
   const bool trackInAllRegions       = fAdeptTransport->GetTrackInAllRegions();
 
+  const auto eventID = eventManager->GetConstCurrentEvent()->GetEventID();
+
+  // Check for GPU steps, to alleviate pressure on the GPU step buffer
+  G4int threadId = G4Threading::G4GetThreadId();
+  fAdeptTransport->ProcessGPUSteps(threadId, eventID);
+
   // setup touchable to be able to get region from GetNextVolume
   steppingManager->SetInitialStep(aTrack);
 
@@ -207,7 +213,6 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
       G4double properTime    = aTrack->GetProperTime();
       auto pdg               = aTrack->GetParticleDefinition()->GetPDGEncoding();
       int id                 = aTrack->GetTrackID();
-      const auto eventID     = eventManager->GetConstCurrentEvent()->GetEventID();
       if (fCurrentEventID != eventID) {
         // Do this to reproducibly seed the AdePT random numbers:
         fCurrentEventID = eventID;

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -18,11 +18,17 @@
 #include <algorithm>
 
 #ifdef ASYNC_MODE
+static std::shared_ptr<AsyncAdePT::AsyncAdePTTransport<AdePTGeant4Integration>> globalAdePTInstance = nullptr;
 std::shared_ptr<AdePTTransportInterface> InstantiateAdePT(AdePTConfiguration &conf)
 {
-  static std::shared_ptr<AsyncAdePT::AsyncAdePTTransport<AdePTGeant4Integration>> adePT{
-      new AsyncAdePT::AsyncAdePTTransport<AdePTGeant4Integration>(conf)};
-  return adePT;
+  if (!globalAdePTInstance) {
+    globalAdePTInstance = std::make_shared<AsyncAdePT::AsyncAdePTTransport<AdePTGeant4Integration>>(conf);
+  }
+  return globalAdePTInstance;
+}
+std::shared_ptr<AsyncAdePT::AsyncAdePTTransport<AdePTGeant4Integration>> GetAdePTInstance()
+{
+  return globalAdePTInstance;
 }
 #endif
 

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -18,17 +18,11 @@
 #include <algorithm>
 
 #ifdef ASYNC_MODE
-static std::shared_ptr<AsyncAdePT::AsyncAdePTTransport<AdePTGeant4Integration>> globalAdePTInstance = nullptr;
 std::shared_ptr<AdePTTransportInterface> InstantiateAdePT(AdePTConfiguration &conf)
 {
-  if (!globalAdePTInstance) {
-    globalAdePTInstance = std::make_shared<AsyncAdePT::AsyncAdePTTransport<AdePTGeant4Integration>>(conf);
-  }
-  return globalAdePTInstance;
-}
-std::shared_ptr<AsyncAdePT::AsyncAdePTTransport<AdePTGeant4Integration>> GetAdePTInstance()
-{
-  return globalAdePTInstance;
+  static std::shared_ptr<AsyncAdePT::AsyncAdePTTransport<AdePTGeant4Integration>> AdePT{
+      new AsyncAdePT::AsyncAdePTTransport<AdePTGeant4Integration>(conf)};
+  return AdePT;
 }
 #endif
 


### PR DESCRIPTION
If the UserSteppingAction is required, we need to copy back every GPU step back to the G4 workers. 

This required to change the kernels, as we need to be able to record every step independent of edep or sensitive detector. 
Since copying back every step can lead to a very large amount of steps, this would quickly fill the buffer. Then, if the buffer gets too full before the Geant4 workers take care of their hits, the GPUStep Management Thread would start copying out the GPUSteps, as implemented in #350. However, this copying is too slow, if every Step is recorded and leads to the GPU running out of HitSlots. 

Previously, the Geant4 workers would only take care of the GPU Steps after their transport has finished. However, this may be too late and the buffer may be too full, leading to copying. Therefore, the Geant4 workers must be able to process some of the steps already earlier. This is now done in the `AdePTTrackingManager`: Before a new track is processed, the `GPUStepProcessing` is called. This way, the GPU step buffer can be kept under control. To enable this, the processing of the GPUSteps is now encapsulated in a single function, that can be called from the `AdePTTrackingManager`.

In the same manner, the PostUserTrackingAction is called. For this, the RecordHit also writes if it is the LastStep of a track.

Note that it is straightforward to calso call the PreUserTrackingAction. This requires a StepCounter, which is availale in the B field update branch, so I will add it *after* the B field branch is merged.

Both can be enabled via:
```
/adept/CallUserSteppingAction true
/adept/CallPostUserTrackingAction true
```

Since this PR touches the kernels, below the physics validation at high statistics, which is as good as it should be:

<img width="586" alt="Screenshot 2025-03-09 at 07 30 15" src="https://github.com/user-attachments/assets/8027a386-2680-4b22-9c4f-8da91a693ea3" />