### PR TITLE
Fix global time in scoring

### DIFF
--- a/include/AdePT/core/AdePTScoringTemplate.cuh
+++ b/include/AdePT/core/AdePTScoringTemplate.cuh
@@ -23,7 +23,8 @@ __device__ void RecordHit(Scoring *scoring_dev, int aParentID, char aParticleTyp
                           vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin, double aPreCharge,
                           vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
                           vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                          double aPostCharge, double aGlobalTime, unsigned int eventId, short threadId, bool isLastStep, bool isFirstStep);
+                          double aPostCharge, double aGlobalTime, unsigned int eventId, short threadId, bool isLastStep,
+                          bool isFirstStep);
 
 template <typename Scoring>
 __device__ void AccountProduced(Scoring *scoring_dev, int num_ele, int num_pos, int num_gam);

--- a/include/AdePT/core/AdePTScoringTemplate.cuh
+++ b/include/AdePT/core/AdePTScoringTemplate.cuh
@@ -23,7 +23,7 @@ __device__ void RecordHit(Scoring *scoring_dev, int aParentID, char aParticleTyp
                           vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin, double aPreCharge,
                           vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
                           vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                          double aPostCharge, unsigned int eventId, short threadId, bool isLastStep, bool isFirstStep);
+                          double aPostCharge, double aGlobalTime, unsigned int eventId, short threadId, bool isLastStep, bool isFirstStep);
 
 template <typename Scoring>
 __device__ void AccountProduced(Scoring *scoring_dev, int num_ele, int num_pos, int num_gam);

--- a/include/AdePT/core/HostScoringImpl.cuh
+++ b/include/AdePT/core/HostScoringImpl.cuh
@@ -155,7 +155,7 @@ __device__ void RecordHit(HostScoring *hostScoring_dev, int aParentID, char aPar
                           vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin, double aPreCharge,
                           vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
                           vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                          double aPostCharge, unsigned int, short, bool, bool)
+                          double aPostCharge, double aGlobalTime, unsigned int, short, bool, bool)
 {
   // Acquire a hit slot
   GPUHit &aGPUHit = *GetNextFreeHit(hostScoring_dev);
@@ -163,7 +163,7 @@ __device__ void RecordHit(HostScoring *hostScoring_dev, int aParentID, char aPar
   // Fill the required data
   FillHit(aGPUHit, aParentID, aParticleType, aStepLength, aTotalEnergyDeposit, aTrackWeight, aPreState, aPrePosition,
           aPreMomentumDirection, aPreEKin, aPreCharge, aPostState, aPostPosition, aPostMomentumDirection, aPostEKin,
-          aPostCharge, 0, 0, false, false);
+          aPostCharge, aGlobalTime, 0, 0, false, false);
 }
 
 /// @brief Account for the number of produced secondaries

--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -690,7 +690,7 @@ __device__ void RecordHit(AsyncAdePT::PerEventScoring * /*scoring*/, int aParent
                           vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin, double aPreCharge,
                           vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
                           vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                          double aPostCharge, unsigned int eventID, short threadID, bool isLastStep, bool isFirstStep)
+                          double aPostCharge, double aGlobalTime, unsigned int eventID, short threadID, bool isLastStep, bool isFirstStep)
 {
   // Acquire a hit slot
   GPUHit &aGPUHit = AsyncAdePT::gHitScoringBuffer_dev.GetNextSlot(threadID);
@@ -698,7 +698,7 @@ __device__ void RecordHit(AsyncAdePT::PerEventScoring * /*scoring*/, int aParent
   // Fill the required data
   FillHit(aGPUHit, aParentID, aParticleType, aStepLength, aTotalEnergyDeposit, aTrackWeight, aPreState, aPrePosition,
           aPreMomentumDirection, aPreEKin, aPreCharge, aPostState, aPostPosition, aPostMomentumDirection, aPostEKin,
-          aPostCharge, eventID, threadID, isLastStep, isLastStep);
+          aPostCharge, aGlobalTime, eventID, threadID, isLastStep, isLastStep);
 }
 
 /// @brief Account for the number of produced secondaries

--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -690,7 +690,8 @@ __device__ void RecordHit(AsyncAdePT::PerEventScoring * /*scoring*/, int aParent
                           vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin, double aPreCharge,
                           vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
                           vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                          double aPostCharge, double aGlobalTime, unsigned int eventID, short threadID, bool isLastStep, bool isFirstStep)
