### PR TITLE
Minor B field improvements

### DIFF
--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -426,6 +426,15 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
                  eKin, currentTrack.eventId, currentTrack.looperCounter, energyDeposit, geometryStepLength,
                  geometricalStepLengthFromPhysics, safety);
           continue;
+          // printf("Killing looper scraping at a boundary: E=%E event=%d loop=%d energyDeposit=%E geoStepLength=%E "
+          //   "physicsStepLength=%E "
+          //   "safety=%E safeLength=%E propagated=%d\n"
+          //   "position %.16f %.16f %.16f direction %.16f %.16f %.16f navState %d nextState %d\n",
+          //   eKin, currentTrack.eventId, currentTrack.looperCounter, energyDeposit, geometryStepLength,
+          //   geometricalStepLengthFromPhysics, safety, safeLength, propagated, pos[0], pos[1], pos[2], dir[0], dir[1],
+          //   dir[2], navState.GetNavIndex(), nextState.GetNavIndex());
+          // continue;
+
         } else if (!nextState.IsOutside()) {
           // Mark the particle. We need to change its navigation state to the next volume before enqueuing it
           // This will happen after recording the step
@@ -450,6 +459,14 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
                  eKin, currentTrack.eventId, currentTrack.looperCounter, energyDeposit, geometryStepLength,
                  geometricalStepLengthFromPhysics, safety);
           continue;
+          // printf("Killing looper due to lack of advance: E=%E event=%d loop=%d energyDeposit=%E geoStepLength=%E "
+          //   "physicsStepLength=%E "
+          //   "safety=%E safeLength=%E propagated=%d\n"
+          //   "position %.16f %.16f %.16f direction %.16f %.16f %.16f navState %d nextState %d\n",
+          //   eKin, currentTrack.eventId, currentTrack.looperCounter, energyDeposit, geometryStepLength,
+          //   geometricalStepLengthFromPhysics, safety, safeLength, propagated, pos[0], pos[1], pos[2], dir[0], dir[1],
+          //   dir[2], navState.GetNavIndex(), nextState.GetNavIndex());
+          // continue;
         }
 
         survive();

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -426,15 +426,6 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
                  eKin, currentTrack.eventId, currentTrack.looperCounter, energyDeposit, geometryStepLength,
                  geometricalStepLengthFromPhysics, safety);
           continue;
-          // printf("Killing looper scraping at a boundary: E=%E event=%d loop=%d energyDeposit=%E geoStepLength=%E "
-          //   "physicsStepLength=%E "
-          //   "safety=%E safeLength=%E propagated=%d\n"
-          //   "position %.16f %.16f %.16f direction %.16f %.16f %.16f navState %d nextState %d\n",
-          //   eKin, currentTrack.eventId, currentTrack.looperCounter, energyDeposit, geometryStepLength,
-          //   geometricalStepLengthFromPhysics, safety, safeLength, propagated, pos[0], pos[1], pos[2], dir[0], dir[1],
-          //   dir[2], navState.GetNavIndex(), nextState.GetNavIndex());
-          // continue;
-
         } else if (!nextState.IsOutside()) {
           // Mark the particle. We need to change its navigation state to the next volume before enqueuing it
           // This will happen after recording the step
@@ -459,14 +450,6 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
                  eKin, currentTrack.eventId, currentTrack.looperCounter, energyDeposit, geometryStepLength,
                  geometricalStepLengthFromPhysics, safety);
           continue;
-          // printf("Killing looper due to lack of advance: E=%E event=%d loop=%d energyDeposit=%E geoStepLength=%E "
-          //   "physicsStepLength=%E "
-          //   "safety=%E safeLength=%E propagated=%d\n"
-          //   "position %.16f %.16f %.16f direction %.16f %.16f %.16f navState %d nextState %d\n",
-          //   eKin, currentTrack.eventId, currentTrack.looperCounter, energyDeposit, geometryStepLength,
-          //   geometricalStepLengthFromPhysics, safety, safeLength, propagated, pos[0], pos[1], pos[2], dir[0], dir[1],
-          //   dir[2], navState.GetNavIndex(), nextState.GetNavIndex());
-          // continue;
         }
 
         survive();

