### PR TITLE
Upgrade to latest g4hepem

### DIFF
--- a/include/AdePT/core/AdePTTransport.cuh
+++ b/include/AdePT/core/AdePTTransport.cuh
@@ -61,7 +61,6 @@ inline __constant__ __device__ struct G4HepEmParameters g4HepEmPars;
 inline __constant__ __device__ struct G4HepEmData g4HepEmData;
 
 inline __constant__ __device__ adeptint::VolAuxData *gVolAuxData = nullptr;
-inline __constant__ __device__ bool ApplyCuts                    = false;
 
 bool InitializeVolAuxArray(adeptint::VolAuxArray &array)
 {
@@ -132,13 +131,6 @@ G4HepEmState *InitG4HepEm(G4HepEmConfig *hepEmConfig)
   COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(g4HepEmData, &dataOnDevice, sizeof(G4HepEmData)));
 
   return state;
-}
-
-bool InitializeApplyCuts(bool applycuts)
-{
-  // Initialize ApplyCut
-  COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(ApplyCuts, &applycuts, sizeof(bool)));
-  return true;
 }
 
 // Kernel function to initialize tracks comming from a Geant4 buffer

--- a/include/AdePT/core/AdePTTransport.cuh
+++ b/include/AdePT/core/AdePTTransport.cuh
@@ -172,9 +172,9 @@ __global__ void InitTracks(adeptint::TrackData *trackinfo, int ntracks, int star
     track.numIALeft[2] = -1.0;
     track.numIALeft[3] = -1.0;
 
-    track.initialRange       = -1.0;
-    track.dynamicRangeFactor = -1.0;
-    track.tlimitMin          = -1.0;
+    track.initialRange       = 1.0e+21;
+    track.dynamicRangeFactor = 0.04;
+    track.tlimitMin          = 1.0E-7;
 
     track.pos                     = {trackinfo[i].position[0], trackinfo[i].position[1], trackinfo[i].position[2]};
     track.dir                     = {trackinfo[i].direction[0], trackinfo[i].direction[1], trackinfo[i].direction[2]};

--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -75,8 +75,6 @@ public:
   /// @brief Create material-cut couple index array
   /// @brief Initialize service and copy geometry & physics data on device
   void Initialize(G4HepEmConfig *hepEmConfig, bool common_data = false);
-  /// @brief Initializes the ApplyCut flag. Can only be called after G4 Physics is build
-  bool InitializeApplyCuts(bool applycuts);
   /// @brief Final cleanup
   void Cleanup();
   /// @brief Interface for transporting a buffer of tracks in AdePT.

--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -74,7 +74,7 @@ public:
   std::vector<std::string> const *GetGPURegionNames() { return fGPURegionNames; }
   /// @brief Create material-cut couple index array
   /// @brief Initialize service and copy geometry & physics data on device
-  void Initialize(bool common_data = false);
+  void Initialize(G4HepEmConfig *hepEmConfig, bool common_data = false);
   /// @brief Initializes the ApplyCut flag. Can only be called after G4 Physics is build
   bool InitializeApplyCuts(bool applycuts);
   /// @brief Final cleanup
@@ -112,7 +112,7 @@ private:
   bool InitializeBField();
   bool InitializeBField(UniformMagneticField &Bfield);
   bool InitializeGeometry(const vecgeom::cxx::VPlacedVolume *world);
-  bool InitializePhysics();
+  bool InitializePhysics(G4HepEmConfig *hepEmConfig);
 };
 
 #include "AdePTTransport.icc"

--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -28,7 +28,6 @@ template <typename FieldType>
 bool InitializeBField(FieldType &);
 template <typename FieldType>
 void FreeField();
-bool InitializeApplyCuts(bool);
 bool InitializeVolAuxArray(adeptint::VolAuxArray &);
 void FreeVolAuxArray(adeptint::VolAuxArray &);
 G4HepEmState *InitG4HepEm(G4HepEmConfig *hepEmConfig);
@@ -89,12 +88,6 @@ bool AdePTTransport<IntegrationLayer>::InitializeBField(UniformMagneticField &Bf
     return adept_impl::InitializeBField(Bfield);
   }
   return true; // no B field provided, but no error encountered, so true is returned
-}
-
-template <typename IntegrationLayer>
-bool AdePTTransport<IntegrationLayer>::InitializeApplyCuts(bool applycuts)
-{
-  return adept_impl::InitializeApplyCuts(applycuts);
 }
 
 template <typename IntegrationLayer>

