### PR TITLE
Enable PreUserTrackingAction and fixes related to leaked energy

### DIFF
--- a/include/AdePT/core/AdePTConfiguration.hh
+++ b/include/AdePT/core/AdePTConfiguration.hh
@@ -30,10 +30,7 @@ public:
   void SetNumThreads(int numThreads) { fNumThreads = numThreads; }
   void SetTrackInAllRegions(bool trackInAllRegions) { fTrackInAllRegions = trackInAllRegions; }
   void SetCallUserSteppingAction(bool callUserSteppingAction) { fCallUserSteppingAction = callUserSteppingAction; }
-  void SetCallPostUserTrackingAction(bool callPostUserTrackingAction)
-  {
-    fCallPostUserTrackingAction = callPostUserTrackingAction;
-  }
+  void SetCallUserTrackingAction(bool callUserTrackingAction) { fCallUserTrackingAction = callUserTrackingAction; }
   void AddGPURegionName(std::string name) { fGPURegionNames.push_back(name); }
   void SetAdePTActivation(bool activateAdePT) { fAdePTActivated = activateAdePT; }
   void SetVerbosity(int verbosity) { fVerbosity = verbosity; };
@@ -56,7 +53,7 @@ public:
 
   bool GetTrackInAllRegions() { return fTrackInAllRegions; }
   bool GetCallUserSteppingAction() { return fCallUserSteppingAction; }
-  bool GetCallPostUserTrackingAction() { return fCallPostUserTrackingAction; }
+  bool GetCallUserTrackingAction() { return fCallUserTrackingAction; }
   bool GetSpeedOfLight() { return fSpeedOfLight; }
   bool IsAdePTActivated() { return fAdePTActivated; }
   int GetNumThreads() { return fNumThreads; };
@@ -78,7 +75,7 @@ public:
 private:
   bool fTrackInAllRegions{false};
   bool fCallUserSteppingAction{false};
-  bool fCallPostUserTrackingAction{false};
+  bool fCallUserTrackingAction{false};
   bool fSpeedOfLight{false};
   bool fAdePTActivated{true};
   int fNumThreads;

--- a/include/AdePT/core/AdePTScoringTemplate.cuh
+++ b/include/AdePT/core/AdePTScoringTemplate.cuh
@@ -23,7 +23,7 @@ __device__ void RecordHit(Scoring *scoring_dev, int aParentID, char aParticleTyp
                           vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin, double aPreCharge,
                           vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
                           vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                          double aPostCharge, unsigned int eventId, short threadId, bool isLastStep);
+                          double aPostCharge, unsigned int eventId, short threadId, bool isLastStep, bool isFirstStep);
 
 template <typename Scoring>
 __device__ void AccountProduced(Scoring *scoring_dev, int num_ele, int num_pos, int num_gam);

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -63,8 +63,8 @@ private:
   bool fTrackInAllRegions = false;
   std::vector<std::string> const *fGPURegionNames;
   // Flags for the kernels to return the last or all steps, needed for PostUserTrackingAction or UserSteppingAction
