### PR TITLE
adjust B field parameters to G4

### DIFF
--- a/include/AdePT/magneticfield/RkIntegrationDriver.h
+++ b/include/AdePT/magneticfield/RkIntegrationDriver.h
@@ -54,10 +54,14 @@ public:
 
   // Invariants
   // ----------
-  static constexpr int Nvar                   = 6;      // For now, adequate to integrate over x, y, z, px, py, pz
-  static constexpr Real_t fEpsilonRelativeMax = 1.0e-6; // For now .. to be a parameter
-  static constexpr Real_t fMinimumStep        = 2.0e-4 * copcore::units::millimeter;
-  static constexpr Real_t kSmall              = 1.0e-30; //  amount to add to vector magnitude to avoid div by zero
+  static constexpr int Nvar                   = 6;     // For now, adequate to integrate over x, y, z, px, py, pz
+  static constexpr Real_t fEpsilonRelativeMax = 0.001; // For now .. to be a parameter
+  // Note: In Geant4, there is an absolute error tolerance via the deltaOneStep variable. The relative error tolerance
+  // per step is given by eps = deltaOneStep / stepLength. To ensure that the eps is reasonable, G4 sets a minimal and a
+  // maximal relative error tolerance. Here in AdePT, we don't use an absolute error tolerance but only define the
+  // maximum relative error tolerance that is then used all the time.
+  static constexpr Real_t fMinimumStep = 0.01 * copcore::units::millimeter;
+  static constexpr Real_t kSmall       = 1.0e-30; //  amount to add to vector magnitude to avoid div by zero
 
   // Auxiliary methods
   // -----------------

--- a/include/AdePT/magneticfield/fieldConstants.h
+++ b/include/AdePT/magneticfield/fieldConstants.h
@@ -10,14 +10,14 @@ namespace fieldConstants {
 
 static constexpr double kB2C = -0.299792458 * (copcore::units::GeV / (copcore::units::tesla * copcore::units::meter));
 //
-static constexpr float deltaIntersection = 1.0e-4 * copcore::units::millimeter;
-// Accuracy required for intersection of curved trajectory with surface(s)
+static constexpr float deltaIntersection = 0.001 * copcore::units::millimeter;
+// Accuracy required for intersection of curved trajectory with surface(s) CURRENTLY NOT USED IN ADEPT
 
-static constexpr float gEpsilonDeflect =
-    1.E-2 * copcore::units::cm; // Allowable deflection during an integration step
-                                // The difference between the endpoint and the projection of the straight-line path
-                                // after such a step Used to ensure the accuracy of (intersecting with volumes) the
-                                // curved path is well approximated by chords.
+static constexpr float deltaChord = 0.25 * copcore::units::millimeter;
+// Allowable deflection during an integration step. The difference between the endpoint and the projection of the
+// straight-line path after such a step Used to ensure the accuracy of (intersecting with volumes) the curved path is
+// well approximated by chords. Although it is used slightly different, this variable describes the same error as
+// deltaChord in G4, so we keep the same name
 
 }; // namespace fieldConstants
 

--- a/include/AdePT/magneticfield/fieldPropagatorConstBz.h
+++ b/include/AdePT/magneticfield/fieldPropagatorConstBz.h
@@ -11,6 +11,8 @@
 #include <AdePT/base/BlockData.h>
 #include <AdePT/navigation/AdePTNavigator.h>
 
+#include "fieldConstants.h"
+
 #include <AdePT/magneticfield/ConstBzFieldStepper.h>
 
 // Data structures for statistics of propagation chords
@@ -42,9 +44,6 @@ private:
 __host__ __device__ Precision fieldPropagatorConstBz::ComputeSafeLength(Precision momentumMag, int charge,
                                                                         const Vector3D &direction)
 {
-  // Maximum allowed error made by approximating step along helix with step along straight line
-  constexpr Precision gEpsilonDeflect = 1.E-2 * copcore::units::cm;
-
   // Direction projection in plane perpendicular to field vector
   Precision dirxy = sqrt((1 - direction[2]) * (1 + direction[2]));
 
@@ -54,7 +53,7 @@ __host__ __device__ Precision fieldPropagatorConstBz::ComputeSafeLength(Precisio
   // Precision curv = bend / (dirxy + 1.e-30);
 
   // Distance along the track direction to reach the maximum allowed error
-  return sqrt(2 * gEpsilonDeflect / (bend * dirxy + 1.e-30));
+  return sqrt(2 * fieldConstants::deltaChord / (bend * dirxy + 1.e-30));
 }
 
 // Determine the step along curved trajectory for charged particles in a field.

--- a/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
+++ b/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
@@ -86,9 +86,9 @@ fieldPropagatorRungeKutta<Field_t, RkDriver_t, Real_t, Navigator_t>::ComputeSafe
 
   // Calculate inverse curvature instead - save a division
   Real_t inv_curv = fabs(PtransB.Mag() / (fieldConstants::kB2C * Real_t(charge) * bmag + 1.0e-30));
-  // acceptable lateral error from field ~ related to delta_chord sagital distance
-  return sqrt(Real_t(2.0) * fieldConstants::gEpsilonDeflect *
-              inv_curv); // max length along curve for deflectionn
+  // acceptable lateral error from field
+  return sqrt(Real_t(2.0) * fieldConstants::deltaChord *
+              inv_curv); // max length along curve for deflection
                          // = sqrt( 2.0 / ( invEpsD * curv) ); // Candidate for fast inv-sqrt
 }
 


### PR DESCRIPTION
This PR renames a variable in AdePT so that it has the same name as the one in G4. gEpsilonDeflect -> deltaChord.

Also, this PR adds some more explanations to the variables and sets the same defaults as G4 (they were more strict in AdePT before)