--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -31,7 +31,7 @@ void FreeField();
 bool InitializeApplyCuts(bool);
 bool InitializeVolAuxArray(adeptint::VolAuxArray &);
 void FreeVolAuxArray(adeptint::VolAuxArray &);
-G4HepEmState *InitG4HepEm();
+G4HepEmState *InitG4HepEm(G4HepEmConfig *hepEmConfig);
 GPUstate *InitializeGPU(TrackBuffer &, int, int);
 AdeptScoring *InitializeScoringGPU(AdeptScoring *scoring);
 void CopySurfaceModelToGPU();
@@ -165,14 +165,14 @@ bool AdePTTransport<IntegrationLayer>::InitializeGeometry(const vecgeom::cxx::VP
 }
 
 template <typename IntegrationLayer>
-bool AdePTTransport<IntegrationLayer>::InitializePhysics()
+bool AdePTTransport<IntegrationLayer>::InitializePhysics(G4HepEmConfig *hepEmConfig)
 {
-  fg4hepem_state = adept_impl::InitG4HepEm();
+  fg4hepem_state = adept_impl::InitG4HepEm(hepEmConfig);
   return true;
 }
 
 template <typename IntegrationLayer>
-void AdePTTransport<IntegrationLayer>::Initialize(bool common_data)
+void AdePTTransport<IntegrationLayer>::Initialize(G4HepEmConfig *hepEmConfig, bool common_data)
 {
   if (fInit) return;
   if (fMaxBatch <= 0)
@@ -194,7 +194,7 @@ void AdePTTransport<IntegrationLayer>::Initialize(bool common_data)
       throw std::runtime_error("AdePTTransport<IntegrationLayer>::Initialize: Cannot initialize geometry on GPU");
 
     // Initialize G4HepEm
-    if (!InitializePhysics())
+    if (!InitializePhysics(hepEmConfig))
       throw std::runtime_error("AdePTTransport<IntegrationLayer>::Initialize cannot initialize physics on GPU");
 
 #ifdef ADEPT_USE_EXT_BFIELD

--- a/include/AdePT/core/AdePTTransportInterface.hh
+++ b/include/AdePT/core/AdePTTransportInterface.hh
@@ -6,6 +6,7 @@
 
 #include "G4VPhysicalVolume.hh"
 #include "VecGeom/navigation/NavigationState.h"
+#include <G4HepEmConfig.hh>
 
 #include <memory>
 #include <string>
@@ -46,7 +47,7 @@ public:
   virtual void SetCUDAStackLimit(int limit)                   = 0;
   virtual void SetCUDAHeapLimit(int limit)                    = 0;
   /// @brief Initialize service and copy geometry & physics data on device
-  virtual void Initialize(bool common_data = false) = 0;
+  virtual void Initialize(G4HepEmConfig *hepEmConfig, bool common_data = false) = 0;
   /// @brief Initialize the ApplyCuts flag on device
   virtual bool InitializeApplyCuts(bool applycuts) = 0;
   /// @brief Interface for transporting a buffer of tracks in AdePT.

--- a/include/AdePT/core/AdePTTransportInterface.hh
+++ b/include/AdePT/core/AdePTTransportInterface.hh
@@ -48,8 +48,6 @@ public:
   virtual void SetCUDAHeapLimit(int limit)                    = 0;
   /// @brief Initialize service and copy geometry & physics data on device
   virtual void Initialize(G4HepEmConfig *hepEmConfig, bool common_data = false) = 0;
-  /// @brief Initialize the ApplyCuts flag on device
-  virtual bool InitializeApplyCuts(bool applycuts) = 0;
   /// @brief Interface for transporting a buffer of tracks in AdePT.
   virtual void Shower(int event, int threadId)            = 0;
   virtual void Cleanup()                                  = 0;

--- a/include/AdePT/core/AdePTTransportStruct.cuh
+++ b/include/AdePT/core/AdePTTransportStruct.cuh
@@ -92,7 +92,6 @@ extern __constant__ struct G4HepEmParameters g4HepEmPars;
 extern __constant__ struct G4HepEmData g4HepEmData;
 
 extern __constant__ __device__ adeptint::VolAuxData *gVolAuxData;
-extern __constant__ __device__ bool ApplyCuts;
 #ifdef ADEPT_USE_EXT_BFIELD
 __device__ GeneralMagneticField *gMagneticField = nullptr;
 #else

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -32,12 +32,15 @@
 #include <VecGeom/surfaces/cuda/BrepCudaManager.h>
 #endif
 
-#include <G4HepEmState.hh>
 #include <G4HepEmData.hh>
 #include <G4HepEmState.hh>
 #include <G4HepEmStateInit.hh>
 #include <G4HepEmParameters.hh>
 #include <G4HepEmMatCutData.hh>
+#include <G4HepEmParametersInit.hh>
+#include <G4HepEmMaterialInit.hh>
+#include <G4HepEmElectronInit.hh>
+#include <G4HepEmGammaInit.hh>
 
 #include <iostream>
 #include <iomanip>
@@ -412,17 +415,38 @@ void CopySurfaceModelToGPU()
 #endif
 }
 
