### PR TITLE
Fix HitSlot overflow

### DIFF
--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -1546,7 +1546,7 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
 
         // if there are more tracks in flight than the total HitCapacity, it could fail at any step!
         // This is really dangerous and requires a larger hit capacity
-        if (1.2 * maxInFlight > gpuState.fHitScoring->HitCapacity() / numThreads && debugLevel > 1)
+        if (1.2 * maxInFlight > gpuState.fHitScoring->HitCapacity() / numThreads)
           std::cerr << "WARNING: particles in flight ( " << maxInFlight << " ) is close or above the HitCapacity ( "
                     << gpuState.fHitScoring->HitCapacity() / numThreads
                     << " )! Must increase "

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -1564,12 +1564,11 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
           // if the next step might fail, one has to wait until the buffers are ready to swap again.
           if (nextStepMightFail) {
             // Wait until swap becomes available
-            if (debugLevel >= 4) {
-              std::cerr << "Warning: stalling transport loop because HitBuffers are overflowing: HitSlots left: "
-                        << (gpuState.fHitScoring->HitCapacity() / numThreads - gpuState.stats->hitBufferOccupancy)
-                        << " Max particles in flight: " << maxInFlight
-                        << "  | Waiting for HitBuffers to be freed by worker " << std::endl;
-            }
+            std::cerr << "Warning: stalling transport loop because HitBuffers are overflowing: HitSlots left: "
+                      << (gpuState.fHitScoring->HitCapacity() / numThreads - gpuState.stats->hitBufferOccupancy)
+                      << " Max particles in flight: " << maxInFlight
+                      << "  | Waiting for HitBuffers to be freed by worker " << std::endl;
+
             auto start = std::chrono::steady_clock::now();
             while (!gpuState.fHitScoring->ReadyToSwapBuffers()) {
               hitProcessing->cv.notify_one();
@@ -1581,7 +1580,7 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
                 std::terminate();
               }
             }
-            if (debugLevel >= 4) {
+            if (debugLevel >= 3) {
               std::cerr << "Hit buffers freed, resuming with swapping of the buffers " << std::endl;
             }
           }

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -1539,11 +1539,55 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
         }
 
         // *** Hit management ***
-        if (!gpuState.fHitScoring->ReadyToSwapBuffers()) {
+
+        // check the maximum number of tracks in flight per thread
+        unsigned int maxInFlight =
+            *std::max_element(gpuState.stats->perEventInFlight, gpuState.stats->perEventInFlight + numThreads);
+
+        // if there are more tracks in flight than the total HitCapacity, it could fail at any step!
+        // This is really dangerous and requires a larger hit capacity
+        if (1.2 * maxInFlight > gpuState.fHitScoring->HitCapacity() / numThreads && debugLevel > 1)
+          std::cerr << "WARNING: particles in flight ( " << maxInFlight << " ) is close or above the HitCapacity ( "
+                    << gpuState.fHitScoring->HitCapacity() / numThreads
+                    << " )! Must increase "
+                       "/adept/setMillionsOfHitSlots or reduce /run/numberOfThreads!"
+                    << std::endl;
+
+        // next step could fail because there are more tracks in flight than hit slots left..
+        bool nextStepMightFail =
+            gpuState.stats->hitBufferOccupancy >= gpuState.fHitScoring->HitCapacity() / numThreads - 1.5 * maxInFlight;
+
+        if (!gpuState.fHitScoring->ReadyToSwapBuffers() && !nextStepMightFail) {
           hitProcessing->cv.notify_one();
         } else {
+
+          // if the next step might fail, one has to wait until the buffers are ready to swap again.
+          if (nextStepMightFail) {
+            // Wait until swap becomes available
+            if (debugLevel >= 4) {
+              std::cerr << "Warning: stalling transport loop because HitBuffers are overflowing: HitSlots left: "
+                        << (gpuState.fHitScoring->HitCapacity() / numThreads - gpuState.stats->hitBufferOccupancy)
+                        << " Max particles in flight: " << maxInFlight
+                        << "  | Waiting for HitBuffers to be freed by worker " << std::endl;
+            }
+            auto start = std::chrono::steady_clock::now();
+            while (!gpuState.fHitScoring->ReadyToSwapBuffers()) {
+              hitProcessing->cv.notify_one();
+              std::this_thread::sleep_for(std::chrono::microseconds(100));
+              // guard to avoid infinite stalls
+              auto now = std::chrono::steady_clock::now();
+              if (std::chrono::duration_cast<std::chrono::seconds>(now - start).count() > 5) {
+                std::cerr << "Error: Timed out waiting for hit buffer to become available.\n";
+                std::terminate();
+              }
+            }
+            if (debugLevel >= 4) {
+              std::cerr << "Hit buffers freed, resuming with swapping of the buffers " << std::endl;
+            }
+          }
+
           if (gpuState.stats->hitBufferOccupancy >= gpuState.fHitScoring->HitCapacity() / numThreads / 2 ||
-              gpuState.stats->hitBufferOccupancy >= 10000 ||
+              gpuState.stats->hitBufferOccupancy >= 10000 || nextStepMightFail ||
               std::any_of(eventStates.begin(), eventStates.end(), [](const auto &state) {
                 return state.load(std::memory_order_acquire) == EventState::RequestHitFlush;
               })) {


### PR DESCRIPTION
This PR fixes the crash that happens if AdePT runs out of hit slots for async AdePT in almost all cases.

It is checked whether there are more particles in flight than there are hit slots left (as the number is only an estimate, I added a factor of 1.5). If that is the case, the next step might cause a crash. Then, one has to wait for the DeviceBuffers to be ready to swapped, before one can continue with the swap (which frees the hit slots), before the next step can be taken.

Note that if more tracks are in flight than total hit slots are available, any time all tracks could generate a hit and cause a crash and overflow. This is not fixable by waiting for freeing the hit slots, this requires simply more slots or less threads (which leads to more slots per thread and less particles in flight).