### PR TITLE
Fix CPU B field in examples, update covfie version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,7 @@ if(ADEPT_USE_EXT_BFIELD)
     message(STATUS "covfie found at: ${COVFIE_INCLUDE_DIR}")
   else()
     set(ADEPT_COVFIE_REPO "https://github.com/acts-project/covfie.git")
-    set(ADEPT_COVFIE_BRANCH "3b7b36ccfe4245dfd54b4b2f895ec11a7ea6333a") # latest version number at 06.08.2025
+    set(ADEPT_COVFIE_BRANCH "v0.15.3") # latest version number at 06.08.2025
 
     message(STATUS "No covfie provided, fetching from: ${ADEPT_COVFIE_REPO} (branch: ${ADEPT_COVFIE_BRANCH})")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,11 +239,8 @@ if(ADEPT_USE_EXT_BFIELD)
     get_target_property(COVFIE_INCLUDE_DIR covfie::core INTERFACE_INCLUDE_DIRECTORIES)
     message(STATUS "covfie found at: ${COVFIE_INCLUDE_DIR}")
   else()
-    set(ADEPT_COVFIE_REPO "https://github.com/SeverinDiederichs/covfie.git")
-    set(ADEPT_COVFIE_BRANCH "export_targets_for_FetchContent")  # New branch with exports
-    ## FIXME use the ones below as soon as branch is merged and a new version is available
-    # set(ADEPT_COVFIE_REPO "https://github.com/acts-project/covfie.git")
-    # set(ADEPT_COVFIE_BRANCH "v0.12.1") # update version number
+    set(ADEPT_COVFIE_REPO "https://github.com/acts-project/covfie.git")
+    set(ADEPT_COVFIE_BRANCH "3b7b36ccfe4245dfd54b4b2f895ec11a7ea6333a") # latest version number at 06.08.2025
 
     message(STATUS "No covfie provided, fetching from: ${ADEPT_COVFIE_REPO} (branch: ${ADEPT_COVFIE_BRANCH})")
 


### PR DESCRIPTION
This fixes a crash that was observed running the example1 with an external B field map:

While the B field on the GPU in texture memory is always clamped and therefore secure against out-of-bounds access, the B field on the CPU that we use in our examples is not. This requires initializing the B field type as clamped.

As the B field type of the reader and writer must be the same in covfie, (and we require an unclamped version for the texture memory), the clamped B field is generated separately from the unclamped one, which is read from file.

The covfie version is updated.