### PR TITLE
Propagating track weight inside AdePT

### DIFF
--- a/include/AdePT/core/AdePTTransport.cuh
+++ b/include/AdePT/core/AdePTTransport.cuh
@@ -162,6 +162,8 @@ __global__ void InitTracks(adeptint::TrackData *trackinfo, int ntracks, int star
     track.localTime  = trackinfo[i].localTime;
     track.properTime = trackinfo[i].properTime;
 
+    track.weight = trackinfo[i].weight;
+
     track.originNavState.Clear();
     track.originNavState = trackinfo[i].originNavState;
 

--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -45,8 +45,8 @@ public:
   void AddTrack(int pdg, int parentId, double energy, double vertexEnergy, double x, double y, double z, double dirx,
                 double diry, double dirz, double vertexX, double vertexY, double vertexZ, double vertexDirx,
                 double vertexDiry, double vertexDirz, double globalTime, double localTime, double properTime,
-                int threadId, unsigned int eventId, unsigned int trackIndex, vecgeom::NavigationState &&state,
-                vecgeom::NavigationState &&originState);
+                float weight, int threadId, unsigned int eventId, unsigned int trackIndex,
+                vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState);
 
   void SetTrackCapacity(size_t capacity) { fCapacity = capacity; }
   /// @brief Get the track capacity on GPU

--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -98,14 +98,17 @@ bool AdePTTransport<IntegrationLayer>::InitializeApplyCuts(bool applycuts)
 }
 
 template <typename IntegrationLayer>
-void AdePTTransport<IntegrationLayer>::AddTrack(
-    int pdg, int parent_id, double energy, double vertexEnergy, double x, double y, double z, double dirx, double diry,
-    double dirz, double vertexX, double vertexY, double vertexZ, double vertexDirx, double vertexDiry,
-    double vertexDirz, double globalTime, double localTime, double properTime, int /*threadId*/, unsigned int eventId,
-    unsigned int /*trackIndex*/, vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState)
+void AdePTTransport<IntegrationLayer>::AddTrack(int pdg, int parent_id, double energy, double vertexEnergy, double x,
+                                                double y, double z, double dirx, double diry, double dirz,
+                                                double vertexX, double vertexY, double vertexZ, double vertexDirx,
+                                                double vertexDiry, double vertexDirz, double globalTime,
+                                                double localTime, double properTime, float weight, int /*threadId*/,
+                                                unsigned int eventId, unsigned int /*trackIndex*/,
+                                                vecgeom::NavigationState &&state,
+                                                vecgeom::NavigationState &&originState)
 {
   fBuffer.toDevice.emplace_back(pdg, parent_id, energy, vertexEnergy, x, y, z, dirx, diry, dirz, vertexX, vertexY,
-                                vertexZ, vertexDirx, vertexDiry, vertexDirz, globalTime, localTime, properTime,
+                                vertexZ, vertexDirx, vertexDiry, vertexDirz, globalTime, localTime, properTime, weight,
                                 std::move(state), std::move(originState));
   if (pdg == 11)
     fBuffer.nelectrons++;

--- a/include/AdePT/core/AdePTTransportInterface.hh
+++ b/include/AdePT/core/AdePTTransportInterface.hh
@@ -20,7 +20,7 @@ public:
   virtual void AddTrack(int pdg, int parentId, double energy, double vertexEnergy, double x, double y, double z,
                         double dirx, double diry, double dirz, double vertexX, double vertexY, double vertexZ,
                         double vertexDirx, double vertexDiry, double vertexDirz, double globalTime, double localTime,
-                        double properTime, int threadId, unsigned int eventId, unsigned int trackIndex,
+                        double properTime, float weight, int threadId, unsigned int eventId, unsigned int trackIndex,
                         vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState) = 0;
 
   /// @brief Set capacity of on-GPU track buffer.

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -106,8 +106,8 @@ __global__ void InjectTracks(AsyncAdePT::TrackDataWithIDs *trackinfo, int ntrack
     Track &track    = generator->InitTrack(
         slot, initialSeed * trackInfo.eventId + trackInfo.trackId, trackInfo.eKin, trackInfo.vertexEkin,
         trackInfo.globalTime, static_cast<float>(trackInfo.localTime), static_cast<float>(trackInfo.properTime),
-        trackInfo.position, trackInfo.direction, trackInfo.vertexPosition, trackInfo.vertexMomentumDirection,
-        trackInfo.eventId, trackInfo.parentId, trackInfo.threadId);
+        trackInfo.weight, trackInfo.position, trackInfo.direction, trackInfo.vertexPosition,
+        trackInfo.vertexMomentumDirection, trackInfo.eventId, trackInfo.parentId, trackInfo.threadId);
     track.navState.Clear();
     track.navState       = trackinfo[i].navState;
     track.originNavState = trackinfo[i].originNavState;
@@ -227,6 +227,7 @@ __global__ void FillFromDeviceBuffer(AllLeaked all, AsyncAdePT::TrackDataWithIDs
       fromDevice[i].globalTime                 = track->globalTime;
       fromDevice[i].localTime                  = track->localTime;
       fromDevice[i].properTime                 = track->properTime;
+      fromDevice[i].weight                     = track->weight;
       fromDevice[i].pdg                        = pdg;
       fromDevice[i].eventId                    = track->eventId;
       fromDevice[i].threadId                   = track->threadId;

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -89,8 +89,8 @@ public:
   void AddTrack(int pdg, int parentId, double energy, double vertexEnergy, double x, double y, double z, double dirx,
                 double diry, double dirz, double vertexX, double vertexY, double vertexZ, double vertexDirx,
                 double vertexDiry, double vertexDirz, double globalTime, double localTime, double properTime,
-                int threadId, unsigned int eventId, unsigned int trackIndex, vecgeom::NavigationState &&state,
-                vecgeom::NavigationState &&originState) override;
+                float weight, int threadId, unsigned int eventId, unsigned int trackIndex,
+                vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState) override;
   /// @brief Set track capacity on GPU
   void SetTrackCapacity(size_t capacity) override { fTrackCapacity = capacity; }
   /// @brief Set Hit buffer capacity on GPU and Host

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -115,11 +115,14 @@ AsyncAdePTTransport<IntegrationLayer>::~AsyncAdePTTransport()
 }
 
 template <typename IntegrationLayer>
