### PR TITLE
Enable event finishing

### DIFF
--- a/include/AdePT/core/AdePTConfiguration.hh
+++ b/include/AdePT/core/AdePTConfiguration.hh
@@ -43,6 +43,7 @@ public:
   void SetHitBufferFlushThreshold(float threshold) { fHitBufferFlushThreshold = threshold; }
   void SetCUDAStackLimit(int limit) { fCUDAStackLimit = limit; }
   void SetCUDAHeapLimit(int limit) { fCUDAHeapLimit = limit; }
+  void SetLastNParticlesOnCPU(int Nparticles) { fLastNParticlesOnCPU = Nparticles; }
 
   // We temporarily load VecGeom geometry from GDML
   void SetVecGeomGDML(std::string filename) { fVecGeomGDML = filename; }
@@ -59,6 +60,7 @@ public:
   int GetTransportBufferThreshold() { return fTransportBufferThreshold; }
   int GetCUDAStackLimit() { return fCUDAStackLimit; }
   int GetCUDAHeapLimit() { return fCUDAHeapLimit; }
+  unsigned short GetLastNParticlesOnCPU() { return fLastNParticlesOnCPU; }
   float GetHitBufferFlushThreshold() { return fHitBufferFlushThreshold; }
   double GetMillionsOfTrackSlots() { return fMillionsOfTrackSlots; }
   double GetMillionsOfHitSlots() { return fMillionsOfHitSlots; }
@@ -81,6 +83,8 @@ private:
   float fHitBufferFlushThreshold{0.8};
   double fMillionsOfTrackSlots{1};
   double fMillionsOfHitSlots{1};
