### PR TITLE
Fix leaks in asynchronous mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,6 @@ set(CMAKE_CUDA_STANDARD_REQUIRED ${CMAKE_CXX_STANDARD_REQUIRED})
 set(CMAKE_CUDA_EXTENSIONS OFF)
 set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
 
-# set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=-fno-sanitize=address") 
-# set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address") 
-
 #----------------------------------------------------------------------------#
 # User options
 #----------------------------------------------------------------------------#

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ set(CMAKE_CUDA_STANDARD_REQUIRED ${CMAKE_CXX_STANDARD_REQUIRED})
 set(CMAKE_CUDA_EXTENSIONS OFF)
 set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
 
+# set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=-fno-sanitize=address") 
+# set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address") 
+
 #----------------------------------------------------------------------------#
 # User options
 #----------------------------------------------------------------------------#

--- a/examples/data/testEm3_regions.gdml
+++ b/examples/data/testEm3_regions.gdml
@@ -1,0 +1,1864 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!-- SPDX-FileCopyrightText: 2022 CERN -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://service-spi.web.cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+
+  <define>
+    <position name="G4_Pb_pos" unit="mm" x="-2.85" y="0" z="0"/>
+    <position name="G4_lApos" unit="mm" x="1.15" y="0" z="0"/>
+  </define>
+
+  <materials>
+    <material name="G4_Galactic" state="gas">
+      <T unit="K" value="2.73"/>
+      <P unit="pascal" value="3e-18"/>
+      <MEE unit="eV" value="21.8"/>
+      <D unit="g/cm3" value="1e-25"/>
+      <fraction n="1" ref="H"/>
+    </material>
+    <isotope N="204" Z="82" name="Pb204">
+      <atom unit="g/mole" value="203.973"/>
+    </isotope>
+    <isotope N="206" Z="82" name="Pb206">
+      <atom unit="g/mole" value="205.974"/>
+    </isotope>
+    <isotope N="207" Z="82" name="Pb207">
+      <atom unit="g/mole" value="206.976"/>
+    </isotope>
+    <isotope N="208" Z="82" name="Pb208">
+      <atom unit="g/mole" value="207.977"/>
+    </isotope>
+    <element name="Pb">
+      <fraction n="0.014" ref="Pb204"/>
+      <fraction n="0.241" ref="Pb206"/>
+      <fraction n="0.221" ref="Pb207"/>
+      <fraction n="0.524" ref="Pb208"/>
+    </element>
+    <material name="G4_Pb" state="solid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="823"/>
+      <D unit="g/cm3" value="11.35"/>
+      <fraction n="1" ref="Pb"/>
+    </material>
+    <isotope N="36" Z="18" name="Ar36">
+      <atom unit="g/mole" value="35.9675"/>
+    </isotope>
+    <isotope N="38" Z="18" name="Ar38">
+      <atom unit="g/mole" value="37.9627"/>
+    </isotope>
+    <isotope N="40" Z="18" name="Ar40">
+      <atom unit="g/mole" value="39.9624"/>
+    </isotope>
+    <element name="Ar">
+      <fraction n="0.003365" ref="Ar36"/>
+      <fraction n="0.000632" ref="Ar38"/>
+      <fraction n="0.996003" ref="Ar40"/>
+    </element>
+    <material name="G4_lAr" state="liquid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="188"/>
+      <D unit="g/cm3" value="1.396"/>
+      <fraction n="1" ref="Ar"/>
+    </material>
+    <isotope N="1" Z="1" name="H1">
+      <atom unit="g/mole" value="1.00782503081372"/>
+    </isotope>
+    <isotope N="2" Z="1" name="H2">
+      <atom unit="g/mole" value="2.01410199966617"/>
+    </isotope>
+    <element name="H">
+      <fraction n="0.999885" ref="H1"/>
+      <fraction n="0.000115" ref="H2"/>
+    </element>
+  </materials>
+
+  <solids>
+    <box lunit="mm" name="Absorber1" x="2.3" y="400" z="400"/>
+    <box lunit="mm" name="Absorber2" x="5.7" y="400" z="400"/>
+    <box lunit="mm" name="Layer" x="8" y="400" z="400"/>
+    <box lunit="mm" name="Calorimeter" x="400" y="400" z="400"/>
+    <box lunit="mm" name="World" x="480" y="480" z="480"/>
+  </solids>
+
+  <structure>
+    <volume name="G4_Pb1">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr1">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb2">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr2">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb3">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr3">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb4">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr4">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb5">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr5">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb6">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr6">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb7">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr7">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb8">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr8">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb9">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr9">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb10">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr10">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb11">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr11">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb12">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr12">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb13">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr13">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb14">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr14">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb15">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr15">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb16">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr16">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb17">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr17">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb18">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr18">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb19">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr19">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb20">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr20">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb21">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr21">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb22">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr22">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb23">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr23">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb24">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr24">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb25">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr25">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb26">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr26">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb27">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr27">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb28">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr28">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb29">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr29">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb30">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr30">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb31">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr31">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb32">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr32">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb33">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr33">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb34">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr34">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb35">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr35">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb36">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr36">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb37">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr37">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb38">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr38">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb39">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr39">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb40">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr40">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb41">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr41">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb42">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr42">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb43">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr43">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb44">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr44">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb45">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr45">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb46">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr46">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb47">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr47">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb48">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr48">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb49">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr49">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="G4_Pb50">
+      <materialref ref="G4_Pb"/>
+      <solidref ref="Absorber1"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="1"/>
+    </volume>
+    <volume name="G4_lAr50">
+      <materialref ref="G4_lAr"/>
+      <solidref ref="Absorber2"/>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="2"/>
+    </volume>
+
+    <volume name="Layer1">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb1"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr1"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer2">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb2"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr2"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer3">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb3"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr3"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer4">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb4"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr4"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer5">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb5"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr5"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer6">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb6"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr6"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer7">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb7"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr7"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer8">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb8"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr8"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer9">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb9"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr9"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer10">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb10"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr10"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer11">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb11"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr11"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer12">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb12"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr12"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer13">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb13"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr13"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer14">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb14"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr14"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer15">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb15"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr15"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer16">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb16"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr16"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer17">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb17"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr17"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer18">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb18"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr18"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer19">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb19"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr19"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer20">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb20"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr20"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer21">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb21"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr21"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer22">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb22"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr22"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer23">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb23"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr23"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer24">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb24"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr24"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer25">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb25"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr25"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer26">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb26"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr26"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer27">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb27"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr27"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer28">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb28"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr28"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer29">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb29"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr29"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer30">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb30"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr30"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer31">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb31"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr31"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer32">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb32"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr32"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer33">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb33"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr33"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer34">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb34"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr34"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer35">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb35"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr35"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer36">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb36"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr36"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer37">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb37"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr37"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer38">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb38"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr38"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer39">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb39"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr39"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer40">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb40"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr40"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer41">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb41"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr41"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer42">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb42"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr42"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer43">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb43"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr43"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer44">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb44"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr44"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer45">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb45"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr45"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer46">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb46"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr46"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer47">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb47"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr47"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer48">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb48"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr48"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer49">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb49"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr49"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+    <volume name="Layer50">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Layer"/>
+      <physvol copynumber="1" name="G4_Pb">
+        <volumeref ref="G4_Pb50"/>
+        <positionref ref="G4_Pb_pos"/>
+      </physvol>
+      <physvol copynumber="2" name="G4_lA">
+        <volumeref ref="G4_lAr50"/>
+        <positionref ref="G4_lApos"/>
+      </physvol>
+    </volume>
+
+
+    <volume name="Calorimeter">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="Calorimeter"/>
+      <physvol copynumber="1" name="Layer0x560dcd38d7b0">
+        <volumeref ref="Layer1"/>
+        <position name="Layer0x560dcd38d7b0_pos" unit="mm" x="-196" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="2" name="Layer0x560dcd38d8c0">
+        <volumeref ref="Layer2"/>
+        <position name="Layer0x560dcd38d8c0_pos" unit="mm" x="-188" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="3" name="Layer0x560dcd38d970">
+        <volumeref ref="Layer3"/>
+        <position name="Layer0x560dcd38d970_pos" unit="mm" x="-180" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="4" name="Layer0x560dcd38da60">
+        <volumeref ref="Layer4"/>
+        <position name="Layer0x560dcd38da60_pos" unit="mm" x="-172" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="5" name="Layer0x560dcd38daf0">
+        <volumeref ref="Layer5"/>
+        <position name="Layer0x560dcd38daf0_pos" unit="mm" x="-164" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="6" name="Layer0x560dcd38dc20">
+        <volumeref ref="Layer6"/>
+        <position name="Layer0x560dcd38dc20_pos" unit="mm" x="-156" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="7" name="Layer0x560dcd38dc80">
+        <volumeref ref="Layer7"/>
+        <position name="Layer0x560dcd38dc80_pos" unit="mm" x="-148" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="8" name="Layer0x560dcd38dce0">
+        <volumeref ref="Layer8"/>
+        <position name="Layer0x560dcd38dce0_pos" unit="mm" x="-140" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="9" name="Layer0x560dcd38dd70">
+        <volumeref ref="Layer9"/>
+        <position name="Layer0x560dcd38dd70_pos" unit="mm" x="-132" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="10" name="Layer0x560dcd38df20">
+        <volumeref ref="Layer10"/>
+        <position name="Layer0x560dcd38df20_pos" unit="mm" x="-124" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="11" name="Layer0x560dcd38dfb0">
+        <volumeref ref="Layer11"/>
+        <position name="Layer0x560dcd38dfb0_pos" unit="mm" x="-116" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="12" name="Layer0x560dcd38e040">
+        <volumeref ref="Layer12"/>
+        <position name="Layer0x560dcd38e040_pos" unit="mm" x="-108" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="13" name="Layer0x560dcd38e0d0">
+        <volumeref ref="Layer13"/>
+        <position name="Layer0x560dcd38e0d0_pos" unit="mm" x="-100" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="14" name="Layer0x560dcd38e160">
+        <volumeref ref="Layer14"/>
+        <position name="Layer0x560dcd38e160_pos" unit="mm" x="-92" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="15" name="Layer0x560dcd38e1f0">
+        <volumeref ref="Layer15"/>
+        <position name="Layer0x560dcd38e1f0_pos" unit="mm" x="-84" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="16" name="Layer0x560dcd38e280">
+        <volumeref ref="Layer16"/>
+        <position name="Layer0x560dcd38e280_pos" unit="mm" x="-76" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="17" name="Layer0x560dcd38e310">
+        <volumeref ref="Layer17"/>
+        <position name="Layer0x560dcd38e310_pos" unit="mm" x="-68" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="18" name="Layer0x560dcd38e4b0">
+        <volumeref ref="Layer18"/>
+        <position name="Layer0x560dcd38e4b0_pos" unit="mm" x="-60" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="19" name="Layer0x560dcd38e540">
+        <volumeref ref="Layer19"/>
+        <position name="Layer0x560dcd38e540_pos" unit="mm" x="-52" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="20" name="Layer0x560dcd38e5d0">
+        <volumeref ref="Layer20"/>
+        <position name="Layer0x560dcd38e5d0_pos" unit="mm" x="-44" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="21" name="Layer0x560dcd38e660">
+        <volumeref ref="Layer21"/>
+        <position name="Layer0x560dcd38e660_pos" unit="mm" x="-36" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="22" name="Layer0x560dcd38e6f0">
+        <volumeref ref="Layer22"/>
+        <position name="Layer0x560dcd38e6f0_pos" unit="mm" x="-28" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="23" name="Layer0x560dcd38e780">
+        <volumeref ref="Layer23"/>
+        <position name="Layer0x560dcd38e780_pos" unit="mm" x="-20" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="24" name="Layer0x560dcd38e810">
+        <volumeref ref="Layer24"/>
+        <position name="Layer0x560dcd38e810_pos" unit="mm" x="-12" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="25" name="Layer0x560dcd38e8a0">
+        <volumeref ref="Layer25"/>
+        <position name="Layer0x560dcd38e8a0_pos" unit="mm" x="-4" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="26" name="Layer0x560dcd38e930">
+        <volumeref ref="Layer26"/>
+        <position name="Layer0x560dcd38e930_pos" unit="mm" x="4" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="27" name="Layer0x560dcd38e9c0">
+        <volumeref ref="Layer27"/>
+        <position name="Layer0x560dcd38e9c0_pos" unit="mm" x="12" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="28" name="Layer0x560dcd38ea50">
+        <volumeref ref="Layer28"/>
+        <position name="Layer0x560dcd38ea50_pos" unit="mm" x="20" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="29" name="Layer0x560dcd38eae0">
+        <volumeref ref="Layer29"/>
+        <position name="Layer0x560dcd38eae0_pos" unit="mm" x="28" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="30" name="Layer0x560dcd38eb70">
+        <volumeref ref="Layer30"/>
+        <position name="Layer0x560dcd38eb70_pos" unit="mm" x="36" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="31" name="Layer0x560dcd38ec00">
+        <volumeref ref="Layer31"/>
+        <position name="Layer0x560dcd38ec00_pos" unit="mm" x="44" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="32" name="Layer0x560dcd38ec90">
+        <volumeref ref="Layer32"/>
+        <position name="Layer0x560dcd38ec90_pos" unit="mm" x="52" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="33" name="Layer0x560dcd38ed20">
+        <volumeref ref="Layer33"/>
+        <position name="Layer0x560dcd38ed20_pos" unit="mm" x="60" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="34" name="Layer0x560dcd38edb0">
+        <volumeref ref="Layer34"/>
+        <position name="Layer0x560dcd38edb0_pos" unit="mm" x="68" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="35" name="Layer0x560dcd38ee40">
+        <volumeref ref="Layer35"/>
+        <position name="Layer0x560dcd38ee40_pos" unit="mm" x="76" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="36" name="Layer0x560dcd38eed0">
+        <volumeref ref="Layer36"/>
+        <position name="Layer0x560dcd38eed0_pos" unit="mm" x="84" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="37" name="Layer0x560dcd38ef60">
+        <volumeref ref="Layer37"/>
+        <position name="Layer0x560dcd38ef60_pos" unit="mm" x="92" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="38" name="Layer0x560dcd38eff0">
+        <volumeref ref="Layer38"/>
+        <position name="Layer0x560dcd38eff0_pos" unit="mm" x="100" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="39" name="Layer0x560dcd38f080">
+        <volumeref ref="Layer39"/>
+        <position name="Layer0x560dcd38f080_pos" unit="mm" x="108" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="40" name="Layer0x560dcd38f110">
+        <volumeref ref="Layer40"/>
+        <position name="Layer0x560dcd38f110_pos" unit="mm" x="116" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="41" name="Layer0x560dcd38f1a0">
+        <volumeref ref="Layer41"/>
+        <position name="Layer0x560dcd38f1a0_pos" unit="mm" x="124" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="42" name="Layer0x560dcd38f230">
+        <volumeref ref="Layer42"/>
+        <position name="Layer0x560dcd38f230_pos" unit="mm" x="132" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="43" name="Layer0x560dcd38f2c0">
+        <volumeref ref="Layer43"/>
+        <position name="Layer0x560dcd38f2c0_pos" unit="mm" x="140" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="44" name="Layer0x560dcd38f350">
+        <volumeref ref="Layer44"/>
+        <position name="Layer0x560dcd38f350_pos" unit="mm" x="148" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="45" name="Layer0x560dcd38f3e0">
+        <volumeref ref="Layer45"/>
+        <position name="Layer0x560dcd38f3e0_pos" unit="mm" x="156" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="46" name="Layer0x560dcd38f470">
+        <volumeref ref="Layer46"/>
+        <position name="Layer0x560dcd38f470_pos" unit="mm" x="164" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="47" name="Layer0x560dcd38f500">
+        <volumeref ref="Layer47"/>
+        <position name="Layer0x560dcd38f500_pos" unit="mm" x="172" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="48" name="Layer0x560dcd38f590">
+        <volumeref ref="Layer48"/>
+        <position name="Layer0x560dcd38f590_pos" unit="mm" x="180" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="49" name="Layer0x560dcd38f620">
+        <volumeref ref="Layer49"/>
+        <position name="Layer0x560dcd38f620_pos" unit="mm" x="188" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="50" name="Layer0x560dcd38f6b0">
+        <volumeref ref="Layer50"/>
+        <position name="Layer0x560dcd38f6b0_pos" unit="mm" x="196" y="0" z="0"/>
+      </physvol>
+      <auxiliary auxtype="g4matcutcouple" auxvalue="0"/>
+    </volume>
+    <volume name="World">
+      <materialref ref="G4_Galactic"/>
+      <solidref ref="World"/>
+      <physvol name="Calorimeter">
+        <volumeref ref="Calorimeter"/>
+      </physvol>
+    </volume>
+  </structure>
+
+  <userinfo>
+    <auxiliary auxtype="Region" auxvalue="caloregion">
+      <auxiliary auxtype="volume" auxvalue="Calorimeter"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer1">
+      <auxiliary auxtype="volume" auxvalue="Layer1"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer2">
+      <auxiliary auxtype="volume" auxvalue="Layer2"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer3">
+      <auxiliary auxtype="volume" auxvalue="Layer3"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer4">
+      <auxiliary auxtype="volume" auxvalue="Layer4"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer5">
+      <auxiliary auxtype="volume" auxvalue="Layer5"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer6">
+      <auxiliary auxtype="volume" auxvalue="Layer6"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer7">
+      <auxiliary auxtype="volume" auxvalue="Layer7"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer8">
+      <auxiliary auxtype="volume" auxvalue="Layer8"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer9">
+      <auxiliary auxtype="volume" auxvalue="Layer9"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer10">
+      <auxiliary auxtype="volume" auxvalue="Layer10"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer11">
+      <auxiliary auxtype="volume" auxvalue="Layer11"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer12">
+      <auxiliary auxtype="volume" auxvalue="Layer12"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer13">
+      <auxiliary auxtype="volume" auxvalue="Layer13"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer14">
+      <auxiliary auxtype="volume" auxvalue="Layer14"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer15">
+      <auxiliary auxtype="volume" auxvalue="Layer15"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer16">
+      <auxiliary auxtype="volume" auxvalue="Layer16"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer17">
+      <auxiliary auxtype="volume" auxvalue="Layer17"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer18">
+      <auxiliary auxtype="volume" auxvalue="Layer18"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer19">
+      <auxiliary auxtype="volume" auxvalue="Layer19"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer20">
+      <auxiliary auxtype="volume" auxvalue="Layer20"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer21">
+      <auxiliary auxtype="volume" auxvalue="Layer21"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer22">
+      <auxiliary auxtype="volume" auxvalue="Layer22"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer23">
+      <auxiliary auxtype="volume" auxvalue="Layer23"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer24">
+      <auxiliary auxtype="volume" auxvalue="Layer24"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer25">
+      <auxiliary auxtype="volume" auxvalue="Layer25"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer26">
+      <auxiliary auxtype="volume" auxvalue="Layer26"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer27">
+      <auxiliary auxtype="volume" auxvalue="Layer27"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer28">
+      <auxiliary auxtype="volume" auxvalue="Layer28"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer29">
+      <auxiliary auxtype="volume" auxvalue="Layer29"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer30">
+      <auxiliary auxtype="volume" auxvalue="Layer30"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer31">
+      <auxiliary auxtype="volume" auxvalue="Layer31"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer32">
+      <auxiliary auxtype="volume" auxvalue="Layer32"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer33">
+      <auxiliary auxtype="volume" auxvalue="Layer33"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer34">
+      <auxiliary auxtype="volume" auxvalue="Layer34"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer35">
+      <auxiliary auxtype="volume" auxvalue="Layer35"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer36">
+      <auxiliary auxtype="volume" auxvalue="Layer36"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer37">
+      <auxiliary auxtype="volume" auxvalue="Layer37"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer38">
+      <auxiliary auxtype="volume" auxvalue="Layer38"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer39">
+      <auxiliary auxtype="volume" auxvalue="Layer39"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer40">
+      <auxiliary auxtype="volume" auxvalue="Layer40"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer41">
+      <auxiliary auxtype="volume" auxvalue="Layer41"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer42">
+      <auxiliary auxtype="volume" auxvalue="Layer42"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer43">
+      <auxiliary auxtype="volume" auxvalue="Layer43"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer44">
+      <auxiliary auxtype="volume" auxvalue="Layer44"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer45">
+      <auxiliary auxtype="volume" auxvalue="Layer45"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer46">
+      <auxiliary auxtype="volume" auxvalue="Layer46"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer47">
+      <auxiliary auxtype="volume" auxvalue="Layer47"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer48">
+      <auxiliary auxtype="volume" auxvalue="Layer48"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer49">
+      <auxiliary auxtype="volume" auxvalue="Layer49"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    <auxiliary auxtype="Region" auxvalue="Layer50">
+      <auxiliary auxtype="volume" auxvalue="Layer50"/>
+      <auxiliary auxtype="gamcut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="ecut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="poscut" auxunit="mm" auxvalue="0.7"/>
+      <auxiliary auxtype="pcut" auxunit="mm" auxvalue="0.7"/>
+    </auxiliary>
+    
+  </userinfo>
+
+  <setup name="Default" version="1.0">
+    <world ref="World"/>
+  </setup>
+
+</gdml>

