### PR TITLE
[mini] minor fixes

### DIFF
--- a/examples/Example1/src/RunAction.cc
+++ b/examples/Example1/src/RunAction.cc
@@ -54,6 +54,6 @@ void RunAction::EndOfRunAction(const G4Run *)
   const std::lock_guard<std::mutex> lock(print_mutex);
   // Print timer just for the master thread since this is called when all workers are done
   if (tid < 0) {
-    G4cout << "Run time: " << time << "\n";
+    std::cout << "Run time: " << time << "\n";
   }
 }

--- a/examples/IntegrationBenchmark/src/RunAction.cc
+++ b/examples/IntegrationBenchmark/src/RunAction.cc
@@ -76,7 +76,7 @@ void RunAction::EndOfRunAction(const G4Run *)
 
   // Print timer just for the master thread since this is called when all workers are done
   if (tid < 0) {
-    G4cout << "Run time: " << time << "\n";
+    std::cout << "Run time: " << time << "\n";
     if (fDoBenchmark) {
       fRun->GetTestManager()->timerStop(Run::timers::TOTAL);
     }

--- a/include/AdePT/core/AdePTConfiguration.hh
+++ b/include/AdePT/core/AdePTConfiguration.hh
@@ -41,6 +41,8 @@ public:
   void SetMillionsOfTrackSlots(double millionSlots) { fMillionsOfTrackSlots = millionSlots; }
   void SetMillionsOfHitSlots(double millionSlots) { fMillionsOfHitSlots = millionSlots; }
   void SetHitBufferFlushThreshold(float threshold) { fHitBufferFlushThreshold = threshold; }
+  void SetCPUCapacityFactor(float CPUCapacityFactor) { fCPUCapacityFactor = CPUCapacityFactor; }
+
   void SetCUDAStackLimit(int limit) { fCUDAStackLimit = limit; }
   void SetCUDAHeapLimit(int limit) { fCUDAHeapLimit = limit; }
   void SetLastNParticlesOnCPU(int Nparticles) { fLastNParticlesOnCPU = Nparticles; }
@@ -64,6 +66,7 @@ public:
   int GetCUDAHeapLimit() { return fCUDAHeapLimit; }
   unsigned short GetLastNParticlesOnCPU() { return fLastNParticlesOnCPU; }
   float GetHitBufferFlushThreshold() { return fHitBufferFlushThreshold; }
+  float GetCPUCapacityFactor() { return fCPUCapacityFactor; }
   double GetMillionsOfTrackSlots() { return fMillionsOfTrackSlots; }
   double GetMillionsOfHitSlots() { return fMillionsOfHitSlots; }
   std::vector<std::string> *GetGPURegionNames() { return &fGPURegionNames; }
@@ -84,6 +87,7 @@ private:
   int fCUDAStackLimit{0};
   int fCUDAHeapLimit{0};
   float fHitBufferFlushThreshold{0.8};
+  float fCPUCapacityFactor{2.5};
   double fMillionsOfTrackSlots{1};
   double fMillionsOfHitSlots{1};
   unsigned short fLastNParticlesOnCPU{0};

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -504,7 +504,8 @@ void FlushScoring(AdePTScoring &scoring)
 /// If memory allocation fails, an exception is thrown. In this case, the caller has to
 /// try again after some wait time or with less transport slots.
 std::unique_ptr<GPUstate, GPUstateDeleter> InitializeGPU(int trackCapacity, int scoringCapacity, int numThreads,
-                                                         TrackBuffer &trackBuffer, std::vector<AdePTScoring> &scoring)
+                                                         TrackBuffer &trackBuffer, std::vector<AdePTScoring> &scoring,
+                                                         double CPUCapacityFactor, double CPUCopyFraction)
 {
   auto gpuState_ptr  = std::unique_ptr<GPUstate, GPUstateDeleter>(new GPUstate());
   GPUstate &gpuState = *gpuState_ptr;
@@ -592,7 +593,7 @@ std::unique_ptr<GPUstate, GPUstateDeleter> InitializeGPU(int trackCapacity, int 
   for (unsigned int i = 0; i < numThreads; ++i) {
     scoring.emplace_back(gpuState.fScoring_dev + i);
   }
-  gpuState.fHitScoring.reset(new HitScoring(scoringCapacity, numThreads));
+  gpuState.fHitScoring.reset(new HitScoring(scoringCapacity, numThreads, CPUCapacityFactor, CPUCopyFraction));
 
   const auto injectQueueSize = adept::MParrayT<QueueIndexPair>::SizeOfInstance(trackBuffer.fNumToDevice);
   void *gpuPtr               = nullptr;

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -66,10 +66,11 @@ private:
   bool fReturnLastStep = false;
   std::string fBfieldFile{""};         ///< Path to magnetic field file (in the covfie format)
   GeneralMagneticField fMagneticField; ///< arbitrary magnetic field
-  double fCPUCapacityFactor{2.5};           ///< Factor by which the ScoringCapacity on Host is larger than on Device. Must be at least 2
-  ///< Filling fraction of the ScoringCapacity on host when the hits are copied out and not taken directly by the G4workers
+  double fCPUCapacityFactor{
+      2.5}; ///< Factor by which the ScoringCapacity on Host is larger than on Device. Must be at least 2
+  ///< Filling fraction of the ScoringCapacity on host when the hits are copied out and not taken directly by the
+  ///< G4workers
   double fCPUCopyFraction{0.5};
-
 
   void Initialize();
   void InitBVH();

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -66,6 +66,10 @@ private:
   bool fReturnLastStep = false;
   std::string fBfieldFile{""};         ///< Path to magnetic field file (in the covfie format)
   GeneralMagneticField fMagneticField; ///< arbitrary magnetic field
+  double fCPUCapacityFactor{2.5};           ///< Factor by which the ScoringCapacity on Host is larger than on Device. Must be at least 2
+  ///< Filling fraction of the ScoringCapacity on host when the hits are copied out and not taken directly by the G4workers
+  double fCPUCopyFraction{0.5};
+
 
   void Initialize();
   void InitBVH();

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -56,11 +56,9 @@ void CloseGPUBuffer(unsigned int, AsyncAdePT::GPUstate &, GPUHit *, const bool);
 std::thread LaunchGPUWorker(int, int, int, AsyncAdePT::TrackBuffer &, AsyncAdePT::GPUstate &,
                             std::vector<std::atomic<AsyncAdePT::EventState>> &, std::condition_variable &,
                             std::vector<AdePTScoring> &, int, int, bool, bool, unsigned short);
-std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> InitializeGPU(int trackCapacity, int scoringCapacity,
-                                                                                 int numThreads,
-                                                                                 AsyncAdePT::TrackBuffer &trackBuffer,
-                                                                                 std::vector<AdePTScoring> &scoring,
-                                                                                 double CPUCapacityFactor, double CPUCopyFraction);
+std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> InitializeGPU(
+    int trackCapacity, int scoringCapacity, int numThreads, AsyncAdePT::TrackBuffer &trackBuffer,
+    std::vector<AdePTScoring> &scoring, double CPUCapacityFactor, double CPUCopyFraction);
 void FreeGPU(std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> &, G4HepEmState &, std::thread &);
 } // namespace async_adept_impl
 
@@ -95,7 +93,9 @@ AsyncAdePTTransport<IntegrationLayer>::AsyncAdePTTransport(AdePTConfiguration &c
       fGPURegionNames{configuration.GetGPURegionNames()}, fCUDAStackLimit{configuration.GetCUDAStackLimit()},
       fCUDAHeapLimit{configuration.GetCUDAHeapLimit()}, fReturnAllSteps{configuration.GetCallUserSteppingAction()},
       fReturnLastStep{configuration.GetCallPostUserTrackingAction()}, fBfieldFile{configuration.GetCovfieBfieldFile()},
-      fLastNParticlesOnCPU{configuration.GetLastNParticlesOnCPU()}, fCPUCopyFraction{configuration.GetHitBufferFlushThreshold()}, fCPUCapacityFactor{configuration.GetCPUCapacityFactor()}
+      fLastNParticlesOnCPU{configuration.GetLastNParticlesOnCPU()},
+      fCPUCopyFraction{configuration.GetHitBufferFlushThreshold()},
+      fCPUCapacityFactor{configuration.GetCPUCapacityFactor()}
 {
   if (fNThread > kMaxThreads)
     throw std::invalid_argument("AsyncAdePTTransport limited to " + std::to_string(kMaxThreads) + " threads");
@@ -301,7 +301,8 @@ void AsyncAdePTTransport<IntegrationLayer>::Initialize()
 
   assert(fBuffer != nullptr);
 
-  fGPUstate  = async_adept_impl::InitializeGPU(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, fScoring, fCPUCapacityFactor, fCPUCopyFraction);
+  fGPUstate  = async_adept_impl::InitializeGPU(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, fScoring,
+                                               fCPUCapacityFactor, fCPUCopyFraction);
   fGPUWorker = async_adept_impl::LaunchGPUWorker(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, *fGPUstate,
                                                  fEventStates, fCV_G4Workers, fScoring, fAdePTSeed, fDebugLevel,
                                                  fReturnAllSteps, fReturnLastStep, fLastNParticlesOnCPU);

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -59,7 +59,8 @@ std::thread LaunchGPUWorker(int, int, int, AsyncAdePT::TrackBuffer &, AsyncAdePT
 std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> InitializeGPU(int trackCapacity, int scoringCapacity,
                                                                                  int numThreads,
                                                                                  AsyncAdePT::TrackBuffer &trackBuffer,
-                                                                                 std::vector<AdePTScoring> &scoring);
+                                                                                 std::vector<AdePTScoring> &scoring,
+                                                                                 double CPUCapacityFactor, double CPUCopyFraction);
 void FreeGPU(std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> &, G4HepEmState &, std::thread &);
 } // namespace async_adept_impl
 
@@ -94,7 +95,7 @@ AsyncAdePTTransport<IntegrationLayer>::AsyncAdePTTransport(AdePTConfiguration &c
       fGPURegionNames{configuration.GetGPURegionNames()}, fCUDAStackLimit{configuration.GetCUDAStackLimit()},
       fCUDAHeapLimit{configuration.GetCUDAHeapLimit()}, fReturnAllSteps{configuration.GetCallUserSteppingAction()},
       fReturnLastStep{configuration.GetCallPostUserTrackingAction()}, fBfieldFile{configuration.GetCovfieBfieldFile()},
-      fLastNParticlesOnCPU{configuration.GetLastNParticlesOnCPU()}
+      fLastNParticlesOnCPU{configuration.GetLastNParticlesOnCPU()}, fCPUCopyFraction{configuration.GetHitBufferFlushThreshold()}, fCPUCapacityFactor{configuration.GetCPUCapacityFactor()}
 {
   if (fNThread > kMaxThreads)
     throw std::invalid_argument("AsyncAdePTTransport limited to " + std::to_string(kMaxThreads) + " threads");
@@ -300,7 +301,7 @@ void AsyncAdePTTransport<IntegrationLayer>::Initialize()
 
   assert(fBuffer != nullptr);
 
-  fGPUstate  = async_adept_impl::InitializeGPU(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, fScoring);
+  fGPUstate  = async_adept_impl::InitializeGPU(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, fScoring, fCPUCapacityFactor, fCPUCopyFraction);
   fGPUWorker = async_adept_impl::LaunchGPUWorker(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, *fGPUstate,
                                                  fEventStates, fCV_G4Workers, fScoring, fAdePTSeed, fDebugLevel,
                                                  fReturnAllSteps, fReturnLastStep, fLastNParticlesOnCPU);

--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -376,12 +376,12 @@ public:
     // We allocate one (circular) HostBuffer in pinned memory
     GPUHit *gpuHits = nullptr;
 
-    // The HostBuffer is set to be 2.5x the GPU buffer HitCapacity. Normally, maximally 2x of the GPU hitbuffer should
+    // The HostBuffer is set to be 3.5x the GPU buffer HitCapacity. Normally, maximally 2x of the GPU hitbuffer should
     // reside in the hostbuffer: once a full buffer that is currently processed by the G4 workers and second another
     // full buffer that is just copied from the GPU. Due to sparsity, we add another factor of .5 to prevent running out
     // of buffer. Also, the filling quota of the CPU buffer decides whether hits are processed directly by the G4
     // workers or if they are copied out
-    unsigned int hostBufferCapacity = 4 * fHitCapacity;
+    unsigned int hostBufferCapacity = 3.5 * fHitCapacity;
     COPCORE_CUDA_CHECK(cudaMallocHost(&gpuHits, sizeof(GPUHit) * hostBufferCapacity));
     fGPUHitBuffer_host.reset(gpuHits);
 

--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -381,7 +381,7 @@ public:
     // full buffer that is just copied from the GPU. Due to sparsity, we add another factor of .5 to prevent running out
     // of buffer. Also, the filling quota of the CPU buffer decides whether hits are processed directly by the G4
     // workers or if they are copied out
-    unsigned int hostBufferCapacity = 2.5 * fHitCapacity;
+    unsigned int hostBufferCapacity = 4 * fHitCapacity;
     COPCORE_CUDA_CHECK(cudaMallocHost(&gpuHits, sizeof(GPUHit) * hostBufferCapacity));
     fGPUHitBuffer_host.reset(gpuHits);
 

--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -294,6 +294,8 @@ class HitScoring {
 
   void *fHitScoringBuffer_deviceAddress = nullptr;
   unsigned int fHitCapacity;
+  double fCPUCapacityFactor;
+  double fCPUCopyFraction;
   unsigned short fActiveBuffer = 0;
   unique_ptr_cuda<std::byte> fGPUSortAuxMemory;
   std::size_t fGPUSortAuxMemorySize;
@@ -346,10 +348,11 @@ class HitScoring {
 
           // If the circular Buffer is too full and the G4Worker didn't pick up the work, we have to copy out the hits
           // to the holdoutBuffer
-          if (fBufferManager->getFillFraction() > 0.5) {
+          if (fBufferManager->getFillFraction() > fCPUCopyFraction) {
             if (debugLevel > 5) {
               std::cout << BOLD_RED << "FillFraction too high: " << fBufferManager->getFillFraction()
-                        << ", copying out " << numHits << " hits for G4Worker " << i << RESET << std::endl;
+                        << ", threshold: " << fCPUCopyFraction << " copying out " << numHits << " hits for G4Worker "
+                        << i << RESET << std::endl;
             }
             ret.holdoutBuffer.resize(numHits);                        // Allocate correct size
             std::copy(ret.begin, ret.end, ret.holdoutBuffer.begin()); // Copy data
@@ -370,18 +373,32 @@ class HitScoring {
   }
 
 public:
-  HitScoring(unsigned int hitCapacity, unsigned int nThread)
-      : fHitCapacity{hitCapacity}, fHitQueues(nThread), fHitQueueLocks(nThread)
+  HitScoring(unsigned int hitCapacity, unsigned int nThread, double CPUCapacityFactor, double CPUCopyFraction)
+      : fHitCapacity{hitCapacity}, fHitQueues(nThread), fHitQueueLocks(nThread), fCPUCapacityFactor(CPUCapacityFactor),
+        fCPUCopyFraction(CPUCopyFraction)
   {
+
+    if (fCPUCapacityFactor <= 2.0) {
+      std::ostringstream oss;
+      oss << "CPUCapacityFactor must be > 2.0 (got " << fCPUCapacityFactor << ")";
+      throw std::invalid_argument(oss.str());
+    }
+
+    if (fCPUCopyFraction < 0.0 || fCPUCopyFraction > 1.0) {
+      std::ostringstream oss;
+      oss << "CPUCopyFraction must be between 0.0 and 1.0 (got " << fCPUCopyFraction << ")";
+      throw std::invalid_argument(oss.str());
+    }
+
     // We allocate one (circular) HostBuffer in pinned memory
     GPUHit *gpuHits = nullptr;
 
-    // The HostBuffer is set to be 3.5x the GPU buffer HitCapacity. Normally, maximally 2x of the GPU hitbuffer should
-    // reside in the hostbuffer: once a full buffer that is currently processed by the G4 workers and second another
-    // full buffer that is just copied from the GPU. Due to sparsity, we add another factor of .5 to prevent running out
-    // of buffer. Also, the filling quota of the CPU buffer decides whether hits are processed directly by the G4
-    // workers or if they are copied out
-    unsigned int hostBufferCapacity = 3.5 * fHitCapacity;
+    // The HostBuffer is set to be fCPUCapacityFactor times the GPU buffer HitCapacity. Normally, maximally 2x of the
+    // GPU hitbuffer should reside in the hostbuffer: once a full buffer that is currently processed by the G4 workers
+    // and second another full buffer that is just copied from the GPU. Due to sparsity, we add another factor of .5 to
+    // prevent running out of buffer. Also, the filling quota of the CPU buffer decides whether hits are processed
+    // directly by the G4 workers or if they are copied out
+    unsigned int hostBufferCapacity = fCPUCapacityFactor * fHitCapacity;
     COPCORE_CUDA_CHECK(cudaMallocHost(&gpuHits, sizeof(GPUHit) * hostBufferCapacity));
     fGPUHitBuffer_host.reset(gpuHits);
 

--- a/include/AdePT/integration/AdePTConfigurationMessenger.hh
+++ b/include/AdePT/integration/AdePTConfigurationMessenger.hh
@@ -47,6 +47,7 @@ private:
   G4UIcmdWithADouble *fSetMillionsOfTrackSlotsCmd;
   G4UIcmdWithADouble *fSetMillionsOfHitSlotsCmd;
   G4UIcmdWithADouble *fSetHitBufferFlushThresholdCmd;
+  G4UIcmdWithADouble *fSetCPUCapacityFactorCmd;
 
   // Temporary method for setting the VecGeom geometry.
   // In the future the geometry will be converted from Geant4 rather than loaded from GDML.

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -430,7 +430,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
         reached_interaction = false;
         // Kill the particle if it left the world.
 
-        if (++currentTrack.looperCounter > 200) {
+        if (++currentTrack.looperCounter > 500) {
           // Kill loopers that are scraping a boundary
           printf("Killing looper scraping at a boundary: E=%E event=%d loop=%d energyDeposit=%E geoStepLength=%E "
                  "physicsStepLength=%E "
@@ -454,7 +454,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
         // Did not yet reach the interaction point due to error in the magnetic
         // field propagation. Try again next time.
 
-        if (++currentTrack.looperCounter > 200) {
+        if (++currentTrack.looperCounter > 500) {
           // Kill loopers that are not advancing in free space
           printf("Killing looper due to lack of advance: E=%E event=%d loop=%d energyDeposit=%E geoStepLength=%E "
                  "physicsStepLength=%E "

--- a/src/AdePTConfigurationMessenger.cc
+++ b/src/AdePTConfigurationMessenger.cc
@@ -71,9 +71,18 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
 
   fSetHitBufferFlushThresholdCmd = new G4UIcmdWithADouble("/adept/setHitBufferThreshold", this);
   fSetHitBufferFlushThresholdCmd->SetGuidance(
-      "Set the usage threshold at which the buffer of hits is copied back to the host from GPU");
+      "In Sync AdePT: set the usage threshold at which the buffer of hits is copied back to the host from GPU "
+      "In Async AdePT: set the usage threshold at which the GPU steps are copied from the buffer and not taken "
+      "directly by the G4 workers");
   fSetHitBufferFlushThresholdCmd->SetParameterName("HitBufferThreshold", false);
   fSetHitBufferFlushThresholdCmd->SetRange("HitBufferThreshold>=0.&&HitBufferThreshold<=1.");
+
+  fSetCPUCapacityFactorCmd = new G4UIcmdWithADouble("/adept/setCPUCapacityFactor", this);
+  fSetCPUCapacityFactorCmd->SetGuidance(
+      "Sets the CPUCapacity factor for scoring with respect to the GPU (see: /adept/setMillionsOfHitSlots). "
+      "Must at least be 2.5");
+  fSetCPUCapacityFactorCmd->SetParameterName("CPUCapacityFactor", false);
+  fSetCPUCapacityFactorCmd->SetRange("CPUCapacityFactor>=2.5");
 
   fSetGDMLCmd = new G4UIcmdWithAString("/adept/setVecGeomGDML", this);
   fSetGDMLCmd->SetGuidance("Temporary method for setting the geometry to use with VecGeom");
@@ -112,6 +121,7 @@ AdePTConfigurationMessenger::~AdePTConfigurationMessenger()
   delete fSetCovfieFileCmd;
   delete fSetFinishOnCpuCmd;
   delete fSetSpeedOfLightCmd;
+  delete fSetCPUCapacityFactorCmd;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -141,6 +151,8 @@ void AdePTConfigurationMessenger::SetNewValue(G4UIcommand *command, G4String new
     fAdePTConfiguration->SetMillionsOfHitSlots(fSetMillionsOfHitSlotsCmd->GetNewDoubleValue(newValue));
   } else if (command == fSetHitBufferFlushThresholdCmd) {
     fAdePTConfiguration->SetHitBufferFlushThreshold(fSetHitBufferFlushThresholdCmd->GetNewDoubleValue(newValue));
+  } else if (command == fSetCPUCapacityFactorCmd) {
+    fAdePTConfiguration->SetCPUCapacityFactor(fSetCPUCapacityFactorCmd->GetNewDoubleValue(newValue));
   } else if (command == fSetGDMLCmd) {
     fAdePTConfiguration->SetVecGeomGDML(newValue);
   } else if (command == fSetCovfieFileCmd) {


### PR DESCRIPTION
Just some minor fixes.

- The looper counter is increased as some particles were killed too early in CMS (in ATLAS it was fine). This may need to revised later a bit more.
- The printout of the timer via G4cout is broken. Not clear at this point why, will be investigated later, this provides a easy fix by just calling `std::cout`
- The allocated memory for the GPU steps on the host is increased as it was failing in some benchmark that should not fail.