### PR TITLE
enable rebinding of G4HepEm random engine

### DIFF
--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -41,6 +41,10 @@ public:
 
   G4HepEmConfig *GetG4HepEmConfig() { return fHepEmTrackingManager->GetConfig(); }
 
+protected:
+  /// @brief Enables to rebind HepEm random engine from derived classes
+  void RebindHepEmRandomEngine() { fHepEmTrackingManager->RebindG4RandomEngine(); }
+
 private:
   /// @brief Steps a particle using the generic G4 tracking, until it dies or enters a user-defined
   /// GPU region, in which case tracking is delegated to AdePT


### PR DESCRIPTION
This PR is needed for both Gauss and Athena to enable reproducibility. In both frameworks, the RNG engine is set to a different pointer for each event, therefore it requires a re-binding of the G4HepEm engine (see https://github.com/mnovak42/g4hepem/pull/127) 

With this PR, the results are reproducible again.

NOTE: does require a new tag of G4HepEm and updating the CI, therefore, this remains a draft for now.