### PR TITLE
Mini cleaning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,6 @@ option(ADEPT_USE_SURF_SINGLE "Use surface model in single precision" OFF)
 option(USE_SPLIT_KERNELS "Run split version of the transport kernels" OFF)
 option(ADEPT_USE_EXT_BFIELD "Use external B field from file via the covfie library" OFF)
 option(DEBUG_SINGLE_THREAD "Run transport kernels in single thread mode" OFF)
-option(WITH_FLUCT "Switch on the energy loss fluctuations" OFF)
 
 #----------------------------------------------------------------------------#
 # Dependencies
@@ -226,10 +225,6 @@ add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe;--diag_suppress=unrecog
 find_package(G4HepEm CONFIG REQUIRED)
 if(G4HepEm_FOUND)
   message(STATUS "G4HepEm found ${G4HepEm_INCLUDE_DIR}")
-endif()
-
-if(NOT WITH_FLUCT)
-  add_compile_definitions(NOFLUCTUATION)
 endif()
 
 #----------------------------------------------------------------------------#

--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <thread>
 #include <condition_variable>
+#include <sstream>
 
 #include <cub/device/device_merge_sort.cuh>
 


### PR DESCRIPTION
This mini PR removes an unused CMake option and adds an include. If run with an older VecGeom version, the include was missing and the code wouldn't compile.