### PR TITLE
Reduce block size for transport kernels

### DIFF
--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -903,14 +903,16 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
                                   std::ref(cvG4Workers), std::ref(debugLevel)};
 
   auto computeThreadsAndBlocks = [](unsigned int nParticles) -> std::pair<unsigned int, unsigned int> {
-    constexpr int TransportThreads             = 256;
-    constexpr int LowOccupancyTransportThreads = 32;
+    constexpr int TransportThreads = 32;
+    // If using a larger block size, it may be worth using a smaller size when transporting few
+    // tracks in order to increase the number of blocks launched
+    // constexpr int LowOccupancyTransportThreads = 32;
 
     auto transportBlocks = nParticles / TransportThreads + 1;
-    if (transportBlocks < 10) {
-      transportBlocks = nParticles / LowOccupancyTransportThreads + 1;
-      return {LowOccupancyTransportThreads, transportBlocks};
-    }
+    // if (transportBlocks < 10) {
+    //   transportBlocks = nParticles / LowOccupancyTransportThreads + 1;
+    //   return {LowOccupancyTransportThreads, transportBlocks};
+    // }
     return {TransportThreads, transportBlocks};
   };
 


### PR DESCRIPTION
Reducing the block size from the previous 256 to 32 provides a speedup in Bfield runs, while not affecting runs without a field. This has been tested on two different GPUs:

```
Nvidia RTX 4080
CMS 2018, 8 Threads x 32 TTbar events
```

**No field**
| Kernels    | Time 256 | Time 32 |
|------------|----------|---------|
| Monolithic | 177      | 175     |
| Split      | 182      | 181     |

**3.8 T Field**
| Kernels    | Time 256 | Time 32 | Speedup |
|------------|----------|---------|---------|
| Monolithic | 339      | 292     | 1.16    |
| Split      | 348      | 296     | 1.17    |


```
Nvidia RTX 4090
CMS 2018, 16 Threads x 128 TTbar events
```
**3.8 T Field**
| Kernels    | Time 256 | Time 32 | Speedup |
|------------|----------|---------|---------|
| Monolithic | 856      | 600     | 1.42    |
| Split      | 928      | 718     | 1.29    |