-  bool fReturnAllSteps = false;
-  bool fReturnLastStep = false;
+  bool fReturnAllSteps         = false;
+  bool fReturnFirstAndLastStep = false;
   std::string fBfieldFile{""};         ///< Path to magnetic field file (in the covfie format)
   GeneralMagneticField fMagneticField; ///< arbitrary magnetic field
   double fCPUCapacityFactor{

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -93,8 +93,8 @@ AsyncAdePTTransport<IntegrationLayer>::AsyncAdePTTransport(AdePTConfiguration &c
       fGPUNetEnergy(fNThread, 0.0), fTrackInAllRegions{configuration.GetTrackInAllRegions()},
       fGPURegionNames{configuration.GetGPURegionNames()}, fCUDAStackLimit{configuration.GetCUDAStackLimit()},
       fCUDAHeapLimit{configuration.GetCUDAHeapLimit()}, fReturnAllSteps{configuration.GetCallUserSteppingAction()},
-      fReturnLastStep{configuration.GetCallPostUserTrackingAction()}, fBfieldFile{configuration.GetCovfieBfieldFile()},
-      fLastNParticlesOnCPU{configuration.GetLastNParticlesOnCPU()},
+      fReturnFirstAndLastStep{configuration.GetCallUserTrackingAction()},
+      fBfieldFile{configuration.GetCovfieBfieldFile()}, fLastNParticlesOnCPU{configuration.GetLastNParticlesOnCPU()},
       fCPUCopyFraction{configuration.GetHitBufferFlushThreshold()},
       fCPUCapacityFactor{configuration.GetCPUCapacityFactor()}
 {
@@ -310,7 +310,7 @@ void AsyncAdePTTransport<IntegrationLayer>::Initialize()
                                                fCPUCapacityFactor, fCPUCopyFraction);
   fGPUWorker = async_adept_impl::LaunchGPUWorker(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, *fGPUstate,
                                                  fEventStates, fCV_G4Workers, fScoring, fAdePTSeed, fDebugLevel,
-                                                 fReturnAllSteps, fReturnLastStep, fLastNParticlesOnCPU);
+                                                 fReturnAllSteps, fReturnFirstAndLastStep, fLastNParticlesOnCPU);
 }
 
 template <typename IntegrationLayer>
@@ -341,7 +341,7 @@ void AsyncAdePTTransport<IntegrationLayer>::ProcessGPUSteps(int threadId, int ev
                   << " state : " << static_cast<unsigned int>(fEventStates[threadId].load(std::memory_order_acquire))
                   << "\033[0m" << std::endl;
       }
-      integrationInstance.ProcessGPUStep(*it, fReturnAllSteps, fReturnLastStep);
+      integrationInstance.ProcessGPUStep(*it, fReturnAllSteps, fReturnFirstAndLastStep);
     }
     async_adept_impl::CloseGPUBuffer(threadId, *fGPUstate, range.first, dataOnBuffer);
   }

--- a/include/AdePT/core/HostScoringImpl.cuh
+++ b/include/AdePT/core/HostScoringImpl.cuh
@@ -155,7 +155,7 @@ __device__ void RecordHit(HostScoring *hostScoring_dev, int aParentID, char aPar
                           vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin, double aPreCharge,
                           vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
                           vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                          double aPostCharge, unsigned int, short, bool)
+                          double aPostCharge, unsigned int, short, bool, bool)
 {
   // Acquire a hit slot
   GPUHit &aGPUHit = *GetNextFreeHit(hostScoring_dev);
@@ -163,7 +163,7 @@ __device__ void RecordHit(HostScoring *hostScoring_dev, int aParentID, char aPar
   // Fill the required data
   FillHit(aGPUHit, aParentID, aParticleType, aStepLength, aTotalEnergyDeposit, aPreState, aPrePosition,
           aPreMomentumDirection, aPreEKin, aPreCharge, aPostState, aPostPosition, aPostMomentumDirection, aPostEKin,
-          aPostCharge, 0, 0, false);
+          aPostCharge, 0, 0, false, false);
 }
 
 /// @brief Account for the number of produced secondaries

--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -691,7 +691,7 @@ __device__ void RecordHit(AsyncAdePT::PerEventScoring * /*scoring*/, int aParent
                           vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin, double aPreCharge,
                           vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
                           vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                          double aPostCharge, unsigned int eventID, short threadID, bool isLastStep)
+                          double aPostCharge, unsigned int eventID, short threadID, bool isLastStep, bool isFirstStep)
 {
   // Acquire a hit slot
   GPUHit &aGPUHit = AsyncAdePT::gHitScoringBuffer_dev.GetNextSlot(threadID);
@@ -699,7 +699,7 @@ __device__ void RecordHit(AsyncAdePT::PerEventScoring * /*scoring*/, int aParent
   // Fill the required data
   FillHit(aGPUHit, aParentID, aParticleType, aStepLength, aTotalEnergyDeposit, aPreState, aPrePosition,
           aPreMomentumDirection, aPreEKin, aPreCharge, aPostState, aPostPosition, aPostMomentumDirection, aPostEKin,
-          aPostCharge, eventID, threadID, isLastStep);
+          aPostCharge, eventID, threadID, isLastStep, isLastStep);
 }
 
 /// @brief Account for the number of produced secondaries