+  unsigned short fLastNParticlesOnCPU{0};
+
   std::vector<std::string> fGPURegionNames{};
   int fNThread = -1;
 

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -827,6 +827,7 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
 
       AllowFinishOffEventArray allowFinishOffEvent;
       for (int i = 0; i < kMaxThreads; ++i) {
+        // if waiting for transport to finish, the last N particles may be finished on CPU
         if (eventStates[i].load(std::memory_order_acquire) == EventState::WaitingForTransportToFinish) {
           allowFinishOffEvent.flags[i] = lastNParticlesOnCPU;
         } else {
@@ -892,6 +893,7 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
 
         waitForOtherStream(gpuState.stream, statsStream);
 
+        // Copy the number of particles in flight to the previous one, which is used within the kernel
         COPCORE_CUDA_CHECK(cudaMemcpyAsync(gpuState.stats_dev->perEventInFlightPrevious,
                                            gpuState.stats_dev->perEventInFlight, kMaxThreads * sizeof(unsigned int),
                                            cudaMemcpyDeviceToDevice, statsStream));

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -42,12 +42,13 @@ public:
   static inline uint64_t fAdePTSeed = 1234567;
 
 private:
-  unsigned short fNThread{0};       ///< Number of G4 workers
-  unsigned int fTrackCapacity{0};   ///< Number of track slots to allocate on device
-  unsigned int fScoringCapacity{0}; ///< Number of hit slots to allocate on device
-  int fDebugLevel{0};               ///< Debug level
-  int fCUDAStackLimit{0};           ///< CUDA device stack limit
-  int fCUDAHeapLimit{0};            ///< CUDA device stack limit
+  unsigned short fNThread{0};             ///< Number of G4 workers
+  unsigned int fTrackCapacity{0};         ///< Number of track slots to allocate on device
+  unsigned int fScoringCapacity{0};       ///< Number of hit slots to allocate on device
+  int fDebugLevel{0};                     ///< Debug level
+  int fCUDAStackLimit{0};                 ///< CUDA device stack limit
+  int fCUDAHeapLimit{0};                  ///< CUDA device heap limit
+  unsigned short fLastNParticlesOnCPU{0}; ///< Number N of last N particles that are finished on CPU
   std::vector<IntegrationLayer> fIntegrationLayerObjects;
   std::unique_ptr<GPUstate, GPUstateDeleter> fGPUstate{nullptr}; ///< CUDA state placeholder
   std::vector<AdePTScoring> fScoring;                            ///< User scoring objects per G4 worker

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -270,7 +270,7 @@ void AsyncAdePTTransport<IntegrationLayer>::Initialize()
   // to device buffer is often full)
   // Allocate buffers to transport particles to/from device. Scale the size of the staging area
   // with the number of threads.
-  fBuffer = std::make_unique<TrackBuffer>(8192 * fNThread, 1024 * fNThread, fNThread);
+  fBuffer = std::make_unique<TrackBuffer>(4 * 8192 * fNThread, 1024 * fNThread, fNThread);
 
   assert(fBuffer != nullptr);
 

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -50,7 +50,7 @@ std::pair<GPUHit *, GPUHit *> GetGPUHitsFromBuffer(unsigned int, unsigned int, A
 void CloseGPUBuffer(unsigned int, AsyncAdePT::GPUstate &, GPUHit *, const bool);
 std::thread LaunchGPUWorker(int, int, int, AsyncAdePT::TrackBuffer &, AsyncAdePT::GPUstate &,
                             std::vector<std::atomic<AsyncAdePT::EventState>> &, std::condition_variable &,
-                            std::vector<AdePTScoring> &, int, int, bool, bool);
+                            std::vector<AdePTScoring> &, int, int, bool, bool, unsigned short);
 std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> InitializeGPU(int trackCapacity, int scoringCapacity,
                                                                                  int numThreads,
                                                                                  AsyncAdePT::TrackBuffer &trackBuffer,
@@ -88,7 +88,8 @@ AsyncAdePTTransport<IntegrationLayer>::AsyncAdePTTransport(AdePTConfiguration &c
       fGPUNetEnergy(fNThread, 0.0), fTrackInAllRegions{configuration.GetTrackInAllRegions()},
       fGPURegionNames{configuration.GetGPURegionNames()}, fCUDAStackLimit{configuration.GetCUDAStackLimit()},
       fCUDAHeapLimit{configuration.GetCUDAHeapLimit()}, fReturnAllSteps{configuration.GetCallUserSteppingAction()},
-      fReturnLastStep{configuration.GetCallPostUserTrackingAction()}, fBfieldFile{configuration.GetCovfieBfieldFile()}
+      fReturnLastStep{configuration.GetCallPostUserTrackingAction()}, fBfieldFile{configuration.GetCovfieBfieldFile()},
+      fLastNParticlesOnCPU{configuration.GetLastNParticlesOnCPU()}
 {
   if (fNThread > kMaxThreads)
     throw std::invalid_argument("AsyncAdePTTransport limited to " + std::to_string(kMaxThreads) + " threads");
@@ -277,7 +278,7 @@ void AsyncAdePTTransport<IntegrationLayer>::Initialize()
   fGPUstate  = async_adept_impl::InitializeGPU(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, fScoring);
   fGPUWorker = async_adept_impl::LaunchGPUWorker(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, *fGPUstate,
                                                  fEventStates, fCV_G4Workers, fScoring, fAdePTSeed, fDebugLevel,
-                                                 fReturnAllSteps, fReturnLastStep);
+                                                 fReturnAllSteps, fReturnLastStep, fLastNParticlesOnCPU);
 }
 
 template <typename IntegrationLayer>

--- a/include/AdePT/core/AsyncAdePTTransportStruct.cuh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.cuh
@@ -142,6 +142,13 @@ struct Stats {
   unsigned int hitBufferOccupancy;
 };
 
+/// @brief Array of flags whether the event can be finished off
+struct AllowFinishOffEventArray {
+  bool flags[kMaxThreads];
+
+  __host__ __device__ bool operator[](int idx) const { return flags[idx]; }
+};
+
 struct QueueIndexPair {
   unsigned int slot;
   short queue;

--- a/include/AdePT/core/AsyncAdePTTransportStruct.cuh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.cuh
@@ -141,13 +141,6 @@ struct Stats {
   unsigned int perEventInFlightPrevious[kMaxThreads]; // Used in transport kernels
   unsigned int perEventLeaked[kMaxThreads];
   unsigned int hitBufferOccupancy;
-
-  __host__ __device__ void SwapPerEventInFlight()
-  {
-    for (int i = 0; i < kMaxThreads; ++i) {
-      perEventInFlightPrevious[i] = perEventInFlight[i];
-    }
-  }
 };
 
 /// @brief Array of flags whether the event can be finished off

--- a/include/AdePT/core/AsyncAdePTTransportStruct.cuh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.cuh
@@ -137,9 +137,17 @@ struct Stats {
   int leakedTracks[ParticleType::NumParticleTypes];
   float queueFillLevel[ParticleType::NumParticleTypes];
   float slotFillLevel;
-  unsigned int perEventInFlight[kMaxThreads];
+  unsigned int perEventInFlight[kMaxThreads];         // Updated asynchronously
+  unsigned int perEventInFlightPrevious[kMaxThreads]; // Used in transport kernels
   unsigned int perEventLeaked[kMaxThreads];
   unsigned int hitBufferOccupancy;
+
+  __host__ __device__ void SwapPerEventInFlight()
+  {
+    for (int i = 0; i < kMaxThreads; ++i) {
+      perEventInFlightPrevious[i] = perEventInFlight[i];
+    }
+  }
 };
 
 /// @brief Array of flags whether the event can be finished off

--- a/include/AdePT/core/AsyncAdePTTransportStruct.cuh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.cuh
@@ -152,9 +152,9 @@ struct Stats {
 
 /// @brief Array of flags whether the event can be finished off
 struct AllowFinishOffEventArray {
-  bool flags[kMaxThreads];
+  unsigned short flags[kMaxThreads];
 
-  __host__ __device__ bool operator[](int idx) const { return flags[idx]; }
+  __host__ __device__ unsigned short operator[](int idx) const { return flags[idx]; }
 };
 
 struct QueueIndexPair {

--- a/include/AdePT/integration/AdePTConfigurationMessenger.hh
+++ b/include/AdePT/integration/AdePTConfigurationMessenger.hh
@@ -35,6 +35,7 @@ private:
   G4UIdirectory *fDir;
   G4UIcmdWithAnInteger *fSetCUDAStackLimitCmd;
   G4UIcmdWithAnInteger *fSetCUDAHeapLimitCmd;
+  G4UIcmdWithAnInteger *fSetFinishOnCpuCmd;
   G4UIcmdWithABool *fSetTrackInAllRegionsCmd;
   G4UIcmdWithABool *fSetCallUserSteppingActionCmd;
   G4UIcmdWithABool *fSetCallPostUserTrackingActionCmd;

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -148,11 +148,12 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       continue;
     }
 
-    if (allowFinishOffEvent[currentTrack.threadId] && InFlightStats->perEventInFlight[currentTrack.threadId] < 20 &&
-        InFlightStats->perEventInFlight[currentTrack.threadId] != 0) {
+    if (allowFinishOffEvent[currentTrack.threadId] &&
+        InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < 20 &&
+        InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
       printf("Thread %d Killing e-/e+ when killing the %d last particles of event %d E=%f lvol=%d after %d steps.\n",
-             currentTrack.threadId, InFlightStats->perEventInFlight[currentTrack.threadId], currentTrack.eventId, eKin,
-             lvolID, currentTrack.stepCounter);
+             currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
+             currentTrack.eventId, eKin, lvolID, currentTrack.stepCounter);
       continue;
     }
 

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -148,14 +148,15 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       continue;
     }
 
-    if (allowFinishOffEvent[currentTrack.threadId] &&
-        InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < 20 &&
+#ifdef ASYNC_MODE
+    if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < allowFinishOffEvent[currentTrack.threadId] &&
         InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
       printf("Thread %d Killing e-/e+ when killing the %d last particles of event %d E=%f lvol=%d after %d steps.\n",
              currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
              currentTrack.eventId, eKin, lvolID, currentTrack.stepCounter);
       continue;
     }
+#endif
 
     auto survive = [&](bool leak = false) {
       returnLastStep          = false; // track survived, do not force return of step

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -90,11 +90,12 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       continue;
     }
 
-    if (allowFinishOffEvent[currentTrack.threadId] && InFlightStats->perEventInFlight[currentTrack.threadId] < 20 &&
-        InFlightStats->perEventInFlight[currentTrack.threadId] != 0) {
+    if (allowFinishOffEvent[currentTrack.threadId] &&
+        InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < 20 &&
+        InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
       printf("Thread %d Killing gammas when killing the %d last particles of event %d E=%f lvol=%d after %d steps.\n",
-             currentTrack.threadId, InFlightStats->perEventInFlight[currentTrack.threadId], currentTrack.eventId, eKin,
-             lvolID, currentTrack.stepCounter);
+             currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
+             currentTrack.eventId, eKin, lvolID, currentTrack.stepCounter);
       continue;
     }
 

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -90,14 +90,15 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       continue;
     }
 
-    if (allowFinishOffEvent[currentTrack.threadId] &&
-        InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < 20 &&
+#ifdef ASYNC_MODE
+    if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < allowFinishOffEvent[currentTrack.threadId] &&
         InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
       printf("Thread %d Killing gammas when killing the %d last particles of event %d E=%f lvol=%d after %d steps.\n",
              currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
              currentTrack.eventId, eKin, lvolID, currentTrack.stepCounter);
       continue;
     }
+#endif
 
     // Write local variables back into track and enqueue
     auto survive = [&](bool leak = false) {

--- a/src/AdePTConfigurationMessenger.cc
+++ b/src/AdePTConfigurationMessenger.cc
@@ -76,6 +76,10 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
   fSetCovfieFileCmd = new G4UIcmdWithAString("/adept/setCovfieBfieldFile", this);
   fSetCovfieFileCmd->SetGuidance("Set the path the the covfie file for reading in an external magnetic field");
 
+  fSetFinishOnCpuCmd = new G4UIcmdWithAnInteger("/adept/FinishLastNParticlesOnCPU", this);
+  fSetFinishOnCpuCmd->SetGuidance("Set N, the number of last N particles per event that are finished on CPU. Default: "
+                                  "0. This is an important parameter for handling loopers in a magnetic field");
+
   fSetCUDAStackLimitCmd = new G4UIcmdWithAnInteger("/adept/setCUDAStackLimit", this);
   fSetCUDAStackLimitCmd->SetGuidance("Set the CUDA device stack limit");
   fSetCUDAHeapLimitCmd = new G4UIcmdWithAnInteger("/adept/setCUDAHeapLimit", this);
@@ -101,7 +105,7 @@ AdePTConfigurationMessenger::~AdePTConfigurationMessenger()
   delete fSetHitBufferFlushThresholdCmd;
   delete fSetGDMLCmd;
   delete fSetCovfieFileCmd;
-  // delete fSetCUDAStackLimitCmd;
+  delete fSetFinishOnCpuCmd;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -137,6 +141,8 @@ void AdePTConfigurationMessenger::SetNewValue(G4UIcommand *command, G4String new
     fAdePTConfiguration->SetCUDAStackLimit(fSetCUDAStackLimitCmd->GetNewIntValue(newValue));
   } else if (command == fSetCUDAHeapLimitCmd) {
     fAdePTConfiguration->SetCUDAHeapLimit(fSetCUDAHeapLimitCmd->GetNewIntValue(newValue));
+  } else if (command == fSetFinishOnCpuCmd) {
+    fAdePTConfiguration->SetLastNParticlesOnCPU(fSetFinishOnCpuCmd->GetNewIntValue(newValue));
   }
 }
 


### PR DESCRIPTION
This PR introduces a new feature for the async mode: `/adept/FinishLastNParticlesOnCPU`.

It is not complete yet, as they are currently just killed and not pushed to the CPU, as this will require #358 to work and be merged.

Still, killing the last N particles can currently be used to assess some performance bottlenecks with the magnetic field.

Also, a timer is added to the printout of the async printouts.

This allows for the plotting the numbers of flight vs time and not just only vs iterations, as this severely skews it towards the fast iterations at the tail:
<img width="637" alt="Screenshot 2025-03-16 at 10 45 45" src="https://github.com/user-attachments/assets/b09065a3-567f-4e92-8528-95d60ff3b772" />
