### PR TITLE
Tweaks for navigation in field.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,20 +92,21 @@ string(REGEX REPLACE "\\+.*$" "" CLEANED_VERSION "${VecGeom_VERSION_STRING}")
 string(REGEX MATCH "2\\.0\\.0-(rc[0-9]+|dev\\.[0-9]+)" _match "${CLEANED_VERSION}")
 set(MATCHED_SUFFIX "${CMAKE_MATCH_1}")
 
+set(_vecgeom_dev_version 5)
 set(_vecgeom_version_ok FALSE)
 
 # Handle dev versions
 if(MATCHED_SUFFIX MATCHES "dev\\.([0-9]+)")
   set(devver "${CMAKE_MATCH_1}")
-  if(devver GREATER_EQUAL 4)
+  if(devver GREATER_EQUAL _vecgeom_dev_version)
     set(_vecgeom_version_ok TRUE)
   endif()
 endif()
 
 # Handle rc versions
-if(MATCHED_SUFFIX MATCHES "rc([0-9]+)")
+if(MATCHED_SUFFIX MATCHES "rc\\.([0-9]+)")
   set(rcver "${CMAKE_MATCH_1}")
-  if(rcver GREATER_EQUAL 4)
+  if(rcver GREATER_EQUAL _vecgeom_dev_version)
     set(_vecgeom_version_ok TRUE)
   endif()
 endif()
@@ -116,7 +117,7 @@ if(CLEANED_VERSION VERSION_GREATER_EQUAL "2.0.0" AND NOT MATCHED_SUFFIX)
 endif()
 
 if(NOT _vecgeom_version_ok)
-  message(FATAL_ERROR "AdePT requires VecGeom >= 2.0.0-dev.4 or >= 2.0.0-rc4, but found '${VecGeom_VERSION_STRING}'")
+  message(FATAL_ERROR "AdePT requires VecGeom >= 2.0.0-dev.${_vecgeom_dev_version} or >= 2.0.0-rc.${_vecgeom_dev_version}, but found '${VecGeom_VERSION_STRING}'")
 else()
   message(STATUS "Using VecGeom version ${Cyan}${VecGeom_VERSION_STRING}${ColorReset}")
 endif()

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -237,6 +237,7 @@ __global__ void ElectronPropagation(Track *electrons, G4HepEmElectronTrack *hepE
     // Check if there's a volume boundary in between.
     currentTrack.propagated = true;
     currentTrack.hitsurfID  = -1;
+    bool zero_first_step    = false;
 
     if (gMagneticField) {
       int iterDone = -1;
@@ -247,7 +248,12 @@ __global__ void ElectronPropagation(Track *electrons, G4HepEmElectronTrack *hepE
               currentTrack.propagated,
               /*lengthDone,*/ currentTrack.safety,
               // activeSize < 100 ? max_iterations : max_iters_tail ), // Was
-              max_iterations, iterDone, slot);
+              max_iterations, iterDone, slot, zero_first_step);
+      // In case of zero step detected by the field propagator this could be due to back scattering, or wrong relocation
+      // in the previous step.
+      // - In case of BS we should just restore the last exited one for the nextState. For now we cannot detect BS.
+      // if (zero_first_step) nextState.SetNavIndex(navState.GetLastExitedState());
+
     } else {
 #ifdef ADEPT_USE_SURF
       currentTrack.geometryStepLength = AdePTNavigator::ComputeStepAndNextVolume(
@@ -415,6 +421,8 @@ __global__ void ElectronRelocation(Track *electrons, G4HepEmElectronTrack *hepEM
 #else
         AdePTNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, currentTrack.nextState);
 #endif
+        // Set the last exited state to be the one before crossing
+        currentTrack.nextState.SetLastExited(currentTrack.navState.GetState());
       }
     }
 

--- a/test/unit/testField/electrons.cu
+++ b/test/unit/testField/electrons.cu
@@ -220,13 +220,14 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
           fieldPropagatorRungeKutta<Field_t, RkDriver_t, Precision, AdePTNavigator>::ComputeSafeLength /*<Real_t>*/ (
               momentumVec, B0fieldVec, Charge);
 
-      int iterDone = -1;
+      int iterDone         = -1;
+      bool zero_first_step = false;
       geometryStepLength =
           fieldPropagatorRungeKutta<Field_t, RkDriver_t, Precision, AdePTNavigator>::ComputeStepAndNextVolume(
               magneticFieldB, energy, Mass, Charge, geometricalStepLengthFromPhysics, safeLength, pos, dir, navState,
               nextState, hitsurf_index, propagated, /*lengthDone,*/ safety,
               // activeSize < 100 ? max_iterations : max_iters_tail ), // Was
-              max_iterations, iterDone, slot);
+              max_iterations, iterDone, slot, zero_first_step);
 #ifdef CHECK_RESULTS
 #define formatBool(b) ((b) ? "yes " : "no")
       constexpr Precision thresholdDiff = 3.0e-3;


### PR DESCRIPTION
- The last exited state must be reset in the field propagator, if not done by `ComputeStepAndNextVolume` when finding the first parent not containing the point. This is needed because the track may return to the same volume due to BS or curvature.

- Added detection of a first step being zero in magnetic field, which can be used in future correlated with normal computation to signal back-scattering. Currently, the returned value is not used.

- Cleanup of pushes for readability in the field propagator.

- Tweaked some debug printouts.

Note: This PR removes the vast majority of tracks that get stuck at boundaries when used with VecGeom 2.0.0-rc5, but is also compatible with 2.0.0-rc4