### PR TITLE
Fix memory problems in scoring

### DIFF
--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -66,7 +66,7 @@ struct ScoringObjects {
 
   ScoringObjects()
   {
-    // Step
+    // Assign step points in local storage and take ownership of the StepPoints
     fG4Step = new (&stepStorage) G4Step;
     fG4Step->SetPreStepPoint(::new (&stepPointStorage[0]) G4StepPoint());
     fG4Step->SetPostStepPoint(::new (&stepPointStorage[1]) G4StepPoint());

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -60,7 +60,8 @@ namespace AdePTGeant4Integration_detail {
 //   // We need the dynamic particle associated to the track to have the correct particle definition, however this can
 //   // only be set at construction time. Similarly, we can only set the dynamic particle for a track when creating it
 //   // For this reason we create one track per particle type, to be reused
-//   // We set position to nullptr and kinetic energy to 0 for the dynamic particle since they need to be updated per hit
+//   // We set position to nullptr and kinetic energy to 0 for the dynamic particle since they need to be updated per
+//   hit
 //   // The same goes for the G4Track global time and position
 //   std::aligned_storage<sizeof(G4DynamicParticle), alignof(G4DynamicParticle)>::type dynParticleStorage[3];
 
@@ -95,7 +96,7 @@ struct ScoringObjects {
   // are in memory pools. Therefore, we construct them as pointer to local memory.
   G4Step *fG4Step = nullptr;
 
-  G4TouchableHandle *fPreG4TouchableHistoryHandle = nullptr;
+  G4TouchableHandle *fPreG4TouchableHistoryHandle  = nullptr;
   G4TouchableHandle *fPostG4TouchableHistoryHandle = nullptr;
 
   // We need the dynamic particle associated to the track to have the correct particle definition, however this can
@@ -108,7 +109,7 @@ struct ScoringObjects {
 
   G4Track *fElectronTrack = nullptr;
   G4Track *fPositronTrack = nullptr;
-  G4Track *fGammaTrack = nullptr;
+  G4Track *fGammaTrack    = nullptr;
 
   ScoringObjects()
   {
@@ -124,12 +125,18 @@ struct ScoringObjects {
         ::new (&toucheableHandleStorage[1]) G4TouchableHandle{::new (&toucheableHistoryStorage[1]) G4TouchableHistory};
 
     // Tracks
-    fElectronTrack = ::new (&trackStorage[0]) G4Track{::new (&dynParticleStorage[0]) G4DynamicParticle{
-      G4ParticleTable::GetParticleTable()->FindParticle("e-"), G4ThreeVector(0, 0, 0), 0}, 0, G4ThreeVector(0, 0, 0)};
-    fPositronTrack = ::new (&trackStorage[1]) G4Track{::new (&dynParticleStorage[1]) G4DynamicParticle{
-      G4ParticleTable::GetParticleTable()->FindParticle("e+"), G4ThreeVector(0, 0, 0), 0}, 0, G4ThreeVector(0, 0, 0)};
-    fGammaTrack = ::new (&trackStorage[2]) G4Track{::new (&dynParticleStorage[2]) G4DynamicParticle{
-      G4ParticleTable::GetParticleTable()->FindParticle("gamma"), G4ThreeVector(0, 0, 0), 0}, 0, G4ThreeVector(0, 0, 0)};
+    fElectronTrack = ::new (&trackStorage[0]) G4Track{
+        ::new (&dynParticleStorage[0])
+            G4DynamicParticle{G4ParticleTable::GetParticleTable()->FindParticle("e-"), G4ThreeVector(0, 0, 0), 0},
+        0, G4ThreeVector(0, 0, 0)};
+    fPositronTrack = ::new (&trackStorage[1]) G4Track{
+        ::new (&dynParticleStorage[1])
+            G4DynamicParticle{G4ParticleTable::GetParticleTable()->FindParticle("e+"), G4ThreeVector(0, 0, 0), 0},
+        0, G4ThreeVector(0, 0, 0)};
+    fGammaTrack = ::new (&trackStorage[2]) G4Track{
+        ::new (&dynParticleStorage[2])
+            G4DynamicParticle{G4ParticleTable::GetParticleTable()->FindParticle("gamma"), G4ThreeVector(0, 0, 0), 0},
+        0, G4ThreeVector(0, 0, 0)};
   }
 
   // Note: no destructor needed since we’re intentionally *not* calling dtors on the placement-new'ed objects

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -36,53 +36,6 @@ namespace AdePTGeant4Integration_detail {
 /// which cause a destruction order fiasco when the pools are destroyed before the objects,
 /// and then the objects' destructors are called.
 /// This also keeps all these objects much closer in memory.
-// struct ScoringObjects {
-//   G4NavigationHistory fPreG4NavigationHistory;
-//   G4NavigationHistory fPostG4NavigationHistory;
-
-//   // Create local storage for placement new of step points:
-//   std::aligned_storage<sizeof(G4StepPoint), alignof(G4StepPoint)>::type stepPointStorage[2];
-//   std::aligned_storage<sizeof(G4Step), alignof(G4Step)>::type stepStorage;
-//   std::aligned_storage<sizeof(G4TouchableHistory), alignof(G4TouchableHistory)>::type toucheableHistoryStorage[2];
-//   std::aligned_storage<sizeof(G4TouchableHandle), alignof(G4TouchableHandle)>::type toucheableHandleStorage[2];
-//   std::aligned_storage<sizeof(G4Track), alignof(G4Track)>::type trackStorage[3];
-
-//   // Cannot run G4Step's and TouchableHandle's destructors, since their internal reference-counted handles
-//   // are in memory pools. Therefore, we construct them as pointer to local memory.
-//   G4Step *fG4Step = new (&stepStorage) G4Step;
-
-//   G4TouchableHandle *fPreG4TouchableHistoryHandle =
-//       ::new (&toucheableHandleStorage[0]) G4TouchableHandle{::new (&toucheableHistoryStorage[0]) G4TouchableHistory};
-
-//   G4TouchableHandle *fPostG4TouchableHistoryHandle =
-//       ::new (&toucheableHandleStorage[1]) G4TouchableHandle{::new (&toucheableHistoryStorage[1]) G4TouchableHistory};
-
-//   // We need the dynamic particle associated to the track to have the correct particle definition, however this can
-//   // only be set at construction time. Similarly, we can only set the dynamic particle for a track when creating it
-//   // For this reason we create one track per particle type, to be reused
-//   // We set position to nullptr and kinetic energy to 0 for the dynamic particle since they need to be updated per
-//   hit
-//   // The same goes for the G4Track global time and position
-//   std::aligned_storage<sizeof(G4DynamicParticle), alignof(G4DynamicParticle)>::type dynParticleStorage[3];
-
-//   G4Track fElectronTrack{::new (dynParticleStorage) G4DynamicParticle{
-//                              G4ParticleTable::GetParticleTable()->FindParticle("e-"), G4ThreeVector(0, 0, 0), 0},
-//                          0, G4ThreeVector(0, 0, 0)};
-//   G4Track fPositronTrack{::new (dynParticleStorage + 1) G4DynamicParticle{
-//                              G4ParticleTable::GetParticleTable()->FindParticle("e+"), G4ThreeVector(0, 0, 0), 0},
-//                          0, G4ThreeVector(0, 0, 0)};
-//   G4Track fGammaTrack{::new (dynParticleStorage + 2) G4DynamicParticle{
-//                           G4ParticleTable::GetParticleTable()->FindParticle("gamma"), G4ThreeVector(0, 0, 0), 0},
-//                       0, G4ThreeVector(0, 0, 0)};
-
-//   ScoringObjects()
-//   {
-//     // Assign step points in local storage:
-//     fG4Step->SetPreStepPoint(::new (stepPointStorage) G4StepPoint());      // Takes ownership
-//     fG4Step->SetPostStepPoint(::new (stepPointStorage + 1) G4StepPoint()); // Takes ownership
-//   }
-// };
-
 struct ScoringObjects {
   G4NavigationHistory fPreG4NavigationHistory;
   G4NavigationHistory fPostG4NavigationHistory;

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -37,19 +37,19 @@ set(SCRIPTS_DIR "${PROJECT_SOURCE_DIR}/test/regression/scripts")
 set(TEMP_DIR "${PROJECT_SOURCE_DIR}/test/regression/ci_tmp")
 
 # This test checks the reproducibility of AdePT by running 8 ttbar events and checking that the energy deposition is exactly the same.
-add_test(NAME reproducibility_cms_ttbar
-    COMMAND bash ${PROJECT_SOURCE_DIR}/test/regression/scripts/reproducibility.sh
-    "$<TARGET_FILE:integrationTest>" "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}" "${SCRIPTS_DIR}" "${TEMP_DIR}"
-    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-)
+#add_test(NAME reproducibility_cms_ttbar
+	# COMMAND bash ${PROJECT_SOURCE_DIR}/test/regression/scripts/reproducibility.sh
+    #  "$<TARGET_FILE:integrationTest>" "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}" "${SCRIPTS_DIR}" "${TEMP_DIR}"
+    #   WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    #)
 
 # test that compares the physics output of a full AdePT run against a high-statistics Geant4 simulation using G4HepEm.
 # The energy deposition per layer error must be < 1% to pass the test
-add_test(NAME testEm3_validation
-    COMMAND bash ${PROJECT_SOURCE_DIR}/test/regression/scripts/validation_testem3.sh
-    "$<TARGET_FILE:integrationTest>" "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}" "${SCRIPTS_DIR}" "${TEMP_DIR}"
-    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-)
+#add_test(NAME testEm3_validation
+	#COMMAND bash ${PROJECT_SOURCE_DIR}/test/regression/scripts/validation_testem3.sh
+    #"$<TARGET_FILE:integrationTest>" "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}" "${SCRIPTS_DIR}" "${TEMP_DIR}"
+    #    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    #)
 
 set(APP_TESTS
 

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -37,19 +37,19 @@ set(SCRIPTS_DIR "${PROJECT_SOURCE_DIR}/test/regression/scripts")
 set(TEMP_DIR "${PROJECT_SOURCE_DIR}/test/regression/ci_tmp")
 
 # This test checks the reproducibility of AdePT by running 8 ttbar events and checking that the energy deposition is exactly the same.
-#add_test(NAME reproducibility_cms_ttbar
-	# COMMAND bash ${PROJECT_SOURCE_DIR}/test/regression/scripts/reproducibility.sh
-    #  "$<TARGET_FILE:integrationTest>" "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}" "${SCRIPTS_DIR}" "${TEMP_DIR}"
-    #   WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-    #)
+add_test(NAME reproducibility_cms_ttbar
+    COMMAND bash ${PROJECT_SOURCE_DIR}/test/regression/scripts/reproducibility.sh
+    "$<TARGET_FILE:integrationTest>" "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}" "${SCRIPTS_DIR}" "${TEMP_DIR}"
+    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+)
 
 # test that compares the physics output of a full AdePT run against a high-statistics Geant4 simulation using G4HepEm.
 # The energy deposition per layer error must be < 1% to pass the test
-#add_test(NAME testEm3_validation
-	#COMMAND bash ${PROJECT_SOURCE_DIR}/test/regression/scripts/validation_testem3.sh
-    #"$<TARGET_FILE:integrationTest>" "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}" "${SCRIPTS_DIR}" "${TEMP_DIR}"
-    #    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
-    #)
+add_test(NAME testEm3_validation
+    COMMAND bash ${PROJECT_SOURCE_DIR}/test/regression/scripts/validation_testem3.sh
+    "$<TARGET_FILE:integrationTest>" "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}" "${SCRIPTS_DIR}" "${TEMP_DIR}"
+    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+)
 
 set(APP_TESTS
 


### PR DESCRIPTION
This fixes a memory problem in the `ScoringObjects`:

Before, the struct had G4Tracks as members. Those G4Tracks were initialized by passing pointers to the `G4DynamicParticle`, which was allocated with `placement new`. Then, when the struct went out of scope, the destructor of G4Track was called, which tries to `delete` the G4DynamicParticle. However, since it wasn't allocated with `new`, this would cause a crash (interestingly only observed in Gauss).

This PR fixes the issue by using pointers to G4Tracks, such that when it goes out of scope, only the pointers are deleted and the destructor is not called. 

To make it more consistent, some parts were moved into the constructor of the object.