### PR TITLE
[mini] fix uninitialized warning

### DIFF
--- a/include/AdePT/integration/HostTrackDataMapper.hh
+++ b/include/AdePT/integration/HostTrackDataMapper.hh
@@ -26,7 +26,7 @@ struct HostTrackData {
   G4LogicalVolume *logicalVolumeAtVertex = nullptr;
   G4ThreeVector vertexPosition;
   G4ThreeVector vertexMomentumDirection;
-  G4double vertexKineticEnergy;
+  G4double vertexKineticEnergy = 0.0;
   char particleType;
 };
 


### PR DESCRIPTION
This fixes a warning of a potentially uninitialized member of the hosttrackdata. Now it is initialized to the G4 default value of 0.