### PR TITLE
enable full uniform B field via RK integrator

### DIFF
--- a/examples/Example1/src/DetectorConstruction.cc
+++ b/examples/Example1/src/DetectorConstruction.cc
@@ -70,9 +70,8 @@ void DetectorConstruction::ConstructSDandField()
 #else
   // Set a 3D magnetic field vector for a uniform field in Bz. If no file is provided, no magnetic field is used in the
   // G4 transport
-  if (std::abs(fMagFieldVector[2]) > 0.0) {
-    G4cout << G4endl
-           << " *** SETTING CONSTANT MAGNETIC FIELD IN Z: fieldValue in z = " << fMagFieldVector[2] / kilogauss
+  if (fMagFieldVector.mag2() > 0.0) {
+    G4cout << G4endl << " *** SETTING CONSTANT MAGNETIC FIELD: fieldValues = " << fMagFieldVector / kilogauss
            << " [kilogauss] *** " << G4endl << G4endl;
 
     field = std::make_unique<UniformField>(fMagFieldVector);

--- a/examples/Example1/src/DetectorConstruction.cc
+++ b/examples/Example1/src/DetectorConstruction.cc
@@ -68,7 +68,7 @@ void DetectorConstruction::ConstructSDandField()
 
     field = std::make_unique<CovfieField>(fFieldFile);
 #else
-  // Set a 3D magnetic field vector for a uniform field in Bz. If no file is provided, no magnetic field is used in the
+  // Set a 3D magnetic field vector for a uniform B field. If no field is provided, no magnetic field is used in the
   // G4 transport
   if (fMagFieldVector.mag2() > 0.0) {
     G4cout << G4endl << " *** SETTING CONSTANT MAGNETIC FIELD: fieldValues = " << fMagFieldVector / kilogauss

--- a/examples/IntegrationBenchmark/src/DetectorConstruction.cc
+++ b/examples/IntegrationBenchmark/src/DetectorConstruction.cc
@@ -68,11 +68,10 @@ void DetectorConstruction::ConstructSDandField()
 
     field = std::make_unique<CovfieField>(fFieldFile);
 #else
-  // Set a 3D magnetic field vector for a uniform field in Bz. If no file is provided, no magnetic field is used in the
+  // Set a 3D magnetic field vector for a uniform B field. If no field is provided, no magnetic field is used in the
   // G4 transport
-  if (std::abs(fMagFieldVector[2]) > 0.0) {
-    G4cout << G4endl
-           << " *** SETTING CONSTANT MAGNETIC FIELD IN Z: fieldValue in z = " << fMagFieldVector[2] / kilogauss
+  if (fMagFieldVector.mag2() > 0.0) {
+    G4cout << G4endl << " *** SETTING CONSTANT MAGNETIC FIELD: fieldValues = " << fMagFieldVector / kilogauss
            << " [kilogauss] *** " << G4endl << G4endl;
 
     field = std::make_unique<UniformField>(fMagFieldVector);

--- a/include/AdePT/core/AdePTTransport.cuh
+++ b/include/AdePT/core/AdePTTransport.cuh
@@ -366,7 +366,6 @@ void FreeGPU(GPUstate &gpuState, G4HepEmState *g4hepem_state)
   delete g4hepem_state;
 
 // Free magnetic field
-// Free magnetic field
 #ifdef ADEPT_USE_EXT_BFIELD
   FreeBField<GeneralMagneticField>();
 #else

--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -14,6 +14,7 @@
 #include <AdePT/core/HostScoringStruct.cuh>
 #include <AdePT/core/AdePTConfiguration.hh>
 #include <AdePT/magneticfield/GeneralMagneticField.h>
+#include <AdePT/magneticfield/UniformMagneticField.h>
 
 #include <VecGeom/base/Config.h>
 #ifdef VECGEOM_ENABLE_CUDA
@@ -108,8 +109,8 @@ private:
   /// @brief Used to map VecGeom to Geant4 volumes for scoring
   void InitializeSensitiveVolumeMapping(const G4VPhysicalVolume *g4world, const vecgeom::VPlacedVolume *world);
   void InitBVH();
-  bool InitializeField(double bz);
-  bool InitializeGeneralField();
+  bool InitializeBField();
+  bool InitializeBField(UniformMagneticField &Bfield);
   bool InitializeGeometry(const vecgeom::cxx::VPlacedVolume *world);
   bool InitializePhysics();
 };

--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -24,12 +24,13 @@
 namespace adept_impl {
 /// Forward declarations for methods implemented in AdePTTransport.cu
 using TrackBuffer = adeptint::TrackBuffer;
-bool InitializeField(double);
+template <typename FieldType>
+bool InitializeBField(FieldType &);
+template <typename FieldType>
+void FreeField();
 bool InitializeApplyCuts(bool);
-bool InitializeGeneralField(GeneralMagneticField &);
 bool InitializeVolAuxArray(adeptint::VolAuxArray &);
 void FreeVolAuxArray(adeptint::VolAuxArray &);
-void FreeGeneralField(GeneralMagneticField &);
 G4HepEmState *InitG4HepEm();
 GPUstate *InitializeGPU(TrackBuffer &, int, int);
 AdeptScoring *InitializeScoringGPU(AdeptScoring *scoring);
@@ -60,19 +61,7 @@ AdePTTransport<IntegrationLayer>::AdePTTransport(AdePTConfiguration &configurati
 }
 
 template <typename IntegrationLayer>
-bool AdePTTransport<IntegrationLayer>::InitializeField(double bz)
-{
-  return adept_impl::InitializeField(bz);
-}
-
-template <typename IntegrationLayer>
-bool AdePTTransport<IntegrationLayer>::InitializeApplyCuts(bool applycuts)
-{
-  return adept_impl::InitializeApplyCuts(applycuts);
-}
-
-template <typename IntegrationLayer>
-bool AdePTTransport<IntegrationLayer>::InitializeGeneralField()
+bool AdePTTransport<IntegrationLayer>::InitializeBField()
 {
   if (!fBfieldFile.empty()) {
     // Initialize magnetic field data from file
@@ -81,9 +70,31 @@ bool AdePTTransport<IntegrationLayer>::InitializeGeneralField()
     }
 
     // Delegate the setup of the global view pointer to adept_impl
-    return adept_impl::InitializeGeneralField(fMagneticField);
+    return adept_impl::InitializeBField(fMagneticField);
   }
   return true; // no file provided, but no error encountered, so true is returned
+}
+
+template <typename IntegrationLayer>
+bool AdePTTransport<IntegrationLayer>::InitializeBField(UniformMagneticField &Bfield)
+{
+  vecgeom::Vector3D<float> position{
+      0.,
+      0.,
+      0.,
+  };
+  auto field_value = Bfield.Evaluate(position);
+  if (field_value.Mag2() > 0) {
+    // Delegate the setup of the global view pointer to adept_impl
+    return adept_impl::InitializeBField(Bfield);
+  }
+  return true; // no B field provided, but no error encountered, so true is returned
+}
+
+template <typename IntegrationLayer>
+bool AdePTTransport<IntegrationLayer>::InitializeApplyCuts(bool applycuts)
+{
+  return adept_impl::InitializeApplyCuts(applycuts);
 }
 
 template <typename IntegrationLayer>
@@ -184,22 +195,17 @@ void AdePTTransport<IntegrationLayer>::Initialize(bool common_data)
       throw std::runtime_error("AdePTTransport<IntegrationLayer>::Initialize cannot initialize physics on GPU");
 
 #ifdef ADEPT_USE_EXT_BFIELD
-    // Try to initialize field from file, otherwise initialize from vector
-    if (!InitializeGeneralField()) {
+    // Try to initialize field from file
+    if (!InitializeBField()) {
       throw std::runtime_error(
           "AdePTTransport<IntegrationLayer>::Initialize cannot initialize GeneralMagneticField on GPU");
-      // NOTE: if the field option is a run-time option and not a compile time option, uncomment the code below
-      // to use uniform field in case no file was provided. ToDo: this requires changing the return of
-      // InitializeGeneralField
-      //   double bz = fIntegrationLayer.GetUniformFieldZ();
-      //   if (!InitializeField(bz))
-      //     throw std::runtime_error("AdePTTransport<IntegrationLayer>::Initialize cannot initialize field on GPU");
     }
-#endif
-    // Initialize field from vector
-    double bz = fIntegrationLayer.GetUniformFieldZ();
-    if (!InitializeField(bz))
+#else
+    auto field_values                            = fIntegrationLayer.GetUniformField(); // Get the field value
+    std::unique_ptr<UniformMagneticField> Bfield = std::make_unique<UniformMagneticField>(field_values);
+    if (!InitializeBField(*Bfield))
       throw std::runtime_error("AdePTTransport<IntegrationLayer>::Initialize cannot initialize field on GPU");
+#endif
 
     // Do the material-cut couple index mapping once
     // as well as set flags for sensitive volumes and region

--- a/include/AdePT/core/AdePTTransportStruct.cuh
+++ b/include/AdePT/core/AdePTTransportStruct.cuh
@@ -7,6 +7,7 @@
 #include <AdePT/core/CommonStruct.h>
 #include <AdePT/core/HostScoringStruct.cuh>
 #include <AdePT/magneticfield/GeneralMagneticField.h>
+#include <AdePT/magneticfield/UniformMagneticField.h>
 
 #include "Track.cuh"
 #include <AdePT/base/TrackManager.cuh>
@@ -91,10 +92,11 @@ extern __constant__ struct G4HepEmParameters g4HepEmPars;
 extern __constant__ struct G4HepEmData g4HepEmData;
 
 extern __constant__ __device__ adeptint::VolAuxData *gVolAuxData;
-extern __constant__ __device__ double BzFieldValue;
 extern __constant__ __device__ bool ApplyCuts;
 #ifdef ADEPT_USE_EXT_BFIELD
 __device__ GeneralMagneticField *gMagneticField = nullptr;
+#else
+__device__ UniformMagneticField *gMagneticField = nullptr;
 #endif
 
 } // namespace adept_impl

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -446,44 +446,33 @@ G4HepEmState *InitG4HepEm()
   return state;
 }
 
-bool InitializeField(double bz)
+template <typename FieldType>
+bool InitializeBField(FieldType &magneticField)
 {
-  // Initialize field
-  COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(BzFieldValue, &bz, sizeof(double)));
+
+  // Allocate and copy the FieldType instance (not the field array itself), and set the global device pointer
+  FieldType *dMagneticFieldInstance = nullptr;
+  COPCORE_CUDA_CHECK(cudaMalloc(&dMagneticFieldInstance, sizeof(FieldType)));
+  COPCORE_CUDA_CHECK(cudaMemcpy(dMagneticFieldInstance, &magneticField, sizeof(FieldType), cudaMemcpyHostToDevice));
+  COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(gMagneticField, &dMagneticFieldInstance, sizeof(FieldType *)));
+
   return true;
 }
 
-bool InitializeGeneralField(GeneralMagneticField &magneticField)
+template <typename FieldType>
+void FreeBField()
 {
-
-#ifdef ADEPT_USE_EXT_BFIELD
-
-  // Allocate and copy the GeneralMagneticField instance (not the field array itself), and set the global device pointer
-  GeneralMagneticField *dMagneticFieldInstance = nullptr;
-  COPCORE_CUDA_CHECK(cudaMalloc(&dMagneticFieldInstance, sizeof(GeneralMagneticField)));
-  COPCORE_CUDA_CHECK(
-      cudaMemcpy(dMagneticFieldInstance, &magneticField, sizeof(GeneralMagneticField), cudaMemcpyHostToDevice));
-  COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(gMagneticField, &dMagneticFieldInstance, sizeof(GeneralMagneticField *)));
-
-#endif
-  return true;
-}
-
-void FreeGeneralField()
-{
-#ifdef ADEPT_USE_EXT_BFIELD
-  GeneralMagneticField *dMagneticFieldInstance = nullptr;
+  FieldType *dMagneticFieldInstance = nullptr;
 
   // Retrieve the global device pointer from the symbol
-  COPCORE_CUDA_CHECK(cudaMemcpyFromSymbol(&dMagneticFieldInstance, gMagneticField, sizeof(GeneralMagneticField *)));
+  COPCORE_CUDA_CHECK(cudaMemcpyFromSymbol(&dMagneticFieldInstance, gMagneticField, sizeof(FieldType *)));
 
   if (dMagneticFieldInstance) {
     // Free the device memory and reset global device pointer
     COPCORE_CUDA_CHECK(cudaFree(dMagneticFieldInstance));
-    GeneralMagneticField *nullPtr = nullptr;
-    COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(gMagneticField, &nullPtr, sizeof(GeneralMagneticField *)));
+    FieldType *nullPtr = nullptr;
+    COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(gMagneticField, &nullPtr, sizeof(FieldType *)));
   }
