### PR TITLE
Add stricter compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,70 @@ option(ADEPT_USE_EXT_BFIELD "Use external B field from file via the covfie libra
 option(DEBUG_SINGLE_THREAD "Run transport kernels in single thread mode" OFF)
 set(ADEPT_DEBUG_TRACK 0 CACHE STRING "Debug tracking level (0=off, >0=on with levels)")
 option(ASYNC_MODE "Enable the async transport backend" OFF)
+option(USE_STRICT_FLAGS "Use strict compiler flags, as also used in CMSSW" OFF)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+
+  set(_warn_flags
+    -Wall
+    -Wextra
+    -Wpedantic
+    -Wno-non-template-friend
+    -Wno-long-long
+    -Wreturn-type
+    -Wpessimizing-move
+    -Wclass-memaccess
+    -Wno-cast-function-type
+    -Wno-unused-but-set-parameter
+    -Wno-ignored-qualifiers
+    -Wno-unused-parameter
+    -Wunused
+    -Wparentheses
+    -Wnon-virtual-dtor
+  )
+
+  set(_error_flags
+    -Werror=pointer-arith
+    -Werror=overlength-strings
+    -Werror=overflow
+    -Werror=array-bounds
+    -Werror=format-contains-nul
+    -Werror=type-limits
+    -Werror=return-type
+    -Werror=missing-braces
+    -Werror=unused-value
+    -Werror=unused-label
+    -Werror=address
+    -Werror=format
+    -Werror=sign-compare
+    -Werror=write-strings
+    -Werror=delete-non-virtual-dtor
+    -Werror=strict-aliasing
+    -Werror=narrowing
+    -Werror=unused-but-set-variable
+    -Werror=reorder
+    -Werror=unused-variable
+    -Werror=conversion-null
+    -Werror=return-local-addr
+  )
+
+  # In soft mode, convert all -Werror=foo to just -Wfoo
+  if(NOT USE_STRICT_FLAGS)
+    set(_converted_errors "")
+    foreach(f IN LISTS _error_flags)
+      string(REPLACE "-Werror=" "-W" _wflag "${f}")
+      list(APPEND _converted_errors "${_wflag}")
+    endforeach()
+    set(_final_flags ${_warn_flags} ${_converted_errors})
+  else()
+    message(STATUS "Enabling strict compiler flags")
+    set(_final_flags ${_warn_flags} ${_error_flags})
+  endif()
+
+  string(JOIN " " _final_flags_str ${_final_flags})
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_final_flags_str}")
+endif()
+
 
 #----------------------------------------------------------------------------#
 # Dependencies
