### PR TITLE
Added non-consecutive reproducible track id

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ option(ADEPT_USE_SURF_SINGLE "Use surface model in single precision" OFF)
 option(USE_SPLIT_KERNELS "Run split version of the transport kernels" OFF)
 option(ADEPT_USE_EXT_BFIELD "Use external B field from file via the covfie library" OFF)
 option(DEBUG_SINGLE_THREAD "Run transport kernels in single thread mode" OFF)
+set(ADEPT_DEBUG_TRACK 0 CACHE STRING "Debug tracking level (0=off, >0=on with levels)")
 
 #----------------------------------------------------------------------------#
 # Dependencies
@@ -218,9 +219,12 @@ add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:RelWithDebInfo>>:
 add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<CONFIG:Debug>>:--device-debug>")
 # - For both, interleave the source in PTX to enhance the debugging experience.
 add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:CUDA>,$<OR:$<CONFIG:RelWithDebInfo>,$<CONFIG:Debug>>>:--source-in-ptx>")
-
 # Disable warnings from the CUDA frontend about unknown GCC pragmas - let the compiler decide what it likes.
 add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:-Xcudafe;--diag_suppress=unrecognized_gcc_pragma>")
+# Add track debug as compile definition for CUDA if debugging requested
+if(ADEPT_DEBUG_TRACK GREATER 0)
+  add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:-DADEPT_DEBUG_TRACK=${ADEPT_DEBUG_TRACK}>")
+endif()
 
 find_package(G4HepEm CONFIG REQUIRED)
 if(G4HepEm_FOUND)

--- a/examples/Example1/src/EventAction.cc
+++ b/examples/Example1/src/EventAction.cc
@@ -94,7 +94,7 @@ void EventAction::EndOfEventAction(const G4Event *aEvent)
   }
 
   if (fVerbosity > 0) {
-    G4cout << "EndOfEventAction " << eventId << "Total energy deposited: " << totalEnergy / MeV << " MeV" << G4endl;
+    G4cout << "EndOfEventAction " << eventId << " Total energy deposited: " << totalEnergy / MeV << " MeV" << G4endl;
   }
 
   // Restore the original IO precission

--- a/include/AdePT/copcore/Ranluxpp.h
+++ b/include/AdePT/copcore/Ranluxpp.h
@@ -83,6 +83,21 @@ public:
     return bits;
   }
 