--- a/include/AdePT/core/ScoringCommons.hh
+++ b/include/AdePT/core/ScoringCommons.hh
@@ -32,6 +32,7 @@ struct GPUHit {
   unsigned int fEventId{0};
   short threadId{-1};
   // bool fFirstStepInVolume{false};
+  bool fFirstStepOfTrack{false};
   bool fLastStepOfTrack{false};
   char fParticleType{0}; // Particle type ID
 };
@@ -74,12 +75,14 @@ __device__ __forceinline__ void FillHit(GPUHit &aGPUHit, int aParentID, char aPa
                                         double aPreCharge, vecgeom::NavigationState const &aPostState,
                                         vecgeom::Vector3D<Precision> const &aPostPosition,
                                         vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                                        double aPostCharge, unsigned int eventID, short threadID, bool isLastStep)
+                                        double aPostCharge, unsigned int eventID, short threadID, bool isLastStep,
+                                        bool isFirstStep)
 {
   aGPUHit.fEventId = eventID;
   aGPUHit.threadId = threadID;
 
-  aGPUHit.fLastStepOfTrack = isLastStep;
+  aGPUHit.fFirstStepOfTrack = isFirstStep;
+  aGPUHit.fLastStepOfTrack  = isLastStep;
   // Fill the required data
   aGPUHit.fParentID           = aParentID;
   aGPUHit.fParticleType       = aParticleType;

--- a/include/AdePT/integration/AdePTConfigurationMessenger.hh
+++ b/include/AdePT/integration/AdePTConfigurationMessenger.hh
@@ -38,7 +38,7 @@ private:
   G4UIcmdWithAnInteger *fSetFinishOnCpuCmd;
   G4UIcmdWithABool *fSetTrackInAllRegionsCmd;
   G4UIcmdWithABool *fSetCallUserSteppingActionCmd;
-  G4UIcmdWithABool *fSetCallPostUserTrackingActionCmd;
+  G4UIcmdWithABool *fSetCallUserTrackingActionCmd;
   G4UIcmdWithABool *fSetSpeedOfLightCmd;
   G4UIcmdWithAString *fAddRegionCmd;
   G4UIcmdWithABool *fActivateAdePTCmd;

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -55,7 +55,7 @@ public:
 
   /// @brief Reconstructs GPU hits on host and calls the user-defined sensitive detector code
   void ProcessGPUStep(GPUHit const &hit, bool const callUserSteppingAction = false,
-                      bool const callPostUserTrackingaction = false);
+                      bool const callUserTrackingaction = false);
 
   /// @brief Takes a range of tracks coming from the device and gives them back to Geant4
   template <typename Iterator>

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -654,6 +654,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     }
 
     if (stopped) {
+      eKin = 0;
       if (!IsElectron) {
         // Annihilate the stopped positron into two gammas heading to opposite
         // directions (isotropic).
@@ -711,21 +712,22 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     // Record the step. Edep includes the continuous energy loss and edep from secondaries which were cut
     if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep)
       adept_scoring::RecordHit(userScoring, currentTrack.parentId,
-                               static_cast<char>(IsElectron ? 0 : 1),       // Particle type
-                               elTrack.GetPStepLength(),                    // Step length
-                               energyDeposit,                               // Total Edep
-                               navState,                                    // Pre-step point navstate
-                               preStepPos,                                  // Pre-step point position
-                               preStepDir,                                  // Pre-step point momentum direction
-                               preStepEnergy,                               // Pre-step point kinetic energy
-                               IsElectron ? -1 : 1,                         // Pre-step point charge
-                               nextState,                                   // Post-step point navstate
-                               pos,                                         // Post-step point position
-                               dir,                                         // Post-step point momentum direction
-                               eKin,                                        // Post-step point kinetic energy
-                               IsElectron ? -1 : 1,                         // Post-step point charge
-                               currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                               returnLastStep);                             // whether this was the last step
+                               static_cast<char>(IsElectron ? 0 : 1),         // Particle type
+                               elTrack.GetPStepLength(),                      // Step length
+                               energyDeposit,                                 // Total Edep
+                               navState,                                      // Pre-step point navstate
+                               preStepPos,                                    // Pre-step point position
+                               preStepDir,                                    // Pre-step point momentum direction
+                               preStepEnergy,                                 // Pre-step point kinetic energy
+                               IsElectron ? -1 : 1,                           // Pre-step point charge
+                               nextState,                                     // Post-step point navstate
+                               pos,                                           // Post-step point position
+                               dir,                                           // Post-step point momentum direction
+                               eKin,                                          // Post-step point kinetic energy
+                               IsElectron ? -1 : 1,                           // Post-step point charge
+                               currentTrack.eventId, currentTrack.threadId,   // eventID and threadID
+                               returnLastStep,                                // whether this was the last step
+                               currentTrack.stepCounter == 1 ? true : false); // whether this was the first step
     if (cross_boundary) {
       // Move to the next boundary now that the Step is recorded
       navState = nextState;

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -195,7 +195,6 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
 
 #ifdef ADEPT_USE_SURF
         AdePTNavigator::RelocateToNextVolume(pos, dir, hitsurf_index, nextState);
-        if (nextState.IsOutside()) continue;
 #else
         AdePTNavigator::RelocateToNextVolume(pos, dir, nextState);
 #endif
@@ -216,10 +215,12 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                    nextState,                                   // Post-step point navstate
                                    pos,                                         // Post-step point position
                                    dir,                                         // Post-step point momentum direction
-                                   0,                                           // Post-step point kinetic energy
+                                   eKin,                                        // Post-step point kinetic energy
                                    0,                                           // Post-step point charge
                                    currentTrack.eventId, currentTrack.threadId, // event and thread ID
-                                   returnLastStep); // whether this is the last step of the track
+                                   returnLastStep,
+                                   currentTrack.stepCounter == 1 ? true
+                                                                 : false); // whether this is the last step of the track
 
         // Move to the next boundary.
         navState = nextState;