--- a/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
+++ b/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
@@ -90,6 +90,7 @@ fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>::ComputeStep
   Real_t remains            = physicsStep;
   const Real_t tiniest_step = 1.0e-7 * physicsStep; // Ignore remainder if < e_s * PhysicsStep
   int chordIters            = 0;
+  Real_t last_good_step     = 0.0; // to be re-used for next cord iteration
 
   constexpr bool inZeroFieldRegion =
       false; // This could be a per-region flag ... - better depend on template parameter?
@@ -127,8 +128,8 @@ fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>::ComputeStep
       const Real_t safeArc                     = min(remains, maxNextSafeMove); // safeLength);
 
       Real_t dydx_end[Nvar]; // not used at the moment, but could be used for FSAL between cord integrations
-      bool done =
-          RkDriver_t::Advance(endPosition, endMomentumVec, charge, safeArc, magField, dydx_end, /*max_trials=*/30);
+      bool done = RkDriver_t::Advance(endPosition, endMomentumVec, charge, safeArc, magField, dydx_end, last_good_step,
+                                      /*max_trials=*/30, chordIters);
 
       //-----------------
       vecgeom::Vector3D<Real_t> chordDir     = endPosition - position; // not yet normalized!

--- a/test/unit/test_magfieldRK.cpp
+++ b/test/unit/test_magfieldRK.cpp
@@ -247,11 +247,12 @@ bool TestDriverAdvance(Field_t const &magField, Real_t hLength = 300)
   PrintFieldVectors::PrintLineSixvecDyDx(yStart, charge, magFieldStartArr, dy_ds);
 
   Vector3D<Real_t> momentumVec = momentumMag * Direction;
+  Real_t lastGoodStep          = 0.;
 
   do {
     Real_t hAdvanced = 0.0;
 
-    done = Driver_t::Advance(Position, momentumVec, charge, hLength, magField, dydx_end, MaxTrials);
+    done = Driver_t::Advance(Position, momentumVec, charge, hLength, magField, dydx_end, lastGoodStep, MaxTrials);
     // Runge-Kutta single call
     ++totalTrials;
     std::cout << "Advanced returned:  done= " << (done ? "Yes" : " No") << " hAdvanced = " << hAdvanced
@@ -350,11 +351,12 @@ bool CheckDriverVsHelix(Field_t const &magField, const Real_t stepLength = 300.0
   constexpr int maxTrials = 500;
 
   Vector3D<Real_t> momentumVec = momentumMag * Direction;
+  Real_t lastGoodStep          = 0.;
 
   do {
     Real_t hAdvanced = 0; //  length integrated
 
-    bool done = Driver_t::Advance(Position, momentumVec, charge, hLength, magField, dydx_end, MaxTrials);
+    bool done = Driver_t::Advance(Position, momentumVec, charge, hLength, magField, dydx_end, lastGoodStep, MaxTrials);
     //   Runge-Kutta single call ( number of steps <= trialsPerCall )
     ++totalTrials;
 


### PR DESCRIPTION
This PR adds two minor improvements to the B field:

1. If the RK integration fails below the minimal step, previously no action was taken and it would just retry this minimal step (and consequently, fail again). Now, if an integration step fails below the minimal step, we take the minimal step anyway, to advance the track. (Comparable to the QuickAdvance in G4).
2. When integrating the cords, we now re-use the last good step for the next cords. As an initial step, we choose the physics step length for the first cord. Previously, for every cord the physics step length was taken. If the physics step length was way too high for the B field integration, it would take 1-2 iterations before the correct length was found. Then, when integrating the next cord, it would again take 1-2 failed iterations before it would work. Now, for the next cord iteration, we re-use the last good step size, which typically immediately results in a good step.
For 128 ttbar events in CMS2018, this led to a 6% performance improvement. 

Additionally, minor cleaning is added in the B field.