### PR TITLE
Improve RNG state

### DIFF
--- a/include/AdePT/copcore/Ranluxpp.h
+++ b/include/AdePT/copcore/Ranluxpp.h
@@ -83,21 +83,6 @@ public:
     return bits;
   }
 
-  /// Return random bits matching the current state without advancing it
-  __host__ __device__ uint64_t GetRandomBits() const
-  {
-    int idx     = fPosition / 64;
-    int offset  = fPosition % 64;
-    int numBits = 64 - offset;
-
-    uint64_t bits = fState[idx] >> offset;
-    if (numBits < w) {
-      bits |= fState[(idx + 1) % 9] << numBits;
-    }
-    bits &= ((uint64_t(1) << w) - 1);
-    return bits;
-  }
-
   /// Return a floating point number, converted from the next random bits.
   __host__ __device__ double NextRandomFloat()
   {
@@ -170,8 +155,6 @@ public:
   __host__ __device__ double operator()() { return this->NextRandomFloat(); }
   /// Generate a random integer value with 48 bits
   __host__ __device__ uint64_t IntRndm() { return this->NextRandomBits(); }
-  /// Generate a random integer value with 48 bits without advancing the state
-  __host__ __device__ uint64_t IntRndmNoAdvance() const { return this->GetRandomBits(); }
 
   /// Branch a new RNG state, also advancing the current one.
   /// The caller must Advance() the branched RNG state to decorrelate the

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -124,6 +124,36 @@ __global__ void InitQueue(adept::MParrayT<T> *queue, size_t Capacity)
   adept::MParrayT<T>::MakeInstanceAt(Capacity, queue);
 }
 