+  /// Return random bits matching the current state without advancing it
+  __host__ __device__ uint64_t GetRandomBits() const
+  {
+    int idx     = fPosition / 64;
+    int offset  = fPosition % 64;
+    int numBits = 64 - offset;
+
+    uint64_t bits = fState[idx] >> offset;
+    if (numBits < w) {
+      bits |= fState[(idx + 1) % 9] << numBits;
+    }
+    bits &= ((uint64_t(1) << w) - 1);
+    return bits;
+  }
+
   /// Return a floating point number, converted from the next random bits.
   __host__ __device__ double NextRandomFloat()
   {
@@ -155,6 +170,8 @@ public:
   __host__ __device__ double operator()() { return this->NextRandomFloat(); }
   /// Generate a random integer value with 48 bits
   __host__ __device__ uint64_t IntRndm() { return this->NextRandomBits(); }
+  /// Generate a random integer value with 48 bits without advancing the state
+  __host__ __device__ uint64_t IntRndmNoAdvance() const { return this->GetRandomBits(); }
 
   /// Branch a new RNG state, also advancing the current one.
   /// The caller must Advance() the branched RNG state to decorrelate the

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -645,7 +645,7 @@ std::unique_ptr<GPUstate, GPUstateDeleter> InitializeGPU(int trackCapacity, int 
 
     gpuState.particles[i].tracks = trackStorage_dev;
 
-    printf("%u track slots allocated for particle type %d on GPU (%.2lf%% of %d total slots allocated)\n", nSlot, i,
+    printf("%lu track slots allocated for particle type %d on GPU (%.2lf%% of %d total slots allocated)\n", nSlot, i,
            ParticleType::relativeQueueSize[i] * 100, trackCapacity);
   }
 

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -57,6 +57,7 @@ struct Track {
   long hitsurfID{0};
 #endif
 
+  uint64_t id{0}; ///< track id (non-consecutive, reproducible)
   unsigned int eventId{0};
   int parentId{-1}; // Stores the track id of the initial particle given to AdePT
   short threadId{-1};
@@ -82,6 +83,7 @@ struct Track {
         looperCounter{0}
   {
     rngState.SetSeed(rngSeed);
+    id                      = rngState.IntRndmNoAdvance();
     pos                     = {position[0], position[1], position[2]};
     dir                     = {direction[0], direction[1], direction[2]};
     vertexPosition          = {vertexPos[0], vertexPos[1], vertexPos[2]};
@@ -90,14 +92,30 @@ struct Track {
 
   /// Construct a secondary from a parent track.
   /// NB: The caller is responsible to branch a new RNG state.
-  __device__ Track(RanluxppDouble const &rngState, double eKin, const vecgeom::Vector3D<Precision> &parentPos,
+  __device__ Track(RanluxppDouble const &rng_state, double eKin, const vecgeom::Vector3D<Precision> &parentPos,
                    const vecgeom::Vector3D<Precision> &newDirection, const vecgeom::NavigationState &newNavState,
                    const Track &parentTrack, const double globalTime)
-      : rngState{rngState}, eKin{eKin}, globalTime{globalTime}, pos{parentPos}, dir{newDirection},
-        navState{newNavState}, originNavState{newNavState}, eventId{parentTrack.eventId},
-        parentId{parentTrack.parentId}, threadId{parentTrack.threadId}, vertexEkin{eKin}, weight{parentTrack.weight},
-        vertexPosition{parentPos}, vertexMomentumDirection{newDirection}, stepCounter{0}, looperCounter{0}
+      : rngState{rng_state}, eKin{eKin}, globalTime{globalTime}, pos{parentPos}, dir{newDirection},
+        navState{newNavState}, originNavState{newNavState}, id{rng_state.IntRndmNoAdvance()},
+        eventId{parentTrack.eventId}, parentId{parentTrack.parentId}, threadId{parentTrack.threadId}, vertexEkin{eKin},
+        weight{parentTrack.weight}, vertexPosition{parentPos}, vertexMomentumDirection{newDirection}, stepCounter{0},
+        looperCounter{0}
   {
+  }
+
+  __host__ __device__ VECGEOM_FORCE_INLINE bool Matches(size_t itrack, size_t stepmin = 0,
+                                                        size_t stepmax = 100000) const
+  {
+    return (itrack == id) && (stepCounter >= stepmin) && (stepCounter <= stepmax);
+  }
+
+  __host__ __device__ void Print() const
+  {
+    printf("== evt %u prim %lu track %lu step %d ekin %g MeV | pos {%.19f, %.19f, %.19f} dir {%.19f, %.19f, "
+           "%.19f} remain_safe %g loop %u\n| state: ",
+           eventId, parentId, id, stepCounter, eKin / copcore::units::MeV, pos[0], pos[1], pos[2], dir[0], dir[1],
+           dir[2], GetSafety(pos), looperCounter);
+    navState.Print();
   }
 
   /// @brief Get recomputed cached safety ay a given track position

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -111,7 +111,7 @@ struct Track {
 
   __host__ __device__ void Print() const
   {
-    printf("== evt %u prim %lu track %lu step %d ekin %g MeV | pos {%.19f, %.19f, %.19f} dir {%.19f, %.19f, "
+    printf("== evt %u prim %d track %lu step %d ekin %g MeV | pos {%.19f, %.19f, %.19f} dir {%.19f, %.19f, "
            "%.19f} remain_safe %g loop %u\n| state: ",
            eventId, parentId, id, stepCounter, eKin / copcore::units::MeV, pos[0], pos[1], pos[2], dir[0], dir[1],
            dir[2], GetSafety(pos), looperCounter);

--- a/include/AdePT/core/TrackDebug.cuh
+++ b/include/AdePT/core/TrackDebug.cuh
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2022 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ADEPT_TRACK_DEBUG_CUH
+#define ADEPT_TRACK_DEBUG_CUH
+
+// Track debug information
+struct TrackDebug {
+  uint64_t track_id{0};
+  long min_step{0};
+  long max_step{10000};
+  bool active{false};
+};
+
+__device__ TrackDebug gTrackDebug;
+
+#endif

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -425,11 +425,12 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 
         if (++currentTrack.looperCounter > 500) {
           // Kill loopers that are scraping a boundary
-          printf("Killing looper scraping at a boundary: E=%E event=%d loop=%d energyDeposit=%E geoStepLength=%E "
+          printf("Killing looper scraping at a boundary: E=%E event=%d track=%lu loop=%d energyDeposit=%E "
+                 "geoStepLength=%E "
                  "physicsStepLength=%E "
                  "safety=%E\n",
-                 eKin, currentTrack.eventId, currentTrack.looperCounter, energyDeposit, geometryStepLength,
-                 geometricalStepLengthFromPhysics, safety);
+                 eKin, currentTrack.eventId, currentTrack.id, currentTrack.looperCounter, energyDeposit,
+                 geometryStepLength, geometricalStepLengthFromPhysics, safety);
           continue;
         } else if (!nextState.IsOutside()) {
           // Mark the particle. We need to change its navigation state to the next volume before enqueuing it
@@ -449,11 +450,12 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 
         if (++currentTrack.looperCounter > 500) {
           // Kill loopers that are not advancing in free space
-          printf("Killing looper due to lack of advance: E=%E event=%d loop=%d energyDeposit=%E geoStepLength=%E "
+          printf("Killing looper due to lack of advance: E=%E event=%d track=%lu loop=%d energyDeposit=%E "
+                 "geoStepLength=%E "
                  "physicsStepLength=%E "
                  "safety=%E\n",
-                 eKin, currentTrack.eventId, currentTrack.looperCounter, energyDeposit, geometryStepLength,
-                 geometricalStepLengthFromPhysics, safety);
+                 eKin, currentTrack.eventId, currentTrack.id, currentTrack.looperCounter, energyDeposit,
+                 geometryStepLength, geometricalStepLengthFromPhysics, safety);
           continue;
         }
 

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -86,8 +86,8 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
 
     currentTrack.stepCounter++;
     if (currentTrack.stepCounter >= maxSteps) {
-      printf("Killing gamma event %d E=%f lvol=%d after %d steps. This indicates a stuck particle!\n",
-             currentTrack.eventId, eKin, lvolID, currentTrack.stepCounter);
+      printf("Killing gamma event %d track %lu E=%f lvol=%d after %d steps. This indicates a stuck particle!\n",
+             currentTrack.eventId, currentTrack.id, eKin, lvolID, currentTrack.stepCounter);
       continue;
     }
 


### PR DESCRIPTION
A `uint_64` number is generated from the track seed at construction time. As long as the seed sequence is reproducible and non-clashing, so are the track id's.

To enable debugging of track N in the step range MIN-MAX: configure with ADEPT_TRACK_DEBUG=1; run like: ADEPT_DEBUG_TRACK=N ADEPT_DEBUG_MINSTEP=MIN ADEPT_DEBUG_MAXSTEP=MAX <executable> [args]

This has to be merged AFTER https://github.com/apt-sim/AdePT/pull/387