### PR TITLE
Fix finish LastParticlesOnCPU

### DIFF
--- a/include/AdePT/integration/G4HepEmTrackingManagerSpecialized.hh
+++ b/include/AdePT/integration/G4HepEmTrackingManagerSpecialized.hh
@@ -31,9 +31,16 @@ public:
   bool CheckEarlyTrackingExit(G4Track *track, G4EventManager *evtMgr, G4UserTrackingAction *userTrackingAction,
                               G4TrackVector &secondaries) const override;
 
+  void ResetFinishEventOnCPUSize(int num_threads) { fFinishEventOnCPU.resize(num_threads, -1); }
+
+  void SetFinishEventOnCPU(int threadid, int eventid) { fFinishEventOnCPU[threadid] = eventid; }
+
+  int GetFinishEventOnCPU(int threadid) { return fFinishEventOnCPU[threadid]; }
+
 private:
   bool fTrackInAllRegions = false;          ///< Whether the whole geometry is a GPU region
   std::set<G4Region const *> fGPURegions{}; ///< List of GPU regions
+  std::vector<int> fFinishEventOnCPU;       ///< vector over number of threads to keep certain leaked tracks on GPU
 
   // G4Region const * fPreviousRegion = nullptr;
 };

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -437,8 +437,6 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
                  "safety=%E\n",
                  eKin, currentTrack.eventId, currentTrack.looperCounter, energyDeposit, geometryStepLength,
                  geometricalStepLengthFromPhysics, safety);
-          // survive(/*leak*/ true);
-          // slotManager.MarkSlotForFreeing(slot);
           continue;
         } else if (!nextState.IsOutside()) {
           // Mark the particle. We need to change its navigation state to the next volume before enqueuing it
@@ -463,8 +461,6 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
                  "safety=%E\n",
                  eKin, currentTrack.eventId, currentTrack.looperCounter, energyDeposit, geometryStepLength,
                  geometricalStepLengthFromPhysics, safety);
-          // survive(/*leak*/ true);
-          // slotManager.MarkSlotForFreeing(slot);
           continue;
         }
 

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -578,6 +578,10 @@ void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsig
   // Create track
   G4Track *secondary = new G4Track(dynamique, track.globalTime, posi);
 
+  // FIXME temporary hack! We set the status of leaked tracks to fStopButAlive to be able to distinguish them to keep
+  // them on the CPU until they die!
+  secondary->SetTrackStatus(fStopButAlive);
+
   // Set time information
   secondary->SetLocalTime(track.localTime);
   secondary->SetProperTime(track.properTime);

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -578,7 +578,7 @@ void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsig
   // Create track
   G4Track *secondary = new G4Track(dynamique, track.globalTime, posi);
 
-  // FIXME temporary hack! We set the status of leaked tracks to fStopButAlive to be able to distinguish them to keep
+  // We set the status of leaked tracks to fStopButAlive to be able to distinguish them to keep
   // them on the CPU until they die!
   secondary->SetTrackStatus(fStopButAlive);
 

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -207,12 +207,10 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
   if (fHepEmTrackingManager->GetFinishEventOnCPU(threadId) >= 0 &&
       fHepEmTrackingManager->GetFinishEventOnCPU(threadId) != eventID) {
     fHepEmTrackingManager->SetFinishEventOnCPU(threadId, -1);
-    std::cout << " Resetting FinishEvent on CPU for thread " << threadId << std::endl;
   }
 
   // first leaked particle detected, let's finish this event on CPU
   if (fHepEmTrackingManager->GetFinishEventOnCPU(threadId) < 0 && aTrack->GetTrackStatus() == fStopButAlive) {
-    std::cout << "Thread " << threadId << " Finishing event " << eventID << " on CPU " << std::endl;
     fHepEmTrackingManager->SetFinishEventOnCPU(threadId, eventID);
   }
 

--- a/src/G4HepEmTrackingManagerSpecialized.cc
+++ b/src/G4HepEmTrackingManagerSpecialized.cc
@@ -28,11 +28,14 @@ bool G4HepEmTrackingManagerSpecialized::CheckEarlyTrackingExit(G4Track *track, G
   // the current volume is not yet updated
   G4Region const *region = track->GetNextVolume()->GetLogicalVolume()->GetRegion();
 
+  G4int threadId = G4Threading::G4GetThreadId();
+
   // TODO: for more efficient use, we only have to check for region within GPURegions, if the region changed.
   //       This can be checked from the pre- and post-steppoint
 
   // Not in the GPU region, continue normal tracking with G4HepEmTrackingManager
-  if (fGPURegions.find(region) == fGPURegions.end() || (fGPURegions.empty() && !GetTrackInAllRegions())) {
+  if (fGPURegions.find(region) == fGPURegions.end() || (fGPURegions.empty() && !GetTrackInAllRegions()) ||
+      fFinishEventOnCPU[threadId] > 0) {
     return false; // Continue tracking with G4HepEmTrackingManager
   } else {
 


### PR DESCRIPTION
This fixes the LastParticlesOnCPU option. Instead of killing the last n particles, they are now properly leaked to the CPU.

Finishing the last 100 particles of a ttbar event on CPU in the B field case is as fast as kiling them. Finishing the last particles accelerates the code significantly, the number of particles per event to be finished on CPU must be tuned.

Currently, the implementation works as follows:

The last n particles in flight of an event are leaked back to the CPU.
As soon as a particle is leaked back to the CPU, the leaking particle is flagged with status `fStopButAlive`. Then, the AdePTTrackingManager recognizes this, and sets a flag to keep the remainder of the event on the CPU, such that secondaries produced from one of the leaked particles also remain on the CPU.
When the first particle is handed to the AdePTTrackingManager with a different eventId (G4 started a new event), the flag to keep particles on the CPU is reset.