-#endif
 }
 
 bool InitializeApplyCuts(bool applycuts)
@@ -1204,9 +1193,17 @@ void FreeGPU(std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> 
   // Free G4HepEm data
   FreeG4HepEmData(g4hepem_state.fData);
 
-  // Free magnetic field map
-  FreeGeneralField();
+  // Free magnetic field
+#ifdef ADEPT_USE_EXT_BFIELD
+  FreeBField<GeneralMagneticField>();
+#else
+  FreeBField<UniformMagneticField>();
+#endif
 }
+
+// explicit instantiation
+template bool InitializeBField<GeneralMagneticField>(GeneralMagneticField &);
+template bool InitializeBField<UniformMagneticField>(UniformMagneticField &);
 
 } // namespace async_adept_impl
 
@@ -1216,7 +1213,6 @@ __constant__ __device__ struct G4HepEmParameters g4HepEmPars;
 __constant__ __device__ struct G4HepEmData g4HepEmData;
 
 __constant__ __device__ adeptint::VolAuxData *gVolAuxData = nullptr;
-__constant__ __device__ double BzFieldValue               = 0;
 __constant__ __device__ bool ApplyCuts                    = false;
 
 /// Transfer volume auxiliary data to GPU

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -17,6 +17,7 @@
 #include <AdePT/core/AsyncAdePTTransportStruct.hh>
 #include <AdePT/core/PerEventScoringStruct.cuh>
 #include <AdePT/magneticfield/GeneralMagneticField.h>