--- a/include/AdePT/core/AdePTConfiguration.hh
+++ b/include/AdePT/core/AdePTConfiguration.hh
@@ -37,6 +37,7 @@ public:
   void SetVerbosity(int verbosity) { fVerbosity = verbosity; };
   void SetTransportBufferThreshold(int threshold) { fTransportBufferThreshold = threshold; }
   void SetMillionsOfTrackSlots(double millionSlots) { fMillionsOfTrackSlots = millionSlots; }
+  void SetMillionsOfLeakSlots(double millionSlots) { fMillionsOfLeakSlots = millionSlots; }
   void SetMillionsOfHitSlots(double millionSlots) { fMillionsOfHitSlots = millionSlots; }
   void SetHitBufferFlushThreshold(float threshold) { fHitBufferFlushThreshold = threshold; }
   void SetCPUCapacityFactor(float CPUCapacityFactor) { fCPUCapacityFactor = CPUCapacityFactor; }
@@ -73,6 +74,7 @@ public:
   float GetHitBufferFlushThreshold() { return fHitBufferFlushThreshold; }
   float GetCPUCapacityFactor() { return fCPUCapacityFactor; }
   double GetMillionsOfTrackSlots() { return fMillionsOfTrackSlots; }
+  double GetMillionsOfLeakSlots() { return fMillionsOfLeakSlots; }
   double GetMillionsOfHitSlots() { return fMillionsOfHitSlots; }
   std::vector<std::string> *GetGPURegionNames() { return &fGPURegionNames; }
   std::vector<std::string> *GetCPURegionNames() { return &fCPURegionNames; }
