### PR TITLE
Split relocation kernels

### DIFF
--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -965,9 +965,9 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
       };
       const AllParticleQueues allParticleQueues = {{electrons.queues, positrons.queues, gammas.queues}};
 #ifdef USE_SPLIT_KERNELS
-      const AllInteractionQueues allGammaInteractionQueues    = {{gammas.queues.interactionQueues[0],
-                                                                  gammas.queues.interactionQueues[1],
-                                                                  gammas.queues.interactionQueues[2], nullptr, nullptr}};
+      const AllInteractionQueues allGammaInteractionQueues = {
+          {gammas.queues.interactionQueues[0], gammas.queues.interactionQueues[1], gammas.queues.interactionQueues[2],
+           nullptr, gammas.queues.interactionQueues[4]}};
       const AllInteractionQueues allElectronInteractionQueues = {{electrons.queues.interactionQueues[0],
                                                                   electrons.queues.interactionQueues[1], nullptr,
                                                                   nullptr, electrons.queues.interactionQueues[4]}};
@@ -1065,7 +1065,7 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
             electrons.queues.leakedTracksCurrent);
         ElectronMSC<true><<<blocks, threads, 0, electrons.stream>>>(
             electrons.tracks, gpuState.hepEmBuffers_d.electronsHepEm, electrons.queues.currentlyActive);
-        InteractionSetup<true, PerEventScoring><<<blocks, threads, 0, electrons.stream>>>(
+        ElectronSetupInteractions<true, PerEventScoring><<<blocks, threads, 0, electrons.stream>>>(
             electrons.tracks, gpuState.hepEmBuffers_d.electronsHepEm, electrons.queues.currentlyActive, secondaries,
             electrons.queues.nextActive, electrons.queues.reachedInteraction, allElectronInteractionQueues,
             electrons.queues.leakedTracksCurrent, gpuState.fScoring_dev, returnAllSteps, returnLastStep);
@@ -1111,11 +1111,7 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
             positrons.queues.leakedTracksCurrent);
         ElectronMSC<false><<<blocks, threads, 0, positrons.stream>>>(
             positrons.tracks, gpuState.hepEmBuffers_d.positronsHepEm, positrons.queues.currentlyActive);
-        // ElectronRelocation<false, PerEventScoring><<<blocks, threads, 0, positrons.stream>>>(
-        //     positrons.tracks, gpuState.hepEmBuffers_d.positronsHepEm, positrons.queues.currentlyActive, secondaries,
-        //     positrons.queues.nextActive, positrons.queues.reachedInteraction, allPositronInteractionQueues,
-        //     positrons.queues.leakedTracksCurrent, gpuState.fScoring_dev, returnAllSteps, returnLastStep);
-        InteractionSetup<false, PerEventScoring><<<blocks, threads, 0, positrons.stream>>>(
+        ElectronSetupInteractions<false, PerEventScoring><<<blocks, threads, 0, positrons.stream>>>(
             positrons.tracks, gpuState.hepEmBuffers_d.positronsHepEm, positrons.queues.currentlyActive, secondaries,
             positrons.queues.nextActive, positrons.queues.reachedInteraction, allPositronInteractionQueues,
             positrons.queues.leakedTracksCurrent, gpuState.fScoring_dev, returnAllSteps, returnLastStep);
@@ -1168,11 +1164,14 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
             gammas.queues.leakedTracksCurrent, gpuState.stats_dev, allowFinishOffEvent);
         GammaPropagation<<<blocks, threads, 0, gammas.stream>>>(gammas.tracks, gpuState.hepEmBuffers_d.gammasHepEm,
                                                                 gammas.queues.currentlyActive);
