### PR TITLE
Fix access to HostTrackData

### DIFF
--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -95,7 +95,7 @@ AsyncAdePTTransport<IntegrationLayer>::AsyncAdePTTransport(AdePTConfiguration &c
       fEventStates(fNThread), fGPUNetEnergy(fNThread, 0.0), fTrackInAllRegions{configuration.GetTrackInAllRegions()},
       fGPURegionNames{configuration.GetGPURegionNames()}, fCPURegionNames{configuration.GetCPURegionNames()},
       fReturnAllSteps{configuration.GetCallUserSteppingAction()},
-      fReturnFirstAndLastStep{configuration.GetCallUserTrackingAction()},
+      fReturnFirstAndLastStep{configuration.GetCallUserTrackingAction() || configuration.GetCallUserSteppingAction()},
       fBfieldFile{configuration.GetCovfieBfieldFile()}, fCPUCapacityFactor{configuration.GetCPUCapacityFactor()},
       fCPUCopyFraction{configuration.GetHitBufferFlushThreshold()}
 {
@@ -440,7 +440,7 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
     G4cout << str.str() << G4endl;
   }
 
-  integrationInstance.ReturnTracks(tracks.begin(), tracks.end(), fDebugLevel);
+  integrationInstance.ReturnTracks(tracks.begin(), tracks.end(), fDebugLevel, fReturnFirstAndLastStep);
 
   async_adept_impl::FlushScoring(fScoring[threadId]);
   fEventStates[threadId].store(EventState::ScoringRetrieved, std::memory_order_release);

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -70,13 +70,13 @@ public:
 
   /// @brief Takes a range of tracks coming from the device and gives them back to Geant4
   template <typename Iterator>
-  void ReturnTracks(Iterator begin, Iterator end, int debugLevel) const
+  void ReturnTracks(Iterator begin, Iterator end, int debugLevel, bool callUserActions = false) const
   {
     if (debugLevel > 1) {
       G4cout << "Returning " << end - begin << " tracks from device" << G4endl;
     }
     for (Iterator it = begin; it != end; ++it) {
-      ReturnTrack(*it, it - begin, debugLevel);
+      ReturnTrack(*it, it - begin, debugLevel, callUserActions);
     }
   }
 
@@ -98,7 +98,8 @@ private:
                   G4TouchableHandle &aPostG4TouchableHandle, G4StepStatus aPreStepStatus, G4StepStatus aPostStepStatus,
                   bool callUserTrackingAction, bool callUserSteppingAction) const;
 
-  void ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex, int debugLevel) const;
+  void ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex, int debugLevel,
+                   bool callUserActions = false) const;
 
   // pointer to specialized G4HepEmTrackingManager. Owned by AdePTTrackingManager,
   // this is just a reference to handle gamma-/lepton-nuclear reactions

--- a/include/AdePT/integration/HostTrackDataMapper.hh
+++ b/include/AdePT/integration/HostTrackDataMapper.hh
@@ -18,9 +18,9 @@ class G4PrimaryParticle;
 
 /// @brief A helper struct to store the data that is stored exclusively on the CPU
 struct HostTrackData {
-  int g4id                               = 0;  // the Geant4 track ID
-  int g4parentid                         = -1; // the Geant4 parent ID
-  uint64_t gpuId                         = 0;  // the GPU’s 64-bit track ID
+  int g4id                               = 0; // the Geant4 track ID
+  int g4parentid                         = 0; // the Geant4 parent ID
+  uint64_t gpuId                         = 0; // the GPU’s 64-bit track ID
   G4PrimaryParticle *primary             = nullptr;
   G4VProcess *creatorProcess             = nullptr;
   G4VUserTrackInformation *userTrackInfo = nullptr;

--- a/include/AdePT/integration/HostTrackDataMapper.hh
+++ b/include/AdePT/integration/HostTrackDataMapper.hh
@@ -117,10 +117,12 @@ public:
     gpuToIndex[gpuId] = idx;
     hostDataVec.emplace_back(); // in-place default construction
 
-    auto &d             = hostDataVec.back();
-    d.gpuId             = gpuId;
-    d.g4id              = useNewId ? currentGpuReturnG4ID-- : static_cast<int>(gpuId);
-    g4idToGpuId[d.g4id] = gpuId; // required for CPU↔GPU↔CPU ping-pong
+    auto &d = hostDataVec.back();
+    d.gpuId = gpuId;
+    d.g4id  = useNewId ? currentGpuReturnG4ID-- : static_cast<int>(gpuId);
+    // Note: this is a hot path and increases run time significantly, but is needed for correct re-mapping of tracks
+    // that go from GPU to CPU back to GPU, as they need to be assigned the same ID on the GPU
+    g4idToGpuId[d.g4id] = gpuId;
     return d;
   }
 

