### PR TITLE
only thread that allocated may deallocate common data in Sync AdePT

### DIFF
--- a/include/AdePT/core/AdePTTransport.cuh
+++ b/include/AdePT/core/AdePTTransport.cuh
@@ -337,7 +337,7 @@ AdeptScoring *InitializeScoringGPU(AdeptScoring *scoring)
   return adept_scoring::InitializeOnGPU(scoring);
 }
 
-void FreeGPU(GPUstate &gpuState, G4HepEmState *g4hepem_state)
+void FreeGPU(GPUstate &gpuState, G4HepEmState *g4hepem_state, bool commonInitThread)
 {
   // Free resources.
   COPCORE_CUDA_CHECK(cudaFree(gpuState.stats_dev));
@@ -355,17 +355,20 @@ void FreeGPU(GPUstate &gpuState, G4HepEmState *g4hepem_state)
     COPCORE_CUDA_CHECK(cudaEventDestroy(gpuState.particles[i].event));
   }
 
-  // Free G4HepEm data
-  FreeG4HepEmData(g4hepem_state->fData);
-  FreeG4HepEmParametersOnGPU(g4hepem_state->fParameters);
-  delete g4hepem_state;
+  // only the thread that initialized the common data may free it
+  if (commonInitThread) {
+    // Free G4HepEm data
+    FreeG4HepEmData(g4hepem_state->fData);
+    FreeG4HepEmParametersOnGPU(g4hepem_state->fParameters);
+    delete g4hepem_state;
 
-// Free magnetic field
+    // Free magnetic field
 #ifdef ADEPT_USE_EXT_BFIELD
-  FreeBField<GeneralMagneticField>();
+    FreeBField<GeneralMagneticField>();
 #else
-  FreeBField<UniformMagneticField>();
+    FreeBField<UniformMagneticField>();
 #endif
+  }
 }
 
 template <typename IntegrationLayer>

--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -83,7 +83,7 @@ public:
   /// @brief Initialize service and copy geometry & physics data on device
   void Initialize(G4HepEmConfig *hepEmConfig, bool common_data = false);
   /// @brief Final cleanup
-  void Cleanup();
+  void Cleanup(bool commonInitThread);
   /// @brief Interface for transporting a buffer of tracks in AdePT.
   void Shower(int event, int threadId);
   void ProcessGPUSteps(int, int) {};

--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -34,7 +34,7 @@ G4HepEmState *InitG4HepEm(G4HepEmConfig *hepEmConfig);
 GPUstate *InitializeGPU(TrackBuffer &, int, int);
 AdeptScoring *InitializeScoringGPU(AdeptScoring *scoring);
 void CopySurfaceModelToGPU();
-void FreeGPU(GPUstate &, G4HepEmState *);
+void FreeGPU(GPUstate &, G4HepEmState *, bool);
 template <typename IntegrationLayer>
 void ShowerGPU(IntegrationLayer &integration, int event, TrackBuffer &buffer, GPUstate &gpuState, AdeptScoring *scoring,
                AdeptScoring *scoring_dev, int debugLevel);
@@ -251,12 +251,12 @@ void AdePTTransport<IntegrationLayer>::InitBVH()
 }
 
 template <typename IntegrationLayer>
-void AdePTTransport<IntegrationLayer>::Cleanup()
+void AdePTTransport<IntegrationLayer>::Cleanup(bool commonInitThread)
 {
   if (!fInit) return;
-  adept_impl::FreeGPU(*fGPUstate, fg4hepem_state);
+  adept_impl::FreeGPU(*fGPUstate, fg4hepem_state, commonInitThread);
   fg4hepem_state = nullptr;
-  adept_impl::FreeVolAuxArray(VolAuxArray::GetInstance());
+  if (commonInitThread) adept_impl::FreeVolAuxArray(VolAuxArray::GetInstance());
   adept_scoring::FreeGPU(fScoring, fScoring_dev);
   delete[] fBuffer.fromDeviceBuff;
 }

--- a/include/AdePT/core/AdePTTransportInterface.hh
+++ b/include/AdePT/core/AdePTTransportInterface.hh
@@ -57,7 +57,7 @@ public:
   virtual void Initialize(G4HepEmConfig *hepEmConfig, bool common_data = false) = 0;
   /// @brief Interface for transporting a buffer of tracks in AdePT.
   virtual void Shower(int event, int threadId)            = 0;
-  virtual void Cleanup()                                  = 0;
+  virtual void Cleanup(bool commonInitThread)             = 0;
   virtual void ProcessGPUSteps(int threadId, int eventId) = 0;
   /// @brief Setup function for the G4HepEmtrackingManager in the integratin layer -  used only in async AdePT
   /// @param threadId thread Id

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -130,7 +130,7 @@ public:
   /// Block until transport of the given event is done.
   void Flush(int threadId, int eventId);
   void ProcessGPUSteps(int threadId, int eventId) override;
-  void Cleanup() override {}
+  void Cleanup(bool) override {}
   /// @brief Setup function used only in async AdePT
   /// @param threadId thread Id
   /// @param hepEmTM specialized G4HepEmTrackingManager

--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -84,6 +84,7 @@ private:
   int fCurrentEventID{0};
   bool fAdePTInitialized{false};
   bool fSpeedOfLight{false};
+  bool fCommonInitThread{false};
 };
 
 #ifdef ASYNC_MODE

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -39,7 +39,7 @@ AdePTTrackingManager::AdePTTrackingManager()
 
 AdePTTrackingManager::~AdePTTrackingManager()
 {
-  if (fAdeptTransport) fAdeptTransport->Cleanup();
+  if (fAdeptTransport) fAdeptTransport->Cleanup(fCommonInitThread);
 }
 
 void AdePTTrackingManager::InitializeAdePT()
@@ -97,6 +97,7 @@ void AdePTTrackingManager::InitializeAdePT()
     // Initialize common data:
     // G4HepEM, Upload VecGeom geometry to GPU, Geometry check, Create volume auxiliary data
     fAdeptTransport->Initialize(fHepEmTrackingManager->GetConfig(), true /*common_data*/);
+    fCommonInitThread = true;
 #endif
 
     // common init done, can notify other workers to proceed their initialization


### PR DESCRIPTION
This fixes an issue in Sync AdePT that probably stems from #386 but could be even older:

In Sync AdePT, one thread initializes the common data on the GPU, however, all threads would try to delete them in the destructor, causing double frees and crashes.

This is fixed by flagging which thread did the common init and only that thread deallocates the common data in the destructor.