### PR TITLE
This adapts to compacting the cuda  VecGeom library into the main one

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,11 +256,10 @@ target_include_directories(AdePT_G4_integration
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/>
 )
 
-target_link_libraries(AdePT_G4_integration
+cuda_rdc_target_link_libraries(AdePT_G4_integration
   PUBLIC
     CopCore
     VecGeom::vecgeom
-    VecGeom::vecgeomcuda_static
     VecGeom::vgdml
     ${Geant4_LIBRARIES}
     G4HepEm::g4HepEm

--- a/test/testField/CMakeLists.txt
+++ b/test/testField/CMakeLists.txt
@@ -31,11 +31,10 @@ target_include_directories(testField
     $<BUILD_INTERFACE:${Geant4_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${G4HepEm_INCLUDE_DIR}>
 )
-target_link_libraries(testField
+cuda_rdc_target_link_libraries(testField
   PRIVATE
     CopCore
     VecGeom::vecgeom
-    VecGeom::vecgeomcuda_static
     VecGeom::vgdml
     ${Geant4_LIBRARIES}
     ${G4HepEm_LIBRARIES}


### PR DESCRIPTION
The MR https://gitlab.cern.ch/VecGeom/VecGeom/-/merge_requests/1296 makes a single VecGeom library, based on cuda_rdc in case of CUDA support. The default mode also changes from static to shared libraries. This PR adapts AdePT to this change and requires a VecGeojm shared libs build.

So this should not be merged until https://gitlab.cern.ch/VecGeom/VecGeom/-/merge_requests/1296  is merged AND the AdePT CI uses it.