### PR TITLE
remove rng state from split kernels

### DIFF
--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -52,7 +52,6 @@ struct Track {
   vecgeom::NavigationState preStepNavState;
   vecgeom::Vector3D<Precision> preStepPos;
   vecgeom::Vector3D<Precision> preStepDir;
-  RanluxppDouble newRNG;
   double preStepEKin{0};
   // Variables used to store navigation results
   double geometryStepLength{0};


### PR DESCRIPTION
In the monolithic kernel a branched RNG state is generated at the beginning before all the threads start diverging.

This was still done in the current split kernel approach and then stored inside the track. However, this is not needed, as the branched RNG state should only be generated in the interaction kernels where it is really needed.

This PR accelerates 64 ttbar events in CMS2018 with 16 threads from 160s to 145s.