### PR TITLE
Add Step-limiting process

### DIFF
--- a/include/AdePT/core/AdePTScoringTemplate.cuh
+++ b/include/AdePT/core/AdePTScoringTemplate.cuh
@@ -17,7 +17,7 @@ template <typename Scoring>
 void FreeGPU(Scoring *scoring, Scoring *scoring_dev);
 
 template <typename Scoring>
-__device__ void RecordHit(Scoring *scoring_dev, uint64_t aTrackID, uint64_t aParentID, short creatorProcessId,
+__device__ void RecordHit(Scoring *scoring_dev, uint64_t aTrackID, uint64_t aParentID, short stepLimProcessId,
                           char aParticleType, double aStepLength, double aTotalEnergyDeposit, float aTrackWeight,
                           vecgeom::NavigationState const &aPreState, vecgeom::Vector3D<Precision> const &aPrePosition,
                           vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin,

--- a/include/AdePT/core/AdePTTransport.cuh
+++ b/include/AdePT/core/AdePTTransport.cuh
@@ -207,8 +207,7 @@ __global__ void InitTracks(adeptint::TrackData *trackinfo, int ntracks, int star
     track.localTime  = trackinfo[i].localTime;
     track.properTime = trackinfo[i].properTime;
 
-    track.weight           = trackinfo[i].weight;
-    track.creatorProcessId = trackinfo[i].creatorProcessId;
+    track.weight = trackinfo[i].weight;
 
     track.originNavState.Clear();
     track.originNavState = trackinfo[i].originNavState;

--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -44,10 +44,10 @@ public:
   int GetNfromDevice() const { return fBuffer.fromDevice.size(); }
 
   /// @brief Adds a track to the buffer
-  void AddTrack(int pdg, uint64_t trackId, uint64_t parentId, short creatorProcessId, double energy, double x, double y,
-                double z, double dirx, double diry, double dirz, double globalTime, double localTime, double properTime,
-                float weight, unsigned short stepCounter, int threadId, unsigned int eventId,
-                vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState);
+  void AddTrack(int pdg, uint64_t trackId, uint64_t parentId, double energy, double x, double y, double z, double dirx,
+                double diry, double dirz, double globalTime, double localTime, double properTime, float weight,
+                unsigned short stepCounter, int threadId, unsigned int eventId, vecgeom::NavigationState &&state,
+                vecgeom::NavigationState &&originState);
 
   void SetTrackCapacity(size_t capacity) { fCapacity = capacity; }
   /// @brief Get the track capacity on GPU

--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -95,15 +95,15 @@ bool AdePTTransport<IntegrationLayer>::InitializeBField(UniformMagneticField &Bf
 }
 
 template <typename IntegrationLayer>
-void AdePTTransport<IntegrationLayer>::AddTrack(int pdg, uint64_t trackId, uint64_t parentId, short creatorProcessId,
-                                                double energy, double x, double y, double z, double dirx, double diry,
-                                                double dirz, double globalTime, double localTime, double properTime,
-                                                float weight, unsigned short stepCounter, int /*threadId*/,
-                                                unsigned int eventId, vecgeom::NavigationState &&state,
+void AdePTTransport<IntegrationLayer>::AddTrack(int pdg, uint64_t trackId, uint64_t parentId, double energy, double x,
+                                                double y, double z, double dirx, double diry, double dirz,
+                                                double globalTime, double localTime, double properTime, float weight,
+                                                unsigned short stepCounter, int /*threadId*/, unsigned int eventId,
+                                                vecgeom::NavigationState &&state,
                                                 vecgeom::NavigationState &&originState)
 {
-  fBuffer.toDevice.emplace_back(pdg, trackId, parentId, creatorProcessId, energy, x, y, z, dirx, diry, dirz, globalTime,
-                                localTime, properTime, weight, stepCounter, std::move(state), std::move(originState));
+  fBuffer.toDevice.emplace_back(pdg, trackId, parentId, energy, x, y, z, dirx, diry, dirz, globalTime, localTime,
+                                properTime, weight, stepCounter, std::move(state), std::move(originState));
   if (pdg == 11)
     fBuffer.nelectrons++;
   else if (pdg == -11)

--- a/include/AdePT/core/AdePTTransportInterface.hh
+++ b/include/AdePT/core/AdePTTransportInterface.hh
@@ -20,9 +20,9 @@ public:
   virtual ~AdePTTransportInterface() {}
 
   /// @brief Adds a track to the buffer
-  virtual void AddTrack(int pdg, uint64_t trackId, uint64_t parentId, short creatorProcessId, double energy, double x,
-                        double y, double z, double dirx, double diry, double dirz, double globalTime, double localTime,
-                        double properTime, float weight, unsigned short stepCounter, int threadId, unsigned int eventId,
+  virtual void AddTrack(int pdg, uint64_t trackId, uint64_t parentId, double energy, double x, double y, double z,
+                        double dirx, double diry, double dirz, double globalTime, double localTime, double properTime,
+                        float weight, unsigned short stepCounter, int threadId, unsigned int eventId,
                         vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState) = 0;
 
   /// @brief Set capacity of on-GPU track buffer.

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -196,12 +196,11 @@ __global__ void InitTracks(AsyncAdePT::TrackDataWithIDs *trackinfo, int ntracks,
     // we need to scramble the initial seed with some more trackinfo to generate a unique seed.
     // otherwise, if a particle returns from the device and is injected again (i.e., via lepton nuclear), it would have
     // the same random number state, causing collisions in the track IDs
-    auto seed = GenerateSeedFromTrackInfo(trackInfo, initialSeed);
-    Track &track =
-        generator->InitTrack(slot, seed, trackInfo.eKin, trackInfo.globalTime, static_cast<float>(trackInfo.localTime),
-                             static_cast<float>(trackInfo.properTime), trackInfo.weight, trackInfo.position,
-                             trackInfo.direction, trackInfo.eventId, trackInfo.trackId, trackInfo.parentId,
-                             trackInfo.creatorProcessId, trackInfo.threadId, trackInfo.stepCounter);
+    auto seed    = GenerateSeedFromTrackInfo(trackInfo, initialSeed);
+    Track &track = generator->InitTrack(
+        slot, seed, trackInfo.eKin, trackInfo.globalTime, static_cast<float>(trackInfo.localTime),
+        static_cast<float>(trackInfo.properTime), trackInfo.weight, trackInfo.position, trackInfo.direction,
+        trackInfo.eventId, trackInfo.trackId, trackInfo.parentId, trackInfo.threadId, trackInfo.stepCounter);
     track.navState.Clear();
     track.navState       = trackinfo[i].navState;
     track.originNavState = trackinfo[i].originNavState;
@@ -312,27 +311,26 @@ __global__ void FillFromDeviceBuffer(AllLeaked all, AsyncAdePT::TrackDataWithIDs
       // NOTE: Sync transport copies data into trackData structs during transport.
       // Async transport stores the slots and copies to trackdata structs for transfer to
       // host here. These approaches should be unified.
-      fromDevice[idx].position[0]      = track->pos[0];
-      fromDevice[idx].position[1]      = track->pos[1];
-      fromDevice[idx].position[2]      = track->pos[2];
-      fromDevice[idx].direction[0]     = track->dir[0];
-      fromDevice[idx].direction[1]     = track->dir[1];
-      fromDevice[idx].direction[2]     = track->dir[2];
-      fromDevice[idx].eKin             = track->eKin;
-      fromDevice[idx].globalTime       = track->globalTime;
-      fromDevice[idx].localTime        = track->localTime;
-      fromDevice[idx].properTime       = track->properTime;
-      fromDevice[idx].weight           = track->weight;
-      fromDevice[idx].pdg              = pdg;
-      fromDevice[idx].eventId          = track->eventId;
-      fromDevice[idx].threadId         = track->threadId;
-      fromDevice[idx].navState         = track->navState;
-      fromDevice[idx].originNavState   = track->originNavState;
-      fromDevice[idx].leakStatus       = track->leakStatus;
-      fromDevice[idx].parentId         = track->parentId;
-      fromDevice[idx].trackId          = track->trackId;
-      fromDevice[idx].creatorProcessId = track->creatorProcessId;
-      fromDevice[idx].stepCounter      = track->stepCounter;
+      fromDevice[idx].position[0]    = track->pos[0];
+      fromDevice[idx].position[1]    = track->pos[1];
+      fromDevice[idx].position[2]    = track->pos[2];
+      fromDevice[idx].direction[0]   = track->dir[0];
+      fromDevice[idx].direction[1]   = track->dir[1];
+      fromDevice[idx].direction[2]   = track->dir[2];
+      fromDevice[idx].eKin           = track->eKin;
+      fromDevice[idx].globalTime     = track->globalTime;
+      fromDevice[idx].localTime      = track->localTime;
+      fromDevice[idx].properTime     = track->properTime;
+      fromDevice[idx].weight         = track->weight;
+      fromDevice[idx].pdg            = pdg;
+      fromDevice[idx].eventId        = track->eventId;
+      fromDevice[idx].threadId       = track->threadId;
+      fromDevice[idx].navState       = track->navState;
+      fromDevice[idx].originNavState = track->originNavState;
+      fromDevice[idx].leakStatus     = track->leakStatus;
+      fromDevice[idx].parentId       = track->parentId;
+      fromDevice[idx].trackId        = track->trackId;
+      fromDevice[idx].stepCounter    = track->stepCounter;
 
       leakedTracks->fSlotManager->MarkSlotForFreeing(trackSlot);
     }

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -91,10 +91,10 @@ public:
   ~AsyncAdePTTransport();
 
   /// @brief Adds a track to the buffer
-  void AddTrack(int pdg, uint64_t trackId, uint64_t parentId, short creatorProcessId, double energy, double x, double y,
-                double z, double dirx, double diry, double dirz, double globalTime, double localTime, double properTime,
-                float weight, unsigned short stepCounter, int threadId, unsigned int eventId,
-                vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState) override;
+  void AddTrack(int pdg, uint64_t trackId, uint64_t parentId, double energy, double x, double y, double z, double dirx,
+                double diry, double dirz, double globalTime, double localTime, double properTime, float weight,
+                unsigned short stepCounter, int threadId, unsigned int eventId, vecgeom::NavigationState &&state,
+                vecgeom::NavigationState &&originState) override;
   /// @brief Set track capacity on GPU
   void SetTrackCapacity(size_t capacity) override { fTrackCapacity = capacity; }
   /// @brief Set leak capacity on GPU

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -138,13 +138,10 @@ void AsyncAdePTTransport<IntegrationLayer>::SetIntegrationLayerForThread(int thr
 }
 
 template <typename IntegrationLayer>
-void AsyncAdePTTransport<IntegrationLayer>::AddTrack(int pdg, uint64_t trackId, uint64_t parentId,
-                                                     short creatorProcessId, double energy, double x, double y,
-                                                     double z, double dirx, double diry, double dirz, double globalTime,
-                                                     double localTime, double properTime, float weight,
-                                                     unsigned short stepCounter, int threadId, unsigned int eventId,
-                                                     vecgeom::NavigationState &&state,
-                                                     vecgeom::NavigationState &&originState)
+void AsyncAdePTTransport<IntegrationLayer>::AddTrack(
+    int pdg, uint64_t trackId, uint64_t parentId, double energy, double x, double y, double z, double dirx, double diry,
+    double dirz, double globalTime, double localTime, double properTime, float weight, unsigned short stepCounter,
+    int threadId, unsigned int eventId, vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState)
 {
   if (pdg != 11 && pdg != -11 && pdg != 22) {
     G4cerr << __FILE__ << ":" << __LINE__ << ": Only supporting EM tracks. Got pdgID=" << pdg << "\n";
@@ -154,7 +151,6 @@ void AsyncAdePTTransport<IntegrationLayer>::AddTrack(int pdg, uint64_t trackId, 
   TrackDataWithIDs track{pdg,
                          trackId,
                          parentId,
-                         creatorProcessId,
                          energy,
                          x,
                          y,

--- a/include/AdePT/core/CommonStruct.h
+++ b/include/AdePT/core/CommonStruct.h
@@ -92,14 +92,13 @@ struct TrackDataWithIDs : public adeptint::TrackData {
   unsigned int eventId{0};
   short threadId{-1};
 
-  TrackDataWithIDs(int pdg_id, uint64_t trackId, uint64_t parentId, short creatorProcessId, double ene, double x,
-                   double y, double z, double dirx, double diry, double dirz, double gTime, double lTime, double pTime,
-                   float weight, unsigned short stepCounter, vecgeom::NavigationState &&state,
-                   vecgeom::NavigationState &&originState, unsigned int eventId = 0, short threadId = -1)
+  TrackDataWithIDs(int pdg_id, uint64_t trackId, uint64_t parentId, double ene, double x, double y, double z,
+                   double dirx, double diry, double dirz, double gTime, double lTime, double pTime, float weight,
+                   unsigned short stepCounter, vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState,
+                   unsigned int eventId = 0, short threadId = -1)
       : TrackData{pdg_id,
                   trackId,
                   parentId,
-                  creatorProcessId,
                   ene,
                   x,
                   y,

--- a/include/AdePT/core/HostScoringImpl.cuh
+++ b/include/AdePT/core/HostScoringImpl.cuh
@@ -149,7 +149,7 @@ void FreeGPU(HostScoring *hostScoring, HostScoring *hostScoring_dev)
 
 /// @brief Record a hit
 template <>
-__device__ void RecordHit(HostScoring *hostScoring_dev, uint64_t aTrackID, uint64_t aParentID, short creatorProcessId,
+__device__ void RecordHit(HostScoring *hostScoring_dev, uint64_t aTrackID, uint64_t aParentID, short stepLimProcessId,
                           char aParticleType, double aStepLength, double aTotalEnergyDeposit, float aTrackWeight,
                           vecgeom::NavigationState const &aPreState, vecgeom::Vector3D<Precision> const &aPrePosition,
                           vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin,
@@ -162,7 +162,7 @@ __device__ void RecordHit(HostScoring *hostScoring_dev, uint64_t aTrackID, uint6
   GPUHit &aGPUHit = *GetNextFreeHit(hostScoring_dev);
 
   // Fill the required data
-  FillHit(aGPUHit, aTrackID, aParentID, creatorProcessId, aParticleType, aStepLength, aTotalEnergyDeposit, aTrackWeight,
+  FillHit(aGPUHit, aTrackID, aParentID, stepLimProcessId, aParticleType, aStepLength, aTotalEnergyDeposit, aTrackWeight,
           aPreState, aPrePosition, aPreMomentumDirection, aPreEKin, aPostState, aPostPosition, aPostMomentumDirection,
           aPostEKin, aGlobalTime, aLocalTime, eventID, threadID, isLastStep, stepCounter);
 }

--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -700,7 +700,7 @@ namespace adept_scoring {
 /// @brief Record a hit
 template <>
 __device__ void RecordHit(AsyncAdePT::PerEventScoring * /*scoring*/, uint64_t aTrackID, uint64_t aParentID,
-                          short creatorProcessId, char aParticleType, double aStepLength, double aTotalEnergyDeposit,
+                          short stepLimProcessId, char aParticleType, double aStepLength, double aTotalEnergyDeposit,
                           float aTrackWeight, vecgeom::NavigationState const &aPreState,
                           vecgeom::Vector3D<Precision> const &aPrePosition,
                           vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin,
@@ -713,7 +713,7 @@ __device__ void RecordHit(AsyncAdePT::PerEventScoring * /*scoring*/, uint64_t aT
   GPUHit &aGPUHit = AsyncAdePT::gHitScoringBuffer_dev.GetNextSlot(threadID);
 
   // Fill the required data
-  FillHit(aGPUHit, aTrackID, aParentID, creatorProcessId, aParticleType, aStepLength, aTotalEnergyDeposit, aTrackWeight,
+  FillHit(aGPUHit, aTrackID, aParentID, stepLimProcessId, aParticleType, aStepLength, aTotalEnergyDeposit, aTrackWeight,
           aPreState, aPrePosition, aPreMomentumDirection, aPreEKin, aPostState, aPostPosition, aPostMomentumDirection,
           aPostEKin, aGlobalTime, aLocalTime, eventID, threadID, isLastStep, stepCounter);
 }

--- a/include/AdePT/core/ScoringCommons.hh
+++ b/include/AdePT/core/ScoringCommons.hh
@@ -30,7 +30,7 @@ struct GPUHit {
   float fTrackWeight{1};
   uint64_t fTrackID{0};  // Track ID
   uint64_t fParentID{0}; // parent Track ID
-  short fCreatorProcessID{-1};
+  short fStepLimProcessId{-1};
   unsigned int fEventId{0};
   short threadId{-1};
   // bool fFirstStepInVolume{false};
@@ -71,7 +71,7 @@ __device__ __forceinline__ void Copy3DVector(vecgeom::Vector3D<Precision> const 
 
 /// @brief Fill the provided hit with the given data
 __device__ __forceinline__ void FillHit(
-    GPUHit &aGPUHit, uint64_t aTrackID, uint64_t aParentID, short aCreatorProcessID, char aParticleType,
+    GPUHit &aGPUHit, uint64_t aTrackID, uint64_t aParentID, short aStepLimProcessId, char aParticleType,
     double aStepLength, double aTotalEnergyDeposit, float aTrackWeight, vecgeom::NavigationState const &aPreState,
     vecgeom::Vector3D<Precision> const &aPrePosition, vecgeom::Vector3D<Precision> const &aPreMomentumDirection,
     double aPreEKin, vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
@@ -86,7 +86,7 @@ __device__ __forceinline__ void FillHit(
   // Fill the required data
   aGPUHit.fTrackID            = aTrackID;
   aGPUHit.fParentID           = aParentID;
-  aGPUHit.fCreatorProcessID   = aCreatorProcessID;
+  aGPUHit.fStepLimProcessId   = aStepLimProcessId;
   aGPUHit.fParticleType       = aParticleType;
   aGPUHit.fStepLength         = aStepLength;
   aGPUHit.fTotalEnergyDeposit = aTotalEnergyDeposit;

--- a/include/AdePT/core/TrackData.h
+++ b/include/AdePT/core/TrackData.h
@@ -28,18 +28,17 @@ struct TrackData {
   int pdg{0};
   uint64_t trackId{0};  ///< track id (non-consecutive, reproducible)
   uint64_t parentId{0}; // track id of the parent
-  short creatorProcessId{-1};
   unsigned short stepCounter{0};
 
   LeakStatus leakStatus{LeakStatus::NoLeak};
 
   TrackData() = default;
-  TrackData(int pdg_id, uint64_t trackId, uint64_t parentId, short creatorProcessId, double ene, double x, double y,
-            double z, double dirx, double diry, double dirz, double gTime, double lTime, double pTime, float weight,
+  TrackData(int pdg_id, uint64_t trackId, uint64_t parentId, double ene, double x, double y, double z, double dirx,
+            double diry, double dirz, double gTime, double lTime, double pTime, float weight,
             unsigned short stepCounter, vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState)
       : navState{std::move(state)}, originNavState{std::move(originState)}, position{x, y, z},
         direction{dirx, diry, dirz}, eKin{ene}, globalTime{gTime}, localTime{lTime}, properTime{pTime}, weight{weight},
-        pdg{pdg_id}, trackId{trackId}, creatorProcessId{creatorProcessId}, parentId{parentId}, stepCounter{stepCounter}
+        pdg{pdg_id}, trackId{trackId}, parentId{parentId}, stepCounter{stepCounter}
   {
   }
 

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -249,9 +249,9 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         // as now the nextState is defined, but the navState is not yet replaced
         if (returnAllSteps)
           adept_scoring::RecordHit(userScoring,
-                                   currentTrack.trackId,  // Track ID
-                                   currentTrack.parentId, // parent Track ID
-                                   currentTrack.creatorProcessId,
+                                   currentTrack.trackId,                        // Track ID
+                                   currentTrack.parentId,                       // parent Track ID
+                                   static_cast<short>(/* transport */ 10),      // step-defining process
                                    2,                                           // Particle type
                                    geometryStepLength,                          // Step length
                                    0,                                           // Total Edep
@@ -304,9 +304,9 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         // particle has left the world, record hit if last or all steps are returned
         if (returnAllSteps || returnLastStep)
           adept_scoring::RecordHit(userScoring,
-                                   currentTrack.trackId,  // Track ID
-                                   currentTrack.parentId, // parent Track ID
-                                   currentTrack.creatorProcessId,
+                                   currentTrack.trackId,                        // Track ID
+                                   currentTrack.parentId,                       // parent Track ID
+                                   static_cast<short>(/* transport */ 10),      // step-defining process
                                    2,                                           // Particle type
                                    geometryStepLength,                          // Step length
                                    0,                                           // Total Edep
@@ -388,7 +388,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         Track &electron = secondaries.electrons.NextTrack(
             newRNG, elKinEnergy, pos,
             vecgeom::Vector3D<Precision>{dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]}, navState,
-            currentTrack, globalTime, short(winnerProcessIndex));
+            currentTrack, globalTime);
 #else
         Track &electron = secondaries.electrons->NextTrack();
         electron.InitAsSecondary(pos, navState, globalTime);
@@ -431,17 +431,16 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
         Track &positron = secondaries.positrons.NextTrack(
             currentTrack.rngState, posKinEnergy, pos,
             vecgeom::Vector3D<Precision>{dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]}, navState,
-            currentTrack, globalTime, short(winnerProcessIndex));
+            currentTrack, globalTime);
 #else
         Track &positron = secondaries.positrons->NextTrack();
         positron.InitAsSecondary(pos, navState, globalTime);
         // Reuse the RNG state of the dying track.
-        positron.parentId         = currentTrack.trackId;
-        positron.creatorProcessId = short(winnerProcessIndex);
-        positron.rngState         = currentTrack.rngState;
-        positron.trackId          = positron.rngState.IntRndm64();
-        positron.eKin             = posKinEnergy;
-        positron.weight           = currentTrack.weight;
+        positron.parentId = currentTrack.trackId;
+        positron.rngState = currentTrack.rngState;
+        positron.trackId  = positron.rngState.IntRndm64();
+        positron.eKin     = posKinEnergy;
+        positron.weight   = currentTrack.weight;
         positron.dir.Set(dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]);
 #endif
         // if tracking or stepping action is called, return initial step
@@ -500,20 +499,18 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
       if (ApplyCuts ? energyEl > theElCut : energyEl > LowEnergyThreshold) {
         // Create a secondary electron and sample/compute directions.
 #ifdef ASYNC_MODE
-        Track &electron =
-            secondaries.electrons.NextTrack(newRNG, energyEl, pos, eKin * dir - newEnergyGamma * newDirGamma, navState,
-                                            currentTrack, globalTime, short(winnerProcessIndex));
+        Track &electron = secondaries.electrons.NextTrack(
+            newRNG, energyEl, pos, eKin * dir - newEnergyGamma * newDirGamma, navState, currentTrack, globalTime);
 #else
         Track &electron = secondaries.electrons->NextTrack();
 
         electron.InitAsSecondary(pos, navState, globalTime);
-        electron.parentId         = currentTrack.trackId;
-        electron.creatorProcessId = short(winnerProcessIndex);
-        electron.rngState         = newRNG;
-        electron.trackId          = electron.rngState.IntRndm64();
-        electron.eKin             = energyEl;
-        electron.weight           = currentTrack.weight;
-        electron.dir              = eKin * dir - newEnergyGamma * newDirGamma;
+        electron.parentId = currentTrack.trackId;
+        electron.rngState = newRNG;
+        electron.trackId  = electron.rngState.IntRndm64();
+        electron.eKin     = energyEl;
+        electron.weight   = currentTrack.weight;
+        electron.dir      = eKin * dir - newEnergyGamma * newDirGamma;
 #endif
         electron.dir.Normalize();
 
@@ -585,16 +582,15 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
 #ifdef ASYNC_MODE
         Track &electron = secondaries.electrons.NextTrack(
             newRNG, photoElecE, pos, vecgeom::Vector3D<Precision>{dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]},
-            navState, currentTrack, globalTime, short(winnerProcessIndex));
+            navState, currentTrack, globalTime);
 #else
         Track &electron = secondaries.electrons->NextTrack();
         electron.InitAsSecondary(pos, navState, globalTime);
-        electron.parentId         = currentTrack.trackId;
-        electron.creatorProcessId = short(winnerProcessIndex);
-        electron.rngState         = newRNG;
-        electron.trackId          = electron.rngState.IntRndm64();
-        electron.eKin             = photoElecE;
-        electron.weight           = currentTrack.weight;
+        electron.parentId = currentTrack.trackId;
+        electron.rngState = newRNG;
+        electron.trackId  = electron.rngState.IntRndm64();
+        electron.eKin     = photoElecE;
+        electron.weight   = currentTrack.weight;
         electron.dir.Set(dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]);
 #endif
         // if tracking or stepping action is called, return initial step
@@ -642,9 +638,9 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
     // If there is some edep from cutting particles, record the step
     if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep) {
       adept_scoring::RecordHit(userScoring,
-                               currentTrack.trackId,  // Track ID
-                               currentTrack.parentId, // parent Track ID
-                               currentTrack.creatorProcessId,
+                               currentTrack.trackId,                        // Track ID
+                               currentTrack.parentId,                       // parent Track ID
+                               short(winnerProcessIndex),                   // step-defining process id
                                2,                                           // Particle type
                                geometryStepLength,                          // Step length
                                edep,                                        // Total Edep

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -275,7 +275,7 @@ __global__ void GammaRelocation(Track *gammas, G4HepEmGammaTrack *hepEMTracks, S
         adept_scoring::RecordHit(userScoring,
                                  currentTrack.trackId,                        // Track ID
                                  currentTrack.parentId,                       // parent Track ID
-                                 currentTrack.creatorProcessId,               // creator process ID
+                                 static_cast<short>(10),                      // step defining process ID
                                  2,                                           // Particle type
                                  currentTrack.geometryStepLength,             // Step length
                                  0,                                           // Total Edep
@@ -317,7 +317,7 @@ __global__ void GammaRelocation(Track *gammas, G4HepEmGammaTrack *hepEMTracks, S
         adept_scoring::RecordHit(userScoring,
                                  currentTrack.trackId,                        // Track ID
                                  currentTrack.parentId,                       // parent Track ID
-                                 currentTrack.creatorProcessId,               // creator process ID
+                                 static_cast<short>(10),                      // step defining process ID
                                  2,                                           // Particle type
                                  currentTrack.geometryStepLength,             // Step length
                                  0,                                           // Total Edep
@@ -419,7 +419,7 @@ __global__ void GammaInteractions(Track *gammas, G4HepEmGammaTrack *hepEMTracks,
         secondaries.electrons.NextTrack(
             newRNG, elKinEnergy, currentTrack.pos,
             vecgeom::Vector3D<Precision>{dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]},
-            currentTrack.navState, currentTrack, currentTrack.globalTime, short(theTrack->GetWinnerProcessIndex()));
+            currentTrack.navState, currentTrack, currentTrack.globalTime);
       }
 
       if (ApplyCuts && (copcore::units::kElectronMassC2 < theGammaCut && posKinEnergy < thePosCut)) {
@@ -429,7 +429,7 @@ __global__ void GammaInteractions(Track *gammas, G4HepEmGammaTrack *hepEMTracks,
         secondaries.positrons.NextTrack(
             currentTrack.rngState, posKinEnergy, currentTrack.pos,
             vecgeom::Vector3D<Precision>{dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]},
-            currentTrack.navState, currentTrack, currentTrack.globalTime, short(theTrack->GetWinnerProcessIndex()));
+            currentTrack.navState, currentTrack, currentTrack.globalTime);
       }
 
       // The current track is killed by not enqueuing into the next activeQueue and the slot is released
@@ -458,7 +458,7 @@ __global__ void GammaInteractions(Track *gammas, G4HepEmGammaTrack *hepEMTracks,
         // Create a secondary electron and sample/compute directions.
         Track &electron = secondaries.electrons.NextTrack(
             newRNG, energyEl, currentTrack.pos, currentTrack.eKin * currentTrack.dir - newEnergyGamma * newDirGamma,
-            currentTrack.navState, currentTrack, currentTrack.globalTime, short(theTrack->GetWinnerProcessIndex()));
+            currentTrack.navState, currentTrack, currentTrack.globalTime);
         electron.dir.Normalize();
       } else {
         edep = energyEl;
@@ -498,8 +498,7 @@ __global__ void GammaInteractions(Track *gammas, G4HepEmGammaTrack *hepEMTracks,
         // Create a secondary electron and sample directions.
         secondaries.electrons.NextTrack(newRNG, photoElecE, currentTrack.pos,
                                         vecgeom::Vector3D<Precision>{dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]},
-                                        currentTrack.navState, currentTrack, currentTrack.globalTime,
-                                        short(theTrack->GetWinnerProcessIndex()));
+                                        currentTrack.navState, currentTrack, currentTrack.globalTime);
 
       } else {
         // If the secondary electron is cut, deposit all the energy of the gamma in this volume
@@ -514,15 +513,15 @@ __global__ void GammaInteractions(Track *gammas, G4HepEmGammaTrack *hepEMTracks,
     // If there is some edep from cutting particles, record the step
     if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep) {
       adept_scoring::RecordHit(userScoring,
-                               currentTrack.trackId,                        // Track ID
-                               currentTrack.parentId,                       // parent Track ID
-                               currentTrack.creatorProcessId,               // creator process ID
-                               2,                                           // Particle type
-                               currentTrack.geometryStepLength,             // Step length
-                               edep,                                        // Total Edep
-                               currentTrack.weight,                         // Track weight
-                               currentTrack.navState,                       // Pre-step point navstate
-                               currentTrack.preStepPos,                     // Pre-step point position
+                               currentTrack.trackId,                                  // Track ID
+                               currentTrack.parentId,                                 // parent Track ID
+                               static_cast<short>(theTrack->GetWinnerProcessIndex()), // step limiting process
+                               2,                                                     // Particle type
+                               currentTrack.geometryStepLength,                       // Step length
+                               edep,                                                  // Total Edep
+                               currentTrack.weight,                                   // Track weight
+                               currentTrack.navState,                                 // Pre-step point navstate
+                               currentTrack.preStepPos,                               // Pre-step point position
                                currentTrack.preStepDir,                     // Pre-step point momentum direction
                                currentTrack.preStepEKin,                    // Pre-step point kinetic energy
                                currentTrack.nextState,                      // Post-step point navstate
@@ -619,7 +618,7 @@ __global__ void GammaConversion(Track *gammas, G4HepEmGammaTrack *hepEMTracks, S
       Track &electron = secondaries.electrons.NextTrack(
           newRNG, elKinEnergy, currentTrack.pos,
           vecgeom::Vector3D<Precision>{dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]}, currentTrack.navState,
-          currentTrack, currentTrack.globalTime, /*CreatorProcessId*/ short(0));
+          currentTrack, currentTrack.globalTime);
 
       // if tracking or stepping action is called, return initial step
       if (returnLastStep) {
@@ -652,7 +651,7 @@ __global__ void GammaConversion(Track *gammas, G4HepEmGammaTrack *hepEMTracks, S
       Track &positron = secondaries.positrons.NextTrack(
           currentTrack.rngState, posKinEnergy, currentTrack.pos,
           vecgeom::Vector3D<Precision>{dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]},
-          currentTrack.navState, currentTrack, currentTrack.globalTime, /*CreatorProcessId*/ short(0));
+          currentTrack.navState, currentTrack, currentTrack.globalTime);
 
       // if tracking or stepping action is called, return initial step
       if (returnLastStep) {
@@ -688,7 +687,7 @@ __global__ void GammaConversion(Track *gammas, G4HepEmGammaTrack *hepEMTracks, S
       adept_scoring::RecordHit(userScoring,
                                currentTrack.trackId,                        // Track ID
                                currentTrack.parentId,                       // parent Track ID
-                               currentTrack.creatorProcessId,               // creator process ID
+                               static_cast<short>(0),                       // step defining process ID
                                2,                                           // Particle type
                                currentTrack.geometryStepLength,             // Step length
                                edep,                                        // Total Edep
@@ -784,7 +783,7 @@ __global__ void GammaCompton(Track *gammas, G4HepEmGammaTrack *hepEMTracks, Seco
       // Create a secondary electron and sample/compute directions.
       Track &electron = secondaries.electrons.NextTrack(
           newRNG, energyEl, currentTrack.pos, currentTrack.eKin * currentTrack.dir - newEnergyGamma * newDirGamma,
-          currentTrack.navState, currentTrack, currentTrack.globalTime, /*CreatorProcessId*/ short(1));
+          currentTrack.navState, currentTrack, currentTrack.globalTime);
       electron.dir.Normalize();
 
       // if tracking or stepping action is called, return initial step
@@ -834,7 +833,7 @@ __global__ void GammaCompton(Track *gammas, G4HepEmGammaTrack *hepEMTracks, Seco
       adept_scoring::RecordHit(userScoring,
                                currentTrack.trackId,                        // Track ID
                                currentTrack.parentId,                       // parent Track ID
-                               currentTrack.creatorProcessId,               // creator process ID
+                               static_cast<short>(1),                       // step defining process ID
                                2,                                           // Particle type
                                currentTrack.geometryStepLength,             // Step length
                                edep,                                        // Total Edep
@@ -929,8 +928,7 @@ __global__ void GammaPhotoelectric(Track *gammas, G4HepEmGammaTrack *hepEMTracks
       Track &electron = secondaries.electrons.NextTrack(
           newRNG, photoElecE, currentTrack.pos,
           vecgeom::Vector3D<Precision>{dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]}, currentTrack.navState,
-          currentTrack, currentTrack.globalTime,
-          /*CreatorProcessId*/ short(2));
+          currentTrack, currentTrack.globalTime);
 
       // if tracking or stepping action is called, return initial step
       if (returnLastStep) {
@@ -969,7 +967,7 @@ __global__ void GammaPhotoelectric(Track *gammas, G4HepEmGammaTrack *hepEMTracks
       adept_scoring::RecordHit(userScoring,
                                currentTrack.trackId,                        // Track ID
                                currentTrack.parentId,                       // parent Track ID
-                               currentTrack.creatorProcessId,               // creator process ID
+                               static_cast<short>(2),                       // step defining process ID
                                2,                                           // Particle type
                                currentTrack.geometryStepLength,             // Step length
                                edep,                                        // Total Edep

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -506,20 +506,17 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
         // not the initializing step, hostTrackInfo must be available
         hostTrackInfo = fHostTrackDataMapper->get(aGPUHit->fTrackID);
 
-        std::cout << " Track " << hostTrackInfo.g4id << " is limited by " << aGPUHit->fCreatorProcessID
-                  << " step number " << aGPUHit->fStepCounter << std::endl;
-
         // setting of the step-defining process
         if (static_cast<int>(parentTrackInfo.particleType) == 0 ||
             static_cast<int>(parentTrackInfo.particleType) == 1) {
 
-          if (aGPUHit->fCreatorProcessID == -2) {
+          if (aGPUHit->fStepLimProcessId == -2) {
             // MSC
             stepDefiningProcess = fHepEmTrackingManager->GetElectronNoProcessVector()[3];
-          } else if (aGPUHit->fCreatorProcessID == -1) {
+          } else if (aGPUHit->fStepLimProcessId == -1) {
             // continuous energy loss by ionization
             stepDefiningProcess = fHepEmTrackingManager->GetElectronNoProcessVector()[0];
-          } else if (aGPUHit->fCreatorProcessID == 3) {
+          } else if (aGPUHit->fStepLimProcessId == 3) {
             // lepton nuclear
             if (static_cast<int>(parentTrackInfo.particleType) == 0)
               stepDefiningProcess = fHepEmTrackingManager->GetElectronNoProcessVector()[4];
@@ -527,21 +524,21 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
               stepDefiningProcess = fHepEmTrackingManager->GetElectronNoProcessVector()[5];
             // continuous energy loss by ionization
             stepDefiningProcess = fHepEmTrackingManager->GetElectronNoProcessVector()[0];
-          } else if (aGPUHit->fCreatorProcessID == 10) {
+          } else if (aGPUHit->fStepLimProcessId == 10) {
             // transportation
             stepDefiningProcess = fHepEmTrackingManager->GetTransportNoProcess();
           } else {
             // discrete interactions
-            stepDefiningProcess = fHepEmTrackingManager->GetElectronNoProcessVector()[aGPUHit->fCreatorProcessID];
+            stepDefiningProcess = fHepEmTrackingManager->GetElectronNoProcessVector()[aGPUHit->fStepLimProcessId];
           }
         } else if (static_cast<int>(parentTrackInfo.particleType) == 2) {
 
-          if (aGPUHit->fCreatorProcessID == 10) {
+          if (aGPUHit->fStepLimProcessId == 10) {
             // transportation
             stepDefiningProcess = fHepEmTrackingManager->GetTransportNoProcess();
           } else {
             // discrete interactions
-            stepDefiningProcess = fHepEmTrackingManager->GetGammaNoProcessVector()[aGPUHit->fCreatorProcessID];
+            stepDefiningProcess = fHepEmTrackingManager->GetGammaNoProcessVector()[aGPUHit->fStepLimProcessId];
           }
         }
       } else {
@@ -551,7 +548,7 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
         if (fHostTrackDataMapper->contains(aGPUHit->fTrackID)) {
           std::cerr << "\033[1;31mERROR: TRACK ALREADY HAS AN ENTRY (trackID = " << aGPUHit->fTrackID
                     << ", parentID = " << aGPUHit->fParentID << ") "
-                    << " creatorprocessId " << aGPUHit->fCreatorProcessID << " pdg charge "
+                    << " stepLimProcessId " << aGPUHit->fStepLimProcessId << " pdg charge "
                     << static_cast<int>(aGPUHit->fParticleType) << " stepCounter " << aGPUHit->fStepCounter << "\033[0m"
                     << std::endl;
           std::abort();
@@ -569,12 +566,13 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
         }
 
         // retrieve creator process from parent particle type
+        // for the initializing step, the step-defining process is the creator process
         if (static_cast<int>(parentTrackInfo.particleType) == 0 ||
             static_cast<int>(parentTrackInfo.particleType) == 1) {
           hostTrackInfo.creatorProcess =
-              fHepEmTrackingManager->GetElectronNoProcessVector()[aGPUHit->fCreatorProcessID];
+              fHepEmTrackingManager->GetElectronNoProcessVector()[aGPUHit->fStepLimProcessId];
         } else if (static_cast<int>(parentTrackInfo.particleType) == 2) {
-          hostTrackInfo.creatorProcess = fHepEmTrackingManager->GetGammaNoProcessVector()[aGPUHit->fCreatorProcessID];
+          hostTrackInfo.creatorProcess = fHepEmTrackingManager->GetGammaNoProcessVector()[aGPUHit->fStepLimProcessId];
         }
 
         hostTrackInfo.logicalVolumeAtVertex = aPreG4TouchableHandle->GetVolume()->GetLogicalVolume();
@@ -590,7 +588,7 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
     } catch (const std::exception &e) {
       std::cerr << "\033[1;31mERROR: EXCEPTION in HostTrackDataMapper: " << e.what()
                 << " (trackID = " << aGPUHit->fTrackID << ", parentID = " << aGPUHit->fParentID << ") "
-                << " creatorprocessId " << aGPUHit->fCreatorProcessID << " pdg charge "
+                << " stepLimProcessId " << aGPUHit->fStepLimProcessId << " pdg charge "
                 << static_cast<int>(aGPUHit->fParticleType) << " stepCounter " << aGPUHit->fStepCounter << "\033[0m"
                 << std::endl;
     } catch (...) {

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -357,8 +357,6 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
       uint64_t gpuParentID;
       trackMapper.tryGetGPUId(aTrack->GetParentID(), gpuParentID);
 
-      short creatorProcessId = -1; // -1 for tracks that come from G4 directly and are not created by AdePT
-
       auto particlePosition     = aTrack->GetPosition();
       auto particleDirection    = aTrack->GetMomentumDirection();
       G4double energy           = aTrack->GetKineticEnergy();
@@ -390,11 +388,10 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
         convertedOrigin = GetVecGeomFromG4State(*aTrack->GetOriginTouchableHandle()->GetHistory());
       }
 
-      fAdeptTransport->AddTrack(pdg, gpuTrackID, gpuParentID, creatorProcessId, energy, particlePosition[0],
-                                particlePosition[1], particlePosition[2], particleDirection[0], particleDirection[1],
-                                particleDirection[2], globalTime, localTime, properTime, weight, stepNumber,
-                                G4Threading::G4GetThreadId(), eventID, std::move(converted),
-                                std::move(convertedOrigin));
+      fAdeptTransport->AddTrack(pdg, gpuTrackID, gpuParentID, energy, particlePosition[0], particlePosition[1],
+                                particlePosition[2], particleDirection[0], particleDirection[1], particleDirection[2],
+                                globalTime, localTime, properTime, weight, stepNumber, G4Threading::G4GetThreadId(),
+                                eventID, std::move(converted), std::move(convertedOrigin));
 
       fTrackCounter++; // increment the track counter for AdePT
 


### PR DESCRIPTION
This adds the step-limiting process to the G4 step information when re-creating the G4 steps to call the SD code.

The creator process ID could be removed from the track.

Now, the step-limiting process is returned with recordHit. If it is an initializing (0th) step, it is the creator process, if it is a later step, it is the step-limiting process.