@@ -97,6 +99,7 @@ private:
   float fHitBufferFlushThreshold{0.8};
   float fCPUCapacityFactor{2.5};
   double fMillionsOfTrackSlots{1};
+  double fMillionsOfLeakSlots{1};
   double fMillionsOfHitSlots{1};
   unsigned short fLastNParticlesOnCPU{0};
 

--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -51,6 +51,10 @@ public:
   void SetTrackCapacity(size_t capacity) { fCapacity = capacity; }
   /// @brief Get the track capacity on GPU
   int GetTrackCapacity() const { return fCapacity; }
+  /// @brief  Set capacity of the leak buffer on GPU
+  void SetLeakCapacity(size_t capacity) { fLeakCapacity = capacity; }
+  /// @brief Get the leak buffer size
+  int GetLeakCapacity(size_t capacity) { return fLeakCapacity; }
   /// @brief Set Hit buffer capacity on GPU and Host
   void SetHitBufferCapacity(size_t capacity) { fHitBufferCapacity = capacity; }
   /// @brief Get the hit buffer size (host/device)
@@ -86,6 +90,7 @@ public:
 private:
   static inline G4HepEmState *fg4hepem_state{nullptr}; ///< The HepEm state singleton
   int fCapacity{1024 * 1024};                          ///< Track container capacity on GPU
+  int fLeakCapacity{1024 * 1024};                      ///< Track container capacity on GPU
   int fHitBufferCapacity{1024 * 1024};                 ///< Capacity of hit buffers
   int fNthreads{0};                                    ///< Number of cpu threads
   int fMaxBatch{0};                                    ///< Max batch size for allocating GPU memory

--- a/include/AdePT/core/AdePTTransportInterface.hh
+++ b/include/AdePT/core/AdePTTransportInterface.hh
@@ -26,6 +26,8 @@ public:
 
   /// @brief Set capacity of on-GPU track buffer.
   virtual void SetTrackCapacity(size_t capacity) = 0;
+  /// @brief Set capacity of on-GPU leak buffer.
+  virtual void SetLeakCapacity(size_t capacity) = 0;
   /// @brief Set Hit buffer capacity on GPU and Host
   virtual void SetHitBufferCapacity(size_t capacity) = 0;
   /// @brief Set maximum batch size

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -919,8 +919,7 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
 
           // copy buffer of tracks to device
           COPCORE_CUDA_CHECK(cudaMemcpyAsync(trackBuffer.toDevice_dev.get(), toDevice.tracks,
-                                             nInject * sizeof(TrackDataWithIDs), cudaMemcpyHostToDevice,
-                                             injectStream));
+                                             nInject * sizeof(TrackDataWithIDs), cudaMemcpyHostToDevice, injectStream));
           // Mark end of copy operation:
           COPCORE_CUDA_CHECK(cudaEventRecord(cudaEvent, injectStream));
 

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -45,6 +45,7 @@ public:
 private:
   unsigned short fNThread{0};             ///< Number of G4 workers
   unsigned int fTrackCapacity{0};         ///< Number of track slots to allocate on device
+  unsigned int fLeakCapacity{0};          ///< Number of leak slots to allocate on device
   unsigned int fScoringCapacity{0};       ///< Number of hit slots to allocate on device
   int fDebugLevel{0};                     ///< Debug level
   int fCUDAStackLimit{0};                 ///< CUDA device stack limit
@@ -94,6 +95,8 @@ public:
                 vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState) override;
   /// @brief Set track capacity on GPU
   void SetTrackCapacity(size_t capacity) override { fTrackCapacity = capacity; }
+  /// @brief Set leak capacity on GPU
+  void SetLeakCapacity(size_t capacity) override { fLeakCapacity = capacity; }
   /// @brief Set Hit buffer capacity on GPU and Host
   virtual void SetHitBufferCapacity(size_t capacity) override { fScoringCapacity = capacity; }
   /// No effect

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -171,6 +171,8 @@ void AsyncAdePTTransport<IntegrationLayer>::AddTrack(int pdg, int parentId, doub
   }
 
   fEventStates[threadId].store(EventState::NewTracksFromG4, std::memory_order_release);
+
+  // printf("INJECTED\n");
 }
 
 template <typename IntegrationLayer>
@@ -352,6 +354,9 @@ void AsyncAdePTTransport<IntegrationLayer>::ProcessGPUSteps(int threadId, int ev
 template <typename IntegrationLayer>
 void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
 {
+  // DEBUG:
+  // std::this_thread::sleep_for(std::chrono::seconds(1));
+
   if (fDebugLevel >= 3) {
     G4cout << "\nFlushing AdePT for event " << eventId << G4endl;
   }
@@ -370,6 +375,15 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
 
     ProcessGPUSteps(threadId, eventId);
   }
+
+  // // DEBUG: Check that no tracks from this event are present in either the injection, in-flight
+  // // or leak queues
+  // // Host side to-device buffer
+  // for (int i = 0; i < fBuffer->getActiveBuffer().nTrack; i++) {
+  //   if (fBuffer->getActiveBuffer().tracks[i].threadId == threadId) {
+  //     printf("INJECTERROR HOST SIDE\n");
+  //   }
+  // }
 
   // Now device should be flushed, so retrieve the tracks:
   std::vector<TrackDataWithIDs> tracks;
@@ -391,6 +405,8 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
     assert(!error);
   }
 #endif
+
+  // Sort the tracks coming from device by energy. This is necessary to ensure reproducibility
   std::sort(tracks.begin(), tracks.end());
 
   const auto oldEnergyTransferred = fGPUNetEnergy[threadId];

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -53,11 +53,11 @@ void FlushScoring(AdePTScoring &);
 std::shared_ptr<const std::vector<GPUHit>> GetGPUHits(unsigned int, AsyncAdePT::GPUstate &);
 std::pair<GPUHit *, GPUHit *> GetGPUHitsFromBuffer(unsigned int, unsigned int, AsyncAdePT::GPUstate &, bool &);
 void CloseGPUBuffer(unsigned int, AsyncAdePT::GPUstate &, GPUHit *, const bool);
-std::thread LaunchGPUWorker(int, int, int, AsyncAdePT::TrackBuffer &, AsyncAdePT::GPUstate &,
+std::thread LaunchGPUWorker(int, int, int, int, AsyncAdePT::TrackBuffer &, AsyncAdePT::GPUstate &,
                             std::vector<std::atomic<AsyncAdePT::EventState>> &, std::condition_variable &,
                             std::vector<AdePTScoring> &, int, int, bool, bool, unsigned short);
 std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> InitializeGPU(
-    int trackCapacity, int scoringCapacity, int numThreads, AsyncAdePT::TrackBuffer &trackBuffer,
+    int trackCapacity, int leakCapacity, int scoringCapacity, int numThreads, AsyncAdePT::TrackBuffer &trackBuffer,
     std::vector<AdePTScoring> &scoring, double CPUCapacityFactor, double CPUCopyFraction);
 void FreeGPU(std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> &, G4HepEmState &, std::thread &);
 } // namespace async_adept_impl
@@ -88,6 +88,7 @@ AsyncAdePTTransport<IntegrationLayer>::AsyncAdePTTransport(AdePTConfiguration &c
                                                            G4HepEmConfig *hepEmConfig)
     : fNThread{(ushort)configuration.GetNumThreads()},
       fTrackCapacity{(uint)(1024 * 1024 * configuration.GetMillionsOfTrackSlots())},
+      fLeakCapacity{(uint)(1024 * 1024 * configuration.GetMillionsOfLeakSlots())},
       fScoringCapacity{(uint)(1024 * 1024 * configuration.GetMillionsOfHitSlots())},
       fDebugLevel{configuration.GetVerbosity()}, fIntegrationLayerObjects(fNThread), fEventStates(fNThread),
       fGPUNetEnergy(fNThread, 0.0), fTrackInAllRegions{configuration.GetTrackInAllRegions()},
@@ -307,11 +308,11 @@ void AsyncAdePTTransport<IntegrationLayer>::Initialize(G4HepEmConfig *hepEmConfi
 
   assert(fBuffer != nullptr);
 
-  fGPUstate  = async_adept_impl::InitializeGPU(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, fScoring,
-                                               fCPUCapacityFactor, fCPUCopyFraction);
-  fGPUWorker = async_adept_impl::LaunchGPUWorker(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, *fGPUstate,
-                                                 fEventStates, fCV_G4Workers, fScoring, fAdePTSeed, fDebugLevel,
-                                                 fReturnAllSteps, fReturnFirstAndLastStep, fLastNParticlesOnCPU);
+  fGPUstate  = async_adept_impl::InitializeGPU(fTrackCapacity, fLeakCapacity, fScoringCapacity, fNThread, *fBuffer,
+                                               fScoring, fCPUCapacityFactor, fCPUCopyFraction);
+  fGPUWorker = async_adept_impl::LaunchGPUWorker(
+      fTrackCapacity, fLeakCapacity, fScoringCapacity, fNThread, *fBuffer, *fGPUstate, fEventStates, fCV_G4Workers,
+      fScoring, fAdePTSeed, fDebugLevel, fReturnAllSteps, fReturnFirstAndLastStep, fLastNParticlesOnCPU);
 }
 
 template <typename IntegrationLayer>

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -171,8 +171,6 @@ void AsyncAdePTTransport<IntegrationLayer>::AddTrack(int pdg, int parentId, doub
   }
 
   fEventStates[threadId].store(EventState::NewTracksFromG4, std::memory_order_release);