-        GammaRelocation<PerEventScoring><<<blocks, threads, 0, gammas.stream>>>(
+        GammaSetupInteractions<PerEventScoring><<<blocks, threads, 0, gammas.stream>>>(
             gammas.tracks, gpuState.hepEmBuffers_d.gammasHepEm, gammas.queues.currentlyActive, secondaries,
             gammas.queues.nextActive, gammas.queues.reachedInteraction, allGammaInteractionQueues,
             gammas.queues.leakedTracksCurrent, gpuState.fScoring_dev, returnAllSteps, returnLastStep);
-
+        GammaRelocation<PerEventScoring><<<blocks, threads, 0, gammas.stream>>>(
+            gammas.tracks, gpuState.hepEmBuffers_d.gammasHepEm, secondaries, gammas.queues.nextActive,
+            gammas.queues.interactionQueues[4], gammas.queues.leakedTracksCurrent, gpuState.fScoring_dev,
+            returnAllSteps, returnLastStep);
         // Copying the number of interacting tracks back to host and using this information to adjust
         // the launch parameters of the interactions kernel is complicated and expensive due to a
         // required additional kernel launch and copy. Instead, launch the kernel with the same

--- a/include/AdePT/core/AsyncAdePTTransportStruct.cuh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.cuh
@@ -104,16 +104,19 @@ Gamma interactions:
 1 - Compton
 2 - Photoelectric
 3 - Unused
+4 - Unused
 Electron interactions:
 0 - Ionization
 1 - Bremsstrahlung
 2 - Unused
 3 - Unused
+4 - Relocation
 Positron interactions:
 0 - Ionization
 1 - Bremsstrahlung
 2 - In flight annihilation
 3 - Stopped annihilation
+4 - Relocation
 
 In-flight and stopped annihilation use different codes but may be merged to save space
 in unused queues or if launching one kernel is faster than two smaller ones
@@ -122,7 +125,7 @@ It is not straightforward to allocate just the needed queues per particle type b
 ParticleQueues needs to be passed by copy to the kernels, which means that we can't do
 dynamic allocations
 */
-  static constexpr char numInteractions = 4;
+  static constexpr char numInteractions = 5;
   adept::MParray *currentlyActive;
   adept::MParray *nextActive;
   adept::MParray *reachedInteraction;
@@ -173,7 +176,7 @@ struct AllParticleQueues {
 
 // A bundle of queues per interaction type
 struct AllInteractionQueues {
-  adept::MParray *queues[4];
+  adept::MParray *queues[5];
 };
 
 struct AllSlotManagers {

--- a/include/AdePT/core/AsyncAdePTTransportStruct.cuh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.cuh
@@ -104,7 +104,7 @@ Gamma interactions:
 1 - Compton
 2 - Photoelectric
 3 - Unused
-4 - Unused
+4 - Relocation
 Electron interactions:
 0 - Ionization
 1 - Bremsstrahlung

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -360,15 +360,17 @@ __global__ void ElectronMSC(Track *electrons, G4HepEmElectronTrack *hepEMTracks,
   }
 }
 
+/***
+ * @brief Adds tracks to interaction and relocation queues depending on their state
+ */
 template <bool IsElectron, typename Scoring>
-__global__ void ElectronRelocation(Track *electrons, G4HepEmElectronTrack *hepEMTracks, const adept::MParray *active,
-                                   Secondaries secondaries, adept::MParray *nextActiveQueue,
-                                   adept::MParray *reachedInteractionQueue, AllInteractionQueues interactionQueues,
-                                   adept::MParray *leakedQueue, Scoring *userScoring, bool returnAllSteps,
-                                   bool returnLastStep)
+__global__ void InteractionSetup(Track *electrons, G4HepEmElectronTrack *hepEMTracks, const adept::MParray *active,
+                                 Secondaries secondaries, adept::MParray *nextActiveQueue,
+                                 adept::MParray *reachedInteractionQueue, AllInteractionQueues interactionQueues,
+                                 adept::MParray *leakedQueue, Scoring *userScoring, bool returnAllSteps,
+                                 bool returnLastStep)
 {
-  constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
-  int activeSize                    = active->size();
+  int activeSize = active->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot           = (*active)[i];
     SlotManager &slotManager = IsElectron ? *secondaries.electrons.fSlotManager : *secondaries.positrons.fSlotManager;
@@ -403,12 +405,10 @@ __global__ void ElectronRelocation(Track *electrons, G4HepEmElectronTrack *hepEM
     G4HepEmTrack *theTrack        = elTrack.GetTrack();
 
     G4HepEmMSCTrackData *mscData = elTrack.GetMSCTrackData();
-    G4HepEmRandomEngine rnge(&currentTrack.rngState);
 
     double energyDeposit = theTrack->GetEnergyDeposit();
 
     bool reached_interaction = true;
-    bool cross_boundary      = false;
     bool printErrors         = true;
 
     // Save the `number-of-interaction-left` in our track.
@@ -417,85 +417,52 @@ __global__ void ElectronRelocation(Track *electrons, G4HepEmElectronTrack *hepEM
       currentTrack.numIALeft[ip] = numIALeft;
     }
 
-    if (currentTrack.nextState.IsOnBoundary()) {
-      // if the particle hit a boundary, and is neither stopped or outside, relocate to have the correct next state
-      // before RecordHit is called
+    // Set Non-stopped, on-boundary tracks for relocation
+    if (currentTrack.nextState.IsOnBoundary() && !currentTrack.stopped) {
+      // Add particle to relocation queue
+      interactionQueues.queues[4]->push_back(slot);
+      continue;
+    }
 
-      // - Set no interaction flag
-      // - Kill loopers stuck at a boundary
-      // - Set cross boundary flag in order to set the correct navstate after scoring
-      // - Kill particles that left the world
+    // Now check whether the non-relocating tracks reached an interaction
+    if (!currentTrack.stopped) {
+      if (!currentTrack.propagated || currentTrack.restrictedPhysicalStepLength) {
+        // Did not yet reach the interaction point due to error in the magnetic
+        // field propagation. Try again next time.
 
-      reached_interaction = false;
-      if (++currentTrack.looperCounter > 500) {
-        // Kill loopers that are scraping a boundary
-        if (printErrors)
-          printf("Killing looper scraping at a boundary: E=%E event=%d loop=%d energyDeposit=%E geoStepLength=%E "
-                 "physicsStepLength=%E "
-                 "safety=%E\n",
-                 currentTrack.eKin, currentTrack.eventId, currentTrack.looperCounter, energyDeposit,
-                 currentTrack.geometryStepLength, theTrack->GetGStepLength(), currentTrack.safety);
-        continue;
-      } else if (!currentTrack.nextState.IsOutside()) {
-        // Mark the particle. We need to change its navigation state to the next volume before enqueuing it
-        // This will happen after recording the step
-        cross_boundary = true;
-        returnLastStep = false; // the track survives, do not force return of step
-      } else {
-        // Particle left the world, don't enqueue it and release the slot
-        slotManager.MarkSlotForFreeing(slot);
-      }
+        if (++currentTrack.looperCounter > 500) {
+          // Kill loopers that are not advancing in free space
+          if (printErrors)
+            printf("Killing looper due to lack of advance: E=%E event=%d loop=%d energyDeposit=%E geoStepLength=%E "
+                   "physicsStepLength=%E "
+                   "safety=%E\n",
+                   currentTrack.eKin, currentTrack.eventId, currentTrack.looperCounter, energyDeposit,
+                   currentTrack.geometryStepLength, theTrack->GetGStepLength(), currentTrack.safety);
+          continue;
+        }
 
-      if (!currentTrack.stopped && !currentTrack.nextState.IsOutside()) {
-#ifdef ADEPT_USE_SURF
-        AdePTNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, currentTrack.hitsurfID,
-                                             currentTrack.nextState);
-#else
-        AdePTNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, currentTrack.nextState);
-#endif
-        // Set the last exited state to be the one before crossing
-        currentTrack.nextState.SetLastExited(currentTrack.navState.GetState());
+        survive();
+        reached_interaction = false;
+      } else if (theTrack->GetWinnerProcessIndex() < 0) {
+        // No discrete process, move on.
+        survive();
+        reached_interaction = false;
+      } else if (G4HepEmElectronManager::CheckDelta(&g4HepEmData, theTrack, currentTrack.Uniform())) {
+        // If there was a delta interaction, the track survives but does not move onto the next kernel
+        survive();
+        reached_interaction = false;
+        // Reset number of interaction left for the winner discrete process.
+        // (Will be resampled in the next iteration.)
+        currentTrack.numIALeft[theTrack->GetWinnerProcessIndex()] = -1.0;
       }
     } else {
-      if (!currentTrack.stopped) {
-        if (!currentTrack.propagated || currentTrack.restrictedPhysicalStepLength) {
-          // Did not yet reach the interaction point due to error in the magnetic
-          // field propagation. Try again next time.
-
-          if (++currentTrack.looperCounter > 500) {
-            // Kill loopers that are not advancing in free space
-            if (printErrors)
-              printf("Killing looper due to lack of advance: E=%E event=%d loop=%d energyDeposit=%E geoStepLength=%E "
-                     "physicsStepLength=%E "
-                     "safety=%E\n",
-                     currentTrack.eKin, currentTrack.eventId, currentTrack.looperCounter, energyDeposit,
-                     currentTrack.geometryStepLength, theTrack->GetGStepLength(), currentTrack.safety);
-            continue;
-          }
-
-          survive();
-          reached_interaction = false;
-        } else if (theTrack->GetWinnerProcessIndex() < 0) {
-          // No discrete process, move on.
-          survive();
-          reached_interaction = false;
-        } else if (G4HepEmElectronManager::CheckDelta(&g4HepEmData, theTrack, currentTrack.Uniform())) {
-          // If there was a delta interaction, the track survives but does not move onto the next kernel
-          survive();
-          reached_interaction = false;
-          // Reset number of interaction left for the winner discrete process.
-          // (Will be resampled in the next iteration.)
-          currentTrack.numIALeft[theTrack->GetWinnerProcessIndex()] = -1.0;
-        }
-      } else {
-        // Stopped positrons annihilate, stopped electrons score and die
-        if (IsElectron) {
-          reached_interaction = false;
-          // Ekin = 0 for correct scoring
-          currentTrack.eKin = 0;
-          // Particle is killed by not enqueuing it for the next iteration. Free the slot it occupies
-          slotManager.MarkSlotForFreeing(slot);
-        }
+      // Stopped positrons annihilate, stopped electrons score and die
+      if (IsElectron) {
+        reached_interaction = false;
+        // Ekin = 0 for correct scoring
+        currentTrack.eKin = 0;
+        // Particle is killed by not enqueuing it for the next iteration. Free the slot it occupies
+        slotManager.MarkSlotForFreeing(slot);
       }
     }
 
@@ -523,6 +490,7 @@ __global__ void ElectronRelocation(Track *electrons, G4HepEmElectronTrack *hepEM
       }
 
     } else {
+      // Only non-interacting, non-relocating tracks score here
       // Note: In this kernel returnLastStep is only true for particles that left the world
       // Score the edep for particles that didn't reach the interaction
       if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep)
@@ -545,21 +513,127 @@ __global__ void ElectronRelocation(Track *electrons, G4HepEmElectronTrack *hepEM
                                  currentTrack.eventId, currentTrack.threadId,   // eventID and threadID
                                  returnLastStep,                                // whether this was the last step
                                  currentTrack.stepCounter == 1 ? true : false); // whether this was the first step
+    }
+  }
+}
 
-      if (cross_boundary) {
-        // Move to the next boundary now that the Step is recorded
-        currentTrack.navState = currentTrack.nextState;
-        // Check if the next volume belongs to the GPU region and push it to the appropriate queue
-        const int nextlvolID          = currentTrack.navState.GetLogicalId();
-        VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];
-        if (nextauxData.fGPUregion > 0)
-          survive();
-        else {
-          // To be safe, just push a bit the track exiting the GPU region to make sure
-          // Geant4 does not relocate it again inside the same region
-          currentTrack.pos += kPushDistance * currentTrack.dir;
-          survive(LeakStatus::OutOfGPURegion);
+template <bool IsElectron, typename Scoring>
+__global__ void ElectronRelocation(Track *electrons, G4HepEmElectronTrack *hepEMTracks, Secondaries secondaries,
+                                   adept::MParray *nextActiveQueue, adept::MParray *relocatingQueue,
+                                   adept::MParray *leakedQueue, Scoring *userScoring, bool returnAllSteps,
+                                   bool returnLastStep)
+{
+  constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
+  int activeSize                    = relocatingQueue->size();
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
+    const int slot           = (*relocatingQueue)[i];
+    SlotManager &slotManager = IsElectron ? *secondaries.electrons.fSlotManager : *secondaries.positrons.fSlotManager;
+
+    Track &currentTrack = electrons[slot];
+    // the MCC vector is indexed by the logical volume id
+    const int lvolID = currentTrack.navState.GetLogicalId();
+
+    VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID]; // FIXME unify VolAuxData
+
+    auto survive = [&](LeakStatus leakReason = LeakStatus::NoLeak) {
+      returnLastStep = false; // track survived, do not force return of step
+      // NOTE: When adapting the split kernels for async mode this won't
+      // work if we want to re-use slots on the fly. Directly copying to
+      // a trackdata struct would be better
+      currentTrack.leakStatus = leakReason;
+      if (leakReason != LeakStatus::NoLeak) {
+        auto success = leakedQueue->push_back(slot);
+        if (!success) {
+          printf("ERROR: No space left in e-/+ leaks queue.\n\
+\tThe threshold for flushing the leak buffer may be too high\n\
+\tThe space allocated to the leak buffer may be too small\n");
+          asm("trap;");
         }
+      } else {
+        nextActiveQueue->push_back(slot);
+      }
+    };
+
+    // Retrieve HepEM track
+    G4HepEmElectronTrack &elTrack = hepEMTracks[slot];
+    G4HepEmTrack *theTrack        = elTrack.GetTrack();
+
+    double energyDeposit = theTrack->GetEnergyDeposit();
+
+    bool cross_boundary = false;
+    bool printErrors    = true;
+
+    // Relocate to have the correct next state before RecordHit is called
+
+    // - Kill loopers stuck at a boundary
+    // - Set cross boundary flag in order to set the correct navstate after scoring
+    // - Kill particles that left the world
+
+    if (++currentTrack.looperCounter > 500) {
+      // Kill loopers that are scraping a boundary
+      if (printErrors)
+        printf("Killing looper scraping at a boundary: E=%E event=%d loop=%d energyDeposit=%E geoStepLength=%E "
+               "physicsStepLength=%E "
+               "safety=%E\n",
+               currentTrack.eKin, currentTrack.eventId, currentTrack.looperCounter, energyDeposit,
+               currentTrack.geometryStepLength, theTrack->GetGStepLength(), currentTrack.safety);
+      continue;
+    }
+
+    if (!currentTrack.nextState.IsOutside()) {
+      // Mark the particle. We need to change its navigation state to the next volume before enqueuing it
+      // This will happen after recording the step
+      returnLastStep = false; // the track survives, do not force return of step
+      // Relocate
+      cross_boundary = true;
+#ifdef ADEPT_USE_SURF
+      AdePTNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, currentTrack.hitsurfID,
+                                           currentTrack.nextState);
+#else
+      AdePTNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, currentTrack.nextState);
+#endif
+      // Set the last exited state to be the one before crossing
+      currentTrack.nextState.SetLastExited(currentTrack.navState.GetState());
+    } else {
+      // Particle left the world, don't enqueue it and release the slot
+      slotManager.MarkSlotForFreeing(slot);
+    }
+
+    // Score
+    if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep)
+      adept_scoring::RecordHit(userScoring, currentTrack.parentId,
+                               static_cast<char>(IsElectron ? 0 : 1),         // Particle type
+                               elTrack.GetPStepLength(),                      // Step length
+                               energyDeposit,                                 // Total Edep
+                               currentTrack.weight,                           // Track weight
+                               currentTrack.navState,                         // Pre-step point navstate
+                               currentTrack.preStepPos,                       // Pre-step point position
+                               currentTrack.preStepDir,                       // Pre-step point momentum direction
+                               currentTrack.preStepEKin,                      // Pre-step point kinetic energy
+                               IsElectron ? -1 : 1,                           // Pre-step point charge
+                               currentTrack.nextState,                        // Post-step point navstate
+                               currentTrack.pos,                              // Post-step point position
+                               currentTrack.dir,                              // Post-step point momentum direction
+                               currentTrack.eKin,                             // Post-step point kinetic energy
+                               IsElectron ? -1 : 1,                           // Post-step point charge
+                               currentTrack.globalTime,                       // global time
+                               currentTrack.eventId, currentTrack.threadId,   // eventID and threadID
+                               returnLastStep,                                // whether this was the last step
+                               currentTrack.stepCounter == 1 ? true : false); // whether this was the first step
+
+    if (cross_boundary) {
+      // Move to the next boundary now that the Step is recorded
+      currentTrack.navState = currentTrack.nextState;
+      // Check if the next volume belongs to the GPU region and push it to the appropriate queue
+      const int nextlvolID          = currentTrack.navState.GetLogicalId();
+      VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];
+      if (nextauxData.fGPUregion > 0)
+        survive();
+      else {
+        // To be safe, just push a bit the track exiting the GPU region to make sure
+        // Geant4 does not relocate it again inside the same region
+        currentTrack.pos += kPushDistance * currentTrack.dir;
+        survive(LeakStatus::OutOfGPURegion);
       }
     }
   }

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -364,11 +364,11 @@ __global__ void ElectronMSC(Track *electrons, G4HepEmElectronTrack *hepEMTracks,
  * @brief Adds tracks to interaction and relocation queues depending on their state
  */
 template <bool IsElectron, typename Scoring>
-__global__ void InteractionSetup(Track *electrons, G4HepEmElectronTrack *hepEMTracks, const adept::MParray *active,
-                                 Secondaries secondaries, adept::MParray *nextActiveQueue,
-                                 adept::MParray *reachedInteractionQueue, AllInteractionQueues interactionQueues,
-                                 adept::MParray *leakedQueue, Scoring *userScoring, bool returnAllSteps,
-                                 bool returnLastStep)
+__global__ void ElectronSetupInteractions(Track *electrons, G4HepEmElectronTrack *hepEMTracks,
+                                          const adept::MParray *active, Secondaries secondaries,
+                                          adept::MParray *nextActiveQueue, adept::MParray *reachedInteractionQueue,
+                                          AllInteractionQueues interactionQueues, adept::MParray *leakedQueue,
+                                          Scoring *userScoring, bool returnAllSteps, bool returnLastStep)
 {
   int activeSize = active->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {


### PR DESCRIPTION
Separate the Relocation kernels for Electrons and gammas into a _setup kernel_ which decides whether a track will relocate, do an interaction, or continue to the next step, and a _relocation kernel_ in which the actual geometry calls are performed.

The reason for this split is that the current relocation kernels, specially in the case of electrons and positrons are very divergent. Only a small portion of the tracks in a warp will do a relocation, but the geometry calls involved are costly, which can slow down the rest of the threads in that warp.

These changes haven't shown a speedup so far in runs without a B-field, but the split should improve profiling results by isolating the relocation code.