-void AsyncAdePTTransport<IntegrationLayer>::AddTrack(
-    int pdg, int parentId, double energy, double vertexEnergy, double x, double y, double z, double dirx, double diry,
-    double dirz, double vertexX, double vertexY, double vertexZ, double vertexDirx, double vertexDiry,
-    double vertexDirz, double globalTime, double localTime, double properTime, int threadId, unsigned int eventId,
-    unsigned int trackId, vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState)
+void AsyncAdePTTransport<IntegrationLayer>::AddTrack(int pdg, int parentId, double energy, double vertexEnergy,
+                                                     double x, double y, double z, double dirx, double diry,
+                                                     double dirz, double vertexX, double vertexY, double vertexZ,
+                                                     double vertexDirx, double vertexDiry, double vertexDirz,
+                                                     double globalTime, double localTime, double properTime,
+                                                     float weight, int threadId, unsigned int eventId,
+                                                     unsigned int trackId, vecgeom::NavigationState &&state,
+                                                     vecgeom::NavigationState &&originState)
 {
   if (pdg != 11 && pdg != -11 && pdg != 22) {
     G4cerr << __FILE__ << ":" << __LINE__ << ": Only supporting EM tracks. Got pdgID=" << pdg << "\n";
@@ -145,6 +148,7 @@ void AsyncAdePTTransport<IntegrationLayer>::AddTrack(
                          globalTime,
                          localTime,
                          properTime,
+                         weight,
                          std::move(state),
                          std::move(originState),
                          eventId,

--- a/include/AdePT/core/CommonStruct.h
+++ b/include/AdePT/core/CommonStruct.h
@@ -95,7 +95,7 @@ struct TrackDataWithIDs : public adeptint::TrackData {
 
   TrackDataWithIDs(int pdg_id, int parentId, double ene, double vertexEne, double x, double y, double z, double dirx,
                    double diry, double dirz, double vertexX, double vertexY, double vertexZ, double vertexDirx,
-                   double vertexDiry, double vertexDirz, double gTime, double lTime, double pTime,
+                   double vertexDiry, double vertexDirz, double gTime, double lTime, double pTime, float weight,
                    vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState, unsigned int eventId = 0,
                    unsigned int trackId = 0, short threadId = -1)
       : TrackData{pdg_id,
@@ -117,6 +117,7 @@ struct TrackDataWithIDs : public adeptint::TrackData {
                   gTime,
                   lTime,
                   pTime,
+                  weight,
                   std::move(state),
                   std::move(originState)},
         eventId{eventId}, trackId{trackId}, threadId{threadId}

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -23,12 +23,13 @@ struct Track {
   RanluxppDouble rngState;
   double eKin{0.};
   double vertexEkin{0.};
+  double globalTime{0.};
+
+  float weight{0.};
   float numIALeft[4]{-1.f, -1.f, -1.f, -1.f};
   float initialRange{-1.f};
   float dynamicRangeFactor{-1.f};
   float tlimitMin{-1.f};
-
-  double globalTime{0.};
   float localTime{0.f};
   float properTime{0.f};
 
@@ -71,10 +72,12 @@ struct Track {
   /// Construct a new track for GPU transport.
   /// NB: The navState remains uninitialised.
   __device__ Track(uint64_t rngSeed, double eKin, double vertexEkin, double globalTime, float localTime,
-                   float properTime, double const position[3], double const direction[3], double const vertexPos[3],
-                   double const vertexDir[3], unsigned int eventId, int parentId, short threadId)
-      : eKin{eKin}, vertexEkin{vertexEkin}, globalTime{globalTime}, localTime{localTime}, properTime{properTime},
-        eventId{eventId}, parentId{parentId}, threadId{threadId}, stepCounter{0}, looperCounter{0}
+                   float properTime, float weight, double const position[3], double const direction[3],
+                   double const vertexPos[3], double const vertexDir[3], unsigned int eventId, int parentId,
+                   short threadId)
+      : eKin{eKin}, vertexEkin{vertexEkin}, weight{weight}, globalTime{globalTime}, localTime{localTime},
+        properTime{properTime}, eventId{eventId}, parentId{parentId}, threadId{threadId}, stepCounter{0},
+        looperCounter{0}
   {
     rngState.SetSeed(rngSeed);
     pos                     = {position[0], position[1], position[2]};
@@ -90,8 +93,8 @@ struct Track {
                    const Track &parentTrack)
       : rngState{rngState}, eKin{eKin}, globalTime{parentTrack.globalTime}, pos{parentPos}, dir{newDirection},
         navState{newNavState}, originNavState{newNavState}, eventId{parentTrack.eventId},
-        parentId{parentTrack.parentId}, threadId{parentTrack.threadId}, vertexEkin{eKin}, vertexPosition{parentPos},
-        vertexMomentumDirection{newDirection}, stepCounter{0}, looperCounter{0}
+        parentId{parentTrack.parentId}, threadId{parentTrack.threadId}, vertexEkin{eKin}, weight{parentTrack.weight},
+        vertexPosition{parentPos}, vertexMomentumDirection{newDirection}, stepCounter{0}, looperCounter{0}
   {
   }
 
@@ -147,6 +150,8 @@ struct Track {
     this->vertexPosition = parentPos;
     // Caller is responsible to set the vertex momentum direction and ekin
 
+    // Caller is responsible to set the weight of the track
+
     // The global time is inherited from the parent
     this->globalTime = gTime;
     this->localTime  = 0.;
@@ -179,6 +184,7 @@ struct Track {
     tdata.navState                   = navState;
     tdata.originNavState             = originNavState;
     tdata.vertexEkin                 = vertexEkin;
+    tdata.weight                     = weight;
   }
 };
 #endif

--- a/include/AdePT/core/TrackData.h
+++ b/include/AdePT/core/TrackData.h
@@ -25,18 +25,19 @@ struct TrackData {
   double globalTime{0};
   double localTime{0};
   double properTime{0};
+  float weight{0};
   int pdg{0};
   int parentId{0};
 
   TrackData() = default;
   TrackData(int pdg_id, int parentId, double ene, double vertexEne, double x, double y, double z, double dirx,
             double diry, double dirz, double vertexX, double vertexY, double vertexZ, double vertexDirx,
-            double vertexDiry, double vertexDirz, double gTime, double lTime, double pTime,
+            double vertexDiry, double vertexDirz, double gTime, double lTime, double pTime, float weight,
             vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState)
       : navState{std::move(state)}, originNavState{std::move(originState)}, position{x, y, z},
         vertexPosition{vertexX, vertexY, vertexZ}, direction{dirx, diry, dirz},
         vertexMomentumDirection{vertexDirx, vertexDiry, vertexDirz}, eKin{ene}, vertexEkin{vertexEne},
-        globalTime{gTime}, localTime{lTime}, properTime{pTime}, pdg{pdg_id}, parentId{parentId}
+        globalTime{gTime}, localTime{lTime}, properTime{pTime}, weight{weight}, pdg{pdg_id}, parentId{parentId}
   {
   }
 

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -515,6 +515,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
             secondary.parentId = currentTrack.parentId;
             secondary.rngState = newRNG;
             secondary.eKin = secondary.vertexEkin = deltaEkin;
+            secondary.weight                      = currentTrack.weight;
             secondary.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
             secondary.vertexMomentumDirection.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
 #endif
@@ -566,6 +567,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
             gamma.parentId = currentTrack.parentId;
             gamma.rngState = newRNG;
             gamma.eKin = gamma.vertexEkin = deltaEkin;
+            gamma.weight                  = currentTrack.weight;
             gamma.dir.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
             gamma.vertexMomentumDirection.Set(dirSecondary[0], dirSecondary[1], dirSecondary[2]);
 
@@ -616,6 +618,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
             gamma1.parentId = currentTrack.parentId;
             gamma1.rngState = newRNG;
             gamma1.eKin = gamma1.vertexEkin = theGamma1Ekin;
+            gamma1.weight                   = currentTrack.weight;
             gamma1.dir.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
             gamma1.vertexMomentumDirection.Set(theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]);
 #endif
@@ -638,6 +641,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
             gamma2.parentId = currentTrack.parentId;
             gamma2.rngState = currentTrack.rngState;
             gamma2.eKin = gamma2.vertexEkin = theGamma2Ekin;
+            gamma2.weight                   = currentTrack.weight;
             gamma2.dir.Set(theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]);
             gamma2.vertexMomentumDirection.Set(theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]);
 #endif
@@ -690,6 +694,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
           gamma1.parentId = currentTrack.parentId;
           gamma1.rngState = newRNG;
           gamma1.eKin = gamma1.vertexEkin = copcore::units::kElectronMassC2;
+          gamma1.weight                   = currentTrack.weight;
           gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);
           gamma1.vertexMomentumDirection.Set(sint * cosPhi, sint * sinPhi, cost);
 
@@ -698,6 +703,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
           gamma2.parentId = currentTrack.parentId;
           gamma2.rngState = currentTrack.rngState;
           gamma2.eKin = gamma2.vertexEkin = copcore::units::kElectronMassC2;
+          gamma2.weight                   = currentTrack.weight;
           gamma2.dir                      = -gamma1.dir;
           gamma2.vertexMomentumDirection  = -gamma1.dir;
 #endif

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -334,6 +334,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         electron.parentId = currentTrack.parentId;
         electron.rngState = newRNG;
         electron.eKin = electron.vertexEkin = elKinEnergy;
+        electron.weight                     = currentTrack.weight;
         electron.dir.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
         electron.vertexMomentumDirection.Set(dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]);
 #endif
@@ -355,6 +356,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         positron.parentId = currentTrack.parentId;
         positron.rngState = currentTrack.rngState;
         positron.eKin = positron.vertexEkin = posKinEnergy;
+        positron.weight                     = currentTrack.weight;
         positron.dir.Set(dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]);
         positron.vertexMomentumDirection.Set(dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]);
 #endif
@@ -396,6 +398,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         electron.parentId = currentTrack.parentId;
         electron.rngState = newRNG;
         electron.eKin = electron.vertexEkin = energyEl;
+        electron.weight                     = currentTrack.weight;
         electron.dir = electron.vertexMomentumDirection = eKin * dir - newEnergyGamma * newDirGamma;
 #endif
 
@@ -448,6 +451,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         electron.parentId = currentTrack.parentId;
         electron.rngState = newRNG;
         electron.eKin = electron.vertexEkin = photoElecE;
+        electron.weight                     = currentTrack.weight;
         electron.dir.Set(dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]);
         electron.vertexMomentumDirection.Set(dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]);
 #endif

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -610,6 +610,9 @@ void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsig
   secondary->SetProperTime(track.properTime);
   secondary->SetParentID(track.parentId);
 
