### PR TITLE
Field cleanup

### DIFF
--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -149,7 +149,9 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     const char *pname[2] = {"e+", "e-"};
     if (gTrackDebug.active) {
       verbose = currentTrack.Matches(gTrackDebug.track_id, gTrackDebug.min_step, gTrackDebug.max_step);
-      if (verbose) currentTrack.Print(pname[IsElectron]);
+      if (verbose) {
+        currentTrack.Print(pname[IsElectron]);
+      }
     }
     printErrors = !gTrackDebug.active || verbose;
 #endif
@@ -583,7 +585,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
                                  : G4HepEmElectronInteractionIoni::SampleETransferBhabha(theElCut, eKin, &rnge);
 
 #if ADEPT_DEBUG_TRACK > 0
-          if (verbose) printf("| IONIZATION: deltaEkin %g ", deltaEkin);
+          if (verbose) printf("| IONIZATION: deltaEkin %g \n", deltaEkin);
 #endif
 
           double dirPrimary[] = {dir.x(), dir.y(), dir.z()};
@@ -598,7 +600,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
             energyDeposit += deltaEkin;
 
 #if ADEPT_DEBUG_TRACK > 0
-            if (verbose) printf("| secondary killed by cut ");
+            if (verbose) printf("| secondary killed by cut \n");
 #endif
 
           } else {
@@ -625,7 +627,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
             energyDeposit += eKin;
             stopped = true;
 #if ADEPT_DEBUG_TRACK > 0
-            if (verbose) printf("\n| STOPPED by tracking cut\n");
+            if (verbose) printf("| STOPPED by tracking cut\n");
 #endif
             break;
           }
@@ -649,14 +651,14 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 
           adept_scoring::AccountProduced(userScoring, /*numElectrons*/ 0, /*numPositrons*/ 0, /*numGammas*/ 1);
 #if ADEPT_DEBUG_TRACK > 0
-          if (verbose) printf("| BREMSSTRAHLUNG: deltaEkin %g ", deltaEkin);
+          if (verbose) printf("| BREMSSTRAHLUNG: deltaEkin %g \n", deltaEkin);
 #endif
           // Apply cuts
           if (ApplyCuts && (deltaEkin < theGammaCut)) {
             // Deposit the energy here and kill the secondary
             energyDeposit += deltaEkin;
 #if ADEPT_DEBUG_TRACK > 0
-            if (verbose) printf("| secondary killed by cut ");
+            if (verbose) printf("| secondary killed by cut \n");
 #endif
           } else {
 #ifdef ASYNC_MODE
@@ -683,7 +685,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
             energyDeposit += eKin;
             stopped = true;
 #if ADEPT_DEBUG_TRACK > 0
-            if (verbose) printf("\n| STOPPED by tracking cut\n");
+            if (verbose) printf("| STOPPED by tracking cut\n");
 #endif
             break;
           }

--- a/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
+++ b/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
@@ -15,10 +15,34 @@
 
 #include <VecGeom/navigation/NavigationState.h>
 