--- a/include/AdePT/integration/HostTrackDataMapper.hh
+++ b/include/AdePT/integration/HostTrackDataMapper.hh
@@ -4,22 +4,23 @@
 #ifndef HOSTTRACKDATAMAPPER_H
 #define HOSTTRACKDATAMAPPER_H
 
+#include "G4VUserTrackInformation.hh"
+#include "G4VProcess.hh"
+
 #include <unordered_map>
 #include <cstdint>
 #include <algorithm>
 #include <limits>
-
-#include "G4VUserTrackInformation.hh"
-#include "G4VProcess.hh"
+#include <memory>
 
 // Forward declaration
 class G4PrimaryParticle;
 
 /// @brief A helper struct to store the data that is stored exclusively on the CPU
 struct HostTrackData {
-  int g4id                               = 0; // the Geant4 track ID
-  int g4parentid                         = 0; // the Geant4 parent ID
-  uint64_t gpuId                         = 0; // the GPU’s 64-bit track ID
+  int g4id                               = 0;  // the Geant4 track ID
+  int g4parentid                         = -1; // the Geant4 parent ID
+  uint64_t gpuId                         = 0;  // the GPU’s 64-bit track ID
   G4PrimaryParticle *primary             = nullptr;
   G4VProcess *creatorProcess             = nullptr;
   G4VUserTrackInformation *userTrackInfo = nullptr;
@@ -28,6 +29,14 @@ struct HostTrackData {
   G4ThreeVector vertexMomentumDirection;
   G4double vertexKineticEnergy = 0.0;
   char particleType;
+
+  HostTrackData() = default;
+
+  HostTrackData(HostTrackData &&) noexcept            = default;
+  HostTrackData &operator=(HostTrackData &&) noexcept = default;
+
+  HostTrackData(HostTrackData const &)            = delete;
+  HostTrackData &operator=(HostTrackData const &) = delete;
 };
 
 // This class provides a mapping between G4 id's (int) and AdePT id's (uint64_t).
@@ -62,28 +71,19 @@ public:
   }
 
   /// HOT PATH: 1 hash + bucket probe, returns a reference into the table
-  HostTrackData &getOrCreate(uint64_t gpuId, bool useNewId = true)
+
+  // Assumes caller knows entry exists
+  HostTrackData &get(uint64_t gpuId) noexcept
   {
-    auto it = gpuToIndex.find(gpuId);
-    if (it != gpuToIndex.end()) {
-      // already have a slot
-      return hostDataVec[it->second];
-    }
-    // new track -> assign next slot
-    int idx           = static_cast<int>(hostDataVec.size());
-    gpuToIndex[gpuId] = idx;
-    hostDataVec.push_back({});
-    auto &d             = hostDataVec.back();
-    d.gpuId             = gpuId;
-    d.g4id              = useNewId ? currentGpuReturnG4ID-- : static_cast<int>(gpuId);
-    g4idToGpuId[d.g4id] = gpuId;
-    return d;
+    auto it = gpuToIndex.find(gpuId); // guaranteed to exist here
+    // assert(it != gpuToIndex.end());
+    return hostDataVec[it->second];
   }
 