-G4HepEmState *InitG4HepEm()
+G4HepEmState *InitG4HepEm(G4HepEmConfig *hepEmConfig)
 {
+  // here we call everything from InitG4HepEmState, as we need to provide the parameters from the G4HepEmConfig and do
+  // not want to initialize to the default values
   auto state = new G4HepEmState;
-  InitG4HepEmState(state);
+
+  // Use the config-provided parameters
+  state->fParameters = hepEmConfig->GetG4HepEmParameters();
+
+  // Initialize data and fill each subtable using its initialize function
+  state->fData = new G4HepEmData;
+  InitG4HepEmData(state->fData);
+  InitMaterialAndCoupleData(state->fData, state->fParameters);
+
+  // electrons, positrons, gamma
+  InitElectronData(state->fData, state->fParameters, true);
+  InitElectronData(state->fData, state->fParameters, false);
+  InitGammaData(state->fData, state->fParameters);
 
   G4HepEmMatCutData *cutData = state->fData->fTheMatCutData;
   G4cout << "fNumG4MatCuts = " << cutData->fNumG4MatCuts << ", fNumMatCutData = " << cutData->fNumMatCutData << G4endl;
 
   // Copy to GPU.
   CopyG4HepEmDataToGPU(state->fData);
-  COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(g4HepEmPars, state->fParameters, sizeof(G4HepEmParameters)));
+  CopyG4HepEmParametersToGPU(state->fParameters);
+
+  // Create G4HepEmParameters with the device pointer
+  G4HepEmParameters parametersOnDevice        = *state->fParameters;
+  parametersOnDevice.fParametersPerRegion     = state->fParameters->fParametersPerRegion_gpu;
+  parametersOnDevice.fParametersPerRegion_gpu = nullptr;
+
+  COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(g4HepEmPars, &parametersOnDevice, sizeof(G4HepEmParameters)));
 
   // Create G4HepEmData with the device pointers.
   G4HepEmData dataOnDevice;
@@ -1218,6 +1242,7 @@ void FreeGPU(std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> 
 
   // Free G4HepEm data
   FreeG4HepEmData(g4hepem_state.fData);
+  FreeG4HepEmParametersOnGPU(g4hepem_state.fParameters);
 
   // Free magnetic field
 #ifdef ADEPT_USE_EXT_BFIELD

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -500,13 +500,6 @@ void FreeBField()
   }
 }
 