+/// @brief Runge-Kutta propagator in magnetic field
+/// @tparam Field_t Field type
+/// @tparam RkDriver_t Driver type
+/// @tparam Real_t Precision type
+/// @tparam Navigator Navigator type
 template <class Field_t, class RkDriver_t, typename Real_t, class Navigator>
 class fieldPropagatorRungeKutta {
 public:
-  static inline __host__ __device__ __host__ __device__ Real_t
+  /// @brief Propagating method attempting to push a particle with the step proposed by physics
+  /// @param magneticField Field map
+  /// @param kinE Kinetc energy
+  /// @param mass Particle mass
+  /// @param charge Particle charge
+  /// @param physicsStep Step to propagate with
+  /// @param safeLength B-field safety depending only on track curvature
+  /// @param position Particle position
+  /// @param direction Particle direction
+  /// @param current_state[in] Current geometry state
+  /// @param next_state[out] Geometry state after propagation
+  /// @param hitsurf_index[out] Index of the hit surface (surface model only)
+  /// @param propagated[out] Checks if the step was fully propagated
+  /// @param safetyIn Geometric isotropic safety
+  /// @param max_iterations Maximum allowed iterations
+  /// @param iterDone[out] Number of iterations performed
+  /// @param threadId Thread id
+  /// @param verbose Verbosity
+  /// @return Length of the step made
+  static inline __host__ __device__ Real_t
   ComputeStepAndNextVolume(Field_t const &magneticField, double kinE, double mass, int charge, double physicsStep,
                            double safeLength, vecgeom::Vector3D<Real_t> &position, vecgeom::Vector3D<Real_t> &direction,
                            vecgeom::NavigationState const &current_state, vecgeom::NavigationState &next_state,
@@ -80,23 +104,10 @@ fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>::ComputeStep
     const int max_iterations, int &itersDone, //  useful for now - to monitor and report -- unclear if needed later
     int indx, bool verbose)
 {
-  // using copcore::units::MeV;
-
-  const Real_t momentumMag              = sqrt(kinE * (kinE + 2.0 * mass));
-  vecgeom::Vector3D<Real_t> momentumVec = momentumMag * direction;
-
-  Precision maxNextSafeMove = safeLength; // It can be reduced if, at the start, a boundary is encountered
-
-  Real_t stepDone           = 0.0;
-  Real_t remains            = physicsStep;
-  const Real_t tiniest_step = 1.0e-7 * physicsStep; // Ignore remainder if < e_s * PhysicsStep
-  int chordIters            = 0;
-  Real_t last_good_step     = 0.0; // to be re-used for next cord iteration
-
+  Real_t stepDone = 0.0;         ///< step already done
+  Real_t remains  = physicsStep; ///< reminder of the step to be done
   constexpr bool inZeroFieldRegion =
       false; // This could be a per-region flag ... - better depend on template parameter?
-  bool found_end = false;
-
   if (inZeroFieldRegion) {
 #ifdef ADEPT_USE_SURF
     stepDone = Navigator_t::ComputeStepAndNextVolume(position, direction, remains, current_state, next_state,
@@ -105,174 +116,215 @@ fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>::ComputeStep
     stepDone = Navigator_t::ComputeStepAndNextVolume(position, direction, remains, current_state, next_state, kPush);
 #endif
     position += stepDone * direction;
-  } else {
-    bool continueIteration       = false;
-    bool fullChord               = false;
-    const Real_t inv_momentumMag = 1.0 / momentumMag;
-
-    Precision safety                       = safetyIn;
-    vecgeom::Vector3D<Real_t> safetyOrigin = position;
-    // Prepare next_state in case we skip navigation inside the safety sphere.
-    current_state.CopyTo(&next_state);
-    next_state.SetBoundaryState(false);
-#if ADEPT_DEBUG_TRACK > 0
-    if (verbose) {
-      printf("| fieldPropagatorRK start pos {%.19f, %.19f, %.19f} dir {%.19f, %.19f, %.19f} physicsStep %g safety %g "
-             "safeLength %g",
-             position[0], position[1], position[2], direction[0], direction[1], direction[2], physicsStep, safety,
-             safeLength);
-      current_state.Print();
-    }
-#endif
-    bool lastWasZero = false; // Debug only ?  JA 2022.09.05
-
-    //  Locate the intersection of the curved trajectory and the boundaries of the current
-    //    volume (including daughters).
-    do {
-      static constexpr Precision ReduceFactor = 0.1;
-      static constexpr int ReduceIters        = 6;
-
-      vecgeom::Vector3D<Real_t> endPosition    = position;
-      vecgeom::Vector3D<Real_t> endMomentumVec = momentumVec;                   // momentumMag * direction;
-      const Real_t safeArc                     = min(remains, maxNextSafeMove); // safeLength);
-
-      Real_t dydx_end[Nvar]; // not used at the moment, but could be used for FSAL between cord integrations
-      bool done = RkDriver_t::Advance(endPosition, endMomentumVec, charge, safeArc, magField, dydx_end, last_good_step,
-                                      /*max_trials=*/30, chordIters);
-
-      //-----------------
-      vecgeom::Vector3D<Real_t> chordDir     = endPosition - position; // not yet normalized!
-      Real_t chordLen                        = chordDir.Length();
-      vecgeom::Vector3D<Real_t> endDirection = inv_momentumMag * endMomentumVec;
-      chordDir *= (1.0 / chordLen); // Now the normalized direction of the chord!
-
-      Precision currentSafety = safety - (endPosition - safetyOrigin).Length();
-#if ADEPT_DEBUG_TRACK > 0
-      if (verbose) printf("| Advance: chordLen %g currentSafety %g ", chordLen, currentSafety);
-#endif
-      Precision move;
-      if (currentSafety > chordLen) {
-        move = chordLen;
-      } else {
-        Precision newSafety = 0;
-        if (stepDone > 0) {
-#ifdef ADEPT_USE_SURF
-          // Use maximum accuracy only if safety is smaller than physicalStepLength
-          newSafety = Navigator_t::ComputeSafety(position, current_state, physicsStep);
-#else
-          newSafety = Navigator_t::ComputeSafety(position, current_state);
-#endif
-#if ADEPT_DEBUG_TRACK > 0
-          if (verbose) printf("| newSafety %g  ", newSafety);
-#endif
-        }
-        if (newSafety > chordLen) {
-          move         = chordLen;
-          safetyOrigin = position;
-          safety       = newSafety;
-        } else {
-#if ADEPT_DEBUG_TRACK > 0
-          if (verbose)
-            printf("\n| +++  ComputeStepAndNextVolume pos {%.17f, %.17f, %.17f} chordDir {%.17f, %.17f, %.17f} "
-                   "chordLen %g push %g\n",
-                   position[0], position[1], position[2], chordDir[0], chordDir[1], chordDir[2], chordLen, kPush);
-#endif
-
-#ifdef ADEPT_USE_SURF
-          move = Navigator_t::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state,
-                                                       hitsurf_index, kPush);
-#else
-          move = Navigator_t::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state, kPush);
-#endif
-        }
-      }
-
-      // Real_t curvedStep;
-
-      lastWasZero = lastWasZero && !(chordIters >= ReduceIters);
-      // if (lastWasZero && chordIters >= ReduceIters) {
-      //   lastWasZero = false;
-      // }
-
-      fullChord = (move == chordLen); // linearStep
-      if (fullChord) {
-        position    = endPosition;
-        momentumVec = endMomentumVec;
-
-        direction = endDirection;
-        move      = safeArc; // curvedStep
-#if ADEPT_DEBUG_TRACK > 0
-        if (verbose) printf("| full chord maxNextSafeMove %g ", safeArc);
-#endif
-
-        maxNextSafeMove   = safeArc; // Reset it, once a step succeeds!!
-        continueIteration = true;
-      } else if (move <= kPush + Navigator_t::kBoundaryPush && stepDone == 0) { // linearStep
-        // Cope with a track at a boundary that wants to bend back into the previous
-        //   volume in the first step (by reducing the attempted distance.)
-        // FIXME: Even for zero steps, the Navigator will return kPush + possibly
-        // Navigator::kBoundaryPush instead of a real 0.
-        move        = 0; // curvedStep
-        lastWasZero = true;
-
-        // Reduce the step attempted in the next iteration to navigate around
-        // boundaries where the chord step may end in a volume we just left.
-        maxNextSafeMove   = ReduceFactor * safeArc;
-        continueIteration = chordIters < ReduceIters;
-
-        if (!continueIteration) {
-          // Let's move to the other side of this boundary -- this side we cannot progress !!
-          move = Navigator_t::kBoundaryPush; // curvedStep
-        }
-#if ADEPT_DEBUG_TRACK > 0
-        if (verbose) printf("| small move %g  maxNextSafeMove %g ", move, maxNextSafeMove);
-#endif
-      } else {
-        assert(next_state.IsOnBoundary());
-        // assert( linearStep == chordLen );
-
-        // USE the intersection point on the chord & surface as the 'solution', ie. instead
-        //     of the (potential) true point on the intersection of the curve and the boundary.
-        // ( This involves a bias -- typically important only for muons in trackers.
-        //   Currently it's controlled/limited by the acceptable step size ie. 'safeLength' )
-        Real_t fraction = vecCore::Max(move / chordLen, 0.); // linearStep
-        move            = fraction * safeArc;                // curvedStep
-#ifndef ENDPOINT_ON_CURVE
-        // Primitive approximation of end direction and linearStep to the crossing point ...
-        position    = position + move * chordDir; // linearStep
-        direction   = direction * (1.0 - fraction) + endDirection * fraction;
-        direction   = direction.Unit();
-        momentumVec = momentumMag * direction;
-        // safeArc is how much the track would have been moved if not hitting the boundary
-        // We approximate the actual reduction along the curved trajectory to be the same
-        // as the reduction of the full chord due to the boundary crossing.
-#else
-        // Alternative approximation of end position & direction -- calling RK again
-        //  Better accuracy (e.g. for comparing with Helix) -- but the point will not be on the surface !!
-        // IntegrateTrackToEnd(magField, position, momentumVec, charge, move, indx); // curvedStep
-        Real_t dydx_end[Nvar]; // not used at the moment, but could be used for FSAL between cord integrations
-        bool done = RkDriver_t::Advance(position, momentumVec, charge, move, magField, dydx_end, /*max_trials=*/30);
-
-        direction = inv_momentumMag * momentumVec; // momentumVec.Unit();
-#endif
-#if ADEPT_DEBUG_TRACK > 0
-        if (verbose) printf("| linear step move %g ", move);
-#endif
-        continueIteration = false;
-      }
-
-      stepDone += move; // curvedStep
-      remains -= move;  // curvedStep
-      chordIters++;
-#if ADEPT_DEBUG_TRACK > 0
-      if (verbose) printf("| stepDone %g remains %g chordIters %d\n", stepDone, remains, chordIters);
-#endif
-
-      found_end = ((move > 0) && next_state.IsOnBoundary()) // curvedStep Fix 2022.09.05 JA
-                  || (remains <= tiniest_step);
-
-    } while (!found_end && continueIteration && (chordIters < max_iterations));
+    return stepDone;
   }
+
+  // Maximum integration trials
+  constexpr int kMaxTrials = 30;
+  // Limit for ignoring remainder depending on physics step
+  const Real_t tiniest_step = 1.0e-7 * physicsStep;
+
+  const Real_t momentumMag              = sqrt(kinE * (kinE + 2.0 * mass));
+  vecgeom::Vector3D<Real_t> momentumVec = momentumMag * direction;
+
+  // The allowed safe move is normally determined by the bending accuracy
+  // This is reduced if starting from a boundary and crossing a boundary in the first step
+  Real_t maxNextSafeMove = safeLength; // It can be reduced if, at the start, a boundary is encountered
+  int chordIters         = 0;          ///< number of iterations for this integration
+  Real_t last_good_step  = 0.0;        ///< to be re-used for next cord iteration
+  bool found_end         = false;
+  bool continueIteration = false;
+  bool fullChord         = false;
+  // bool lastWasZero             = false; // Debug only ?  JA 2022.09.05
+  const Real_t inv_momentumMag = 1.0 / momentumMag;
+
+  // Cache safety origin and value at the start point
+  Precision safety                       = safetyIn;
+  vecgeom::Vector3D<Real_t> safetyOrigin = position;
+  // Prepare next_state in case we skip navigation inside the safety sphere.
+  current_state.CopyTo(&next_state);
+  next_state.SetBoundaryState(false);
+#if ADEPT_DEBUG_TRACK > 0
+  if (verbose) {
+    printf("| fieldPropagatorRK start pos {%.19f, %.19f, %.19f} dir {%.19f, %.19f, %.19f} physicsStep %g safety %g "
+           "safeLength %g",
+           position[0], position[1], position[2], direction[0], direction[1], direction[2], physicsStep, safety,
+           safeLength);
+    current_state.Print();
+  }
+#endif
+
+  //  Locate the intersection of the curved trajectory and the boundaries of the current
+  //    volume (including daughters).
+  do {
+    static constexpr Precision ReduceFactor = 0.1; ///< Factor to reduce the first step in case of crossing
+    static constexpr int ReduceIters        = 6;   ///< Number of reduced step trials to move away from the boundary
+
+    // Position and momentum at the end of the current arc
+    vecgeom::Vector3D<Real_t> endPosition    = position;
+    vecgeom::Vector3D<Real_t> endMomentumVec = momentumVec;
+
+    // Note: safeArc is not limited by geometry, so after pushing we need to validate that we have not crossed
+    const Real_t safeArc = min(remains, maxNextSafeMove);
+
+    Real_t dydx_end[Nvar]; // not used at the moment, but could be used for FSAL between cord integrations
+                           // Integrate the step.
+    /*bool done = */
+    RkDriver_t::Advance(endPosition, endMomentumVec, charge, safeArc, magField, dydx_end, last_good_step, kMaxTrials,
+                        chordIters);
+
+    //----------------- Get chord
+    vecgeom::Vector3D<Real_t> chordDir = endPosition - position; // not yet normalized!
+    Real_t chordLen                    = chordDir.Length();
+    chordDir *= (1.0 / chordLen); // Now the normalized direction of the chord!
+    vecgeom::Vector3D<Real_t> endDirection = inv_momentumMag * endMomentumVec;
+    // Normalize direction, which is NOT after calling Advance
+    endDirection.Normalize();
+
+    // Subtract from the existing safety after the move
+    Precision currentSafety = safety - (endPosition - safetyOrigin).Length();
+#if ADEPT_DEBUG_TRACK > 0
+    if (verbose)
+      printf("| Advance #%d: safeArc %g | chordLen %g | reducedSafety %g ", chordIters, safeArc, chordLen,
+             currentSafety);
+#endif
+    Precision move;
+    if (currentSafety > chordLen) {
+      // The move is still safe
+      move = chordLen;
+    } else {
+      // Safety is violated by the move, set it to 0 and recompute it if not the first step
+      Precision newSafety = 0;
+      if (stepDone > 0) {
+        // Use maximum accuracy only if safety is smaller than the step remainder
+        newSafety = Navigator_t::ComputeSafety(position, current_state, remains);
+#if ADEPT_DEBUG_TRACK > 0
+        if (verbose) printf("| newSafety %g  ", newSafety);
+#endif
+      }
+      if (newSafety > chordLen) {
+        // The recomputed safety was actually larger than the chord -> safe step
+        move = chordLen;
+        // update safety with the computed one BEFORE the arc sdvance
+        safetyOrigin = position;
+        safety       = newSafety;
+      } else {
+        // We need to check if the arc actually crosses any boundary along the chord and withing chordLen
+#if ADEPT_DEBUG_TRACK > 0
+        if (verbose)
+          printf("\n| +++  ComputeStepAndNextVolume pos {%.17f, %.17f, %.17f} chordDir {%.17f, %.17f, %.17f} "
+                 "chordLen %g push %g\n",
+                 position[0], position[1], position[2], chordDir[0], chordDir[1], chordDir[2], chordLen, kPush);
+#endif
+
+#ifdef ADEPT_USE_SURF
+        move = Navigator_t::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state,
+                                                     hitsurf_index, kPush);
+#else
+        move = Navigator_t::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state, kPush);
+#endif
+      }
+    }
+
+    // lastWasZero &= chordIters < ReduceIters;
+
+    fullChord = (move >= chordLen);
+    if (fullChord) {
+      // No boundary hit along the chord -> update
+      // Note: the arc may have actually hit a corner, but this is accepted within the sagita error
+      // which is accounted for by chordLen
+      position    = endPosition;
+      momentumVec = endMomentumVec;
+
+      direction = endDirection;
+      move      = safeArc; // curvedStep
+#if ADEPT_DEBUG_TRACK > 0
+      if (verbose) printf("| full chord advance %g ", safeArc);
+#endif
+
+      maxNextSafeMove   = safeArc; // Reset it, once a step succeeds!!
+      continueIteration = true;
+    } else if (stepDone == 0 && move <= kPush + Navigator_t::kBoundaryPush) {
+      // Cope with a track at a boundary that wants to bend back into the previous
+      // volume in the first step (by reducing the attempted distance.)
+
+      // Deal with back-scattered tracks that need to be relocated. Check distance along initial direction.
+#ifdef ADEPT_USE_SURF
+      move = Navigator_t::ComputeStepAndNextVolume(position, direction, remains, current_state, next_state,
+                                                   hitsurf_index, kPush);
+#else
+      move = Navigator_t::ComputeStepAndNextVolume(position, direction, remains, current_state, next_state, kPush);
+#endif
+
+      if (move <= kPush + Navigator_t::kBoundaryPush) {
+#if ADEPT_DEBUG_TRACK > 0
+        if (verbose) printf("| BACK-SCATTERING detected\n");
+#endif
+        position += (kPush + Navigator_t::kBoundaryPush) * direction;
+        return (kPush + Navigator_t::kBoundaryPush);
+      }
+
+      // Reduce the step attempted in the next iteration to navigate around
+      // boundaries where the chord step may end in a volume we just left.
+      // lastWasZero = true;
+      move              = 0.;
+      maxNextSafeMove   = ReduceFactor * safeArc;
+      continueIteration = chordIters < ReduceIters;
+
+      if (!continueIteration) {
+        // Let's move to the other side of this boundary -- this side we cannot progress !!
+        move = Navigator_t::kBoundaryPush; // curvedStep
+      }
+#if ADEPT_DEBUG_TRACK > 0
+      if (verbose)
+        printf("| FIRST STEP BENDING BACK %g  reducedAdvance %g continue %d", move, maxNextSafeMove, continueIteration);
+#endif
+    } else {
+      // A boundary is on the way at non-zero distance
+      assert(next_state.IsOnBoundary());
+      // assert( linearStep == chordLen );
+
+      // USE the intersection point on the chord & surface as the 'solution', ie. instead
+      //     of the (potential) true point on the intersection of the curve and the boundary.
+      // ( This involves a bias -- typically important only for muons in trackers.
+      //   Currently it's controlled/limited by the acceptable step size ie. 'safeLength' )
+      Real_t fraction = vecCore::Max(move / chordLen, 0.); // linearStep
+      // The actual distance to the boundary is along the arc, so changing it as below would
+      // be appropriate, however this won't put the last step on the real boundary which is error-prone
+      // move = fraction * safeArc; // curvedStep
+#ifndef ENDPOINT_ON_CURVE
+      // Primitive approximation of end direction and linearStep to the crossing point ...
+      position    = position + move * chordDir; // linearStep
+      direction   = direction * (1.0 - fraction) + endDirection * fraction;
+      direction   = direction.Unit();
+      momentumVec = momentumMag * direction;
+      // safeArc is how much the track would have been moved if not hitting the boundary
+      // We approximate the actual reduction along the curved trajectory to be the same
+      // as the reduction of the full chord due to the boundary crossing.
+#else
+      // Alternative approximation of end position & direction -- calling RK again
+      //  Better accuracy (e.g. for comparipropagated the moment, but could be used for FSAL between cord integrations
+      bool done = RkDriver_t::Advance(position, momentumVec, charge, move, magField, dydx_end, /*max_trials=*/30);
+
+      direction = inv_momentumMag * momentumVec; // momentumVec.Unit();
+#endif
+#if ADEPT_DEBUG_TRACK > 0
+      if (verbose) printf("| linear step to crossing point %g ", move);
+#endif
+      continueIteration = false;
+    }
+
+    stepDone += move; // curvedStep
+    remains -= move;  // curvedStep
+    chordIters++;
+    found_end = ((move > 0) && next_state.IsOnBoundary()) // curvedStep Fix 2022.09.05 JA
+                || (remains <= tiniest_step);
+#if ADEPT_DEBUG_TRACK > 0
+    if (verbose)
+      printf("| stepDone %g remains %g foundEnd = %d chordIters %d\n", stepDone, remains, found_end, chordIters);
+#endif
+
+  } while (!found_end && continueIteration && (chordIters < max_iterations));
 
   propagated = found_end;
   itersDone += chordIters;

