### PR TITLE
[mini] Set current touchable from prestep point

### DIFF
--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -613,7 +613,10 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
   aTrack->SetGlobalTime(aGPUHit->fGlobalTime); // Real data
   aTrack->SetLocalTime(aGPUHit->fLocalTime);   // Real data
   // aTrack->SetProperTime(0);                                                                // Missing data
-  // aTrack->SetTouchableHandle(aTrackTouchableHistory);                                      // Missing data
+  if (const auto preVolume = aPreG4TouchableHandle->GetVolume();
+      preVolume != nullptr) {                          // protect against nullptr if postNavState is outside
+    aTrack->SetTouchableHandle(aPreG4TouchableHandle); // Real data
+  }
   if (const auto postVolume = aPostG4TouchableHandle->GetVolume();
       postVolume != nullptr) {                              // protect against nullptr if postNavState is outside
     aTrack->SetNextTouchableHandle(aPostG4TouchableHandle); // Real data

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -614,7 +614,7 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
   aTrack->SetLocalTime(aGPUHit->fLocalTime);   // Real data
   // aTrack->SetProperTime(0);                                                                // Missing data
   if (const auto preVolume = aPreG4TouchableHandle->GetVolume();
-      preVolume != nullptr) {                          // protect against nullptr if postNavState is outside
+      preVolume != nullptr) {                          // protect against nullptr if NavState is outside
     aTrack->SetTouchableHandle(aPreG4TouchableHandle); // Real data
   }
   if (const auto postVolume = aPostG4TouchableHandle->GetVolume();


### PR DESCRIPTION
Previously, only the postStepPoint touchable was set. This PR alsp sets the preStepPoint touchable. Needed for CMS, as otherwise this line from a sensitive detector 
```c++
  const G4String& rname = aStep->GetTrack()->GetVolume()->GetLogicalVolume()->GetRegion()->GetName();
``` 
crashes.