### PR TITLE
add nextTouchableHandle to track MC truth information

### DIFF
--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -618,7 +618,7 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
   if (const auto postVolume = aPostG4TouchableHandle->GetVolume();
       postVolume != nullptr) {                              // protect against nullptr if postNavState is outside
     aTrack->SetNextTouchableHandle(aPostG4TouchableHandle); // Real data
-  } // Missing data
+  }
   // aTrack->SetOriginTouchableHandle(nullptr);                                               // Missing data
   aTrack->SetKineticEnergy(aGPUHit->fPostStepPoint.fEKin);       // Real data
   aTrack->SetMomentumDirection(aPostStepPointMomentumDirection); // Real data

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -615,7 +615,10 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
   aTrack->SetLocalTime(aGPUHit->fLocalTime);   // Real data
   // aTrack->SetProperTime(0);                                                                // Missing data
   // aTrack->SetTouchableHandle(aTrackTouchableHistory);                                      // Missing data
-  // aTrack->SetNextTouchableHandle(nullptr);                                                 // Missing data
+  if (const auto postVolume = aPostG4TouchableHandle->GetVolume();
+      postVolume != nullptr) {                              // protect against nullptr if postNavState is outside
+    aTrack->SetNextTouchableHandle(aPostG4TouchableHandle); // Real data
+  } // Missing data
   // aTrack->SetOriginTouchableHandle(nullptr);                                               // Missing data
   aTrack->SetKineticEnergy(aGPUHit->fPostStepPoint.fEKin);       // Real data
   aTrack->SetMomentumDirection(aPostStepPointMomentumDirection); // Real data


### PR DESCRIPTION
Previously, we set the touchable handle of the postStepPoint. However, in Athena, the `track->GetNextVolume` method is used, which requires the NextTouchableHandle of the track to be set. This is set to the touchable handle of the postStepPoint. 