-
-  // printf("INJECTED\n");
 }
 
 template <typename IntegrationLayer>
@@ -354,9 +352,6 @@ void AsyncAdePTTransport<IntegrationLayer>::ProcessGPUSteps(int threadId, int ev
 template <typename IntegrationLayer>
 void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
 {
-  // DEBUG:
-  // std::this_thread::sleep_for(std::chrono::seconds(1));
-
   if (fDebugLevel >= 3) {
     G4cout << "\nFlushing AdePT for event " << eventId << G4endl;
   }
@@ -375,15 +370,6 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
 
     ProcessGPUSteps(threadId, eventId);
   }
-
-  // // DEBUG: Check that no tracks from this event are present in either the injection, in-flight
-  // // or leak queues
-  // // Host side to-device buffer
-  // for (int i = 0; i < fBuffer->getActiveBuffer().nTrack; i++) {
-  //   if (fBuffer->getActiveBuffer().tracks[i].threadId == threadId) {
-  //     printf("INJECTERROR HOST SIDE\n");
-  //   }
-  // }
 
   // Now device should be flushed, so retrieve the tracks:
   std::vector<TrackDataWithIDs> tracks;

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -302,8 +302,8 @@ void AsyncAdePTTransport<IntegrationLayer>::Initialize(G4HepEmConfig *hepEmConfi
   // Allocate buffers to transport particles to/from device. Scale the size of the staging area
   // with the number of threads.
   G4cout << "\nAllocating " << 4 * 8192 * fNThread << " To-device buffer slots" << G4endl;
-  G4cout << "\nAllocating " << 1024 * fNThread << " From-device buffer slots" << G4endl;
-  fBuffer = std::make_unique<TrackBuffer>(4 * 8192 * fNThread, 1024 * fNThread, fNThread);
+  G4cout << "\nAllocating " << 2048 * fNThread << " From-device buffer slots" << G4endl;
+  fBuffer = std::make_unique<TrackBuffer>(4 * 8192 * fNThread, 2048 * fNThread, fNThread);
 
   assert(fBuffer != nullptr);
 

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -297,10 +297,12 @@ void AsyncAdePTTransport<IntegrationLayer>::Initialize(G4HepEmConfig *hepEmConfi
   volAuxArray.fAuxData    = auxData;
   AsyncAdePT::InitVolAuxArray(volAuxArray);
 
-  // TODO: Make this configurable or figure out a reasonable value (Currently, it seems that the
-  // to device buffer is often full)
+  // FIXME: The size of the buffer should be more explicitly configured
+  // NOTE: Increasing the size of the leak buffer size can probably improve performance
   // Allocate buffers to transport particles to/from device. Scale the size of the staging area
   // with the number of threads.
+  G4cout << "\nAllocating " << 4 * 8192 * fNThread << " To-device buffer slots" << G4endl;
+  G4cout << "\nAllocating " << 1024 * fNThread << " From-device buffer slots" << G4endl;
   fBuffer = std::make_unique<TrackBuffer>(4 * 8192 * fNThread, 1024 * fNThread, fNThread);
 
   assert(fBuffer != nullptr);
@@ -414,12 +416,10 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
     G4cout << str.str() << G4endl;
   }
 
-  if (tracks.empty()) {
-    async_adept_impl::FlushScoring(fScoring[threadId]);
-    fEventStates[threadId].store(EventState::ScoringRetrieved, std::memory_order_release);
-  }
-
   integrationInstance.ReturnTracks(tracks.begin(), tracks.end(), fDebugLevel);
+
+  async_adept_impl::FlushScoring(fScoring[threadId]);
+  fEventStates[threadId].store(EventState::ScoringRetrieved, std::memory_order_release);
 }
 
 } // namespace AsyncAdePT

