### PR TITLE
Enable using fNumThreads from AdePTconfig

### DIFF
--- a/include/AdePT/core/AdePTConfiguration.hh
+++ b/include/AdePT/core/AdePTConfiguration.hh
@@ -94,7 +94,7 @@ private:
   bool fSetMultipleStepsInMSCWithTransportation{false};
   bool fSetEnergyLossFluctuation{false};
   bool fAdePTActivated{true};
-  int fNumThreads;
+  int fNumThreads{-1};
   int fVerbosity{0};
   int fTransportBufferThreshold{200};
   int fCUDAStackLimit{0};
@@ -109,7 +109,6 @@ private:
 
   std::vector<std::string> fGPURegionNames{};
   std::vector<std::string> fCPURegionNames{};
-  int fNThread = -1;
 
   std::string fVecGeomGDML{""};
   std::string fCovfieBfieldFile{""};


### PR DESCRIPTION
G4 applications don't necessary need to use a G4RunManager. In that case, AdePT can retrieve the number of threads via the AdePTConfig, which is passed to the constructor of the AdePTTrackingManager. Then, in the physicslist, the number of threads must be passed via the AdePTConfig to the AdePTTrackingManager. Needed in CMSSW.

This PR adds a safe guard for the possible nullptr access for the G4RunManager, sets a default value for fNumThreads and deletes an used variable.