### PR TITLE
Setting step status when on boundary

### DIFF
--- a/examples/Example1/src/RunAction.cc
+++ b/examples/Example1/src/RunAction.cc
@@ -54,6 +54,6 @@ void RunAction::EndOfRunAction(const G4Run *)
   const std::lock_guard<std::mutex> lock(print_mutex);
   // Print timer just for the master thread since this is called when all workers are done
   if (tid < 0) {
-    G4cout << "Run time: " << time << "\n";
+    std::cout << "Run time: " << time << "\n";
   }
 }

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -82,7 +82,8 @@ private:
   void FillG4NavigationHistory(vecgeom::NavigationState aNavState, G4NavigationHistory &aG4NavigationHistory) const;
 
   void FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step, G4TouchableHandle &aPreG4TouchableHandle,
-                  G4TouchableHandle &aPostG4TouchableHandle) const;
+                  G4TouchableHandle &aPostG4TouchableHandle, G4StepStatus aPreStepStatus,
+                  G4StepStatus aPostStepStatus) const;
 
   void ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex, int debugLevel) const;
 

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -466,6 +466,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       survive();
     }
     }
+
     // If there is some edep from cutting particles, record the step
     if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep) {
       adept_scoring::RecordHit(userScoring,


### PR DESCRIPTION
Set the step status if on a boundary. 

This change should be paired in the future with returning all steps done in sensitive volumes, even if they don't deposit any energy.