@@ -183,11 +247,16 @@ if(Geant4_FOUND)
   # so we do a compile check.
   check_cxx_source_compiles("
     #include \"G4VTrackingManager.hh\"
-    class testtm_ : public G4VTrackingManager {
-    public:
-      void HandOverOneTrack(G4Track*) {}
+    #include \"G4Track.hh\"
+
+    struct testtm_ : G4VTrackingManager {
+      void HandOverOneTrack(G4Track*) override {}
     };
-    int main() { testtm_ model; return 0; }" AdePT_HAS_G4VTRACKINGMANAGER)
+
+    int main() {
+      testtm_ t;
+      return 0;
+    }" AdePT_HAS_G4VTRACKINGMANAGER)
 else()
   message(STATUS "Did not find Geant4")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,9 +73,14 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     -Wunused
     -Wparentheses
     -Wnon-virtual-dtor
+    -Wno-unused-local-typedefs
+    -Wno-attributes
+    -Wno-psabi
   )
 
   set(_error_flags
+    -Werror=main
+    -Werror=switch
     -Werror=pointer-arith
     -Werror=overlength-strings
     -Werror=overflow

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ option(ADEPT_USE_EXT_BFIELD "Use external B field from file via the covfie libra
 option(DEBUG_SINGLE_THREAD "Run transport kernels in single thread mode" OFF)
 set(ADEPT_DEBUG_TRACK 0 CACHE STRING "Debug tracking level (0=off, >0=on with levels)")
 option(ASYNC_MODE "Enable the async transport backend" OFF)
-option(USE_STRICT_FLAGS "Use strict compiler flags, as also used in CMSSW" OFF)
+option(ENFORCE_STRICT_FLAGS "Enforce strict compiler flags, as also used in CMSSW" OFF)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 
@@ -101,7 +101,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
   )
 
   # In soft mode, convert all -Werror=foo to just -Wfoo
-  if(NOT USE_STRICT_FLAGS)
+  if(NOT ENFORCE_STRICT_FLAGS)
     set(_converted_errors "")
     foreach(f IN LISTS _error_flags)
       string(REPLACE "-Werror=" "-W" _wflag "${f}")

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ The table below shows the available CMake options for AdePT that may be used to 
 |ADEPT_MIXED_PRECISION|OFF|Use B-field integration and surface model in mixed precision|
 |DEBUG_SINGLE_THREAD|OFF| Run transport kernels in single thread mode |
 |ADEPT_DEBUG_TRACK|0| Debug tracking level (0=off, >0=on with levels) |
-|USE_STRICT_FLAGS|0| Use strict compiler flags, as also used in CMSSW. Many warnings are promoted to errors using this flag. |
+|ENFORCE_STRICT_FLAGS|0| Use strict compiler flags, as also used in CMSSW. Many warnings are promoted to errors using this flag. |
 
 To build, run:
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The table below shows the available CMake options for AdePT that may be used to 
 |ADEPT_MIXED_PRECISION|OFF|Use B-field integration and surface model in mixed precision|
 |DEBUG_SINGLE_THREAD|OFF| Run transport kernels in single thread mode |
 |ADEPT_DEBUG_TRACK|0| Debug tracking level (0=off, >0=on with levels) |
+|USE_STRICT_FLAGS|0| Use strict compiler flags, as also used in CMSSW. Many warnings are promoted to errors using this flag. |
 
 To build, run:
 

--- a/examples/Example1/example1.cpp
+++ b/examples/Example1/example1.cpp
@@ -20,8 +20,7 @@ int main(int argc, char **argv)
 {
   // Macro name from arguments
   G4String batchMacroName;
-  G4bool useInteractiveMode = true;
-  G4bool useAdePT           = true;
+  G4bool useAdePT     = true;
   G4bool allSensitive = false; // If set, ignores the sensitive detector flags in the GDML and marks all volumes as
                                // sensitive. Useful for validation of geometries with no SD info
   G4String helpMsg("Usage: " + G4String(argv[0]) +
@@ -34,8 +33,7 @@ int main(int argc, char **argv)
       G4cout << helpMsg << G4endl;
       return 0;
     } else if (argument == "-m") {
-      batchMacroName     = G4String(argv[i + 1]);
-      useInteractiveMode = false;
+      batchMacroName = G4String(argv[i + 1]);
       ++i;
     } else if (argument == "--noadept") {
       useAdePT = false;

--- a/examples/Example1/src/DetectorConstruction.cc
+++ b/examples/Example1/src/DetectorConstruction.cc
@@ -26,7 +26,7 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 DetectorConstruction::DetectorConstruction(bool allSensitive)
-    : fAllSensitive(allSensitive), G4VUserDetectorConstruction()
+    : G4VUserDetectorConstruction(), fAllSensitive(allSensitive)
 {
   fDetectorMessenger = new DetectorMessenger(this);
 }

--- a/include/AdePT/copcore/Macros.h
+++ b/include/AdePT/copcore/Macros.h
@@ -74,4 +74,16 @@
 #define COPCORE_DEVICE_COMPILATION
 #endif
 
+// Pragmas to locally suppress -Wpedantic for __int128 or other non-standard extensions
+#if defined(__GNUC__) && !defined(__clang__) && !defined(COPCORE_DEVICE_COMPILATION)
+#define DISABLE_PEDANTIC_WARNINGS _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+#define ENABLE_PEDANTIC_WARNINGS _Pragma("GCC diagnostic pop")
+#elif defined(__clang__) && !defined(COPCORE_DEVICE_COMPILATION)
+#define DISABLE_PEDANTIC_WARNINGS _Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Wpedantic\"")
+#define ENABLE_PEDANTIC_WARNINGS _Pragma("clang diagnostic pop")
+#else
+#define DISABLE_PEDANTIC_WARNINGS
+#define ENABLE_PEDANTIC_WARNINGS
+#endif
+
 #endif // COPCORE_MACROS_H_

--- a/include/AdePT/copcore/ranluxpp/mulmod.h
+++ b/include/AdePT/copcore/ranluxpp/mulmod.h
@@ -50,11 +50,14 @@ __host__ __device__ static void multiply9x9(const uint64_t *in1, const uint64_t 
       uint64_t lower = fac1 * fac2;
       uint64_t upper = __umul64hi(fac1, fac2);
 #elif defined(__SIZEOF_INT128__)
+      // disable pedantic warnings, as __int128 is not in the C++ standard
+      DISABLE_PEDANTIC_WARNINGS
       unsigned __int128 prod = fac1;
       prod                   = prod * fac2;
 
       uint64_t upper = prod >> 64;
       uint64_t lower = static_cast<uint64_t>(prod);
+      ENABLE_PEDANTIC_WARNINGS
 #else
       uint64_t upper1 = fac1 >> 32;
       uint64_t lower1 = static_cast<uint32_t>(fac1);
@@ -241,5 +244,10 @@ __host__ __device__ static void powermod(const uint64_t *base, uint64_t *res, ui
     mod_m(mul, fac);
   }
 }
+
+// end disabling of -Wpedantic
+#if defined(__GNUC__) && !defined(__CUDA_ARCH__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -86,19 +86,18 @@ std::ostream &operator<<(std::ostream &stream, TrackDataWithIDs const &track)
 template <typename IntegrationLayer>
 AsyncAdePTTransport<IntegrationLayer>::AsyncAdePTTransport(AdePTConfiguration &configuration,
                                                            G4HepEmTrackingManagerSpecialized *hepEmTM)
-    : fNThread{(ushort)configuration.GetNumThreads()},
+    : fAdePTSeed{configuration.GetAdePTSeed()}, fNThread{(ushort)configuration.GetNumThreads()},
       fTrackCapacity{(uint)(1024 * 1024 * configuration.GetMillionsOfTrackSlots())},
       fLeakCapacity{(uint)(1024 * 1024 * configuration.GetMillionsOfLeakSlots())},
       fScoringCapacity{(uint)(1024 * 1024 * configuration.GetMillionsOfHitSlots())},
-      fDebugLevel{configuration.GetVerbosity()}, fEventStates(fNThread), fGPUNetEnergy(fNThread, 0.0),
-      fTrackInAllRegions{configuration.GetTrackInAllRegions()}, fGPURegionNames{configuration.GetGPURegionNames()},
-      fCPURegionNames{configuration.GetCPURegionNames()}, fCUDAStackLimit{configuration.GetCUDAStackLimit()},
-      fCUDAHeapLimit{configuration.GetCUDAHeapLimit()}, fAdePTSeed{configuration.GetAdePTSeed()},
+      fDebugLevel{configuration.GetVerbosity()}, fCUDAStackLimit{configuration.GetCUDAStackLimit()},
+      fCUDAHeapLimit{configuration.GetCUDAHeapLimit()}, fLastNParticlesOnCPU{configuration.GetLastNParticlesOnCPU()},
+      fEventStates(fNThread), fGPUNetEnergy(fNThread, 0.0), fTrackInAllRegions{configuration.GetTrackInAllRegions()},
+      fGPURegionNames{configuration.GetGPURegionNames()}, fCPURegionNames{configuration.GetCPURegionNames()},
       fReturnAllSteps{configuration.GetCallUserSteppingAction()},
       fReturnFirstAndLastStep{configuration.GetCallUserTrackingAction()},
-      fBfieldFile{configuration.GetCovfieBfieldFile()}, fLastNParticlesOnCPU{configuration.GetLastNParticlesOnCPU()},
-      fCPUCopyFraction{configuration.GetHitBufferFlushThreshold()},
-      fCPUCapacityFactor{configuration.GetCPUCapacityFactor()}
+      fBfieldFile{configuration.GetCovfieBfieldFile()}, fCPUCapacityFactor{configuration.GetCPUCapacityFactor()},
+      fCPUCopyFraction{configuration.GetHitBufferFlushThreshold()}
 {
   if (fNThread > kMaxThreads)
     throw std::invalid_argument("AsyncAdePTTransport limited to " + std::to_string(kMaxThreads) + " threads");

--- a/include/AdePT/core/ScoringCommons.hh
+++ b/include/AdePT/core/ScoringCommons.hh
@@ -31,7 +31,7 @@ struct GPUHit {
   uint64_t fTrackID{0};  // Track ID
   uint64_t fParentID{0}; // parent Track ID
   short fStepLimProcessId{-1};
-  unsigned int fEventId{0};
+  int fEventId{0};
   short threadId{-1};
   // bool fFirstStepInVolume{false};
   bool fLastStepOfTrack{false};

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -100,6 +100,10 @@ private:
 
   void ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex, int debugLevel) const;
 
+  // pointer to specialized G4HepEmTrackingManager. Owned by AdePTTrackingManager,
+  // this is just a reference to handle gamma-/lepton-nuclear reactions
+  G4HepEmTrackingManagerSpecialized *fHepEmTrackingManager;
+
   // helper class to provide the CPU-only data for the returning GPU tracks
   std::unique_ptr<HostTrackDataMapper> fHostTrackDataMapper;
 
@@ -107,9 +111,6 @@ private:
   static std::vector<G4LogicalVolume const *> fglobal_vecgeom_lv_to_g4_map;
   std::unique_ptr<AdePTGeant4Integration_detail::ScoringObjects, AdePTGeant4Integration_detail::Deleter>
       fScoringObjects{nullptr};
-  // pointer to specialized G4HepEmTrackingManager. Owned by AdePTTrackingManager,
-  // this is just a reference to handle gamma-/lepton-nuclear reactions
-  G4HepEmTrackingManagerSpecialized *fHepEmTrackingManager;
 };
 
 #endif

--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -67,7 +67,6 @@ private:
   std::unique_ptr<G4HepEmTrackingManagerSpecialized> fHepEmTrackingManager;
   static inline int fNumThreads{0};
   std::set<G4Region const *> fGPURegions{};
-  int fVerbosity{0};
 // std::shared_ptr<AdePTTransportInterface> fAdeptTransport;
 #ifndef ASYNC_MODE
   std::unique_ptr<AdePTTransportInterface> fAdeptTransport;
@@ -75,6 +74,7 @@ private:
   std::shared_ptr<AdePTTransportInterface> fAdeptTransport;
 #endif
   AdePTConfiguration *const fAdePTConfiguration;
+  int fVerbosity{0};
   unsigned int fTrackCounter{0};
   int fCurrentEventID{0};
   bool fAdePTInitialized{false};

--- a/include/AdePT/magneticfield/RkIntegrationDriver.h
+++ b/include/AdePT/magneticfield/RkIntegrationDriver.h
@@ -112,8 +112,8 @@ inline __host__ __device__ bool RkIntegrationDriver<Stepper_t, Real_t, Int_t, Eq
   // For first cord integration try full cordlength otherwise use last step from previous cord integration
   Real_t htry = cordIters == 0 ? length : vecCore::Min(hgood, length);
 
-  bool done    = false;
-  int numSteps = 0;
+  bool done             = false;
+  unsigned int numSteps = 0;
 
   bool allFailed = true;  // Have all steps until now failed
   bool goodStep  = false; // last step was good
@@ -122,8 +122,7 @@ inline __host__ __device__ bool RkIntegrationDriver<Stepper_t, Real_t, Int_t, Eq
 
     goodStep = IntegrateStep(yStart, dydx, chargeInt, stepAdvance, htry, magField, yEnd, dydx_next, hnext);
 
-    Real_t hdid = goodStep ? htry : 0.0;
-    allFailed   = allFailed && !goodStep;
+    allFailed = allFailed && !goodStep;
 
     done  = (stepAdvance >= length);
     hgood = vecCore::Max(hnext, Real_t(fMinimumStep));
@@ -133,7 +132,9 @@ inline __host__ __device__ bool RkIntegrationDriver<Stepper_t, Real_t, Int_t, Eq
 #endif
     htry = hgood;
     if (goodStep && !done) {
+#ifdef __CUDA_ARCH__
 #pragma unroll
+#endif
       for (int i = 0; i < Nvar; i++) {
         yStart[i] = yEnd[i];
         dydx[i]   = dydx_next[i]; // Using FSAL property !

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -45,9 +45,11 @@ AdePTTrackingManager::~AdePTTrackingManager()
 
 void AdePTTrackingManager::InitializeAdePT()
 {
-  // Check if this is a sequential run
+#ifndef ASYNC_MODE
+  // in Sync AdePT, check if this is a sequential run
   G4RunManager::RMType rmType = G4RunManager::GetRunManager()->GetRunManagerType();
   bool sequential             = (rmType == G4RunManager::sequentialRM);
+#endif
 
   auto tid = G4Threading::G4GetThreadId();
 

--- a/test/regression/IntegrationTest/integrationTest.cpp
+++ b/test/regression/IntegrationTest/integrationTest.cpp
@@ -20,15 +20,14 @@ int main(int argc, char **argv)
 {
   // Macro name from arguments
   G4String batchMacroName;
-  G4String outputDirectory  = "";
-  G4String outputFilename   = "";
-  bool doBenchmark          = false;
-  bool doValidation         = false;
-  bool doAccumulatedEvents  = false; // whether the edep is accumulated across events in the validation csv file
-  G4bool useInteractiveMode = true;
-  G4bool useAdePT           = true;
-  G4bool allSensitive = false; // If set, ignores the sensitive detector flags in the GDML and marks all volumes as
-                               // sensitive. Useful for validation of geometries with no SD info
+  G4String outputDirectory = "";
+  G4String outputFilename  = "";
+  bool doBenchmark         = false;
+  bool doValidation        = false;
+  bool doAccumulatedEvents = false; // whether the edep is accumulated across events in the validation csv file
+  G4bool useAdePT          = true;
+  G4bool allSensitive      = false; // If set, ignores the sensitive detector flags in the GDML and marks all volumes as
+                                    // sensitive. Useful for validation of geometries with no SD info
   G4String helpMsg("Usage: " + G4String(argv[0]) +
                    " [option(s)] \n No additional arguments triggers an interactive mode "
                    "executing vis.mac macro. \n Options:\n\t-h\t\tdisplay this help "
@@ -39,8 +38,7 @@ int main(int argc, char **argv)
       G4cout << helpMsg << G4endl;
       return 0;
     } else if (argument == "-m") {
-      batchMacroName     = G4String(argv[i + 1]);
-      useInteractiveMode = false;
+      batchMacroName = G4String(argv[i + 1]);
       ++i;
     } else if (argument == "--output_dir") {
       outputDirectory = G4String(argv[i + 1]);

--- a/test/regression/IntegrationTest/src/DetectorConstruction.cc
+++ b/test/regression/IntegrationTest/src/DetectorConstruction.cc
@@ -26,7 +26,7 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 DetectorConstruction::DetectorConstruction(bool allSensitive)
-    : fAllSensitive(allSensitive), G4VUserDetectorConstruction()
+    : G4VUserDetectorConstruction(), fAllSensitive(allSensitive)
 {
   fDetectorMessenger = new DetectorMessenger(this);
 }

--- a/test/unit/compare_integration_precision.cpp
+++ b/test/unit/compare_integration_precision.cpp
@@ -80,7 +80,7 @@ void IntegrateForDistance(const UniformMagneticField &magField, const Real_t max
     done          = (totalDistanceDone >= maxDistance);
     stepSizeTryIn = vecCore::Max(minStepSize, stepSizeNextOut);
     if (goodStep && !done) {
-      for (int i = 0; i < Nvar; i++) {
+      for (unsigned int i = 0; i < Nvar; i++) {
         yCurrentIn[i]    = yNextOut[i];
         dydxCurrentIn[i] = dydxNextOut[i]; // Using FSAL property !
       }

--- a/test/unit/test_magfieldRK.cpp
+++ b/test/unit/test_magfieldRK.cpp
@@ -216,9 +216,6 @@ bool TestDriverAdvance(Field_t const &magField, Real_t hLength = 300)
   Vector3D<double> Momentum = momentumMag * Direction;
 
   Real_t dy_ds[Nvar];
-  Real_t yOut[Nvar];      // Output:  y values at end,
-  Real_t yerr[Nvar];      //          estimated errors,
-  Real_t next_dyds[Nvar]; //          next value of dydx
 
   int charge = -1;
 
@@ -315,10 +312,6 @@ bool CheckDriverVsHelix(Field_t const &magField, const Real_t stepLength = 300.0
   Vector3D<Real_t> const startMomentum = momentumMag * startDirection;
 
   Real_t dy_ds[Nvar];
-  Real_t yOut[Nvar];      // Output:  y values at end,
-  Real_t yerr[Nvar];      //          estimated errors,
-  Real_t next_dyds[Nvar]; //          next value of dydx
-
   int charge = -1;
 
   Vector3D<float> magFieldStart(1, 2, 3);
@@ -347,8 +340,7 @@ bool CheckDriverVsHelix(Field_t const &magField, const Real_t stepLength = 300.0
   }
 
   bool unfinished    = true;
-  Real_t hTry        = hLength; // suggested 'good' length per integration step
-  Real_t sumAdvanced = 0;       //  length integrated
+  Real_t sumAdvanced = 0; //  length integrated
 
   constexpr int maxTrials = 500;
 
@@ -446,11 +438,11 @@ int main(int argc, char **argv)
 
   cout << " -- Testing mag-field equation with float.   " << endl;
   cout << " ---------------------------------------------------------------------" << endl;
-  bool okUniformFloat = TestEquation<float, UniformMagneticField>(*pConstantBfield);
-  bool okBxFloat      = TestEquation<float, UniformMagneticField>(Bx);
-  bool okByFloat      = TestEquation<float, UniformMagneticField>(By);
-  bool okBzFloat      = TestEquation<float, UniformMagneticField>(Bz);
-  bool allEqGood      = okUniformFloat && okBxFloat && okByFloat && okBzFloat;
+  // NOTE: No return value of testEquation is queried or used!
+  TestEquation<float, UniformMagneticField>(*pConstantBfield);
+  TestEquation<float, UniformMagneticField>(Bx);
+  TestEquation<float, UniformMagneticField>(By);
+  TestEquation<float, UniformMagneticField>(Bz);
   cout << endl;
 
   cout << " ---------------------------------------------------------------------" << endl;


### PR DESCRIPTION
This PR adds stricter compiler flags to AdePT. Additionally, a new compile time option is introduced to enforce some of the flags. This setting enforces the same error flags as CMSSW. If they are not enforced, still, they are printed as warnings.

This new setting revealed many minor issues, but also a bigger one, where the `parentTrackInfo` was used instead of the `hostTrackInfo`.

Note that even stricter flags could be set, but those reveal countless issues in VecGeom and G4VG, so it is left for future cleaning.