### PR TITLE
Make energy loss and multisteps in MSC with transportation configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ option(USE_SPLIT_KERNELS "Run split version of the transport kernels" OFF)
 option(ADEPT_USE_EXT_BFIELD "Use external B field from file via the covfie library" OFF)
 option(DEBUG_SINGLE_THREAD "Run transport kernels in single thread mode" OFF)
 option(WITH_FLUCT "Switch on the energy loss fluctuations" OFF)
+option(MULTI_STEPS_IN_MSC "Switch on multiple steps in MSC with transportation in G4HepEm" OFF)
 
 #----------------------------------------------------------------------------#
 # Dependencies
@@ -228,9 +229,16 @@ if(G4HepEm_FOUND)
   message(STATUS "G4HepEm found ${G4HepEm_INCLUDE_DIR}")
 endif()
 
-# The NOFLUCTUATION flag is passed and used in G4HepEm
-if(NOT WITH_FLUCT)
-  add_compile_definitions(NOFLUCTUATION)
+# If fluctuations are turned off, the AdePT physics list switches off all fluctuations in G4HepEm
+# (otherwise it is using the default setting of the G4 application)
+if(WITH_FLUCT)
+  add_compile_definitions(WITH_FLUCT)
+endif()
+
+# If multiple steps in multiple scattering are turned off, the AdePT physics list switches them off in G4HepEm
+# I.e., this affects only the particles that are tracked on CPU in G4HepEm
+if(MULTI_STEPS_IN_MSC)
+  add_compile_definitions(MULTI_STEPS_IN_MSC)
 endif()
 
 #----------------------------------------------------------------------------#

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,6 @@ option(ADEPT_USE_SURF_SINGLE "Use surface model in single precision" OFF)
 option(USE_SPLIT_KERNELS "Run split version of the transport kernels" OFF)
 option(ADEPT_USE_EXT_BFIELD "Use external B field from file via the covfie library" OFF)
 option(DEBUG_SINGLE_THREAD "Run transport kernels in single thread mode" OFF)
-option(WITH_FLUCT "Switch on the energy loss fluctuations" OFF)
-option(MULTI_STEPS_IN_MSC "Switch on multiple steps in MSC with transportation in G4HepEm" OFF)
 
 #----------------------------------------------------------------------------#
 # Dependencies
@@ -227,18 +225,6 @@ add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe;--diag_suppress=unrecog
 find_package(G4HepEm CONFIG REQUIRED)
 if(G4HepEm_FOUND)
   message(STATUS "G4HepEm found ${G4HepEm_INCLUDE_DIR}")
-endif()
-
-# If fluctuations are turned off, the AdePT physics list switches off all fluctuations in G4HepEm
-# (otherwise it is using the default setting of the G4 application)
-if(WITH_FLUCT)
-  add_compile_definitions(WITH_FLUCT)
-endif()
-
-# If multiple steps in multiple scattering are turned off, the AdePT physics list switches them off in G4HepEm
-# I.e., this affects only the particles that are tracked on CPU in G4HepEm
-if(MULTI_STEPS_IN_MSC)
-  add_compile_definitions(MULTI_STEPS_IN_MSC)
 endif()
 
 #----------------------------------------------------------------------------#

--- a/include/AdePT/core/AdePTConfiguration.hh
+++ b/include/AdePT/core/AdePTConfiguration.hh
@@ -43,7 +43,12 @@ public:
   void SetCUDAStackLimit(int limit) { fCUDAStackLimit = limit; }
   void SetCUDAHeapLimit(int limit) { fCUDAHeapLimit = limit; }
   void SetLastNParticlesOnCPU(int Nparticles) { fLastNParticlesOnCPU = Nparticles; }