+  // Set weight
+  secondary->SetWeight(track.weight);
+
   // Set vertex information
   secondary->SetVertexPosition(
       G4ThreeVector(track.vertexPosition[0], track.vertexPosition[1], track.vertexPosition[2]));

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -232,6 +232,7 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
       G4double globalTime    = aTrack->GetGlobalTime();
       G4double localTime     = aTrack->GetLocalTime();
       G4double properTime    = aTrack->GetProperTime();
+      G4double weight        = aTrack->GetWeight();
       auto pdg               = aTrack->GetParticleDefinition()->GetPDGEncoding();
       int id                 = aTrack->GetTrackID();
       if (fCurrentEventID != eventID) {
@@ -273,7 +274,7 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
       fAdeptTransport->AddTrack(pdg, id, energy, vertexEnergy, particlePosition[0], particlePosition[1],
                                 particlePosition[2], particleDirection[0], particleDirection[1], particleDirection[2],
                                 vertexPosition[0], vertexPosition[1], vertexPosition[2], vertexDirection[0],
-                                vertexDirection[1], vertexDirection[2], globalTime, localTime, properTime,
+                                vertexDirection[1], vertexDirection[2], globalTime, localTime, properTime, weight,
                                 G4Threading::G4GetThreadId(), eventID, fTrackCounter++, std::move(converted),
                                 std::move(convertedOrigin));
 


### PR DESCRIPTION
Part of the modifications required to run AdePT in ATLAS Athena, mirrors this change in G4HepEM: https://github.com/mnovak42/g4hepem/pull/108/commits/0d57bd8b4f6dfb9a73052689bd54338e377d6fe4

`CMS2018, 32 TTbar, 8 Threads, Transport on full detector`

|        | Sync    | Async   |
|--------|---------|---------|
| Master | 291.489 | 151.281 |
| New    | 290.848 | 151.887 |
