### PR TITLE
[mini] Improve sync AdePT output

### DIFF
--- a/include/AdePT/core/AdePTTransport.cuh
+++ b/include/AdePT/core/AdePTTransport.cuh
@@ -383,11 +383,10 @@ void FreeGPU(GPUstate &gpuState, G4HepEmState *g4hepem_state)
 
 template <typename IntegrationLayer>
 void ShowerGPU(IntegrationLayer &integration, int event, adeptint::TrackBuffer &buffer, GPUstate &gpuState,
-               AdeptScoring *scoring, AdeptScoring *scoring_dev)
+               AdeptScoring *scoring, AdeptScoring *scoring_dev, int debugLevel)
 {
   using TrackData   = adeptint::TrackData;
   using VolAuxArray = adeptint::VolAuxArray;
-  auto &config      = adeptint::CommonConfig::GetInstance();
   // Capacity of the different containers aka the maximum number of particles.
   auto &cudaManager = vecgeom::cxx::CudaManager::Instance();
 
@@ -565,7 +564,7 @@ void ShowerGPU(IntegrationLayer &integration, int event, adeptint::TrackBuffer &
     numElectrons = gpuState.allmgr_h.trackmgr[ParticleType::Electron]->fStats.fInFlight;
     numPositrons = gpuState.allmgr_h.trackmgr[ParticleType::Positron]->fStats.fInFlight;
     numGammas    = gpuState.allmgr_h.trackmgr[ParticleType::Gamma]->fStats.fInFlight;
-    if (config.fDebugLevel > 1) {
+    if (debugLevel > 1) {
       printf("iter %d: elec %d, pos %d, gam %d, leak %d\n", niter++, numElectrons, numPositrons, numGammas, numLeaked);
     }
     if (numElectrons == previousElectrons && numPositrons == previousPositrons && numGammas == previousGammas) {
@@ -582,7 +581,7 @@ void ShowerGPU(IntegrationLayer &integration, int event, adeptint::TrackBuffer &
 
   } while (inFlight > 0 && loopingNo < 200);
 
-  if (config.fDebugLevel > 0) {
+  if (debugLevel > 0) {
     std::cout << inFlight << " in flight, " << numLeaked << " leaked, " << num_compact << " compacted\n";
   }
 

--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -37,14 +37,14 @@ void CopySurfaceModelToGPU();
 void FreeGPU(GPUstate &, G4HepEmState *);
 template <typename IntegrationLayer>
 void ShowerGPU(IntegrationLayer &integration, int event, TrackBuffer &buffer, GPUstate &gpuState, AdeptScoring *scoring,
-               AdeptScoring *scoring_dev);
+               AdeptScoring *scoring_dev, int debugLevel);
 
 } // namespace adept_impl
 
 template <typename IntegrationLayer>
 AdePTTransport<IntegrationLayer>::AdePTTransport(AdePTConfiguration &configuration)
 {
-  fDebugLevel        = 0;
+  fDebugLevel        = configuration.GetVerbosity();
   fBufferThreshold   = configuration.GetTransportBufferThreshold();
   fMaxBatch          = 2 * configuration.GetTransportBufferThreshold();
   fTrackInAllRegions = configuration.GetTrackInAllRegions();
@@ -294,7 +294,7 @@ void AdePTTransport<IntegrationLayer>::Shower(int event, int /*threadId*/)
               << "GPU transporting event " << event << " for CPU thread " << fIntegrationLayer.GetThreadID() << ": "
               << std::flush;
   }
-  adept_impl::ShowerGPU(fIntegrationLayer, event, fBuffer, *fGPUstate, fScoring, fScoring_dev);
+  adept_impl::ShowerGPU(fIntegrationLayer, event, fBuffer, *fGPUstate, fScoring, fScoring_dev, fDebugLevel);
 
   for (auto const &track : fBuffer.fromDevice) {
     if (track.pdg == 11)

--- a/include/AdePT/core/CommonStruct.h
+++ b/include/AdePT/core/CommonStruct.h
@@ -40,17 +40,6 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
 // Common data structures used by the integration with Geant4
 namespace adeptint {
 
-/// @brief Common configuration data for AdePT transport
-struct CommonConfig {
-  int fDebugLevel; ///< Debug level
-
-  static CommonConfig &GetInstance()
-  {
-    static CommonConfig theConfig;
-    return theConfig;
-  }
-};
-
 /// @brief Auxiliary logical volume data. This stores in the same structure the material-cuts couple index,
 /// the sensitive volume handler index and the flag if the region is active for AdePT.
 struct VolAuxData {

--- a/src/AdePTTrackingManager.cu
+++ b/src/AdePTTrackingManager.cu
@@ -13,7 +13,7 @@
 // Explicit instantiation of the ShowerGPU<AdePTGeant4Integration> function
 namespace adept_impl {
 template void ShowerGPU<AdePTGeant4Integration>(AdePTGeant4Integration &, int, adeptint::TrackBuffer &, GPUstate &,
-                                                HostScoring *, HostScoring *);
+                                                HostScoring *, HostScoring *, int);
 } // namespace adept_impl
 
 #endif


### PR DESCRIPTION
Previously, sync AdePT was not passing the debug level, so no output depending on `/adept/verbose` could be generated.

This is fixed in this PR. Furthermore, the time and eventId is printed, which is useful to get plots like these:
![Screenshot from 2025-03-18 10-44-16](https://github.com/user-attachments/assets/01ac978c-a436-4940-8e2d-ab79857a9f10)