-  void SetSpeedOfLightCmd(bool speedOfLight) { fSpeedOfLight = speedOfLight; }
+  void SetSpeedOfLight(bool speedOfLight) { fSpeedOfLight = speedOfLight; }
+  void SetMultipleStepsInMSCWithTransportation(bool setMultipleSteps)
+  {
+    fSetMultipleStepsInMSCWithTransportation = setMultipleSteps;
+  }
+  void SetEnergyLossFluctuation(bool setELossFluct) { fSetEnergyLossFluctuation = setELossFluct; }
 
   // We temporarily load VecGeom geometry from GDML
   void SetVecGeomGDML(std::string filename) { fVecGeomGDML = filename; }
@@ -55,6 +60,8 @@ public:
   bool GetCallUserSteppingAction() { return fCallUserSteppingAction; }
   bool GetCallUserTrackingAction() { return fCallUserTrackingAction; }
   bool GetSpeedOfLight() { return fSpeedOfLight; }
+  bool GetMultipleStepsInMSCWithTransportation() { return fSetMultipleStepsInMSCWithTransportation; }
+  bool GetEnergyLossFluctuation() { return fSetEnergyLossFluctuation; }
   bool IsAdePTActivated() { return fAdePTActivated; }
   int GetNumThreads() { return fNumThreads; };
   int GetVerbosity() { return fVerbosity; };
@@ -77,6 +84,8 @@ private:
   bool fCallUserSteppingAction{false};
   bool fCallUserTrackingAction{false};
   bool fSpeedOfLight{false};
+  bool fSetMultipleStepsInMSCWithTransportation{false};
+  bool fSetEnergyLossFluctuation{false};
   bool fAdePTActivated{true};
   int fNumThreads;
   int fVerbosity{0};

--- a/include/AdePT/integration/AdePTConfigurationMessenger.hh
+++ b/include/AdePT/integration/AdePTConfigurationMessenger.hh
@@ -40,6 +40,8 @@ private:
   G4UIcmdWithABool *fSetCallUserSteppingActionCmd;
   G4UIcmdWithABool *fSetCallUserTrackingActionCmd;
   G4UIcmdWithABool *fSetSpeedOfLightCmd;
+  G4UIcmdWithABool *fSetMultipleStepsInMSCWithTransportationCmd;
+  G4UIcmdWithABool *fSetEnergyLossFluctuationCmd;
   G4UIcmdWithAString *fAddRegionCmd;
   G4UIcmdWithABool *fActivateAdePTCmd;
   G4UIcmdWithAnInteger *fSetVerbosityCmd;

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -190,7 +190,8 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     theTrack->SetOnBoundary(navState.IsOnBoundary());
     theTrack->SetCharge(Charge);
     G4HepEmMSCTrackData *mscData = elTrack.GetMSCTrackData();
-    mscData->fIsFirstStep        = currentTrack.initialRange < 0;
+    // the default is 1.0e21 but there are float vs double conversions, so we check for 1e20
+    mscData->fIsFirstStep        = currentTrack.initialRange > 1.0e+20;
     mscData->fInitialRange       = currentTrack.initialRange;
     mscData->fDynamicRangeFactor = currentTrack.dynamicRangeFactor;
     mscData->fTlimitMin          = currentTrack.tlimitMin;

--- a/src/AdePTConfigurationMessenger.cc
+++ b/src/AdePTConfigurationMessenger.cc
@@ -93,6 +93,15 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
   fSetCUDAStackLimitCmd->SetGuidance("Set the CUDA device stack limit");
   fSetCUDAHeapLimitCmd = new G4UIcmdWithAnInteger("/adept/setCUDAHeapLimit", this);
   fSetCUDAHeapLimitCmd->SetGuidance("Set the CUDA device heap limit");
+
+  fSetMultipleStepsInMSCWithTransportationCmd =
+      new G4UIcmdWithABool("/adept/SetMultipleStepsInMSCWithTransportation", this);
+  fSetMultipleStepsInMSCWithTransportationCmd->SetGuidance(
+      "If true, this configures G4HepEm to use multiple steps in MSC on CPU. This does not affect GPU transport");
+
+  fSetEnergyLossFluctuationCmd = new G4UIcmdWithABool("/adept/SetEnergyLossFluctuation", this);
+  fSetEnergyLossFluctuationCmd->SetGuidance(
+      "If true, this configures G4HepEm to use energy loss fluctuations. This affects both CPU and GPU transport");
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -117,6 +126,8 @@ AdePTConfigurationMessenger::~AdePTConfigurationMessenger()
   delete fSetFinishOnCpuCmd;
   delete fSetSpeedOfLightCmd;
   delete fSetCPUCapacityFactorCmd;
