### PR TITLE
improve memory usage for hostTrackData

### DIFF
--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -894,6 +894,11 @@ void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsig
 
     // LeakStatus::OutOfGPURegion: just give track back to G4
     G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(leakedTrack);
+
+    // the track is now handled on CPU. The hostTrackData can safely be deleted, except for the g4idToGPUid mapping,
+    // as the GPU id would need to be the same for the reproducibility if the track returns to the GPU, as the trackID
+    // is used for seeding the rng
+    fHostTrackDataMapper->retireToCPU(track.trackId);
   }
 }
 


### PR DESCRIPTION
This PR improves the data usage of the HostTrackData.

Before, when tracks where deleted, the g4idToGPUid map could not be cleaned as it is needed if a track goes from GPU to CPU to GPU. In that case, we have to ensure that the second time the track goes to the GPU it has the same track ID as the first time, as the track ID is used to seed the RNG. However, when the track is actually done, we can safely delete all of it. Now, we have two functions, one to fully remove a track from the hostTrackData and one to "retire" it to the CPU so that we keep the g4idToGPUid in case the CPU decides to put the track back on the GPU. This is only needed in case the of the out of gpu region leak.

Also, a destructor is added to clean all data, as before the data was only cleaned upon a new event, leading to a memory leak