+#include <AdePT/magneticfield/UniformMagneticField.h>
 
 #include <VecGeom/base/Config.h>
 #include <VecGeom/management/CudaManager.h> // forward declares vecgeom::cxx::VPlacedVolume
@@ -74,8 +75,8 @@ private:
 
   void Initialize();
   void InitBVH();
-  bool InitializeField(double bz);
-  bool InitializeGeneralField();
+  bool InitializeBField();
+  bool InitializeBField(UniformMagneticField &Bfield);
   bool InitializeGeometry(const vecgeom::cxx::VPlacedVolume *world);
   bool InitializePhysics();
 

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -44,9 +44,10 @@
 /// Forward declarations
 namespace async_adept_impl {
 void CopySurfaceModelToGPU();
-bool InitializeField(double);
-bool InitializeGeneralField(GeneralMagneticField &);
-void FreeGeneralField(GeneralMagneticField &);
+template <typename FieldType>
+bool InitializeBField(FieldType &);
+template <typename FieldType>
+void FreeField();
 bool InitializeApplyCuts(bool applycuts);
 G4HepEmState *InitG4HepEm();
 void FlushScoring(AdePTScoring &);
@@ -167,13 +168,7 @@ void AsyncAdePTTransport<IntegrationLayer>::AddTrack(
 }
 
 template <typename IntegrationLayer>
-bool AsyncAdePTTransport<IntegrationLayer>::InitializeField(double bz)
-{
-  return async_adept_impl::InitializeField(bz);
-}
-
-template <typename IntegrationLayer>
-bool AsyncAdePTTransport<IntegrationLayer>::InitializeGeneralField()
+bool AsyncAdePTTransport<IntegrationLayer>::InitializeBField()
 {
   if (!fBfieldFile.empty()) {
     // Initialize magnetic field data from file
@@ -182,9 +177,25 @@ bool AsyncAdePTTransport<IntegrationLayer>::InitializeGeneralField()
     }
 
     // Delegate the setup of the global view pointer to adept_impl
-    return async_adept_impl::InitializeGeneralField(fMagneticField);
+    return async_adept_impl::InitializeBField(fMagneticField);
   }
   return true; // no file provided, but no error encountered, so true is returned
+}
+
+template <typename IntegrationLayer>
+bool AsyncAdePTTransport<IntegrationLayer>::InitializeBField(UniformMagneticField &Bfield)
+{
+  vecgeom::Vector3D<float> position{
+      0.,
+      0.,
+      0.,
+  };
+  auto field_value = Bfield.Evaluate(position);
+  if (field_value.Mag2() > 0) {
+    // Delegate the setup of the global view pointer to adept_impl
+    return async_adept_impl::InitializeBField(Bfield);
+  }
+  return true; // no B field provided, but no error encountered, so true is returned
 }
 
 template <typename IntegrationLayer>