--- a/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
+++ b/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
@@ -260,8 +260,7 @@ fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>::ComputeStep
 #if ADEPT_DEBUG_TRACK > 0
         if (verbose) printf("| BACK-SCATTERING detected\n");
 #endif
-        position += (kPush + Navigator_t::kBoundaryPush) * direction;
-        return (kPush + Navigator_t::kBoundaryPush);
+        return 0.;
       }
 
       // Reduce the step attempted in the next iteration to navigate around

--- a/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
+++ b/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
@@ -303,7 +303,7 @@ fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>::ComputeStep
 #else
       // Alternative approximation of end position & direction -- calling RK again
       //  Better accuracy (e.g. for comparing with Helix) but the point will not be on the surface !!
-      // bool done = 
+      // bool done =
       RkDriver_t::Advance(position, momentumVec, charge, move, magField, dydx_end, /*max_trials=*/30);
 
       direction = inv_momentumMag * momentumVec; // requires re-normalization after Advance

--- a/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
+++ b/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
@@ -105,7 +105,7 @@ fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>::ComputeStep
     int indx, bool verbose)
 {
   Real_t stepDone = 0.0;         ///< step already done
-  Real_t remains  = physicsStep; ///< reminder of the step to be done
+  Real_t remains  = physicsStep; ///< remainder of the step to be done
   constexpr bool inZeroFieldRegion =
       false; // This could be a per-region flag ... - better depend on template parameter?
   if (inZeroFieldRegion) {
@@ -167,7 +167,7 @@ fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>::ComputeStep
     // Note: safeArc is not limited by geometry, so after pushing we need to validate that we have not crossed
     const Real_t safeArc = min(remains, maxNextSafeMove);
 
-    Real_t dydx_end[Nvar]; // not used at the moment, but could be used for FSAL between cord integrations
+    Real_t dydx_end[Nvar]; // not re-used at the moment, but could be used for FSAL between cord integrations
                            // Integrate the step.
     /*bool done = */
     RkDriver_t::Advance(endPosition, endMomentumVec, charge, safeArc, magField, dydx_end, last_good_step, kMaxTrials,
@@ -205,7 +205,7 @@ fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>::ComputeStep
       if (newSafety > chordLen) {
         // The recomputed safety was actually larger than the chord -> safe step
         move = chordLen;
-        // update safety with the computed one BEFORE the arc sdvance
+        // update safety with the computed one BEFORE the arc advance
         safetyOrigin = position;
         safety       = newSafety;
       } else {
@@ -302,10 +302,12 @@ fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>::ComputeStep
       // as the reduction of the full chord due to the boundary crossing.
 #else
       // Alternative approximation of end position & direction -- calling RK again
-      //  Better accuracy (e.g. for comparipropagated the moment, but could be used for FSAL between cord integrations
-      bool done = RkDriver_t::Advance(position, momentumVec, charge, move, magField, dydx_end, /*max_trials=*/30);
+      //  Better accuracy (e.g. for comparing with Helix) but the point will not be on the surface !!
+      // bool done = 
+      RkDriver_t::Advance(position, momentumVec, charge, move, magField, dydx_end, /*max_trials=*/30);
 
-      direction = inv_momentumMag * momentumVec; // momentumVec.Unit();
+      direction = inv_momentumMag * momentumVec; // requires re-normalization after Advance
+      direction.Normalize();
 #endif
 #if ADEPT_DEBUG_TRACK > 0
       if (verbose) printf("| linear step to crossing point %g ", move);

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -73,8 +73,10 @@ void AdePTTrackingManager::InitializeAdePT()
     if (fAdePTConfiguration->GetVecGeomGDML().empty()) {
       auto *tman  = G4TransportationManager::GetTransportationManager();
       auto *world = tman->GetNavigatorForTracking()->GetWorldVolume();
+      std::cout << "Loading geometry via G4VG\n";
       AdePTGeant4Integration::CreateVecGeomWorld(world);
     } else {
+      std::cout << "Loading geometry via VGDML\n";
       AdePTGeant4Integration::CreateVecGeomWorld(fAdePTConfiguration->GetVecGeomGDML());
     }
 


### PR DESCRIPTION
This is an initial cleanup of the RK pusher. It introduces a couple of fixes and adds comments to the algorithm:
- Crossing a boundary in the first step now checks and detects back-scattering, in which case it returns rather than reducing the integration step.
- The last linear step was moving the track with the corrected arc fraction matching the chord intersection. This approximates better the length of the final arc step, but puts the point not on the boundary and biases the next step in the next volume
- The new direction after the RK advance was not normalized, generating errors downstream navigation

Note: there is also a printout improvement commit - if we want to keep this separate we can rebase instead of squash