### PR TITLE
clean kernel and fix vecgeom version check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,17 +71,58 @@ message(STATUS "Using VecCore version ${Cyan}${VecCore_VERSION}${ColorReset}")
 find_package(XercesC REQUIRED)
 
 # Find VecGeom geometry headers library
-set(VecGeom_VERSION_REQ 2.0.0-dev.3)
 find_package(VecGeom REQUIRED)
-# Older versions did not provide VecGeom_VERSION_STRING, but only VecGeom_VERSION
+
+### VecGeom Version check
+
+# Use VecGeom_VERSION_STRING if defined, otherwise fall back to VecGeom_VERSION
 if(NOT VecGeom_VERSION_STRING)
   set(VecGeom_VERSION_STRING ${VecGeom_VERSION})
 endif()
-if(VecGeom_VERSION_STRING STRLESS VecGeom_VERSION_REQ)
-  message(FATAL_ERROR "AdePT requires at least VecGeom ${VecGeom_VERSION_REQ}, found ${VecGeom_VERSION_STRING}" )
+
+# VecGeom might append build metadata (e.g. '+master.abc123') to the version string.
+# Strip everything after the '+' to focus on the version core.
+string(REGEX REPLACE "\\+.*$" "" CLEANED_VERSION "${VecGeom_VERSION_STRING}")
+
+
+# Try to match the core version suffix to extract either:
+# - an RC version like "rc3", "rc4"
+# - a dev version like "dev.3", "dev.4"
+# This works even if the full suffix is like "rc3.213" or "dev.4.99"
+string(REGEX MATCH "2\\.0\\.0-(rc[0-9]+|dev\\.[0-9]+)" _match "${CLEANED_VERSION}")
+set(MATCHED_SUFFIX "${CMAKE_MATCH_1}")
+
+set(_vecgeom_version_ok FALSE)
+
+# Handle dev versions
+if(MATCHED_SUFFIX MATCHES "dev\\.([0-9]+)")
+  set(devver "${CMAKE_MATCH_1}")
+  if(devver GREATER_EQUAL 4)
+    set(_vecgeom_version_ok TRUE)
+  endif()
+endif()
+
+# Handle rc versions
+if(MATCHED_SUFFIX MATCHES "rc([0-9]+)")
+  set(rcver "${CMAKE_MATCH_1}")
+  if(rcver GREATER_EQUAL 4)
+    set(_vecgeom_version_ok TRUE)
+  endif()
+endif()
+
+# Handle stable releases >= 2.0.0
+if(CLEANED_VERSION VERSION_GREATER_EQUAL "2.0.0" AND NOT MATCHED_SUFFIX)
+  set(_vecgeom_version_ok TRUE)
+endif()
+
+if(NOT _vecgeom_version_ok)
+  message(FATAL_ERROR "AdePT requires VecGeom >= 2.0.0-dev.4 or >= 2.0.0-rc4, but found '${VecGeom_VERSION_STRING}'")
 else()
   message(STATUS "Using VecGeom version ${Cyan}${VecGeom_VERSION_STRING}${ColorReset}")
 endif()
+
+### end version check for VecGeom
+
 # Make sure VecGeom::vgdml is enabled
 if(NOT TARGET VecGeom::vgdml)
   message(FATAL_ERROR "AdePT requires VecGeom compiled with GDML support")

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -28,6 +28,7 @@
 #include <memory>
 #include <thread>
 #include <unordered_map>