-bool InitializeApplyCuts(bool applycuts)
-{
-  // Initialize ApplyCut
-  COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(ApplyCuts, &applycuts, sizeof(bool)));
-  return true;
-}
-
 void FlushScoring(AdePTScoring &scoring)
 {
   scoring.CopyToHost();
@@ -1264,7 +1257,6 @@ __constant__ __device__ struct G4HepEmParameters g4HepEmPars;
 __constant__ __device__ struct G4HepEmData g4HepEmData;
 
 __constant__ __device__ adeptint::VolAuxData *gVolAuxData = nullptr;
-__constant__ __device__ bool ApplyCuts                    = false;
 
 /// Transfer volume auxiliary data to GPU
 void InitVolAuxArray(adeptint::VolAuxArray &array)

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -111,8 +111,6 @@ public:
   std::vector<std::string> const *GetGPURegionNames() override { return fGPURegionNames; }
   /// No effect
   void Initialize(G4HepEmConfig *hepEmConfig, bool) override {}
-  /// @brief Initializes the ApplyCut flag. Can only be called after G4 Physics is build
-  bool InitializeApplyCuts(bool applycuts);
   /// @brief Finish GPU transport, bring hits and tracks to host
   /// @details The shower call exists to maintain the same interface as the
   /// synchronous AdePT mode, since in this case the transport loop is always

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -73,15 +73,15 @@ private:
   ///< G4workers
   double fCPUCopyFraction{0.5};
 
-  void Initialize();
+  void Initialize(G4HepEmConfig *hepEmConfig);
   void InitBVH();
   bool InitializeBField();
   bool InitializeBField(UniformMagneticField &Bfield);
   bool InitializeGeometry(const vecgeom::cxx::VPlacedVolume *world);
-  bool InitializePhysics();
+  bool InitializePhysics(G4HepEmConfig *hepEmConfig);
 
 public:
-  AsyncAdePTTransport(AdePTConfiguration &configuration);
+  AsyncAdePTTransport(AdePTConfiguration &configuration, G4HepEmConfig *hepEmConfig);
   AsyncAdePTTransport(const AsyncAdePTTransport &other) = delete;
   ~AsyncAdePTTransport();
 
@@ -110,7 +110,7 @@ public:
   void SetCUDAHeapLimit(int limit) override {};
   std::vector<std::string> const *GetGPURegionNames() override { return fGPURegionNames; }
   /// No effect
-  void Initialize(bool) override {}
+  void Initialize(G4HepEmConfig *hepEmConfig, bool) override {}
   /// @brief Initializes the ApplyCut flag. Can only be called after G4 Physics is build
   bool InitializeApplyCuts(bool applycuts);
   /// @brief Finish GPU transport, bring hits and tracks to host

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -105,7 +105,7 @@ AsyncAdePTTransport<IntegrationLayer>::AsyncAdePTTransport(AdePTConfiguration &c
     std::atomic_init(&eventState, EventState::ScoringRetrieved);
   }
 
-  AsyncAdePTTransport::Initialize(hepEmConfig); // FIXME check if I can really comment this out as it is called later
+  AsyncAdePTTransport::Initialize(hepEmConfig);
 }
 
 template <typename IntegrationLayer>

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -48,7 +48,6 @@ template <typename FieldType>
 bool InitializeBField(FieldType &);
 template <typename FieldType>
 void FreeField();
-bool InitializeApplyCuts(bool applycuts);
 G4HepEmState *InitG4HepEm(G4HepEmConfig *hepEmConfig);
 void FlushScoring(AdePTScoring &);
 std::shared_ptr<const std::vector<GPUHit>> GetGPUHits(unsigned int, AsyncAdePT::GPUstate &);
@@ -201,12 +200,6 @@ bool AsyncAdePTTransport<IntegrationLayer>::InitializeBField(UniformMagneticFiel
     return async_adept_impl::InitializeBField(Bfield);
   }
   return true; // no B field provided, but no error encountered, so true is returned
-}
-
-template <typename IntegrationLayer>
-bool AsyncAdePTTransport<IntegrationLayer>::InitializeApplyCuts(bool applycuts)
-{
-  return async_adept_impl::InitializeApplyCuts(applycuts);
 }
 
 template <typename IntegrationLayer>

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -49,7 +49,7 @@ bool InitializeBField(FieldType &);
 template <typename FieldType>
 void FreeField();
 bool InitializeApplyCuts(bool applycuts);
-G4HepEmState *InitG4HepEm();
+G4HepEmState *InitG4HepEm(G4HepEmConfig *hepEmConfig);
 void FlushScoring(AdePTScoring &);
 std::shared_ptr<const std::vector<GPUHit>> GetGPUHits(unsigned int, AsyncAdePT::GPUstate &);
 std::pair<GPUHit *, GPUHit *> GetGPUHitsFromBuffer(unsigned int, unsigned int, AsyncAdePT::GPUstate &, bool &);
@@ -85,7 +85,8 @@ std::ostream &operator<<(std::ostream &stream, TrackDataWithIDs const &track)
 } // namespace
 
 template <typename IntegrationLayer>
-AsyncAdePTTransport<IntegrationLayer>::AsyncAdePTTransport(AdePTConfiguration &configuration)
+AsyncAdePTTransport<IntegrationLayer>::AsyncAdePTTransport(AdePTConfiguration &configuration,
+                                                           G4HepEmConfig *hepEmConfig)
     : fNThread{(ushort)configuration.GetNumThreads()},
       fTrackCapacity{(uint)(1024 * 1024 * configuration.GetMillionsOfTrackSlots())},
       fScoringCapacity{(uint)(1024 * 1024 * configuration.GetMillionsOfHitSlots())},
@@ -105,7 +106,7 @@ AsyncAdePTTransport<IntegrationLayer>::AsyncAdePTTransport(AdePTConfiguration &c
     std::atomic_init(&eventState, EventState::ScoringRetrieved);
   }
 