+                          double aPostCharge, double aGlobalTime, unsigned int eventID, short threadID, bool isLastStep,
+                          bool isFirstStep)
 {
   // Acquire a hit slot
   GPUHit &aGPUHit = AsyncAdePT::gHitScoringBuffer_dev.GetNextSlot(threadID);

--- a/include/AdePT/core/ScoringCommons.hh
+++ b/include/AdePT/core/ScoringCommons.hh
@@ -28,6 +28,7 @@ struct GPUHit {
   double fStepLength{0};
   double fTotalEnergyDeposit{0};
   double fNonIonizingEnergyDeposit{0};
+  double fGlobalTime{0.};
   float fTrackWeight{1};
   int fParentID{0}; // Track ID
   unsigned int fEventId{0};
@@ -74,7 +75,7 @@ __device__ __forceinline__ void FillHit(
     float aTrackWeight, vecgeom::NavigationState const &aPreState, vecgeom::Vector3D<Precision> const &aPrePosition,
     vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin, double aPreCharge,
     vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
-    vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin, double aPostCharge,
+    vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin, double aPostCharge, double aGlobalTime,
     unsigned int eventID, short threadID, bool isLastStep, bool isFirstStep)
 {
   aGPUHit.fEventId = eventID;
@@ -88,6 +89,7 @@ __device__ __forceinline__ void FillHit(
   aGPUHit.fStepLength         = aStepLength;
   aGPUHit.fTotalEnergyDeposit = aTotalEnergyDeposit;
   aGPUHit.fTrackWeight        = aTrackWeight;
+  aGPUHit.fGlobalTime         = aGlobalTime;
   // Pre step point
   aGPUHit.fPreStepPoint.fNavigationState = aPreState;
   Copy3DVector(aPrePosition, aGPUHit.fPreStepPoint.fPosition);

--- a/include/AdePT/core/ScoringCommons.hh
+++ b/include/AdePT/core/ScoringCommons.hh
@@ -75,8 +75,8 @@ __device__ __forceinline__ void FillHit(
     float aTrackWeight, vecgeom::NavigationState const &aPreState, vecgeom::Vector3D<Precision> const &aPrePosition,
     vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin, double aPreCharge,
     vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
-    vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin, double aPostCharge, double aGlobalTime,
-    unsigned int eventID, short threadID, bool isLastStep, bool isFirstStep)
+    vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin, double aPostCharge,
+    double aGlobalTime, unsigned int eventID, short threadID, bool isLastStep, bool isFirstStep)
 {
   aGPUHit.fEventId = eventID;
   aGPUHit.threadId = threadID;

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -92,8 +92,8 @@ struct Track {
   /// NB: The caller is responsible to branch a new RNG state.
   __device__ Track(RanluxppDouble const &rngState, double eKin, const vecgeom::Vector3D<Precision> &parentPos,
                    const vecgeom::Vector3D<Precision> &newDirection, const vecgeom::NavigationState &newNavState,
-                   const Track &parentTrack)
-      : rngState{rngState}, eKin{eKin}, globalTime{parentTrack.globalTime}, pos{parentPos}, dir{newDirection},
+                   const Track &parentTrack, const double globalTime)
+      : rngState{rngState}, eKin{eKin}, globalTime{globalTime}, pos{parentPos}, dir{newDirection},
         navState{newNavState}, originNavState{newNavState}, eventId{parentTrack.eventId},
         parentId{parentTrack.parentId}, threadId{parentTrack.threadId}, vertexEkin{eKin}, weight{parentTrack.weight},
         vertexPosition{parentPos}, vertexMomentumDirection{newDirection}, stepCounter{0}, looperCounter{0}

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -517,7 +517,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 #ifdef ASYNC_MODE
             Track &secondary = secondaries.electrons.NextTrack(
                 newRNG, deltaEkin, pos, vecgeom::Vector3D<Precision>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
-                navState, currentTrack);
+                navState, currentTrack, globalTime);
 #else
             Track &secondary = secondaries.electrons->NextTrack();
             secondary.InitAsSecondary(pos, navState, globalTime);
@@ -569,7 +569,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 #ifdef ASYNC_MODE
             secondaries.gammas.NextTrack(
                 newRNG, deltaEkin, pos, vecgeom::Vector3D<Precision>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
-                navState, currentTrack);
+                navState, currentTrack, globalTime);
 #else
             Track &gamma = secondaries.gammas->NextTrack();
             gamma.InitAsSecondary(pos, navState, globalTime);
@@ -620,7 +620,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
             secondaries.gammas.NextTrack(
                 newRNG, theGamma1Ekin, pos,
                 vecgeom::Vector3D<Precision>{theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]}, navState,
-                currentTrack);
+                currentTrack, globalTime);
 #else
             Track &gamma1 = secondaries.gammas->NextTrack();
             gamma1.InitAsSecondary(pos, navState, globalTime);