+#include <optional>
 
 class G4Region;
 class G4VPhysicalVolume;

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -253,12 +253,8 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       safety = currentTrack.GetSafety(pos);
       if (safety < physicalStepLength) {
         // Recompute safety and update it in the track.
-#ifdef ADEPT_USE_SURF
         // Use maximum accuracy only if safety is samller than physicalStepLength
         safety = AdePTNavigator::ComputeSafety(pos, navState, physicalStepLength);
-#else
-        safety = AdePTNavigator::ComputeSafety(pos, navState);
-#endif
         currentTrack.SetSafety(pos, safety);
 #if ADEPT_DEBUG_TRACK > 0
         if (verbose) printf("| new safety %g ", safety);
@@ -421,12 +417,8 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
           pos += displacement;
         } else {
           // Recompute safety.
-#ifdef ADEPT_USE_SURF
           // Use maximum accuracy only if safety is samller than physicalStepLength
           safety = AdePTNavigator::ComputeSafety(pos, navState, dispR);
-#else
-          safety = AdePTNavigator::ComputeSafety(pos, navState);
-#endif
           currentTrack.SetSafety(pos, safety);
           reducedSafety = sFact * safety;
 
@@ -857,11 +849,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
       // Move to the next boundary now that the Step is recorded
       navState = nextState;
       // Check if the next volume belongs to the GPU region and push it to the appropriate queue
-#ifndef ADEPT_USE_SURF
-      const int nextlvolID = navState.Top()->GetLogicalVolume()->id();
-#else
       const int nextlvolID = navState.GetLogicalId();
-#endif
 #ifdef ASYNC_MODE
       VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];
 #else

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -66,11 +66,7 @@ __global__ void ElectronHowFar(Track *electrons, G4HepEmElectronTrack *hepEMTrac
     const int slot      = (*active)[i];
     Track &currentTrack = electrons[slot];
     // the MCC vector is indexed by the logical volume id
-#ifndef ADEPT_USE_SURF // FIXME remove as soon as surface model branch is merged!
-    const int lvolID = currentTrack.navState.Top()->GetLogicalVolume()->id();
-#else
     const int lvolID = currentTrack.navState.GetLogicalId();
-#endif
 
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID]; // FIXME unify VolAuxData
 
@@ -153,12 +149,8 @@ __global__ void ElectronHowFar(Track *electrons, G4HepEmElectronTrack *hepEMTrac
       safety = currentTrack.GetSafety(currentTrack.pos);
       if (safety < physicalStepLength) {
         // Recompute safety and update it in the track.
-#ifdef ADEPT_USE_SURF
         // Use maximum accuracy only if safety is samller than physicalStepLength
         safety = AdePTNavigator::ComputeSafety(currentTrack.pos, currentTrack.navState, physicalStepLength);
-#else
-        safety = AdePTNavigator::ComputeSafety(currentTrack.pos, currentTrack.navState);
-#endif
         currentTrack.SetSafety(currentTrack.pos, safety);
       }
     }