-  // Assumes caller knows entry exists
-  HostTrackData &get(uint64_t gpuId) { return hostDataVec[gpuToIndex.at(gpuId)]; }
-
-  // Assumes caller knows entry exists
+  /// @brief Sets the gpuid by reference and returns whether the entry already existed
+  /// @param g4id int G4 id that is checked
+  /// @param gpuid uint64 gpu id that is returned
+  /// @return whether the GPU id already existed
   bool tryGetGPUId(int g4id, uint64_t &gpuid)
   {
     auto it = g4idToGpuId.find(g4id);
@@ -95,18 +95,32 @@ public:
     return true;
   }
 
-  // Assumes caller knows entry does not exist yet
+  HostTrackData &getOrCreate(uint64_t gpuId, bool useNewId = true)
+  {
+    auto [it, inserted] = gpuToIndex.emplace(gpuId, -1);
+    if (!inserted) return hostDataVec[it->second];
+
+    const int idx = static_cast<int>(hostDataVec.size());
+    hostDataVec.emplace_back(); // in-place default construction
+    it->second = idx;
+
+    auto &d             = hostDataVec.back();
+    d.gpuId             = gpuId;
+    d.g4id              = useNewId ? currentGpuReturnG4ID-- : static_cast<int>(gpuId);
+    g4idToGpuId[d.g4id] = gpuId;
+    return d;
+  }
+
   HostTrackData &create(uint64_t gpuId, bool useNewId = true)
   {
-    int idx           = static_cast<int>(hostDataVec.size());
+    const int idx     = static_cast<int>(hostDataVec.size());
     gpuToIndex[gpuId] = idx;
-    hostDataVec.push_back({});
-    auto &d = hostDataVec.back();
-    d.gpuId = gpuId;
-    d.g4id  = useNewId ? currentGpuReturnG4ID-- : static_cast<int>(gpuId);
-    // Note: this is a hot path and increases run time significantly, but is needed for correct re-mapping of tracks
-    // that go from GPU to CPU back to GPU, as they need to be assigned the same ID on the GPU
-    g4idToGpuId[d.g4id] = gpuId;
+    hostDataVec.emplace_back(); // in-place default construction
+
+    auto &d             = hostDataVec.back();
+    d.gpuId             = gpuId;
+    d.g4id              = useNewId ? currentGpuReturnG4ID-- : static_cast<int>(gpuId);
+    g4idToGpuId[d.g4id] = gpuId; // required for CPU↔GPU↔CPU ping-pong
     return d;
   }
 

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -327,9 +327,9 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
       uint64_t gpuTrackID;
       bool entryExists = trackMapper.tryGetGPUId(aTrack->GetTrackID(), gpuTrackID);
 
-      HostTrackData hostTrackData;
+      // if the entry doesn't exist, it is filled with all the available G4Track information
       if (!entryExists) {
-        hostTrackData = trackMapper.create(gpuTrackID, /*useNewId=*/false);
+        HostTrackData &hostTrackData = trackMapper.create(gpuTrackID, /*useNewId=*/false);
 
         hostTrackData.primary        = aTrack->GetDynamicParticle()->GetPrimaryParticle();
         hostTrackData.creatorProcess = const_cast<G4VProcess *>(aTrack->GetCreatorProcess());


### PR DESCRIPTION
This PR fixes a bug in the access of the HostTrackData, so only a local copy was modified and not the stored data.
This led to many tracks using the default constructed HostTrackData. The fix does not change the run time. This was found during the LHCb validation, as the joining of hits with their parents did not work:

<img width="672" height="426" alt="Screenshot from 2025-08-21 14-01-14" src="https://github.com/user-attachments/assets/208bb180-c18b-41ce-bd7b-57ed4a7df14a" />

Now it does:
<img width="685" height="426" alt="Screenshot from 2025-08-21 13-59-57" src="https://github.com/user-attachments/assets/a86aac21-a5c9-4dab-82c1-3d5499348978" />


- [x] test in LHCb