### PR TITLE
remove error-prone name check and G4VG linking test

### DIFF
--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -116,11 +116,6 @@ void AdePTGeant4Integration::MapVecGeomToG4(std::vector<G4VPhysicalVolume const 
       auto g4pvol_d = g4_lvol->GetDaughter(id);
       auto pvol_d   = vg_lvol->GetDaughters()[id];
 
-      // VecGeom does not strip pointers from logical volume names
-      if (std::string(pvol_d->GetLogicalVolume()->GetName()).rfind(g4pvol_d->GetLogicalVolume()->GetName(), 0) != 0)
-        throw std::runtime_error("Fatal: CheckGeometry: Volume names " +
-                                 std::string(pvol_d->GetLogicalVolume()->GetName()) + " and " +
-                                 std::string(g4pvol_d->GetLogicalVolume()->GetName()) + " mismatch");
       visitGeometry(g4pvol_d, pvol_d);
     }
   };
@@ -258,11 +253,6 @@ void visitGeometry(G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVolume cons
     const auto g4pvol_d = g4_lvol->GetDaughter(id);
     const auto pvol_d   = vg_lvol->GetDaughters()[id];
 
-    // VecGeom does not strip pointers from logical volume names
-    if (std::string(pvol_d->GetLogicalVolume()->GetName()).rfind(g4pvol_d->GetLogicalVolume()->GetName(), 0) != 0)
-      throw std::runtime_error("Fatal: CheckGeometry: Volume names " +
-                               std::string(pvol_d->GetLogicalVolume()->GetName()) + " and " +
-                               std::string(g4pvol_d->GetLogicalVolume()->GetName()) + " mismatch");
     visitGeometry(g4pvol_d, pvol_d, context);
   }
 }
@@ -331,11 +321,6 @@ void AdePTGeant4Integration::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4
       auto g4pvol_d = g4_lvol->GetDaughter(id);
       auto pvol_d   = vg_lvol->GetDaughters()[id];
 
-      // VecGeom does not strip pointers from logical volume names
-      if (std::string(pvol_d->GetLogicalVolume()->GetName()).rfind(g4pvol_d->GetLogicalVolume()->GetName(), 0) != 0)
-        throw std::runtime_error("Fatal: CheckGeometry: Volume names " +
-                                 std::string(pvol_d->GetLogicalVolume()->GetName()) + " and " +
-                                 std::string(g4pvol_d->GetLogicalVolume()->GetName()) + " mismatch");
       visitGeometry(g4pvol_d, pvol_d);
     }
   };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,14 +48,6 @@ add_executable(test_copcore_link test_copcore_link.cpp)
 target_include_directories(test_copcore_link PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(test_copcore_link PRIVATE CopCore)
 
-# - Check G4VG links as expected
-if(VecGeom_SURF_FOUND)
-  message(STATUS "${Magenta}Disabled g4vg when using VecGeom surface model${ColorReset}")
-else()
-  add_executable(test_g4vg_link test_g4vg_link.cpp)
-  target_link_libraries(test_g4vg_link PRIVATE G4VG::g4vg VecGeom::vecgeomcuda)
-endif()
-
 #----------------------------------------------------------------------------#
 # Basic Unit Tests
 #----------------------------------------------------------------------------#

--- a/test/test_g4vg_link.cpp
+++ b/test/test_g4vg_link.cpp
@@ -1,6 +1,0 @@
-// SPDX-FileCopyrightText: 2020 CERN
-// SPDX-License-Identifier: Apache-2.0
-
-#include <G4VG.hh>
-
-int main() {}


### PR DESCRIPTION
A minor cleaning PR that removes the error-prone name check (which is triggered in FullSimLight) and the G4VG linking test, as we now build it directly.