@@ -258,28 +269,22 @@ void AsyncAdePTTransport<IntegrationLayer>::Initialize()
     throw std::runtime_error("AsyncAdePTTransport::Initialize: Cannot initialize geometry on GPU");
 
   // Initialize G4HepEm
-  fIntegrationLayerObjects.front().GetUniformFieldZ();
   if (!InitializePhysics())
     throw std::runtime_error("AsyncAdePTTransport::Initialize cannot initialize physics on GPU");
 
   // Initialize field
-  const double bz =
-      fIntegrationLayerObjects[0].GetUniformFieldZ(); // Get the field value from one of the worker threads
-  if (!InitializeField(bz))
-    throw std::runtime_error("AdePTTransport<IntegrationLayer>::Initialize cannot initialize field on GPU");
-
 #ifdef ADEPT_USE_EXT_BFIELD
-  // Try to initialize field from file, otherwise initialize from vector
-  if (!InitializeGeneralField()) {
+  // Try to initialize field from file
+  if (!InitializeBField()) {
     throw std::runtime_error(
         "AdePTTransport<IntegrationLayer>::Initialize cannot initialize GeneralMagneticField on GPU");
-    // NOTE: if the field option is a run-time option and not a compile time option, uncomment the code below
-    // to use uniform field in case no file was provided. ToDo: this requires changing the return of
-    // InitializeGeneralField
-    //   double bz = fIntegrationLayer.GetUniformFieldZ();
-    //   if (!InitializeField(bz))
-    //     throw std::runtime_error("AdePTTransport<IntegrationLayer>::Initialize cannot initialize field on GPU");
   }
+#else
+  auto field_values =
+      fIntegrationLayerObjects[0].GetUniformField(); // Get the field value from one of the worker threads
+  std::unique_ptr<UniformMagneticField> Bfield = std::make_unique<UniformMagneticField>(field_values);
+  if (!InitializeBField(*Bfield))
+    throw std::runtime_error("AdePTTransport<IntegrationLayer>::Initialize cannot initialize field on GPU");
 #endif
 
   // Check VecGeom geometry matches Geant4. Initialize auxiliary per-LV data. Initialize scoring map.

--- a/include/AdePT/core/AsyncAdePTTransportStruct.cuh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.cuh
@@ -10,6 +10,7 @@
 #include <AdePT/core/PerEventScoringImpl.cuh>
 #include <AdePT/core/Track.cuh>
 #include <AdePT/magneticfield/GeneralMagneticField.h>
+#include <AdePT/magneticfield/UniformMagneticField.h>
 
 #include <AdePT/base/SlotManager.cuh>
 #include <AdePT/base/ResourceManagement.cuh>
@@ -210,12 +211,12 @@ extern __constant__ __device__ struct G4HepEmData g4HepEmData;
 // Pointer for array of volume auxiliary data on device
 extern __constant__ __device__ adeptint::VolAuxData *gVolAuxData;
 
-// constexpr float BzFieldValue = 0.1 * copcore::units::tesla;
-extern __constant__ __device__ double BzFieldValue;
 extern __constant__ __device__ bool ApplyCuts;
 constexpr double kPush = 1.e-8 * copcore::units::cm;
 #ifdef ADEPT_USE_EXT_BFIELD
 __device__ GeneralMagneticField *gMagneticField = nullptr;
+#else
+__device__ UniformMagneticField *gMagneticField = nullptr;
 #endif
 
 } // namespace AsyncAdePT

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -71,7 +71,7 @@ public:
 
   /// @brief Returns the Z value of the user-defined uniform magnetic field
   /// @details This function can only be called when the user-defined field is a G4UniformMagField
