### PR TITLE
Initialize AdePT from G4 workers

### DIFF
--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -54,7 +54,8 @@ void AdePTTrackingManager::InitializeAdePT()
 
   // a condition variable and a mutex is used for the initialization:
   // The first G4 worker that reaches the initialization, needs to initialize AdePT.
-  // At the same time, all other G4 workers must wait for the common initialization to be finished, before they are allowed to continue
+  // At the same time, all other G4 workers must wait for the common initialization to be finished, before they are
+  // allowed to continue
   static std::once_flag onceFlag;
   static std::mutex initMutex;
   static std::condition_variable initCV;

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -117,8 +117,8 @@ void AdePTTrackingManager::InitializeAdePT()
   if (!sequential) { // if sequential, the instance is already created
     fAdeptTransport = std::make_unique<AdePTTransport<AdePTGeant4Integration>>(*fAdePTConfiguration);
   }
-    // Initialize per-thread data
-    fAdeptTransport->Initialize(fHepEmTrackingManager->GetConfig());
+  // Initialize per-thread data
+  fAdeptTransport->Initialize(fHepEmTrackingManager->GetConfig());
 #endif
 
   // Initialize the GPU region list


### PR DESCRIPTION
In the experimental frameworks, AdePT must be initialized by the G4 workers, because at the initialization time of the master thread, the number of G4 workers is not yet known.

Therefore, the initialization is postponed to the first G4 worker. Then, all other G4 workers must wait for the first worker to have initialized AdePT before they can proceed.

This fixes running with AdePT in Gauss and Athena.