### PR TITLE
Reuse already initialized HepEm tracks in split kernels mode

### DIFF
--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -25,7 +25,9 @@ struct Track {
   double globalTime{0.};
 
   float weight{0.};
+#ifndef USE_SPLIT_KERNELS
   float numIALeft[4]{-1.f, -1.f, -1.f, -1.f};
+#endif
   // default values taken from G4HepEmMSCTrackData.hh
   float initialRange{1.0e+21};
   float dynamicRangeFactor{0.04};
@@ -67,6 +69,7 @@ struct Track {
 
 #ifdef USE_SPLIT_KERNELS
   bool propagated{false};
+  bool hepEmTrackExists{false};
 
   // Variables used to store results from G4HepEM
   bool restrictedPhysicalStepLength{false};
@@ -146,12 +149,13 @@ struct Track {
   __host__ __device__ void InitAsSecondary(const vecgeom::Vector3D<Precision> &parentPos,
                                            const vecgeom::NavigationState &parentNavState, double gTime)
   {
+#ifndef USE_SPLIT_KERNELS
     // The caller is responsible to branch a new RNG state and to set the energy.
     this->numIALeft[0] = -1.0;
     this->numIALeft[1] = -1.0;
     this->numIALeft[2] = -1.0;
     this->numIALeft[3] = -1.0;
-
+#endif
     this->initialRange       = 1.0e+21;
     this->dynamicRangeFactor = 0.04;
     this->tlimitMin          = 1.0E-7;


### PR DESCRIPTION
When using split kernels, we keep a pool of HepEm tracks that we use to avoid instantiating and initializing a track in each kernel of a step. We can take advantage of this by re-using and not re-initializing tracks after the first step for a particle. 

Acessing and setting HepEm track data is a large source of long scoreboard stalls. This change provides a speedup of around 8% for the split kernels. The same optimization has also been tried on the monolithic kernels but it doesn't seem to give any speedup in that case. 

There is a small diference in energy deposition, which is likely caused by the fact that fields like the numIALeft or mscData are stored in `double` by G4HepEm and `float` by AdePT. By keeping these fields in the HepEm track and avoiding these two conversions the results are slightly altered (`double` to `float` to store the values in the AdePT track and `float` to `double` to initialise the HepEm track in the following iteration).

As we don't need to store some of the values from the HepEm track, these changes also allow to save some space in the tracks, which is much needed for the split kernels, as we already need extra memory in the form of extra track fields and the HepEm track pool.

```
RTX 4080, CMS2026 (Scoring disabled)
8 threads, 32 TTbar events
```
| Kernels             | Time |
|---------------------|------|
| Monolithic          | 256  |
| Split               | 260  |
| Split + HepEm reuse | 240  |

`ncu` shows the reduction in long scoreboard stalls for the `ElectronHowFar` kernel:
**Master**
<img width="1143" height="47" alt="image" src="https://github.com/user-attachments/assets/a1255357-c639-4ddb-9234-6a634c9a91d9" />
<img width="2366" height="191" alt="image" src="https://github.com/user-attachments/assets/bf227ac9-574c-4118-af56-8bfd3553a20b" />

**Reuse HepEm**
<img width="1143" height="47" alt="image" src="https://github.com/user-attachments/assets/37bc081d-8e72-4965-a3ae-622115015659" />
<img width="2366" height="191" alt="image" src="https://github.com/user-attachments/assets/3ea12d34-32ac-4789-b2a1-67504e1554b3" />