@@ -266,10 +267,11 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                    nextState,                                   // Post-step point navstate
                                    pos,                                         // Post-step point position
                                    dir,                                         // Post-step point momentum direction
-                                   0,                                           // Post-step point kinetic energy
+                                   eKin,                                        // Post-step point kinetic energy
                                    0,                                           // Post-step point charge
                                    currentTrack.eventId, currentTrack.threadId, // event and thread ID
-                                   returnLastStep); // whether this is the last step of the track
+                                   returnLastStep, // whether this is the last step of the track
+                                   currentTrack.stepCounter == 1 ? true : false); // whether this is the first step
       }
       continue;
     } else {
@@ -485,7 +487,8 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                newEnergyGamma,                              // Post-step point kinetic energy
                                0,                                           // Post-step point charge
                                currentTrack.eventId, currentTrack.threadId, // event and thread ID
-                               returnLastStep); // whether this is the last step of the track
+                               returnLastStep, // whether this is the last step of the track
+                               currentTrack.stepCounter == 1 ? true : false); // whether this is the first step
     }
   }
 }

--- a/src/AdePTConfigurationMessenger.cc
+++ b/src/AdePTConfigurationMessenger.cc
@@ -20,6 +20,7 @@
 AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *adeptConfiguration)
     : G4UImessenger(), fAdePTConfiguration(adeptConfiguration)
 {
+  std::cout << " CALLING CONFIGURATIONMESSENGER CONSTRUCTOR " << std::endl;
   fDir = new G4UIdirectory("/adept/");
   fDir->SetGuidance("adept configuration messenger");
 
@@ -33,13 +34,8 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
       "secondary before the primary has finished its track."
       " NOTE: This means that every single step is recorded on GPU and send back to CPU, which can impact performance");
 