-  double GetUniformFieldZ() const;
+  vecgeom::Vector3D<float> GetUniformField() const;
 
   int GetEventID() const { return G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID(); }
 

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -615,15 +615,19 @@ void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsig
   G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(secondary);
 }
 
-double AdePTGeant4Integration::GetUniformFieldZ() const
+vecgeom::Vector3D<float> AdePTGeant4Integration::GetUniformField() const
 {
+  vecgeom::Vector3D<float> Bfield(0., 0., 0.);
+
   G4MagneticField *field =
       (G4MagneticField *)G4TransportationManager::GetTransportationManager()->GetFieldManager()->GetDetectorField();
+
   if (field) {
     G4double origin[3] = {0., 0., 0.};
-    G4double Bfield[3] = {0., 0., 0.};
-    field->GetFieldValue(origin, Bfield);
-    return Bfield[2];
-  } else
-    return 0;
+    G4double temp[3]   = {0., 0., 0.};
+    field->GetFieldValue(origin, temp);
+    Bfield.Set(temp[0], temp[1], temp[2]);
+  }
+
+  return Bfield;
 }


### PR DESCRIPTION
Previously, only a constant Bz field was available.

As needed for the B5 example, a full uniform magnetic field is required. There was an not-up-to-date analytical Bany field integrator. Since it was not up to date, here I propose to simply use the RK integrator.

Now, similar to the GeneralMagneticField, a UniformMagneticField is created on the host, and passed to the device.

This cleans up quite a bit of logic on the B field.