@@ -233,11 +225,7 @@ __global__ void ElectronPropagation(Track *electrons, G4HepEmElectronTrack *hepE
 
     Track &currentTrack = electrons[slot];
     // the MCC vector is indexed by the logical volume id
-#ifndef ADEPT_USE_SURF // FIXME remove as soon as surface model branch is merged!
-    const int lvolID = currentTrack.navState.Top()->GetLogicalVolume()->id();
-#else
     const int lvolID = currentTrack.navState.GetLogicalId();
-#endif
 
     // Retrieve HepEM track
     G4HepEmElectronTrack &elTrack = hepEMTracks[slot];
@@ -306,11 +294,7 @@ __global__ void ElectronMSC(Track *electrons, G4HepEmElectronTrack *hepEMTracks,
 
     Track &currentTrack = electrons[slot];
     // the MCC vector is indexed by the logical volume id
-#ifndef ADEPT_USE_SURF // FIXME remove as soon as surface model branch is merged!
-    const int lvolID = currentTrack.navState.Top()->GetLogicalVolume()->id();
-#else
     const int lvolID = currentTrack.navState.GetLogicalId();
-#endif
 
     // Retrieve HepEM track
     G4HepEmElectronTrack &elTrack = hepEMTracks[slot];
@@ -344,12 +328,8 @@ __global__ void ElectronMSC(Track *electrons, G4HepEmElectronTrack *hepEMTracks,
           currentTrack.pos += displacement;
         } else {
           // Recompute safety.
-#ifdef ADEPT_USE_SURF
           // Use maximum accuracy only if safety is samller than physicalStepLength
           safety = AdePTNavigator::ComputeSafety(currentTrack.pos, currentTrack.navState, dispR);
-#else
-          safety = AdePTNavigator::ComputeSafety(currentTrack.pos, currentTrack.navState);
-#endif
           currentTrack.SetSafety(currentTrack.pos, safety);
           reducedSafety = sFact * safety;
 
@@ -393,11 +373,7 @@ __global__ void ElectronRelocation(Track *electrons, G4HepEmElectronTrack *hepEM
 
     Track &currentTrack = electrons[slot];
     // the MCC vector is indexed by the logical volume id
-#ifndef ADEPT_USE_SURF // FIXME remove as soon as surface model branch is merged!
-    const int lvolID = currentTrack.navState.Top()->GetLogicalVolume()->id();
-#else
     const int lvolID = currentTrack.navState.GetLogicalId();
-#endif
 
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID]; // FIXME unify VolAuxData
 
@@ -569,11 +545,7 @@ __global__ void ElectronRelocation(Track *electrons, G4HepEmElectronTrack *hepEM
         // Move to the next boundary now that the Step is recorded
         currentTrack.navState = currentTrack.nextState;
         // Check if the next volume belongs to the GPU region and push it to the appropriate queue
-#ifndef ADEPT_USE_SURF
-        const int nextlvolID = currentTrack.navState.Top()->GetLogicalVolume()->id();
-#else
-        const int nextlvolID = currentTrack.navState.GetLogicalId();
-#endif
+        const int nextlvolID          = currentTrack.navState.GetLogicalId();
         VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];
         if (nextauxData.fGPUregion > 0)
           survive();
@@ -647,11 +619,7 @@ __global__ void ElectronInteractions(Track *electrons, G4HepEmElectronTrack *hep
 
     Track &currentTrack = electrons[slot];
     // the MCC vector is indexed by the logical volume id
-#ifndef ADEPT_USE_SURF // FIXME remove as soon as surface model branch is merged!
-    const int lvolID = currentTrack.navState.Top()->GetLogicalVolume()->id();
-#else
     const int lvolID = currentTrack.navState.GetLogicalId();
-#endif
 
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID]; // FIXME unify VolAuxData
 
@@ -912,11 +880,7 @@ __global__ void ElectronIonization(Track *electrons, G4HepEmElectronTrack *hepEM
 
     Track &currentTrack = electrons[slot];
     // the MCC vector is indexed by the logical volume id
-#ifndef ADEPT_USE_SURF // FIXME remove as soon as surface model branch is merged!
-    const int lvolID = currentTrack.navState.Top()->GetLogicalVolume()->id();
-#else
     const int lvolID = currentTrack.navState.GetLogicalId();
-#endif
 
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID]; // FIXME unify VolAuxData
 
@@ -1037,11 +1001,7 @@ __global__ void ElectronBremsstrahlung(Track *electrons, G4HepEmElectronTrack *h
 
     Track &currentTrack = electrons[slot];
     // the MCC vector is indexed by the logical volume id
-#ifndef ADEPT_USE_SURF // FIXME remove as soon as surface model branch is merged!
-    const int lvolID = currentTrack.navState.Top()->GetLogicalVolume()->id();
-#else
     const int lvolID = currentTrack.navState.GetLogicalId();
-#endif
 
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID]; // FIXME unify VolAuxData
 
@@ -1163,11 +1123,7 @@ __global__ void PositronAnnihilation(Track *electrons, G4HepEmElectronTrack *hep
 
     Track &currentTrack = electrons[slot];
     // the MCC vector is indexed by the logical volume id
-#ifndef ADEPT_USE_SURF // FIXME remove as soon as surface model branch is merged!
-    const int lvolID = currentTrack.navState.Top()->GetLogicalVolume()->id();
-#else
     const int lvolID = currentTrack.navState.GetLogicalId();
-#endif
 
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID]; // FIXME unify VolAuxData
 
@@ -1283,11 +1239,7 @@ __global__ void PositronStoppedAnnihilation(Track *electrons, G4HepEmElectronTra
 
     Track &currentTrack = electrons[slot];
     // the MCC vector is indexed by the logical volume id
-#ifndef ADEPT_USE_SURF // FIXME remove as soon as surface model branch is merged!
-    const int lvolID = currentTrack.navState.Top()->GetLogicalVolume()->id();
-#else
     const int lvolID = currentTrack.navState.GetLogicalId();
-#endif
 
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID]; // FIXME unify VolAuxData
 

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -39,11 +39,7 @@ __global__ void __launch_bounds__(256, 1)
     Track &currentTrack = gammas[slot];
     auto navState       = currentTrack.navState;
 
-#ifndef ADEPT_USE_SURF // FIXME remove as soon as surface model branch is merged!
-    int lvolID = navState.Top()->GetLogicalVolume()->id();
-#else
-    int lvolID = navState.GetLogicalId();
-#endif
+    int lvolID                = navState.GetLogicalId();
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID]; // FIXME unify VolAuxData
 #else
 
@@ -65,11 +61,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
     Track &currentTrack = (*gammas)[slot];
     auto navState       = currentTrack.navState;
 
-#ifndef ADEPT_USE_SURF // FIXME remove as soon as surface model branch is merged!
-    int lvolID = navState.Top()->GetLogicalVolume()->id();
-#else
-    int lvolID = navState.GetLogicalId();
-#endif
+    int lvolID                = navState.GetLogicalId();
     VolAuxData const &auxData = auxDataArray[lvolID]; // FIXME unify VolAuxData
 
 #endif
@@ -278,11 +270,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         navState = nextState;
         // printf("  -> pvol=%d pos={%g, %g, %g} \n", navState.TopId(), pos[0], pos[1], pos[2]);
         //  Check if the next volume belongs to the GPU region and push it to the appropriate queue
-#ifndef ADEPT_USE_SURF
-        const int nextlvolID = navState.Top()->GetLogicalVolume()->id();
-#else
         const int nextlvolID = navState.GetLogicalId();
-#endif
 
 #ifdef ASYNC_MODE // FIXME unify VolAuxData
         VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -32,11 +32,7 @@ __global__ void GammaHowFar(Track *gammas, G4HepEmGammaTrack *hepEMTracks, const
     const int slot      = (*active)[i];
     Track &currentTrack = gammas[slot];
 
-#ifndef ADEPT_USE_SURF // FIXME remove as soon as surface model branch is merged!
-    int lvolID = currentTrack.navState.Top()->GetLogicalVolume()->id();
-#else
-    int lvolID = currentTrack.navState.GetLogicalId();
-#endif
+    int lvolID                = currentTrack.navState.GetLogicalId();
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID]; // FIXME unify VolAuxData
 
     currentTrack.leaked      = false;
@@ -112,11 +108,7 @@ __global__ void GammaPropagation(Track *gammas, G4HepEmGammaTrack *hepEMTracks, 
     const int slot      = (*active)[i];
     Track &currentTrack = gammas[slot];
 
-#ifndef ADEPT_USE_SURF // FIXME remove as soon as surface model branch is merged!
-    int lvolID = currentTrack.navState.Top()->GetLogicalVolume()->id();
-#else
     int lvolID = currentTrack.navState.GetLogicalId();
-#endif
 
     G4HepEmGammaTrack &gammaTrack = hepEMTracks[slot];
     G4HepEmTrack *theTrack        = gammaTrack.GetTrack();
@@ -174,11 +166,7 @@ __global__ void GammaRelocation(Track *gammas, G4HepEmGammaTrack *hepEMTracks, c
     auto &slotManager   = *secondaries.gammas.fSlotManager;
     Track &currentTrack = gammas[slot];
 
-#ifndef ADEPT_USE_SURF // FIXME remove as soon as surface model branch is merged!
-    int lvolID = currentTrack.navState.Top()->GetLogicalVolume()->id();
-#else
     int lvolID = currentTrack.navState.GetLogicalId();
-#endif
 
     // Write local variables back into track and enqueue
     auto survive = [&](LeakStatus leakReason = LeakStatus::NoLeak) {
@@ -250,11 +238,7 @@ __global__ void GammaRelocation(Track *gammas, G4HepEmGammaTrack *hepEMTracks, c
         currentTrack.navState = currentTrack.nextState;
         // printf("  -> pvol=%d pos={%g, %g, %g} \n", navState.TopId(), pos[0], pos[1], pos[2]);
         //  Check if the next volume belongs to the GPU region and push it to the appropriate queue
-#ifndef ADEPT_USE_SURF
-        const int nextlvolID = currentTrack.navState.Top()->GetLogicalVolume()->id();
-#else
-        const int nextlvolID = currentTrack.navState.GetLogicalId();
-#endif
+        const int nextlvolID          = currentTrack.navState.GetLogicalId();
         VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];
         if (nextauxData.fGPUregion > 0)
           survive();
@@ -331,11 +315,7 @@ __global__ void GammaInteractions(Track *gammas, G4HepEmGammaTrack *hepEMTracks,
     auto &slotManager   = *secondaries.gammas.fSlotManager;
     Track &currentTrack = gammas[slot];
 
-#ifndef ADEPT_USE_SURF // FIXME remove as soon as surface model branch is merged!
-    int lvolID = currentTrack.navState.Top()->GetLogicalVolume()->id();
-#else
-    int lvolID = currentTrack.navState.GetLogicalId();
-#endif
+    int lvolID                = currentTrack.navState.GetLogicalId();
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID]; // FIXME unify VolAuxData
 
     // Write local variables back into track and enqueue
@@ -532,11 +512,7 @@ __global__ void GammaConversion(Track *gammas, G4HepEmGammaTrack *hepEMTracks, S
     auto &slotManager   = *secondaries.gammas.fSlotManager;
     Track &currentTrack = gammas[slot];
 
-#ifndef ADEPT_USE_SURF // FIXME remove as soon as surface model branch is merged!
-    int lvolID = currentTrack.navState.Top()->GetLogicalVolume()->id();
-#else
-    int lvolID = currentTrack.navState.GetLogicalId();
-#endif
+    int lvolID                = currentTrack.navState.GetLogicalId();
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID]; // FIXME unify VolAuxData
 
     // Write local variables back into track and enqueue
@@ -660,11 +636,7 @@ __global__ void GammaCompton(Track *gammas, G4HepEmGammaTrack *hepEMTracks, Seco
     auto &slotManager   = *secondaries.gammas.fSlotManager;
     Track &currentTrack = gammas[slot];
 
-#ifndef ADEPT_USE_SURF // FIXME remove as soon as surface model branch is merged!
-    int lvolID = currentTrack.navState.Top()->GetLogicalVolume()->id();
-#else
-    int lvolID = currentTrack.navState.GetLogicalId();
-#endif
+    int lvolID                = currentTrack.navState.GetLogicalId();
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID]; // FIXME unify VolAuxData
 
     // Write local variables back into track and enqueue
@@ -784,11 +756,7 @@ __global__ void GammaPhotoelectric(Track *gammas, G4HepEmGammaTrack *hepEMTracks
     auto &slotManager   = *secondaries.gammas.fSlotManager;
     Track &currentTrack = gammas[slot];
 
-#ifndef ADEPT_USE_SURF // FIXME remove as soon as surface model branch is merged!
-    int lvolID = currentTrack.navState.Top()->GetLogicalVolume()->id();
-#else
-    int lvolID = currentTrack.navState.GetLogicalId();
-#endif
+    int lvolID                = currentTrack.navState.GetLogicalId();
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID]; // FIXME unify VolAuxData
 
     // Write local variables back into track and enqueue

--- a/include/AdePT/magneticfield/fieldPropagatorConstBz.h
+++ b/include/AdePT/magneticfield/fieldPropagatorConstBz.h
@@ -117,12 +117,8 @@ __host__ __device__ Precision fieldPropagatorConstBz::ComputeStepAndNextVolume(
     } else {
       Precision newSafety = 0;
       if (stepDone > 0) {
-#ifdef ADEPT_USE_SURF
-        // Use maximum accuracy only if safety is samller than physicalStepLength
+        // Use maximum accuracy only if safety is smaller than physicalStepLength
         newSafety = Navigator::ComputeSafety(position, current_state, remains);
-#else
-        newSafety = Navigator::ComputeSafety(position, current_state);
-#endif
       }
       if (newSafety > chordLen) {
         move         = chordLen;


### PR DESCRIPTION
This PR cleans / fixes 3 things:

1. a missing include of `<optional>` which was discovered with a different compiler
2. it cleans the macros for the surface model for the safety calculation (which were actually only needed to ensure the correct vecgeom version) in the kernels, which can now be done that VecGeom is tagged and the surface model merged.
3. It fixes the CMake version check logic. Due to string comparisons, all kinds of ugly misses happened. Now, it correctly identifies and rejects older versions and accepts correct versions.