--- a/include/AdePT/core/AsyncAdePTTransportStruct.cuh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.cuh
@@ -186,7 +186,6 @@ struct GPUstate {
   // TracksOnHost: Some or all the tracks have been transferred from device to host and are waiting in the copy buffer
   // SavingTracks: Tracks are being copied to per-event queues
   // TracksSaved: Tracks have been moved from the copy buffer to their respective per-event queues
-  // ExtractionFinished: No more tracks left on device, all tracks are available in the per-event queues
   enum class ExtractState {
     Idle,
     ExtractionRequested,
@@ -196,8 +195,7 @@ struct GPUstate {
     CopyingTracks,
     TracksOnHost,
     SavingTracks,
-    TracksSaved,
-    ExtractionFinished
+    TracksSaved
   };
   std::atomic<ExtractState> extractState;
   std::atomic_bool runTransport{true}; ///< Keep transport thread running

--- a/include/AdePT/core/AsyncAdePTTransportStruct.cuh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.cuh
@@ -140,6 +140,8 @@ struct Stats {
   unsigned int perEventInFlight[kMaxThreads];         // Updated asynchronously
   unsigned int perEventInFlightPrevious[kMaxThreads]; // Used in transport kernels
   unsigned int perEventLeaked[kMaxThreads];
+  unsigned int nLeakedCurrent[ParticleType::NumParticleTypes];
+  unsigned int nLeakedNext[ParticleType::NumParticleTypes];
   unsigned int hitBufferOccupancy;
 };
 

--- a/include/AdePT/core/AsyncAdePTTransportStruct.cuh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.cuh
@@ -58,7 +58,6 @@ public:
 struct LeakedTracks {
   Track *fTracks;
   adept::MParray *fLeakedQueue;
-  adept::MParray *fLeakedQueueNext;
   SlotManager *fSlotManager;
 };
 
@@ -177,7 +176,29 @@ struct GPUstate {
 
   enum class InjectState { Idle, CreatingSlots, ReadyToEnqueue, Enqueueing };
   std::atomic<InjectState> injectState;
-  enum class ExtractState { Idle, FreeingSlots, ReadyToCopy, CopyToHost };
+  // ExtractState:
+  // Idle: No flush has been requested
+  // ExtractionRequested: An event requested a flush, waiting for transport to finish
+  // TracksNeedTransfer: An event requested a flush, leak buffer on device has tracks to transfer
+  // PreparingTracks: Tracks are being copied to the staging buffer
+  // TracksReadyToCopy: Staging buffer is ready to be copied to host
+  // CopyingTracks: Tracks are being copied to host
+  // TracksOnHost: Some or all the tracks have been transferred from device to host and are waiting in the copy buffer
+  // SavingTracks: Tracks are being copied to per-event queues
+  // TracksSaved: Tracks have been moved from the copy buffer to their respective per-event queues
+  // ExtractionFinished: No more tracks left on device, all tracks are available in the per-event queues
+  enum class ExtractState {
+    Idle,
+    ExtractionRequested,
+    TracksNeedTransfer,
+    PreparingTracks,
+    TracksReadyToCopy,
+    CopyingTracks,
+    TracksOnHost,
+    SavingTracks,
+    TracksSaved,
+    ExtractionFinished
+  };
   std::atomic<ExtractState> extractState;
   std::atomic_bool runTransport{true}; ///< Keep transport thread running
 

--- a/include/AdePT/core/CommonStruct.h
+++ b/include/AdePT/core/CommonStruct.h
@@ -149,6 +149,8 @@ struct TrackBuffer {
 
   unsigned int fNumToDevice{0};   ///< number of slots in the toDevice buffer
   unsigned int fNumFromDevice{0}; ///< number of slots in the fromDevice buffer
+  unsigned int fNumLeaksTransferred{
+      0}; ///< Used to keep track of the number of tracks transferred from device during extraction
   unique_ptr_cuda<TrackDataWithIDs, CudaHostDeleter<TrackDataWithIDs>>
       toDevice_host;                              ///< Tracks to be transported to the device
   unique_ptr_cuda<TrackDataWithIDs> toDevice_dev; ///< toDevice buffer of tracks
@@ -156,6 +158,8 @@ struct TrackBuffer {
   unique_ptr_cuda<TrackDataWithIDs> fromDevice_dev;                                     ///< fromDevice buffer of tracks
   unique_ptr_cuda<unsigned int, CudaHostDeleter<unsigned int>>
       nFromDevice_host; ///< Number of tracks collected on device
+  unique_ptr_cuda<unsigned int, CudaHostDeleter<unsigned int>>
+      nRemainingLeaks_host; ///< Number of tracks still left to transfer from device during extraction
 
   std::vector<std::vector<TrackDataWithIDs>> fromDeviceBuffers;
   std::mutex fromDeviceMutex;

--- a/include/AdePT/integration/AdePTConfigurationMessenger.hh
+++ b/include/AdePT/integration/AdePTConfigurationMessenger.hh
@@ -48,6 +48,7 @@ private:
   G4UIcmdWithAnInteger *fSetVerbosityCmd;
   G4UIcmdWithAnInteger *fSetTransportBufferThresholdCmd;
   G4UIcmdWithADouble *fSetMillionsOfTrackSlotsCmd;
+  G4UIcmdWithADouble *fSetMillionsOfLeakSlotsCmd;
   G4UIcmdWithADouble *fSetMillionsOfHitSlotsCmd;
   G4UIcmdWithADouble *fSetHitBufferFlushThresholdCmd;
   G4UIcmdWithADouble *fSetCPUCapacityFactorCmd;

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -159,7 +159,14 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       // work if we want to re-use slots on the fly. Directly copying to
       // a trackdata struct would be better
       if (leak) {
-        leakedQueue->push_back(slot);
+        // printf("LEAK ELECTRON\n");
+        auto success = leakedQueue->push_back(slot);
+        if (!success) {
+          printf("ERROR: No space left in e-/+ leaks queue.\n\
+\tThe threshold for flushing the leak buffer may be too high\n\
+\tThe space allocated to the leak buffer may be too small\n");
+          asm("trap;");
+        }
       } else
         nextActiveQueue->push_back(slot);
 #else

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -28,9 +28,6 @@
 
 using VolAuxData = adeptint::VolAuxData;
 
-// DEBUG
-// __device__ unsigned int electronleaks;
-
 // Compute velocity based on the kinetic energy of the particle
 __device__ double GetVelocity(double eKin)
 {
@@ -162,8 +159,6 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       // work if we want to re-use slots on the fly. Directly copying to
       // a trackdata struct would be better
       if (leak) {
-        // printf("PRINTLEAK ELECTRON\n");
-        // atomicAdd(&electronleaks, 1);
         auto success = leakedQueue->push_back(slot);
         if (!success) {
           printf("ERROR: No space left in e-/+ leaks queue.\n\
@@ -175,9 +170,9 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
         nextActiveQueue->push_back(slot);
 #else
       currentTrack.CopyTo(trackdata, Pdg);
-      if (leak) {
+      if (leak)
         leakedQueue->push_back(trackdata);
-      } else
+      else
         electrons->fNextTracks->push_back(slot);
 #endif
     };

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -45,7 +45,7 @@ namespace AsyncAdePT {
 // generate secondaries.
 template <bool IsElectron, typename Scoring>
 static __device__ __forceinline__ void TransportElectrons(Track *electrons, const adept::MParray *active,
-                                                          Secondaries &secondaries, adept::MParray *activeQueue,
+                                                          Secondaries &secondaries, adept::MParray *nextActiveQueue,
                                                           adept::MParray *leakedQueue, Scoring *userScoring,
                                                           Stats *InFlightStats,
                                                           AllowFinishOffEventArray allowFinishOffEvent,
@@ -158,15 +158,16 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       // NOTE: When adapting the split kernels for async mode this won't
       // work if we want to re-use slots on the fly. Directly copying to
       // a trackdata struct would be better
-      if (leak)
+      if (leak) {
+        // printf("LEAK\n");
         leakedQueue->push_back(slot);
-      else
-        activeQueue->push_back(slot);
+      } else
+        nextActiveQueue->push_back(slot);
 #else
       currentTrack.CopyTo(trackdata, Pdg);
-      if (leak)
+      if (leak) {
         leakedQueue->push_back(trackdata);
-      else
+      } else
         electrons->fNextTracks->push_back(slot);
 #endif
     };
@@ -769,21 +770,21 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 #ifdef ASYNC_MODE
 template <typename Scoring>
 __global__ void TransportElectrons(Track *electrons, const adept::MParray *active, Secondaries secondaries,
-                                   adept::MParray *activeQueue, adept::MParray *leakedQueue, Scoring *userScoring,
+                                   adept::MParray *nextActiveQueue, adept::MParray *leakedQueue, Scoring *userScoring,
                                    Stats *InFlightStats, AllowFinishOffEventArray allowFinishOffEvent,
                                    bool returnAllSteps, bool returnLastStep)
 {
-  TransportElectrons</*IsElectron*/ true, Scoring>(electrons, active, secondaries, activeQueue, leakedQueue,
+  TransportElectrons</*IsElectron*/ true, Scoring>(electrons, active, secondaries, nextActiveQueue, leakedQueue,
                                                    userScoring, InFlightStats, allowFinishOffEvent, returnAllSteps,
                                                    returnLastStep);
 }
 template <typename Scoring>
 __global__ void TransportPositrons(Track *positrons, const adept::MParray *active, Secondaries secondaries,
-                                   adept::MParray *activeQueue, adept::MParray *leakedQueue, Scoring *userScoring,
+                                   adept::MParray *nextActiveQueue, adept::MParray *leakedQueue, Scoring *userScoring,
                                    Stats *InFlightStats, AllowFinishOffEventArray allowFinishOffEvent,
                                    bool returnAllSteps, bool returnLastStep)
 {
-  TransportElectrons</*IsElectron*/ false, Scoring>(positrons, active, secondaries, activeQueue, leakedQueue,
+  TransportElectrons</*IsElectron*/ false, Scoring>(positrons, active, secondaries, nextActiveQueue, leakedQueue,
                                                     userScoring, InFlightStats, allowFinishOffEvent, returnAllSteps,
                                                     returnLastStep);
 }

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -159,7 +159,6 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       // work if we want to re-use slots on the fly. Directly copying to
       // a trackdata struct would be better
       if (leak) {
-        // printf("LEAK\n");
         leakedQueue->push_back(slot);
       } else
         nextActiveQueue->push_back(slot);

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -28,6 +28,9 @@
 
 using VolAuxData = adeptint::VolAuxData;
 
+// DEBUG
+// __device__ unsigned int electronleaks;
+
 // Compute velocity based on the kinetic energy of the particle
 __device__ double GetVelocity(double eKin)
 {
@@ -159,7 +162,8 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       // work if we want to re-use slots on the fly. Directly copying to
       // a trackdata struct would be better
       if (leak) {
-        // printf("LEAK ELECTRON\n");
+        // printf("PRINTLEAK ELECTRON\n");
+        // atomicAdd(&electronleaks, 1);
         auto success = leakedQueue->push_back(slot);
         if (!success) {
           printf("ERROR: No space left in e-/+ leaks queue.\n\

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -103,7 +103,15 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       currentTrack.navState   = navState;
 #ifdef ASYNC_MODE
       if (leak) {
-        leakedQueue->push_back(slot);
+        // printf("LEAK GAMMA\n");
+        auto success = leakedQueue->push_back(slot);
+        // printf("USAGE: %lu / %lu\n", leakedQueue->size(), leakedQueue->max_size());
+        if (!success) {
+          printf("ERROR: No space left in gammas leaks queue.\n\
+\tThe threshold for flushing the leak buffer may be too high\n\
+\tThe space allocated to the leak buffer may be too small\n");
+          asm("trap;");
+        }
       } else
         nextActiveQueue->push_back(slot);
 #else

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -19,6 +19,9 @@
 
 using VolAuxData = adeptint::VolAuxData;
 
+// DEBUG
+// __device__ unsigned int gammaleaks;
+
 #ifdef ASYNC_MODE
 namespace AsyncAdePT {
 // Asynchronous TransportGammas Interface
@@ -103,7 +106,8 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       currentTrack.navState   = navState;
 #ifdef ASYNC_MODE
       if (leak) {
-        // printf("LEAK GAMMA\n");
+        // printf("PRINTLEAK GAMMA\n");
+        // atomicAdd(&gammaleaks, 1);
         auto success = leakedQueue->push_back(slot);
         // printf("USAGE: %lu / %lu\n", leakedQueue->size(), leakedQueue->max_size());
         if (!success) {
@@ -293,8 +297,8 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       // gamma-nuclear reactions in comparison to without gamma-nuclear reactions. Thus, an empty step without a
       // reaction is needed to compensate for the smaller step size returned by HowFar.
 
-      // Reset number of interaction left for the winner discrete process also in the currentTrack (SampleInteraction()
-      // resets it for theTrack), will be resampled in the next iteration.
+      // Reset number of interaction left for the winner discrete process also in the currentTrack
+      // (SampleInteraction() resets it for theTrack), will be resampled in the next iteration.
       currentTrack.numIALeft[0] = -1.0;
     }
 

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -24,9 +24,10 @@ namespace AsyncAdePT {
 // Asynchronous TransportGammas Interface
 template <typename Scoring>
 __global__ void __launch_bounds__(256, 1)
-    TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
-                    adept::MParray *leakedQueue, Scoring *userScoring, Stats *InFlightStats,
-                    AllowFinishOffEventArray allowFinishOffEvent, bool returnAllSteps, bool returnLastStep)
+    TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries,
+                    adept::MParray *nextActiveQueue, adept::MParray *leakedQueue, Scoring *userScoring,
+                    Stats *InFlightStats, AllowFinishOffEventArray allowFinishOffEvent, bool returnAllSteps,
+                    bool returnLastStep)
 {
   constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
   constexpr unsigned short maxSteps = 10'000;
@@ -101,15 +102,16 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       currentTrack.properTime = properTime;
       currentTrack.navState   = navState;
 #ifdef ASYNC_MODE
-      if (leak)
+      if (leak) {
+        // printf("LEAK\n");
         leakedQueue->push_back(slot);
-      else
-        activeQueue->push_back(slot);
+      } else
+        nextActiveQueue->push_back(slot);
 #else
       currentTrack.CopyTo(trackdata, Pdg);
-      if (leak)
+      if (leak) {
         leakedQueue->push_back(trackdata);
-      else
+      } else
         gammas->fNextTracks->push_back(slot);
 #endif
     };

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -103,7 +103,6 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       currentTrack.navState   = navState;
 #ifdef ASYNC_MODE
       if (leak) {
-        // printf("LEAK\n");
         leakedQueue->push_back(slot);
       } else
         nextActiveQueue->push_back(slot);

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -19,9 +19,6 @@
 
 using VolAuxData = adeptint::VolAuxData;
 
-// DEBUG
-// __device__ unsigned int gammaleaks;
-
 #ifdef ASYNC_MODE
 namespace AsyncAdePT {
 // Asynchronous TransportGammas Interface
@@ -106,10 +103,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       currentTrack.navState   = navState;
 #ifdef ASYNC_MODE
       if (leak) {
-        // printf("PRINTLEAK GAMMA\n");
-        // atomicAdd(&gammaleaks, 1);
         auto success = leakedQueue->push_back(slot);
-        // printf("USAGE: %lu / %lu\n", leakedQueue->size(), leakedQueue->max_size());
         if (!success) {
           printf("ERROR: No space left in gammas leaks queue.\n\
 \tThe threshold for flushing the leak buffer may be too high\n\
@@ -120,9 +114,9 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         nextActiveQueue->push_back(slot);
 #else
       currentTrack.CopyTo(trackdata, Pdg);
-      if (leak) {
+      if (leak)
         leakedQueue->push_back(trackdata);
-      } else
+      else
         gammas->fNextTracks->push_back(slot);
 #endif
     };

--- a/src/AdePTConfigurationMessenger.cc
+++ b/src/AdePTConfigurationMessenger.cc
@@ -64,6 +64,10 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
   fSetMillionsOfTrackSlotsCmd->SetGuidance(
       "Set the total number of track slots that will be allocated on the GPU, in millions");
 
+  fSetMillionsOfLeakSlotsCmd = new G4UIcmdWithADouble("/adept/setMillionsOfLeakSlots", this);
+  fSetMillionsOfLeakSlotsCmd->SetGuidance(
+      "Set the total number of leak slots that will be allocated on the GPU, in millions");
+
   fSetMillionsOfHitSlotsCmd = new G4UIcmdWithADouble("/adept/setMillionsOfHitSlots", this);
   fSetMillionsOfHitSlotsCmd->SetGuidance(
       "Set the total number of hit slots that will be allocated on the GPU, in millions");
@@ -165,6 +169,8 @@ void AdePTConfigurationMessenger::SetNewValue(G4UIcommand *command, G4String new
     fAdePTConfiguration->SetTransportBufferThreshold(fSetTransportBufferThresholdCmd->GetNewIntValue(newValue));
   } else if (command == fSetMillionsOfTrackSlotsCmd) {
     fAdePTConfiguration->SetMillionsOfTrackSlots(fSetMillionsOfTrackSlotsCmd->GetNewDoubleValue(newValue));
+  } else if (command == fSetMillionsOfLeakSlotsCmd) {
+    fAdePTConfiguration->SetMillionsOfLeakSlots(fSetMillionsOfLeakSlotsCmd->GetNewDoubleValue(newValue));
   } else if (command == fSetMillionsOfHitSlotsCmd) {
     fAdePTConfiguration->SetMillionsOfHitSlots(fSetMillionsOfHitSlotsCmd->GetNewDoubleValue(newValue));
   } else if (command == fSetHitBufferFlushThresholdCmd) {

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -593,13 +593,6 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
 void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex,
                                          int debugLevel) const
 {
-  // DEBUG
-  // if (track.pdg != 22) {
-  //   printf("RETURN ELECTRON\n");
-  // } else {
-  //   printf("RETURN GAMMA\n");
-  // }
-
   constexpr double tolerance = 10. * vecgeom::kTolerance;
 
   // Build the secondaries and put them back on the Geant4 stack

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -593,6 +593,12 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
 void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex,
                                          int debugLevel) const
 {
+  // if (track.pdg != 22) {
+  //   printf("RETURN ELECTRON\n");
+  // } else {
+  //   printf("RETURN GAMMA\n");
+  // }
+
   constexpr double tolerance = 10. * vecgeom::kTolerance;
 
   // Build the secondaries and put them back on the Geant4 stack

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -593,6 +593,8 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
 void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex,
                                          int debugLevel) const
 {
+  // printf("RETURN\n");
+
   constexpr double tolerance = 10. * vecgeom::kTolerance;
 
   // Build the secondaries and put them back on the Geant4 stack
@@ -605,7 +607,9 @@ void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsig
   }
   G4ParticleMomentum direction(track.direction[0], track.direction[1], track.direction[2]);
 
-  G4DynamicParticle *dynamique =
+  // printf("%lf\n", track.eKin);
+
+  G4DynamicParticle *dynamic =
       new G4DynamicParticle(G4ParticleTable::GetParticleTable()->FindParticle(track.pdg), direction, track.eKin);
 
   G4ThreeVector posi(track.position[0], track.position[1], track.position[2]);
@@ -614,11 +618,11 @@ void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsig
   posi += tolerance * direction;
 
   // Create track
-  G4Track *secondary = new G4Track(dynamique, track.globalTime, posi);
+  G4Track *secondary = new G4Track(dynamic /* Now owned by G4Track */, track.globalTime, posi);
 
   // We set the status of leaked tracks to fStopButAlive to be able to distinguish them to keep
   // them on the CPU until they die!
-  secondary->SetTrackStatus(fStopButAlive);
+  // secondary->SetTrackStatus(fStopButAlive);
 
   // Set time information
   secondary->SetLocalTime(track.localTime);

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -650,6 +650,7 @@ void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsig
 
   // Give ownership of the touchable history to the touchable handle, which will now manage its lifetime
   G4TouchableHandle originTouchableHandle(originTouchableHistory.release() /* Now owned by G4TouchableHandle */);
+  secondary->SetOriginTouchableHandle(originTouchableHandle);
 
   // Give the track to G4
   G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(secondary);

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -593,8 +593,6 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
 void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex,
                                          int debugLevel) const
 {
-  // printf("RETURN\n");
-
   constexpr double tolerance = 10. * vecgeom::kTolerance;
 
   // Build the secondaries and put them back on the Geant4 stack
@@ -607,8 +605,6 @@ void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsig
   }
   G4ParticleMomentum direction(track.direction[0], track.direction[1], track.direction[2]);
 
-  // // printf("%lf\n", track.eKin);
-
   G4DynamicParticle *dynamic =
       new G4DynamicParticle(G4ParticleTable::GetParticleTable()->FindParticle(track.pdg), direction, track.eKin);
 
@@ -617,11 +613,9 @@ void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsig
   // push it to make sure it is not relocated again in the GPU region
   posi += tolerance * direction;
 
-  // // Create track
+  // Create track
   G4Track *secondary = new G4Track(dynamic /* Now owned by G4Track */, track.globalTime, posi);
 
-  // We set the status of leaked tracks to fStopButAlive to be able to distinguish them to keep
-  // them on the CPU until they die!
   secondary->SetTrackStatus(fAlive);
 
   // Set time information

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -593,6 +593,7 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
 void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex,
                                          int debugLevel) const
 {
+  // DEBUG
   // if (track.pdg != 22) {
   //   printf("RETURN ELECTRON\n");
   // } else {

--- a/src/G4HepEmTrackingManagerSpecialized.cc
+++ b/src/G4HepEmTrackingManagerSpecialized.cc
@@ -34,8 +34,7 @@ bool G4HepEmTrackingManagerSpecialized::CheckEarlyTrackingExit(G4Track *track, G
   //       This can be checked from the pre- and post-steppoint
 
   // Not in the GPU region, continue normal tracking with G4HepEmTrackingManager
-  if (fGPURegions.find(region) == fGPURegions.end() || (fGPURegions.empty() && !GetTrackInAllRegions()) ||
-      fFinishEventOnCPU[threadId] > 0) {
+  if ((!GetTrackInAllRegions() && fGPURegions.find(region) == fGPURegions.end()) || fFinishEventOnCPU[threadId] > 0) {
     return false; // Continue tracking with G4HepEmTrackingManager
   } else {
 

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -23,8 +23,8 @@ endmacro()
 #----------------------------------------------------------------------------#
 # Common Data
 #----------------------------------------------------------------------------#
-file(COPY "${PROJECT_SOURCE_DIR}/examples/data/testEm3.gdml" DESTINATION "${PROJECT_BINARY_DIR}")
-set(TESTING_GDML "${PROJECT_BINARY_DIR}/testEm3.gdml")
+# file(COPY "${PROJECT_SOURCE_DIR}/examples/data/testEm3.gdml" DESTINATION "${PROJECT_BINARY_DIR}")
+# file(COPY "${PROJECT_SOURCE_DIR}/examples/data/testEm3_regions.gdml" DESTINATION "${PROJECT_BINARY_DIR}")
 
 #----------------------------------------------------------------------------#
 # G4 App-based Tests
@@ -47,6 +47,14 @@ add_test(NAME reproducibility_cms_ttbar
 # The energy deposition per layer error must be < 1% to pass the test
 add_test(NAME testEm3_validation
     COMMAND bash ${PROJECT_SOURCE_DIR}/test/regression/scripts/validation_testem3.sh
+    "$<TARGET_FILE:integrationTest>" "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}" "${SCRIPTS_DIR}" "${TEMP_DIR}"
+    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+)
+
+# test that compares the physics output of a full AdePT run with transport only in some regions against a high-statistics 
+# Geant4 simulation using G4HepEm. The energy deposition per layer error must be < 1% to pass the test
+add_test(NAME testEm3_validation_regions
+    COMMAND bash ${PROJECT_SOURCE_DIR}/test/regression/scripts/validation_testem3_regions.sh
     "$<TARGET_FILE:integrationTest>" "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}" "${SCRIPTS_DIR}" "${TEMP_DIR}"
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
 )

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -21,12 +21,6 @@ macro(add_to_test TESTS)
 endmacro()
 
 #----------------------------------------------------------------------------#
-# Common Data
-#----------------------------------------------------------------------------#
-# file(COPY "${PROJECT_SOURCE_DIR}/examples/data/testEm3.gdml" DESTINATION "${PROJECT_BINARY_DIR}")
-# file(COPY "${PROJECT_SOURCE_DIR}/examples/data/testEm3_regions.gdml" DESTINATION "${PROJECT_BINARY_DIR}")
-
-#----------------------------------------------------------------------------#
 # G4 App-based Tests
 #----------------------------------------------------------------------------#
 

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -43,6 +43,14 @@ add_test(NAME reproducibility_cms_ttbar
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
 )
 
+# This test checks the reproducibility of AdePT with transport only in some regions by running 8 ttbar events and checking that the 
+# energy deposition is exactly the same.
+add_test(NAME reproducibility_cms_ttbar_regions
+    COMMAND bash ${PROJECT_SOURCE_DIR}/test/regression/scripts/reproducibility_regions.sh
+    "$<TARGET_FILE:integrationTest>" "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}" "${SCRIPTS_DIR}" "${TEMP_DIR}"
+    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+)
+
 # test that compares the physics output of a full AdePT run against a high-statistics Geant4 simulation using G4HepEm.
 # The energy deposition per layer error must be < 1% to pass the test
 add_test(NAME testEm3_validation

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -43,9 +43,9 @@ add_test(NAME reproducibility_cms_ttbar
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
 )
 
-# This test checks the reproducibility of AdePT with transport only in some regions by running 8 ttbar events and checking that the 
-# energy deposition is exactly the same.
-add_test(NAME reproducibility_cms_ttbar_regions
+# This test checks the reproducibility of AdePT with transport only in some regions by running 50 e- events in the testEm3 geometry
+# and checking that the energy deposition is exactly the same.
+add_test(NAME reproducibility_regions
     COMMAND bash ${PROJECT_SOURCE_DIR}/test/regression/scripts/reproducibility_regions.sh
     "$<TARGET_FILE:integrationTest>" "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}" "${SCRIPTS_DIR}" "${TEMP_DIR}"
     WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}

--- a/test/regression/IntegrationTest/src/RunAction.cc
+++ b/test/regression/IntegrationTest/src/RunAction.cc
@@ -76,7 +76,7 @@ void RunAction::EndOfRunAction(const G4Run *)
 
   // Print timer just for the master thread since this is called when all workers are done
   if (tid < 0) {
-    G4cout << "Run time: " << time << "\n";
+    std::cout << "Run time: " << time << "\n";
     if (fDoBenchmark) {
       fRun->GetTestManager()->timerStop(Run::timers::TOTAL);
     }

--- a/test/regression/IntegrationTest/src/RunAction.cc
+++ b/test/regression/IntegrationTest/src/RunAction.cc
@@ -76,7 +76,7 @@ void RunAction::EndOfRunAction(const G4Run *)
 
   // Print timer just for the master thread since this is called when all workers are done
   if (tid < 0) {
-    std::cout << "Run time: " << time << "\n";
+    G4cout << "Run time: " << time << "\n";
     if (fDoBenchmark) {
       fRun->GetTestManager()->timerStop(Run::timers::TOTAL);
     }

--- a/test/regression/scripts/example_template.mac
+++ b/test/regression/scripts/example_template.mac
@@ -24,7 +24,8 @@
 /adept/setCUDAStackLimit 8192
 
 # If true, particles are transported on the GPU across the whole geometry, GPU regions are ignored
-/adept/setTrackInAllRegions true
+/adept/setTrackInAllRegions $track_in_all_regions
+$regions
 
 /process/em/applyCuts true
 

--- a/test/regression/scripts/example_template.mac
+++ b/test/regression/scripts/example_template.mac
@@ -20,6 +20,7 @@
 /adept/setTransportBufferThreshold 125000
 ## Total number of GPU track slots (not per thread)
 /adept/setMillionsOfTrackSlots $num_trackslots
+/adept/setMillionsOfLeakSlots $num_leakslots
 /adept/setMillionsOfHitSlots $num_hitslots
 /adept/setCUDAStackLimit 8192
 

--- a/test/regression/scripts/example_template.mac
+++ b/test/regression/scripts/example_template.mac
@@ -17,7 +17,7 @@
 /detector/filename $gdml_name
 /adept/setVerbosity 0
 ## Threshold for buffering tracks before sending to GPU
-/adept/setTransportBufferThreshold 250000
+/adept/setTransportBufferThreshold 125000
 ## Total number of GPU track slots (not per thread)
 /adept/setMillionsOfTrackSlots $num_trackslots
 /adept/setMillionsOfHitSlots $num_hitslots
@@ -41,7 +41,7 @@ $regions
 /run/initialize
 
 ## User-defined Event verbosity: 1 = total edep, 2 = energy deposit per placed sensitive volume
-/eventAction/verbose 2
+/eventAction/verbose 1
 
 /gun/$gun_type # hepmc or setDefault
 $hepmc_part

--- a/test/regression/scripts/python_scripts/macro_generator.py
+++ b/test/regression/scripts/python_scripts/macro_generator.py
@@ -6,7 +6,8 @@
 import argparse
 import os
 
-def generate_macro(template_path, output_path, gdml_name, num_threads, num_events, num_trackslots, num_hitslots, gun_type, event_file):
+
+def generate_macro(template_path, output_path, gdml_name, num_threads, num_events, num_trackslots, num_hitslots, gun_type, event_file, track_in_all_regions, regions):
     # Read the template file
     with open(template_path, 'r') as template_file:
         template_content = template_file.read()
@@ -18,8 +19,10 @@ def generate_macro(template_path, output_path, gdml_name, num_threads, num_event
     macro_content = macro_content.replace("$num_trackslots", str(num_trackslots))
     macro_content = macro_content.replace("$num_hitslots", str(num_hitslots))
     macro_content = macro_content.replace("$gun_type", str(gun_type))
+    macro_content = macro_content.replace(
+        "$track_in_all_regions", str(track_in_all_regions))
 
-    if(str(gun_type) == "hepmc"):
+    if (str(gun_type) == "hepmc"):
         hepmc_part = "/generator/hepmcAscii/maxevents 256 \n\
                       /generator/hepmcAscii/firstevent 0 \n\
                       /generator/hepmcAscii/open $event_file \n\
@@ -29,9 +32,14 @@ def generate_macro(template_path, output_path, gdml_name, num_threads, num_event
     else:
         macro_content = macro_content.replace("$hepmc_part", str(""))
 
-
-        
-
+    # Regions should be a comma-separated list of region names
+    region_part = []
+    for i in regions.split(","):
+        region = i.strip()
+        if region:  # Empty regions list or empty region name
+            region_part.append(f"/adept/addGPURegion {region}")
+    region_part = "\n".join(region_part)
+    macro_content = macro_content.replace("$regions", region_part)
 
     # Write the output macro file
     with open(output_path, 'w') as output_file:
@@ -39,17 +47,31 @@ def generate_macro(template_path, output_path, gdml_name, num_threads, num_event
 
     print(f"Macro file generated: {output_path}")
 
+
 def main():
-    parser = argparse.ArgumentParser(description="Generate Geant4 macro file from template.")
-    parser.add_argument("--template", required=True, help="Path to the macro template file.")
-    parser.add_argument("--output", required=True, help="Path to save the generated macro file.")
-    parser.add_argument("--gdml_name", required=True, help="Path to the GDML geometry file.")
-    parser.add_argument("--num_threads", type=int, required=True, help="Number of threads to use.")
-    parser.add_argument("--num_events", type=int, required=True, help="Number of events to simulate.")
-    parser.add_argument("--num_trackslots", type=int, default=12, help="Number of trackslots in million. Should be chosen according to the GPU memory")
-    parser.add_argument("--num_hitslots", type=int, default=12, help="Number of hitslots in million. Should be chosen according to the GPU memory")
-    parser.add_argument("--gun_type", default="setDefault", help="Type of particle gun. Must be 'hepmc' or 'setDefault'.")
-    parser.add_argument("--event_file", help="Path to the hepmc3 event file" )
+    parser = argparse.ArgumentParser(
+        description="Generate Geant4 macro file from template.")
+    parser.add_argument("--template", required=True,
+                        help="Path to the macro template file.")
+    parser.add_argument("--output", required=True,
+                        help="Path to save the generated macro file.")
+    parser.add_argument("--gdml_name", required=True,
+                        help="Path to the GDML geometry file.")
+    parser.add_argument("--num_threads", type=int, required=True,
+                        help="Number of threads to use.")
+    parser.add_argument("--num_events", type=int, required=True,
+                        help="Number of events to simulate.")
+    parser.add_argument("--num_trackslots", type=int, default=12,
+                        help="Number of trackslots in million. Should be chosen according to the GPU memory")
+    parser.add_argument("--num_hitslots", type=int, default=12,
+                        help="Number of hitslots in million. Should be chosen according to the GPU memory")
+    parser.add_argument("--gun_type", default="setDefault",
+                        help="Type of particle gun. Must be 'hepmc' or 'setDefault'.")
+    parser.add_argument("--event_file", help="Path to the hepmc3 event file")
+    parser.add_argument("--track_in_all_regions", required=False,
+                        default="True", help="True or False")
+    parser.add_argument("--regions", type=str, required=False, default="",
+                        help="Comma-separated list of regions in which to do GPU transport, only if track_in_all_regions is False")
     args = parser.parse_args()
 
     if str(args.gun_type) not in ["hepmc", "setDefault"]:
@@ -72,8 +94,11 @@ def main():
         num_trackslots=args.num_trackslots,
         num_hitslots=args.num_hitslots,
         gun_type=args.gun_type,
-        event_file=args.event_file
+        event_file=args.event_file,
+        track_in_all_regions=args.track_in_all_regions,
+        regions=args.regions
     )
+
 
 if __name__ == "__main__":
     main()

--- a/test/regression/scripts/python_scripts/macro_generator.py
+++ b/test/regression/scripts/python_scripts/macro_generator.py
@@ -7,7 +7,7 @@ import argparse
 import os
 
 
-def generate_macro(template_path, output_path, gdml_name, num_threads, num_events, num_trackslots, num_hitslots, gun_type, event_file, track_in_all_regions, regions):
+def generate_macro(template_path, output_path, gdml_name, num_threads, num_events, num_trackslots, num_leakslots, num_hitslots, gun_type, event_file, track_in_all_regions, regions):
     # Read the template file
     with open(template_path, 'r') as template_file:
         template_content = template_file.read()
@@ -17,6 +17,7 @@ def generate_macro(template_path, output_path, gdml_name, num_threads, num_event
     macro_content = macro_content.replace("$num_threads", str(num_threads))
     macro_content = macro_content.replace("$num_events", str(num_events))
     macro_content = macro_content.replace("$num_trackslots", str(num_trackslots))
+    macro_content = macro_content.replace("$num_leakslots", str(num_leakslots))
     macro_content = macro_content.replace("$num_hitslots", str(num_hitslots))
     macro_content = macro_content.replace("$gun_type", str(gun_type))
     macro_content = macro_content.replace(
@@ -63,6 +64,8 @@ def main():
                         help="Number of events to simulate.")
     parser.add_argument("--num_trackslots", type=int, default=12,
                         help="Number of trackslots in million. Should be chosen according to the GPU memory")
+    parser.add_argument("--num_leakslots", type=float, default=12,
+                        help="Number of leakslots in million. Should be chosen according to the GPU memory")
     parser.add_argument("--num_hitslots", type=int, default=12,
                         help="Number of hitslots in million. Should be chosen according to the GPU memory")
     parser.add_argument("--gun_type", default="setDefault",
@@ -92,6 +95,7 @@ def main():
         num_threads=args.num_threads,
         num_events=args.num_events,
         num_trackslots=args.num_trackslots,
+        num_leakslots=args.num_leakslots,
         num_hitslots=args.num_hitslots,
         gun_type=args.gun_type,
         event_file=args.event_file,

--- a/test/regression/scripts/reproducibility.sh
+++ b/test/regression/scripts/reproducibility.sh
@@ -41,6 +41,7 @@ $CI_TEST_DIR/python_scripts/macro_generator.py \
     --num_trackslots 8 \
     --num_hitslots 4 \
     --gun_type hepmc \
+    --track_in_all_regions True\
     --event_file ${PROJECT_BINARY_DIR}/ppttbar.hepmc3
 
 

--- a/test/regression/scripts/reproducibility_regions.sh
+++ b/test/regression/scripts/reproducibility_regions.sh
@@ -24,7 +24,7 @@ cleanup() {
 }
 
 # register cleanup to be called on exit
-trap cleanup EXIT
+# trap cleanup EXIT
 # called it directly ensure clean environment
 cleanup
 
@@ -35,23 +35,26 @@ mkdir -p ${CI_TMP_DIR}
 $CI_TEST_DIR/python_scripts/macro_generator.py \
     --template ${CI_TEST_DIR}/example_template.mac \
     --output ${CI_TMP_DIR}/reproducibility_regions.mac \
-    --gdml_name ${PROJECT_SOURCE_DIR}/examples/data/cms2018_sd.gdml \
+    --gdml_name ${PROJECT_SOURCE_DIR}/examples/data/testEm3_regions.gdml \
     --num_threads 4 \
-    --num_events 8 \
-    --num_trackslots 8 \
-    --num_hitslots 4 \
-    --gun_type hepmc \
-    --event_file ${PROJECT_BINARY_DIR}/ppttbar.hepmc3 \
-    --track_in_all_regions False \
-    --regions "EcalRegion, HcalRegion"
-    
+    --num_events 50 \
+    --num_trackslots 3 \
+    --num_leakslots 0.3 \
+    --num_hitslots 20 \
+    --track_in_all_regions False\
+    --gun_type setDefault\
+    --regions "caloregion, Layer1, Layer2, Layer3, Layer4, Layer5, Layer6, Layer7, Layer8, Layer9, Layer10,\
+            Layer11, Layer12, Layer13, Layer14, Layer15, Layer16, Layer17, Layer18, Layer19, Layer20,\
+            Layer31, Layer32, Layer33, Layer34, Layer35, Layer36, Layer37, Layer38, Layer39, Layer40,\
+            Layer41, Layer42, Layer43, Layer44, Layer45, Layer46, Layer47, Layer48, Layer49, Layer50"
 
+# Choose a small num_leakslots value in order to test the throttling mechanism
 
 # run test
-$ADEPT_EXECUTABLE --do_validation --accumulated_events -m ${CI_TMP_DIR}/reproducibility_regions.mac --output_dir ${CI_TMP_DIR} --output_file cms_ttbar_run1
-$ADEPT_EXECUTABLE --do_validation --accumulated_events -m ${CI_TMP_DIR}/reproducibility_regions.mac --output_dir ${CI_TMP_DIR} --output_file cms_ttbar_run2 
+$ADEPT_EXECUTABLE --do_validation --accumulated_events -m ${CI_TMP_DIR}/reproducibility_regions.mac --output_dir ${CI_TMP_DIR} --output_file testem3_run1 --allsensitive
+$ADEPT_EXECUTABLE --do_validation --accumulated_events -m ${CI_TMP_DIR}/reproducibility_regions.mac --output_dir ${CI_TMP_DIR} --output_file testem3_run2 --allsensitive
 
 # allow for small rounding error of 1e-6 due to summation per thread
-$CI_TEST_DIR/python_scripts/check_reproducibility.py --file1 ${CI_TMP_DIR}/cms_ttbar_run1.csv \
-                                                     --file2 ${CI_TMP_DIR}/cms_ttbar_run2.csv \
+$CI_TEST_DIR/python_scripts/check_reproducibility.py --file1 ${CI_TMP_DIR}/testem3_run1.csv \
+                                                     --file2 ${CI_TMP_DIR}/testem3_run2.csv \
                                                      --tol 1e-5

--- a/test/regression/scripts/reproducibility_regions.sh
+++ b/test/regression/scripts/reproducibility_regions.sh
@@ -1,0 +1,57 @@
+#! /usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025 CERN
+# SPDX-License-Identifier: Apache-2.0
+
+# This is a CI test for reproducbility. The same 8 ttbar events are executed twice
+# and then it is checked that the total energy deposition is exactly the same.
+
+# abort on first encounted error
+set -eu -o pipefail
+
+
+# Read input parameters
+ADEPT_EXECUTABLE=$1
+PROJECT_BINARY_DIR=$2
+PROJECT_SOURCE_DIR=$3
+CI_TEST_DIR=$4
+CI_TMP_DIR=$5
+
+# Define cleanup function of temporary files
+cleanup() {
+  echo "Cleaning up temporary files..."
+  rm -rf ${CI_TMP_DIR}
+}
+
+# register cleanup to be called on exit
+trap cleanup EXIT
+# called it directly ensure clean environment
+cleanup
+
+# Create temporary directory
+mkdir -p ${CI_TMP_DIR}
+
+# generate macro
+$CI_TEST_DIR/python_scripts/macro_generator.py \
+    --template ${CI_TEST_DIR}/example_template.mac \
+    --output ${CI_TMP_DIR}/reproducibility_regions.mac \
+    --gdml_name ${PROJECT_SOURCE_DIR}/examples/data/cms2018_sd.gdml \
+    --num_threads 4 \
+    --num_events 8 \
+    --num_trackslots 8 \
+    --num_hitslots 4 \
+    --gun_type hepmc \
+    --event_file ${PROJECT_BINARY_DIR}/ppttbar.hepmc3 \
+    --track_in_all_regions False \
+    --regions "EcalRegion, HcalRegion"
+    
+
+
+# run test
+$ADEPT_EXECUTABLE --do_validation --accumulated_events -m ${CI_TMP_DIR}/reproducibility_regions.mac --output_dir ${CI_TMP_DIR} --output_file cms_ttbar_run1
+$ADEPT_EXECUTABLE --do_validation --accumulated_events -m ${CI_TMP_DIR}/reproducibility_regions.mac --output_dir ${CI_TMP_DIR} --output_file cms_ttbar_run2 
+
+# allow for small rounding error of 1e-6 due to summation per thread
+$CI_TEST_DIR/python_scripts/check_reproducibility.py --file1 ${CI_TMP_DIR}/cms_ttbar_run1.csv \
+                                                     --file2 ${CI_TMP_DIR}/cms_ttbar_run2.csv \
+                                                     --tol 1e-5

--- a/test/regression/scripts/validation_testem3.sh
+++ b/test/regression/scripts/validation_testem3.sh
@@ -40,6 +40,7 @@ $CI_TEST_DIR/python_scripts/macro_generator.py \
     --num_events 100 \
     --num_trackslots 3 \
     --num_hitslots 20 \
+    --track_in_all_regions True\
     --gun_type setDefault 
 
 

--- a/test/regression/scripts/validation_testem3_regions.sh
+++ b/test/regression/scripts/validation_testem3_regions.sh
@@ -36,7 +36,7 @@ $CI_TEST_DIR/python_scripts/macro_generator.py \
     --template ${CI_TEST_DIR}/example_template.mac \
     --output ${CI_TMP_DIR}/validation_testem3_regions.mac \
     --gdml_name ${PROJECT_SOURCE_DIR}/examples/data/testEm3_regions.gdml \
-    --num_threads 4 \
+    --num_threads 8 \
     --num_events 250 \
     --num_trackslots 3 \
     --num_hitslots 20 \

--- a/test/regression/scripts/validation_testem3_regions.sh
+++ b/test/regression/scripts/validation_testem3_regions.sh
@@ -34,26 +34,26 @@ mkdir -p ${CI_TMP_DIR}
 # use gun_type hepmc or setDefault
 $CI_TEST_DIR/python_scripts/macro_generator.py \
     --template ${CI_TEST_DIR}/example_template.mac \
-    --output ${CI_TMP_DIR}/validation_testem3.mac \
-    --gdml_name ${PROJECT_SOURCE_DIR}/examples/data/testEm3.gdml \
+    --output ${CI_TMP_DIR}/validation_testem3_regions.mac \
+    --gdml_name ${PROJECT_SOURCE_DIR}/examples/data/testEm3_regions.gdml \
     --num_threads 4 \
     --num_events 250 \
     --num_trackslots 3 \
     --num_hitslots 20 \
-    --track_in_all_regions True\
-    --gun_type setDefault 
-
+    --track_in_all_regions False\
+    --gun_type setDefault\
+    --regions "caloregion, Layer1, Layer2, Layer3, Layer4, Layer5, Layer6, Layer7, Layer8, Layer9, Layer10,\
+            Layer11, Layer12, Layer13, Layer14, Layer15, Layer16, Layer17, Layer18, Layer19, Layer20,\
+            Layer31, Layer32, Layer33, Layer34, Layer35, Layer36, Layer37, Layer38, Layer39, Layer40,\
+            Layer41, Layer42, Layer43, Layer44, Layer45, Layer46, Layer47, Layer48, Layer49, Layer50"
 
 # run test
 $ADEPT_EXECUTABLE --do_validation --allsensitive --accumulated_events \
-                  -m "${CI_TMP_DIR}/validation_testem3.mac" \
+                  -m "${CI_TMP_DIR}/validation_testem3_regions.mac" \
                   --output_dir "${CI_TMP_DIR}" \
                   --output_file "adept_em3_2.5e4_e-"
 
 # Validating the relative error per layer
-# The saved G4 benchmark file was run with --noadept and 1e7 primary 10 GeV electrons.
-# Comparing against 1e5 primary electrons (500 per event, 200 events) with AdePT should give errors below 1%.
-# This is a compromise between run time and accuracy of the test 
 $CI_TEST_DIR/python_scripts/check_validation.py --file1 ${CI_TMP_DIR}/adept_em3_2.5e4_e-.csv \
                                                 --file2 ${CI_TEST_DIR}/benchmark_files/g4_em3_10e6_e-.csv \
                                                 --n1 2.5e4 --n2 1e6 --tol 0.01 \


### PR DESCRIPTION
This fixes the extraction of leaked tracks in Async mode. The previous extraction of leaks didn't work in most cases for two main reasons:
- The size of the buffer used for extracting the leaked tracks is limited, so if there are too many, the extraction needs to be done in multiple steps. However, there was no mechanism to do this, tracks would get postponed until the next extraction step, but the corresponding events were notified that all leaks had been extracted. This means that whenever the number of leaks exceeded the buffer size the overflow was lost.
- There wasn't a way to guarantee that all leaks corresponding to the event requesting a flush had been extracted. The tracks are not extracted in order of insertion, and the transport kernels were allowed to insert new tracks into the leak queues in-between transfers of tracks from device to host. This means that we couldn't know when all leaks corresponding to an event had actually been extracted.

With these changes:
- The leak queues are frozen whenever an event requests a flush of their leaks. We keep two leak queues per particle type, we swap them at the start of the leak extraction, and don't swap them back until the extraction ends and another event requests a flush. This ensures that when we finish transferring the frozen queue, all leaks associated to that event have been extracted.
- We use a new state machine that doesn't return to the idle state until all leaks have been transferred. The functionality is similar to that of the scoring thread, but instead of running separately from the transport loop, the work is done by the AdePT thread.
- Returning all leaks uncovers an issue with the MPMC queues used to store leaked tracks during transport. These queues have a fixed size and need to be emptied before they can be used again, and it is left to the user to check whether the queue is full. The queues were inadvertedly overflowing in specific use cases (Such as the testEm3 geometry when running large events), this has been solved by stopping transport in situations where the queues are close to overflowing but a leak extraction is already in progress. Since this is not an issue in more realistic use cases, this mechanism ensures that the execution will be error-free in all situations without affecting runtime in realistic runs.
- In specific use cases like running large events in testEm3 the results were sometimes non-reproducible. This was likely due to some interference between the leak extraction, hit extraction, and particle injection, which ran on the same stream. The issue is solved by running these three operations on different streams, but should be revisited in the future.

The new `ExtractStates` are the following:
- **Idle**: No extraction is in progress
-  **ExtractionRequested**: An event requested a flush, waiting for transport to finish
    - We move from `Idle` to `ExtractionRequested` when an event has requested a flush, and their `EventState` is `HitsFlushed`. The number of particles in flight for that event is guaranteed to be 0 at this point
    - We wait for the transport kernels to finish running as they are writing to the same leak queues that we need to transfer
-  **TracksNeedTransfer**: An event requested a flush, leak buffer on device has tracks to transfer
    - Transport has finished, the leak queues are frozen and we can start transferring tracks
-  **PreparingTracks**: Tracks are being copied to the staging buffer
    - Tracks are copied from the leak queues to the transfer buffer, the numbers of transferred and remaining tracks are copied to the host.
-  **TracksReadyToCopy**: Staging buffer is ready to be copied to host
-  **CopyingTracks**: Tracks are being copied to host
-  **TracksOnHost**: Some or all the tracks have been transferred from device to host and are waiting in the copy buffer
-  **SavingTracks**: Tracks are being copied to per-event queues
    - Tracks are copied from the transfer buffer, which can contain tracks for all events, into per-event queues
-  **TracksSaved**: Tracks have been moved from the copy buffer to their respective per-event queues
    - All tracks are stored in the per-event queues, so the transfer buffer can be re-used. If there are any remaining leaks on GPU the state goes back to `TracksNeedTransfer`, otherwise the state moves to `Idle`

![extract_state_machine](https://github.com/user-attachments/assets/9d6ad298-a14d-416a-9a62-7f40838d27eb)