+  delete fSetMultipleStepsInMSCWithTransportationCmd;
+  delete fSetEnergyLossFluctuationCmd;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -127,11 +138,16 @@ void AdePTConfigurationMessenger::SetNewValue(G4UIcommand *command, G4String new
   if (command == fSetTrackInAllRegionsCmd) {
     fAdePTConfiguration->SetTrackInAllRegions(fSetTrackInAllRegionsCmd->GetNewBoolValue(newValue));
   } else if (command == fSetCallUserSteppingActionCmd) {
-    fAdePTConfiguration->SetCallUserSteppingAction(newValue);
+    fAdePTConfiguration->SetCallUserSteppingAction(fSetCallUserSteppingActionCmd->GetNewBoolValue(newValue));
   } else if (command == fSetCallUserTrackingActionCmd) {
-    fAdePTConfiguration->SetCallUserTrackingAction(newValue);
+    fAdePTConfiguration->SetCallUserTrackingAction(fSetCallUserTrackingActionCmd->GetNewBoolValue(newValue));
   } else if (command == fSetSpeedOfLightCmd) {
-    fAdePTConfiguration->SetSpeedOfLightCmd(newValue);
+    fAdePTConfiguration->SetSpeedOfLight(fSetSpeedOfLightCmd->GetNewBoolValue(newValue));
+  } else if (command == fSetMultipleStepsInMSCWithTransportationCmd) {
+    fAdePTConfiguration->SetMultipleStepsInMSCWithTransportation(
+        fSetMultipleStepsInMSCWithTransportationCmd->GetNewBoolValue(newValue));
+  } else if (command == fSetEnergyLossFluctuationCmd) {
+    fAdePTConfiguration->SetEnergyLossFluctuation(fSetEnergyLossFluctuationCmd->GetNewBoolValue(newValue));
   } else if (command == fAddRegionCmd) {
     fAdePTConfiguration->AddGPURegionName(newValue);
   } else if (command == fActivateAdePTCmd) {

--- a/src/AdePTPhysics.cc
+++ b/src/AdePTPhysics.cc
@@ -40,6 +40,12 @@ void AdePTPhysics::ConstructProcess()
 {
   // Register custom tracking manager for e-/e+ and gammas.
   fTrackingManager = new AdePTTrackingManager();
+
+  auto g4hepemconfig = fTrackingManager->GetG4HepEmConfig();
+  g4hepemconfig->SetMultipleStepsInMSCWithTransportation(
+      fAdePTConfiguration->GetMultipleStepsInMSCWithTransportation());
+  g4hepemconfig->SetEnergyLossFluctuation(fAdePTConfiguration->GetEnergyLossFluctuation());
+
   G4Electron::Definition()->SetTrackingManager(fTrackingManager);
   G4Positron::Definition()->SetTrackingManager(fTrackingManager);
   G4Gamma::Definition()->SetTrackingManager(fTrackingManager);


### PR DESCRIPTION
This PR makes the multiple steps and energy loss fluctuations in G4HepEm configurable from within AdePT.
Now, those are run time and not compile time options.

When turning off the multiple steps in G4HepEm, AdePT and G4HepEm show below 0.04% agreement:
![Screenshot from 2025-04-08 13-53-21](https://github.com/user-attachments/assets/db5a94c1-f3f3-4d89-aaad-5ea4f2e48080)

As the default parameters were fixed for G4HepEm, one comparison (previously to < 0) needed to be fixed. Furthermore, a few UI commands were fixed that required to fetch the boolean value.