+// 64-bit MurmurHash3 finalizer (good avalanche)
+__device__ inline uint64_t murmur3_64(uint64_t x)
+{
+  x ^= x >> 33;
+  x *= 0xff51afd7ed558ccdULL;
+  x ^= x >> 33;
+  x *= 0xc4ceb9fe1a85ec53ULL;
+  x ^= x >> 33;
+  return x;
+}
+
+/// Generate a “random” uint64_t ID on the device by combining:
+///   • base = initialSeed * eventId + trackId
+///   • eKin (double)
+///   • globalTime (double)
+__device__ inline uint64_t GenerateSeed(uint64_t base, double eKin, double globalTime)
+{
+  // 1) grab the raw bit‐patterns of the doubles
+  uint64_t eb = __double_as_longlong(eKin);
+  uint64_t tb = __double_as_longlong(globalTime);
+
+  // 2) mix them in boost::hash_combine style
+  uint64_t seed = base;
+  seed ^= eb + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
+  seed ^= tb + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
+
+  // 3) final avalanche
+  return murmur3_64(seed);
+}
+
 // Kernel function to initialize tracks comming from a Geant4 buffer
 __global__ void InitTracks(AsyncAdePT::TrackDataWithIDs *trackinfo, int ntracks, Secondaries secondaries,
                            const vecgeom::VPlacedVolume *world, adept::MParrayT<QueueIndexPair> *toBeEnqueued,
@@ -151,11 +181,14 @@ __global__ void InitTracks(AsyncAdePT::TrackDataWithIDs *trackinfo, int ntracks,
 
     // TODO: Delay when not enough slots?
     const auto slot = generator->NextSlot();
-    Track &track    = generator->InitTrack(
-        slot, initialSeed * trackInfo.eventId + trackInfo.trackId, trackInfo.eKin, trackInfo.vertexEkin,
-        trackInfo.globalTime, static_cast<float>(trackInfo.localTime), static_cast<float>(trackInfo.properTime),
-        trackInfo.weight, trackInfo.position, trackInfo.direction, trackInfo.vertexPosition,
-        trackInfo.vertexMomentumDirection, trackInfo.eventId, trackInfo.parentId, trackInfo.threadId);
+    // we need to scramble the initial seed with some more trackinfo to generate a unique seed. otherwise, if a particle
+    // returns from the device and is injected again, it would have the same random number state
+    auto seed = GenerateSeed(initialSeed * trackInfo.eventId + trackInfo.trackId, trackInfo.eKin, trackInfo.globalTime);
+    Track &track = generator->InitTrack(
+        slot, seed, trackInfo.eKin, trackInfo.vertexEkin, trackInfo.globalTime, static_cast<float>(trackInfo.localTime),
+        static_cast<float>(trackInfo.properTime), trackInfo.weight, trackInfo.position, trackInfo.direction,
+        trackInfo.vertexPosition, trackInfo.vertexMomentumDirection, trackInfo.eventId, trackInfo.parentId,
+        trackInfo.threadId);
     track.navState.Clear();
     track.navState       = trackinfo[i].navState;
     track.originNavState = trackinfo[i].originNavState;

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -124,7 +124,7 @@ __global__ void InitQueue(adept::MParrayT<T> *queue, size_t Capacity)
   adept::MParrayT<T>::MakeInstanceAt(Capacity, queue);
 }
 
-// 64-bit MurmurHash3 finalizer (good avalanche)
+// Use the 64-bit MurmurHash3 finalizer for avalanche behaviour so that every input bit can influence every output bit
 __device__ inline uint64_t murmur3_64(uint64_t x)
 {
   x ^= x >> 33;

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -92,7 +92,7 @@ struct Track {
         looperCounter{0}, zeroStepCounter{0}
   {
     rngState.SetSeed(rngSeed);
-    id                      = rngState.IntRndmNoAdvance();
+    id                      = rngState.IntRndm();
     pos                     = {position[0], position[1], position[2]};
     dir                     = {direction[0], direction[1], direction[2]};
     vertexPosition          = {vertexPos[0], vertexPos[1], vertexPos[2]};
@@ -106,10 +106,10 @@ struct Track {
                    const vecgeom::Vector3D<Precision> &newDirection, const vecgeom::NavigationState &newNavState,
                    const Track &parentTrack, const double globalTime)
       : rngState{rng_state}, eKin{eKin}, globalTime{globalTime}, pos{parentPos}, dir{newDirection},
-        navState{newNavState}, originNavState{newNavState}, id{rng_state.IntRndmNoAdvance()},
-        eventId{parentTrack.eventId}, parentId{parentTrack.parentId}, threadId{parentTrack.threadId}, vertexEkin{eKin},
-        weight{parentTrack.weight}, vertexPosition{parentPos}, vertexMomentumDirection{newDirection}, stepCounter{0},
-        looperCounter{0}, zeroStepCounter{0}, leakStatus{LeakStatus::NoLeak}
+        navState{newNavState}, originNavState{newNavState}, id{rngState.IntRndm()}, eventId{parentTrack.eventId},
+        parentId{parentTrack.parentId}, threadId{parentTrack.threadId}, vertexEkin{eKin}, weight{parentTrack.weight},
+        vertexPosition{parentPos}, vertexMomentumDirection{newDirection}, stepCounter{0}, looperCounter{0},
+        zeroStepCounter{0}, leakStatus{LeakStatus::NoLeak}
   {
   }
 

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -799,9 +799,11 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
           double sinPhi, cosPhi;
           sincos(phi, &sinPhi, &cosPhi);
 
-          newRNG.Advance();
+          // as the branched newRNG may have already been used by interactions before, we need to create a new one
+          RanluxppDouble newRNG2(currentTrack.rngState.Branch());
+
 #ifdef ASYNC_MODE
-          Track &gamma1 = secondaries.gammas.NextTrack(newRNG, double{copcore::units::kElectronMassC2}, pos,
+          Track &gamma1 = secondaries.gammas.NextTrack(newRNG2, double{copcore::units::kElectronMassC2}, pos,
                                                        vecgeom::Vector3D<Precision>{sint * cosPhi, sint * sinPhi, cost},
                                                        navState, currentTrack, globalTime);
 
@@ -812,9 +814,8 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
           Track &gamma1 = secondaries.gammas->NextTrack();
           Track &gamma2 = secondaries.gammas->NextTrack();
           gamma1.InitAsSecondary(pos, navState, globalTime);
-          newRNG.Advance();
           gamma1.parentId = currentTrack.parentId;
-          gamma1.rngState = newRNG;
+          gamma1.rngState = newRNG2;
           gamma1.eKin = gamma1.vertexEkin = copcore::units::kElectronMassC2;
           gamma1.weight                   = currentTrack.weight;
           gamma1.dir.Set(sint * cosPhi, sint * sinPhi, cost);

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -589,10 +589,9 @@ __device__ __forceinline__ void PerformStoppedAnnihilation(const int slot, Track
       double sinPhi, cosPhi;
       sincos(phi, &sinPhi, &cosPhi);
 
-      // Perform the discrete interaction, branch a new RNG state with advance so it is
-      // ready to be used. As another state may have already branched from the current rngState, advance it first
+      // as the other branched newRNG may have already been used by interactions before, we need to advance and create a new one
       currentTrack.rngState.Advance();
-      auto newRNG = RanluxppDouble(currentTrack.rngState.Branch());
+      RanluxppDouble newRNG(currentTrack.rngState.Branch());
 
       Track &gamma1 = secondaries.gammas.NextTrack(newRNG, double{copcore::units::kElectronMassC2}, currentTrack.pos,
                                                    vecgeom::Vector3D<Precision>{sint * cosPhi, sint * sinPhi, cost},

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -589,7 +589,8 @@ __device__ __forceinline__ void PerformStoppedAnnihilation(const int slot, Track
       double sinPhi, cosPhi;
       sincos(phi, &sinPhi, &cosPhi);
 
-      // as the other branched newRNG may have already been used by interactions before, we need to advance and create a new one
+      // as the other branched newRNG may have already been used by interactions before, we need to advance and create a
+      // new one
       currentTrack.rngState.Advance();
       RanluxppDouble newRNG(currentTrack.rngState.Branch());
 

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -590,7 +590,8 @@ __device__ __forceinline__ void PerformStoppedAnnihilation(const int slot, Track
       sincos(phi, &sinPhi, &cosPhi);
 
       // Perform the discrete interaction, branch a new RNG state with advance so it is
-      // ready to be used.
+      // ready to be used. As another state may have already branched from the current rngState, advance it first
+      currentTrack.rngState.Advance();
       auto newRNG = RanluxppDouble(currentTrack.rngState.Branch());
 
       Track &gamma1 = secondaries.gammas.NextTrack(newRNG, double{copcore::units::kElectronMassC2}, currentTrack.pos,

--- a/test/regression/scripts/validation_testem3.sh
+++ b/test/regression/scripts/validation_testem3.sh
@@ -37,7 +37,7 @@ $CI_TEST_DIR/python_scripts/macro_generator.py \
     --output ${CI_TMP_DIR}/validation_testem3.mac \
     --gdml_name ${PROJECT_SOURCE_DIR}/examples/data/testEm3.gdml \
     --num_threads 4 \
-    --num_events 250 \
+    --num_events 400 \
     --num_trackslots 3 \
     --num_hitslots 15 \
     --track_in_all_regions True\
@@ -56,6 +56,6 @@ $ADEPT_EXECUTABLE --do_validation --allsensitive --accumulated_events \
 # This is a compromise between run time and accuracy of the test 
 $CI_TEST_DIR/python_scripts/check_validation.py --file1 ${CI_TMP_DIR}/adept_em3_2.5e4_e-.csv \
                                                 --file2 ${CI_TEST_DIR}/benchmark_files/g4hepem_em3_10e7_e-.csv \
-                                                --n1 2.5e4 --n2 1e7 --tol 0.01 \
+                                                --n1 4e4 --n2 1e7 --tol 0.01 \
                                                 # --plot_file plot.png # uncomment to plot the validation plot
 

--- a/test/regression/scripts/validation_testem3_regions.sh
+++ b/test/regression/scripts/validation_testem3_regions.sh
@@ -37,7 +37,7 @@ $CI_TEST_DIR/python_scripts/macro_generator.py \
     --output ${CI_TMP_DIR}/validation_testem3_regions.mac \
     --gdml_name ${PROJECT_SOURCE_DIR}/examples/data/testEm3_regions.gdml \
     --num_threads 8 \
-    --num_events 250 \
+    --num_events 400 \
     --num_trackslots 3 \
     --num_hitslots 15 \
     --track_in_all_regions False\
@@ -56,6 +56,6 @@ $ADEPT_EXECUTABLE --do_validation --allsensitive --accumulated_events \
 # Validating the relative error per layer
 $CI_TEST_DIR/python_scripts/check_validation.py --file1 ${CI_TMP_DIR}/adept_em3_2.5e4_e-.csv \
                                                 --file2 ${CI_TEST_DIR}/benchmark_files/g4hepem_em3_10e7_e-.csv \
-                                                --n1 2.5e4 --n2 1e7 --tol 0.01 \
+                                                --n1 4e4 --n2 1e7 --tol 0.01 \
                                                 # --plot_file plot.png # uncomment to plot the validation plot
 


### PR DESCRIPTION
This PR improves the RNG handling in 3 ways:

1. the initial seed was depending only on the AdePT initial seed, the event id, and the track id. Thus, if a particle left the GPU region and was injected again, it would have received the same seed. This is fixed by generating the seed by scrambling the original seed with the kinetic energy and the global time.

2. When the new ID was generated from the rng state without advancing it, there must have been some truncation because multiple collisions in the trackIds were observed at a rate way too high. This is solved by advancing the state.

3. When a positron fell below the tracking cut, it would annihilate to two gammas. However, this could happen after the first interaction, meaning the newRNG was already used on the first generated secondary. This would lead to collisions of state. 

There are still too many collisions observed, which are currently under investigation.

The failing of the CI was just a random fluctuation, the accuracy is not impacted by this PR.