### PR TITLE
[mini] fix gdml copy

### DIFF
--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -23,8 +23,8 @@ endmacro()
 #----------------------------------------------------------------------------#
 # Common Data
 #----------------------------------------------------------------------------#
+file(COPY "${PROJECT_SOURCE_DIR}/examples/data/testEm3.gdml" DESTINATION "${PROJECT_BINARY_DIR}")
 set(TESTING_GDML "${PROJECT_BINARY_DIR}/testEm3.gdml")
-file(COPY "${PROJECT_SOURCE_DIR}/examples/data/testEm3.gdml" DESTINATION "${TESTING_GDML}")
 
 #----------------------------------------------------------------------------#
 # G4 App-based Tests


### PR DESCRIPTION
This mini PR fixes a minor hiccup from #373 :

The copying of the gdml was flawed, if one tried to reconfigure the cmake config (e.g., switching from `-DASYNC_MODE=ON` to `OFF`) it would fail with:

```
CMake Error at test/regression/CMakeLists.txt:27 (file):
  file COPY cannot copy file
  "/home/ndiederi/software/AdePT/examples/data/testEm3.gdml" to
  "/home/ndiederi/software/AdePT/adept-build/testEm3.gdml/testEm3.gdml": Not
  a directory.
```

This PR fixes it by using the directory as destination and not the file itself.