-  fSetCallPostUserTrackingActionCmd = new G4UIcmdWithABool("/adept/CallPostUserTrackingAction", this);
-  fSetCallPostUserTrackingActionCmd->SetGuidance(
-      "If true, the PostUserTrackingAction is called for on every track. NOTE: This "
-      "means that the last step of every track is recorded on GPU and send back to CPU");
-
-  fSetCallPostUserTrackingActionCmd = new G4UIcmdWithABool("/adept/CallPostUserTrackingAction", this);
-  fSetCallPostUserTrackingActionCmd->SetGuidance(
+  fSetCallUserTrackingActionCmd = new G4UIcmdWithABool("/adept/CallUserTrackingAction", this);
+  fSetCallUserTrackingActionCmd->SetGuidance(
       "If true, the PostUserTrackingAction is called for on every track. NOTE: This "
       "means that the last step of every track is recorded on GPU and send back to CPU");
 
@@ -104,12 +100,13 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
 
 AdePTConfigurationMessenger::~AdePTConfigurationMessenger()
 {
+  std::cout << " CALLING CONFIGURATIONMESSENGER DESTRUCTOR" << std::endl;
   delete fDir;
   delete fSetCUDAStackLimitCmd;
   delete fSetCUDAHeapLimitCmd;
   delete fSetTrackInAllRegionsCmd;
   delete fSetCallUserSteppingActionCmd;
-  delete fSetCallPostUserTrackingActionCmd;
+  delete fSetCallUserTrackingActionCmd;
   delete fAddRegionCmd;
   delete fActivateAdePTCmd;
   delete fSetVerbosityCmd;
@@ -133,8 +130,8 @@ void AdePTConfigurationMessenger::SetNewValue(G4UIcommand *command, G4String new
     fAdePTConfiguration->SetTrackInAllRegions(fSetTrackInAllRegionsCmd->GetNewBoolValue(newValue));
   } else if (command == fSetCallUserSteppingActionCmd) {
     fAdePTConfiguration->SetCallUserSteppingAction(newValue);
-  } else if (command == fSetCallPostUserTrackingActionCmd) {
-    fAdePTConfiguration->SetCallPostUserTrackingAction(newValue);
+  } else if (command == fSetCallUserTrackingActionCmd) {
+    fAdePTConfiguration->SetCallUserTrackingAction(newValue);
   } else if (command == fSetSpeedOfLightCmd) {
     fAdePTConfiguration->SetSpeedOfLightCmd(newValue);
   } else if (command == fAddRegionCmd) {

--- a/src/AdePTConfigurationMessenger.cc
+++ b/src/AdePTConfigurationMessenger.cc
@@ -20,7 +20,6 @@
 AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *adeptConfiguration)
     : G4UImessenger(), fAdePTConfiguration(adeptConfiguration)
 {
-  std::cout << " CALLING CONFIGURATIONMESSENGER CONSTRUCTOR " << std::endl;
   fDir = new G4UIdirectory("/adept/");
   fDir->SetGuidance("adept configuration messenger");
 
@@ -100,7 +99,6 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
 
 AdePTConfigurationMessenger::~AdePTConfigurationMessenger()
 {
-  std::cout << " CALLING CONFIGURATIONMESSENGER DESTRUCTOR" << std::endl;
   delete fDir;
   delete fSetCUDAStackLimitCmd;
   delete fSetCUDAHeapLimitCmd;


### PR DESCRIPTION
This PR fixes multiple issues:

Now, the `PreUserTrackingAction` is also called. The Flag is renamed from `/adept/CallPostUserSteppingAction` to `/adept/CallUserSteppingAction`. Note, since we currently do not pass the steps done in G4 to the GPU, this works only if we track everywhere.

An early return for if nextstate outside was removed from the gamma kernel as it is needed to calculate the energy leak.
The ekin is set correctly for leaking positrons. The ekin is corrected for stopped electrons.