@@ -641,7 +641,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
             secondaries.gammas.NextTrack(
                 currentTrack.rngState, theGamma2Ekin, pos,
                 vecgeom::Vector3D<Precision>{theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]}, navState,
-                currentTrack);
+                currentTrack, globalTime);
 #else
             Track &gamma2 = secondaries.gammas->NextTrack();
             gamma2.InitAsSecondary(pos, navState, globalTime);
@@ -690,11 +690,11 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 #ifdef ASYNC_MODE
           Track &gamma1 = secondaries.gammas.NextTrack(newRNG, double{copcore::units::kElectronMassC2}, pos,
                                                        vecgeom::Vector3D<Precision>{sint * cosPhi, sint * sinPhi, cost},
-                                                       navState, currentTrack);
+                                                       navState, currentTrack, globalTime);
 
           // Reuse the RNG state of the dying track.
           Track &gamma2 = secondaries.gammas.NextTrack(currentTrack.rngState, double{copcore::units::kElectronMassC2},
-                                                       pos, -gamma1.dir, navState, currentTrack);
+                                                       pos, -gamma1.dir, navState, currentTrack, globalTime);
 #else
           Track &gamma1 = secondaries.gammas->NextTrack();
           Track &gamma2 = secondaries.gammas->NextTrack();

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -619,8 +619,8 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 #ifdef ASYNC_MODE
             secondaries.gammas.NextTrack(
                 newRNG, theGamma1Ekin, pos,
-                vecgeom::Vector3D<Precision>{theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]}, navState,
-                currentTrack, globalTime);
+                vecgeom::Vector3D<Precision>{theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]}, navState, currentTrack,
+                globalTime);
 #else
             Track &gamma1 = secondaries.gammas->NextTrack();
             gamma1.InitAsSecondary(pos, navState, globalTime);
@@ -640,8 +640,8 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 #ifdef ASYNC_MODE
             secondaries.gammas.NextTrack(
                 currentTrack.rngState, theGamma2Ekin, pos,
-                vecgeom::Vector3D<Precision>{theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]}, navState,
-                currentTrack, globalTime);
+                vecgeom::Vector3D<Precision>{theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]}, navState, currentTrack,
+                globalTime);
 #else
             Track &gamma2 = secondaries.gammas->NextTrack();
             gamma2.InitAsSecondary(pos, navState, globalTime);

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -342,7 +342,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         secondaries.electrons.NextTrack(
             newRNG, elKinEnergy, pos,
             vecgeom::Vector3D<Precision>{dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]}, navState,
-            currentTrack);
+            currentTrack, globalTime);
 #else
         Track &electron = secondaries.electrons->NextTrack();
         electron.InitAsSecondary(pos, navState, globalTime);
@@ -363,7 +363,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         secondaries.positrons.NextTrack(
             currentTrack.rngState, posKinEnergy, pos,
             vecgeom::Vector3D<Precision>{dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]}, navState,
-            currentTrack);
+            currentTrack, globalTime);
 #else
         Track &positron = secondaries.positrons->NextTrack();
         positron.InitAsSecondary(pos, navState, globalTime);
@@ -405,7 +405,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         // Create a secondary electron and sample/compute directions.
 #ifdef ASYNC_MODE
         Track &electron = secondaries.electrons.NextTrack(
-            newRNG, energyEl, pos, eKin * dir - newEnergyGamma * newDirGamma, navState, currentTrack);
+            newRNG, energyEl, pos, eKin * dir - newEnergyGamma * newDirGamma, navState, currentTrack, globalTime);
 #else
         Track &electron = secondaries.electrons->NextTrack();
 
@@ -459,7 +459,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
 #ifdef ASYNC_MODE
         secondaries.electrons.NextTrack(newRNG, photoElecE, pos,
                                         vecgeom::Vector3D<Precision>{dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]},
-                                        navState, currentTrack);
+                                        navState, currentTrack, globalTime);
 #else
         Track &electron = secondaries.electrons->NextTrack();
         electron.InitAsSecondary(pos, navState, globalTime);

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -225,6 +225,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                    dir,                                         // Post-step point momentum direction
                                    eKin,                                        // Post-step point kinetic energy
                                    0,                                           // Post-step point charge
