### PR TITLE
cleaner TrackingManager initialization via constructor

### DIFF
--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -26,7 +26,7 @@
 
 class AdePTTrackingManager : public G4VTrackingManager {
 public:
-  AdePTTrackingManager();
+  explicit AdePTTrackingManager(AdePTConfiguration *config, int verbosity = 0);
   ~AdePTTrackingManager();
 
   void BuildPhysicsTable(const G4ParticleDefinition &) override;
@@ -38,11 +38,6 @@ public:
   void FlushEvent() override;
 
   void InitializeAdePT();
-
-  /// Set verbosity for integration
-  void SetVerbosity(int verbosity) { fVerbosity = verbosity; }
-
-  void SetAdePTConfiguration(AdePTConfiguration *aAdePTConfiguration) { fAdePTConfiguration = aAdePTConfiguration; }
 
   G4HepEmConfig *GetG4HepEmConfig() { return fHepEmTrackingManager->GetConfig(); }
 
@@ -79,7 +74,7 @@ private:
 #else
   std::shared_ptr<AdePTTransportInterface> fAdeptTransport;
 #endif
-  AdePTConfiguration *fAdePTConfiguration;
+  AdePTConfiguration *const fAdePTConfiguration;
   unsigned int fTrackCounter{0};
   int fCurrentEventID{0};
   bool fAdePTInitialized{false};

--- a/src/AdePTPhysics.cc
+++ b/src/AdePTPhysics.cc
@@ -39,7 +39,7 @@ AdePTPhysics::~AdePTPhysics()
 void AdePTPhysics::ConstructProcess()
 {
   // Register custom tracking manager for e-/e+ and gammas.
-  fTrackingManager = new AdePTTrackingManager();
+  fTrackingManager = new AdePTTrackingManager(fAdePTConfiguration, /*verbosity=*/0);
 
   auto g4hepemconfig = fTrackingManager->GetG4HepEmConfig();
   g4hepemconfig->SetMultipleStepsInMSCWithTransportation(
@@ -49,8 +49,4 @@ void AdePTPhysics::ConstructProcess()
   G4Electron::Definition()->SetTrackingManager(fTrackingManager);
   G4Positron::Definition()->SetTrackingManager(fTrackingManager);
   G4Gamma::Definition()->SetTrackingManager(fTrackingManager);
-
-  // Setup tracking manager
-  fTrackingManager->SetVerbosity(0);
-  fTrackingManager->SetAdePTConfiguration(fAdePTConfiguration);
 }

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -30,9 +30,10 @@ std::shared_ptr<AdePTTransportInterface> InstantiateAdePT(AdePTConfiguration &co
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-AdePTTrackingManager::AdePTTrackingManager()
+AdePTTrackingManager::AdePTTrackingManager(AdePTConfiguration *config, int verbosity)
+    : fHepEmTrackingManager(std::make_unique<G4HepEmTrackingManagerSpecialized>()), fAdePTConfiguration(config),
+      fVerbosity(verbosity)
 {
-  fHepEmTrackingManager = std::make_unique<G4HepEmTrackingManagerSpecialized>();
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......


### PR DESCRIPTION
In Athena, an issue was observed that the fAdePTConfiguration was not correctly set. The issue was tracked down to the fAdePTConfiguration being a garbage pointer despite the setter being called right after the constructor. The problem was solved by setting the fAdePTConfiguration directly in the constructor.