-  AsyncAdePTTransport::Initialize();
+  AsyncAdePTTransport::Initialize(hepEmConfig); // FIXME check if I can really comment this out as it is called later
 }
 
 template <typename IntegrationLayer>
@@ -250,15 +251,15 @@ bool AsyncAdePTTransport<IntegrationLayer>::InitializeGeometry(const vecgeom::cx
 }
 
 template <typename IntegrationLayer>
-bool AsyncAdePTTransport<IntegrationLayer>::InitializePhysics()
+bool AsyncAdePTTransport<IntegrationLayer>::InitializePhysics(G4HepEmConfig *hepEmConfig)
 {
   // Initialize shared physics data
-  fg4hepem_state.reset(async_adept_impl::InitG4HepEm());
+  fg4hepem_state.reset(async_adept_impl::InitG4HepEm(hepEmConfig));
   return true;
 }
 
 template <typename IntegrationLayer>
-void AsyncAdePTTransport<IntegrationLayer>::Initialize()
+void AsyncAdePTTransport<IntegrationLayer>::Initialize(G4HepEmConfig *hepEmConfig)
 {
   const auto numVolumes = vecgeom::GeoManager::Instance().GetRegisteredVolumesCount();
   if (numVolumes == 0) throw std::runtime_error("AsyncAdePTTransport::Initialize: Number of geometry volumes is zero.");
@@ -273,7 +274,7 @@ void AsyncAdePTTransport<IntegrationLayer>::Initialize()
     throw std::runtime_error("AsyncAdePTTransport::Initialize: Cannot initialize geometry on GPU");
 
   // Initialize G4HepEm
-  if (!InitializePhysics())
+  if (!InitializePhysics(hepEmConfig))
     throw std::runtime_error("AsyncAdePTTransport::Initialize cannot initialize physics on GPU");
 
   // Initialize field

--- a/include/AdePT/core/AsyncAdePTTransportStruct.cuh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.cuh
@@ -211,7 +211,6 @@ extern __constant__ __device__ struct G4HepEmData g4HepEmData;
 // Pointer for array of volume auxiliary data on device
 extern __constant__ __device__ adeptint::VolAuxData *gVolAuxData;
 
-extern __constant__ __device__ bool ApplyCuts;
 constexpr double kPush = 1.e-8 * copcore::units::cm;
 #ifdef ADEPT_USE_EXT_BFIELD
 __device__ GeneralMagneticField *gMagneticField = nullptr;

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -27,9 +27,11 @@ struct Track {
 
   float weight{0.};
   float numIALeft[4]{-1.f, -1.f, -1.f, -1.f};
-  float initialRange{-1.f};
-  float dynamicRangeFactor{-1.f};
-  float tlimitMin{-1.f};
+  // default values taken from G4HepEmMSCTrackData.hh
+  float initialRange{1.0e+21};
+  float dynamicRangeFactor{0.04};
+  float tlimitMin{1.0E-7};
+
   float localTime{0.f};
   float properTime{0.f};
 
@@ -132,9 +134,9 @@ struct Track {
     this->numIALeft[2] = -1.0;
     this->numIALeft[3] = -1.0;
 
-    this->initialRange       = -1.0;
-    this->dynamicRangeFactor = -1.0;
-    this->tlimitMin          = -1.0;
+    this->initialRange       = 1.0e+21;
+    this->dynamicRangeFactor = 0.04;
+    this->tlimitMin          = 1.0E-7;
 
     // A secondary inherits the position of its parent; the caller is responsible
     // to update the directions.

--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -44,6 +44,8 @@ public:
 
   void SetAdePTConfiguration(AdePTConfiguration *aAdePTConfiguration) { fAdePTConfiguration = aAdePTConfiguration; }
 
+  G4HepEmConfig *GetG4HepEmConfig() { return fHepEmTrackingManager->GetConfig(); }
+
 private:
   /// @brief Steps a particle using the generic G4 tracking, until it dies or enters a user-defined
   /// GPU region, in which case tracking is delegated to AdePT

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -408,8 +408,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     const double theElCut    = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fSecElProdCutE;
     const double theGammaCut = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fSecGamProdCutE;
 
-    const int iregion = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fG4RegionIndex;
-    ;
+    const int iregion    = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fG4RegionIndex;
     const bool ApplyCuts = g4HepEmPars.fParametersPerRegion[iregion].fIsApplyCuts;
 
     if (!stopped) {

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -408,6 +408,10 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     const double theElCut    = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fSecElProdCutE;
     const double theGammaCut = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fSecGamProdCutE;
 
+    const int iregion = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fG4RegionIndex;
+    ;
+    const bool ApplyCuts = g4HepEmPars.fParametersPerRegion[iregion].fIsApplyCuts;
+
     if (!stopped) {
       if (nextState.IsOnBoundary()) {
         // For now, just count that we hit something.

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -297,6 +297,10 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
     const double theElCut    = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fSecElProdCutE;
     const double theGammaCut = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fSecGamProdCutE;
 
+    const int iregion = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fG4RegionIndex;
+    ;
+    const bool ApplyCuts = g4HepEmPars.fParametersPerRegion[iregion].fIsApplyCuts;
+
     double edep           = 0.;
     double newEnergyGamma = 0.; // gamma energy after compton scattering
 

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -295,10 +295,10 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
     RanluxppDouble newRNG(currentTrack.rngState.Branch());
 
     const double theElCut    = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fSecElProdCutE;
+    const double thePosCut   = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fSecPosProdCutE;
     const double theGammaCut = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fSecGamProdCutE;
 
-    const int iregion = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fG4RegionIndex;
-    ;
+    const int iregion    = g4HepEmData.fTheMatCutData->fMatCutData[auxData.fMCIndex].fG4RegionIndex;
     const bool ApplyCuts = g4HepEmPars.fParametersPerRegion[iregion].fIsApplyCuts;
 
     double edep           = 0.;
@@ -346,7 +346,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
 #endif
       }
 
-      if (ApplyCuts && (copcore::units::kElectronMassC2 < theGammaCut && posKinEnergy < theElCut)) {
+      if (ApplyCuts && (copcore::units::kElectronMassC2 < theGammaCut && posKinEnergy < thePosCut)) {
         // Deposit: posKinEnergy + 2 * copcore::units::kElectronMassC2 and kill the secondary
         edep += posKinEnergy + 2 * copcore::units::kElectronMassC2;
       } else {

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -133,11 +133,6 @@ void AdePTTrackingManager::BuildPhysicsTable(const G4ParticleDefinition &part)
     InitializeAdePT();
   }
 
-  if (fAdePTInitialized) {
-    // Set ApplyCuts flag on device since now G4 physics is initialized
-    fAdeptTransport->InitializeApplyCuts(G4EmParameters::Instance()->ApplyCuts());
-  }
-
   // Bulid PhysicsTable for G4HepEm
   fHepEmTrackingManager->BuildPhysicsTable(part);
 

--- a/test/unit/testField/testField.cpp
+++ b/test/unit/testField/testField.cpp
@@ -169,6 +169,7 @@ int *CreateMCCindex(const G4VPhysicalVolume *g4world, const vecgeom::VPlacedVolu
 void FreeG4HepEm(G4HepEmState *state)
 {
   FreeG4HepEmData(state->fData);
+  FreeG4HepEmParametersOnGPU(state->fParameters);
 }
 
 void InitBVH()

--- a/test/unit/testField/testField.cu
+++ b/test/unit/testField/testField.cu
@@ -41,7 +41,14 @@ void InitG4HepEmGPU(G4HepEmState *state)
 {
   // Copy to GPU.
   CopyG4HepEmDataToGPU(state->fData);
-  COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(g4HepEmPars, state->fParameters, sizeof(G4HepEmParameters)));
+  CopyG4HepEmParametersToGPU(state->fParameters);
+
+  // Create G4HepEmParameters with the device pointer
+  G4HepEmParameters parametersOnDevice        = *state->fParameters;
+  parametersOnDevice.fParametersPerRegion     = state->fParameters->fParametersPerRegion_gpu;
+  parametersOnDevice.fParametersPerRegion_gpu = nullptr;
+
+  COPCORE_CUDA_CHECK(cudaMemcpyToSymbol(g4HepEmPars, &parametersOnDevice, sizeof(G4HepEmParameters)));
 
   // Create G4HepEmData with the device pointers.
   G4HepEmData dataOnDevice;


### PR DESCRIPTION
This PR updates AdePT such that it can use the latest version of G4HepEm.
It enables to use the perRegion parameters in G4HepEm.

Furthermore, the positron cut is now used from G4HepEm. The ApplyCut value is taken directly from G4HepEm and not via a global constant. Some default parameters are set correctly. This fixes a bug, as before, if the `MinimalMSCStepLimit` was set, the results were wrong and it could even lead to stalls.

This PR will also require updating the CI to the latest tagged version of G4HepEm. 