+                                   globalTime,                                  // global time
                                    currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                    returnLastStep,
                                    currentTrack.stepCounter == 1 ? true
@@ -278,6 +279,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                    dir,                                         // Post-step point momentum direction
                                    eKin,                                        // Post-step point kinetic energy
                                    0,                                           // Post-step point charge
+                                   globalTime,                                  // global time
                                    currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                    returnLastStep, // whether this is the last step of the track
                                    currentTrack.stepCounter == 1 ? true : false); // whether this is the first step
@@ -504,6 +506,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                dir,                                         // Post-step point momentum direction
                                newEnergyGamma,                              // Post-step point kinetic energy
                                0,                                           // Post-step point charge
+                               globalTime,                                  // global time
                                currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                returnLastStep, // whether this is the last step of the track
                                currentTrack.stepCounter == 1 ? true : false); // whether this is the first step

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -510,7 +510,7 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
   aTrack->SetTrackID(aGPUHit->fParentID);      // Missing data
   aTrack->SetParentID(aGPUHit->fParentID);     // ID of the initial particle that entered AdePT
   aTrack->SetPosition(aPostStepPointPosition); // Real data
-  // aTrack->SetGlobalTime(0);                                                                // Missing data
+  aTrack->SetGlobalTime(aGPUHit->fGlobalTime);                                                // Real data
   // aTrack->SetLocalTime(0);                                                                 // Missing data
   // aTrack->SetProperTime(0);                                                                // Missing data
   // aTrack->SetTouchableHandle(aTrackTouchableHistory);                                      // Missing data
@@ -568,7 +568,7 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
   G4StepPoint *aPostStepPoint = aG4Step->GetPostStepPoint();
   aPostStepPoint->SetPosition(aPostStepPointPosition); // Real data
   // aPostStepPoint->SetLocalTime(0);                                                                 // Missing data
-  // aPostStepPoint->SetGlobalTime(0);                                                                // Missing data
+  aPostStepPoint->SetGlobalTime(aGPUHit->fGlobalTime);                                                // Real data
   // aPostStepPoint->SetProperTime(0);                                                                // Missing data
   aPostStepPoint->SetMomentumDirection(aPostStepPointMomentumDirection); // Real data
   aPostStepPoint->SetKineticEnergy(aGPUHit->fPostStepPoint.fEKin);       // Real data

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -510,7 +510,7 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
   aTrack->SetTrackID(aGPUHit->fParentID);      // Missing data
   aTrack->SetParentID(aGPUHit->fParentID);     // ID of the initial particle that entered AdePT
   aTrack->SetPosition(aPostStepPointPosition); // Real data
-  aTrack->SetGlobalTime(aGPUHit->fGlobalTime);                                                // Real data
+  aTrack->SetGlobalTime(aGPUHit->fGlobalTime); // Real data
   // aTrack->SetLocalTime(0);                                                                 // Missing data
   // aTrack->SetProperTime(0);                                                                // Missing data
   // aTrack->SetTouchableHandle(aTrackTouchableHistory);                                      // Missing data
@@ -568,7 +568,7 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
   G4StepPoint *aPostStepPoint = aG4Step->GetPostStepPoint();
   aPostStepPoint->SetPosition(aPostStepPointPosition); // Real data
   // aPostStepPoint->SetLocalTime(0);                                                                 // Missing data
-  aPostStepPoint->SetGlobalTime(aGPUHit->fGlobalTime);                                                // Real data
+  aPostStepPoint->SetGlobalTime(aGPUHit->fGlobalTime); // Real data
   // aPostStepPoint->SetProperTime(0);                                                                // Missing data
   aPostStepPoint->SetMomentumDirection(aPostStepPointMomentumDirection); // Real data
   aPostStepPoint->SetKineticEnergy(aGPUHit->fPostStepPoint.fEKin);       // Real data


### PR DESCRIPTION
This PR fixes the global time in the scoring, as it is now passed back to Geant4. Also, a bug is fixed: for calculating the global time, the initial velocity must be used, before updating the kinetic energy due to energy loss. Before, stopped particles would then lead to an infinite global time. Now it conforms with G4.

The globalTime for secondaries is also corrected: before it was taking the globaltime from `currentTrack`, however, the member `currentTrack.globalTime` was only updated in survive, so after the secondary was created. Now the current globalTime is passed to the constructor.

Now, the time seems to be fully correct in the Gauss histograms