### PR TITLE
fix out of bounds access

### DIFF
--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -861,7 +861,7 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
       // ------------------
 
       AllowFinishOffEventArray allowFinishOffEvent;
-      for (int i = 0; i < kMaxThreads; ++i) {
+      for (int i = 0; i < numThreads; ++i) {
         // if waiting for transport to finish, the last N particles may be finished on CPU
         if (eventStates[i].load(std::memory_order_acquire) == EventState::WaitingForTransportToFinish) {
           allowFinishOffEvent.flags[i] = lastNParticlesOnCPU;


### PR DESCRIPTION
That call used the wrong variable, leading to far out of bounds accesses