### PR TITLE
return preStep global time

### DIFF
--- a/include/AdePT/core/AdePTScoringTemplate.cuh
+++ b/include/AdePT/core/AdePTScoringTemplate.cuh
@@ -23,8 +23,8 @@ __device__ void RecordHit(Scoring *scoring_dev, uint64_t aTrackID, uint64_t aPar
                           vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin,
                           vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
                           vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                          double aGlobalTime, double aLocalTime, unsigned int eventId, short threadId, bool isLastStep,
-                          unsigned short stepCounter);
+                          double aGlobalTime, double aLocalTime, double aPreGlobalTime, unsigned int eventId,
+                          short threadId, bool isLastStep, unsigned short stepCounter);
 
 template <typename Scoring>
 __device__ void AccountProduced(Scoring *scoring_dev, int num_ele, int num_pos, int num_gam);

--- a/include/AdePT/core/HostScoringImpl.cuh
+++ b/include/AdePT/core/HostScoringImpl.cuh
@@ -155,8 +155,8 @@ __device__ void RecordHit(HostScoring *hostScoring_dev, uint64_t aTrackID, uint6
                           vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin,
                           vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
                           vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                          double aGlobalTime, double aLocalTime, unsigned int eventID, short threadID, bool isLastStep,
-                          unsigned short stepCounter)
+                          double aGlobalTime, double aLocalTime, double aPreGlobalTime, unsigned int eventID,
+                          short threadID, bool isLastStep, unsigned short stepCounter)
 {
   // Acquire a hit slot
   GPUHit &aGPUHit = *GetNextFreeHit(hostScoring_dev);
@@ -164,7 +164,7 @@ __device__ void RecordHit(HostScoring *hostScoring_dev, uint64_t aTrackID, uint6
   // Fill the required data
   FillHit(aGPUHit, aTrackID, aParentID, stepLimProcessId, aParticleType, aStepLength, aTotalEnergyDeposit, aTrackWeight,
           aPreState, aPrePosition, aPreMomentumDirection, aPreEKin, aPostState, aPostPosition, aPostMomentumDirection,
-          aPostEKin, aGlobalTime, aLocalTime, eventID, threadID, isLastStep, stepCounter);
+          aPostEKin, aGlobalTime, aLocalTime, aPreGlobalTime, eventID, threadID, isLastStep, stepCounter);
 }
 
 /// @brief Account for the number of produced secondaries

--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -706,8 +706,8 @@ __device__ void RecordHit(AsyncAdePT::PerEventScoring * /*scoring*/, uint64_t aT
                           vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin,
                           vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
                           vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                          double aGlobalTime, double aLocalTime, unsigned int eventID, short threadID, bool isLastStep,
-                          unsigned short stepCounter)
+                          double aGlobalTime, double aLocalTime, double aPreGlobalTime, unsigned int eventID,
+                          short threadID, bool isLastStep, unsigned short stepCounter)
 {
   // Acquire a hit slot
   GPUHit &aGPUHit = AsyncAdePT::gHitScoringBuffer_dev.GetNextSlot(threadID);
@@ -715,7 +715,7 @@ __device__ void RecordHit(AsyncAdePT::PerEventScoring * /*scoring*/, uint64_t aT
   // Fill the required data
   FillHit(aGPUHit, aTrackID, aParentID, stepLimProcessId, aParticleType, aStepLength, aTotalEnergyDeposit, aTrackWeight,
           aPreState, aPrePosition, aPreMomentumDirection, aPreEKin, aPostState, aPostPosition, aPostMomentumDirection,
-          aPostEKin, aGlobalTime, aLocalTime, eventID, threadID, isLastStep, stepCounter);
+          aPostEKin, aGlobalTime, aLocalTime, aPreGlobalTime, eventID, threadID, isLastStep, stepCounter);
 }
 
 /// @brief Account for the number of produced secondaries

--- a/include/AdePT/core/ScoringCommons.hh
+++ b/include/AdePT/core/ScoringCommons.hh
@@ -27,6 +27,7 @@ struct GPUHit {
   // double fNonIonizingEnergyDeposit{0};
   double fGlobalTime{0.};
   double fLocalTime{0.};
+  double fPreGlobalTime{0.};
   float fTrackWeight{1};
   uint64_t fTrackID{0};  // Track ID
   uint64_t fParentID{0}; // parent Track ID
@@ -76,7 +77,7 @@ __device__ __forceinline__ void FillHit(
     vecgeom::Vector3D<Precision> const &aPrePosition, vecgeom::Vector3D<Precision> const &aPreMomentumDirection,
     double aPreEKin, vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
     vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin, double aGlobalTime, double aLocalTime,
-    unsigned int eventID, short threadID, bool isLastStep, unsigned short stepCounter)
+    double aPreGlobalTime, unsigned int eventID, short threadID, bool isLastStep, unsigned short stepCounter)
 {
   aGPUHit.fEventId = eventID;
   aGPUHit.threadId = threadID;
@@ -93,6 +94,7 @@ __device__ __forceinline__ void FillHit(
   aGPUHit.fTrackWeight        = aTrackWeight;
   aGPUHit.fGlobalTime         = aGlobalTime;
   aGPUHit.fLocalTime          = aLocalTime;
+  aGPUHit.fPreGlobalTime      = aPreGlobalTime;
   // Pre step point
   aGPUHit.fPreStepPoint.fNavigationState = aPreState;
   Copy3DVector(aPrePosition, aGPUHit.fPreStepPoint.fPosition);

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -52,6 +52,7 @@ struct Track {
   vecgeom::Vector3D<Precision> preStepPos;
   vecgeom::Vector3D<Precision> preStepDir;
   double preStepEKin{0};
+  double preStepGlobalTime{0.};
   // Variables used to store navigation results
   double geometryStepLength{0};
   double safeLength{0};

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -143,9 +143,10 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     vecgeom::Vector3D<Precision> preStepPos(pos);
     auto dir = currentTrack.dir;
     vecgeom::Vector3D<Precision> preStepDir(dir);
-    double globalTime = currentTrack.globalTime;
-    double localTime  = currentTrack.localTime;
-    double properTime = currentTrack.properTime;
+    double globalTime        = currentTrack.globalTime;
+    double preStepGlobalTime = currentTrack.globalTime;
+    double localTime         = currentTrack.localTime;
+    double properTime        = currentTrack.properTime;
     vecgeom::NavigationState nextState;
 
     currentTrack.stepCounter++;
@@ -619,25 +620,27 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 
             // if tracking or stepping action is called, return initial step
             if (returnLastStep) {
-              adept_scoring::RecordHit(userScoring, secondary.trackId, secondary.parentId,
-                                       /*CreatorProcessId*/ short(0),
-                                       /* electron*/ 0,                       // Particle type
-                                       0,                                     // Step length
-                                       0,                                     // Total Edep
-                                       secondary.weight,                      // Track weight
-                                       navState,                              // Pre-step point navstate
-                                       secondary.pos,                         // Pre-step point position
-                                       secondary.dir,                         // Pre-step point momentum direction
-                                       secondary.eKin,                        // Pre-step point kinetic energy
-                                       navState,                              // Post-step point navstate
-                                       secondary.pos,                         // Post-step point position
-                                       secondary.dir,                         // Post-step point momentum direction
-                                       secondary.eKin,                        // Post-step point kinetic energy
-                                       globalTime,                            // global time
-                                       0.,                                    // local time
-                                       secondary.eventId, secondary.threadId, // eventID and threadID
-                                       false,                                 // whether this was the last step
-                                       secondary.stepCounter);                // whether this was the first step
+              adept_scoring::RecordHit(
+                  userScoring, secondary.trackId, secondary.parentId,
+                  /*CreatorProcessId*/ short(0),
+                  /* electron*/ 0,  // Particle type
+                  0,                // Step length
+                  0,                // Total Edep
+                  secondary.weight, // Track weight
+                  navState,         // Pre-step point navstate
+                  secondary.pos,    // Pre-step point position
+                  secondary.dir,    // Pre-step point momentum direction
+                  secondary.eKin,   // Pre-step point kinetic energy
+                  navState,         // Post-step point navstate
+                  secondary.pos,    // Post-step point position
+                  secondary.dir,    // Post-step point momentum direction
+                  secondary.eKin,   // Post-step point kinetic energy
+                  globalTime,       // global time
+                  0.,               // local time
+                  globalTime,       // global time at preStepPoint, for initializingStep its the globalTime
+                  secondary.eventId, secondary.threadId, // eventID and threadID
+                  false,                                 // whether this was the last step
+                  secondary.stepCounter);                // whether this was the first step
             }
           }
 
@@ -698,24 +701,26 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 #endif
             // if tracking or stepping action is called, return initial step
             if (returnLastStep) {
-              adept_scoring::RecordHit(userScoring, gamma.trackId, gamma.parentId, /*CreatorProcessId*/ short(1),
-                                       /* gamma*/ 2,                  // Particle type
-                                       0,                             // Step length
-                                       0,                             // Total Edep
-                                       gamma.weight,                  // Track weight
-                                       navState,                      // Pre-step point navstate
-                                       gamma.pos,                     // Pre-step point position
-                                       gamma.dir,                     // Pre-step point momentum direction
-                                       gamma.eKin,                    // Pre-step point kinetic energy
-                                       navState,                      // Post-step point navstate
-                                       gamma.pos,                     // Post-step point position
-                                       gamma.dir,                     // Post-step point momentum direction
-                                       gamma.eKin,                    // Post-step point kinetic energy
-                                       globalTime,                    // global time
-                                       0.,                            // local time
-                                       gamma.eventId, gamma.threadId, // eventID and threadID
-                                       false,                         // whether this was the last step
-                                       gamma.stepCounter);            // whether this was the first step
+              adept_scoring::RecordHit(
+                  userScoring, gamma.trackId, gamma.parentId, /*CreatorProcessId*/ short(1),
+                  /* gamma*/ 2,                  // Particle type
+                  0,                             // Step length
+                  0,                             // Total Edep
+                  gamma.weight,                  // Track weight
+                  navState,                      // Pre-step point navstate
+                  gamma.pos,                     // Pre-step point position
+                  gamma.dir,                     // Pre-step point momentum direction
+                  gamma.eKin,                    // Pre-step point kinetic energy
+                  navState,                      // Post-step point navstate
+                  gamma.pos,                     // Post-step point position
+                  gamma.dir,                     // Post-step point momentum direction
+                  gamma.eKin,                    // Post-step point kinetic energy
+                  globalTime,                    // global time
+                  0.,                            // local time
+                  globalTime,                    // global time at preStepPoint, for initializingStep its the globalTime
+                  gamma.eventId, gamma.threadId, // eventID and threadID
+                  false,                         // whether this was the last step
+                  gamma.stepCounter);            // whether this was the first step
             }
           }
 
@@ -776,24 +781,26 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 #endif
             // if tracking or stepping action is called, return initial step
             if (returnLastStep) {
-              adept_scoring::RecordHit(userScoring, gamma1.trackId, gamma1.parentId, /*CreatorProcessId*/ short(2),
-                                       /* gamma*/ 2,                    // Particle type
-                                       0,                               // Step length
-                                       0,                               // Total Edep
-                                       gamma1.weight,                   // Track weight
-                                       navState,                        // Pre-step point navstate
-                                       gamma1.pos,                      // Pre-step point position
-                                       gamma1.dir,                      // Pre-step point momentum direction
-                                       gamma1.eKin,                     // Pre-step point kinetic energy
-                                       navState,                        // Post-step point navstate
-                                       gamma1.pos,                      // Post-step point position
-                                       gamma1.dir,                      // Post-step point momentum direction
-                                       gamma1.eKin,                     // Post-step point kinetic energy
-                                       globalTime,                      // global time
-                                       0.,                              // local time
-                                       gamma1.eventId, gamma1.threadId, // eventID and threadID
-                                       false,                           // whether this was the last step
-                                       gamma1.stepCounter);             // whether this was the first step
+              adept_scoring::RecordHit(
+                  userScoring, gamma1.trackId, gamma1.parentId, /*CreatorProcessId*/ short(2),
+                  /* gamma*/ 2,  // Particle type
+                  0,             // Step length
+                  0,             // Total Edep
+                  gamma1.weight, // Track weight
+                  navState,      // Pre-step point navstate
+                  gamma1.pos,    // Pre-step point position
+                  gamma1.dir,    // Pre-step point momentum direction
+                  gamma1.eKin,   // Pre-step point kinetic energy
+                  navState,      // Post-step point navstate
+                  gamma1.pos,    // Post-step point position
+                  gamma1.dir,    // Post-step point momentum direction
+                  gamma1.eKin,   // Post-step point kinetic energy
+                  globalTime,    // global time
+                  0.,            // local time
+                  globalTime,    // global time at preStepPoint, for initializingStep its the globalTime
+                  gamma1.eventId, gamma1.threadId, // eventID and threadID
+                  false,                           // whether this was the last step
+                  gamma1.stepCounter);             // whether this was the first step
             }
           }
           if (ApplyCuts && (theGamma2Ekin < theGammaCut)) {
@@ -820,24 +827,26 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 #endif
             // if tracking or stepping action is called, return initial step
             if (returnLastStep) {
-              adept_scoring::RecordHit(userScoring, gamma2.trackId, gamma2.parentId, /*CreatorProcessId*/ short(2),
-                                       /* gamma*/ 2,                    // Particle type
-                                       0,                               // Step length
-                                       0,                               // Total Edep
-                                       gamma2.weight,                   // Track weight
-                                       navState,                        // Pre-step point navstate
-                                       gamma2.pos,                      // Pre-step point position
-                                       gamma2.dir,                      // Pre-step point momentum direction
-                                       gamma2.eKin,                     // Pre-step point kinetic energy
-                                       navState,                        // Post-step point navstate
-                                       gamma2.pos,                      // Post-step point position
-                                       gamma2.dir,                      // Post-step point momentum direction
-                                       gamma2.eKin,                     // Post-step point kinetic energy
-                                       globalTime,                      // global time
-                                       0.,                              // local time
-                                       gamma2.eventId, gamma2.threadId, // eventID and threadID
-                                       false,                           // whether this was the last step
-                                       gamma2.stepCounter);             // whether this was the first step
+              adept_scoring::RecordHit(
+                  userScoring, gamma2.trackId, gamma2.parentId, /*CreatorProcessId*/ short(2),
+                  /* gamma*/ 2,  // Particle type
+                  0,             // Step length
+                  0,             // Total Edep
+                  gamma2.weight, // Track weight
+                  navState,      // Pre-step point navstate
+                  gamma2.pos,    // Pre-step point position
+                  gamma2.dir,    // Pre-step point momentum direction
+                  gamma2.eKin,   // Pre-step point kinetic energy
+                  navState,      // Post-step point navstate
+                  gamma2.pos,    // Post-step point position
+                  gamma2.dir,    // Post-step point momentum direction
+                  gamma2.eKin,   // Post-step point kinetic energy
+                  globalTime,    // global time
+                  0.,            // local time
+                  globalTime,    // global time at preStepPoint, for initializingStep its the globalTime
+                  gamma2.eventId, gamma2.threadId, // eventID and threadID
+                  false,                           // whether this was the last step
+                  gamma2.stepCounter);             // whether this was the first step
             }
           }
           break;
@@ -909,38 +918,40 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
           // if tracking or stepping action is called, return initial step
           if (returnLastStep) {
             adept_scoring::RecordHit(userScoring, gamma1.trackId, gamma1.parentId, /*CreatorProcessId*/ short(2),
-                                     /* gamma*/ 2,                    // Particle type
-                                     0,                               // Step length
-                                     0,                               // Total Edep
-                                     gamma1.weight,                   // Track weight
-                                     navState,                        // Pre-step point navstate
-                                     gamma1.pos,                      // Pre-step point position
-                                     gamma1.dir,                      // Pre-step point momentum direction
-                                     gamma1.eKin,                     // Pre-step point kinetic energy
-                                     navState,                        // Post-step point navstate
-                                     gamma1.pos,                      // Post-step point position
-                                     gamma1.dir,                      // Post-step point momentum direction
-                                     gamma1.eKin,                     // Post-step point kinetic energy
-                                     globalTime,                      // global time
-                                     0.,                              // local time
+                                     /* gamma*/ 2,  // Particle type
+                                     0,             // Step length
+                                     0,             // Total Edep
+                                     gamma1.weight, // Track weight
+                                     navState,      // Pre-step point navstate
+                                     gamma1.pos,    // Pre-step point position
+                                     gamma1.dir,    // Pre-step point momentum direction
+                                     gamma1.eKin,   // Pre-step point kinetic energy
+                                     navState,      // Post-step point navstate
+                                     gamma1.pos,    // Post-step point position
+                                     gamma1.dir,    // Post-step point momentum direction
+                                     gamma1.eKin,   // Post-step point kinetic energy
+                                     globalTime,    // global time
+                                     0.,            // local time
+                                     globalTime, // global time at preStepPoint, for initializingStep its the globalTime
                                      gamma1.eventId, gamma1.threadId, // eventID and threadID
                                      false,                           // whether this was the last step
                                      gamma1.stepCounter);             // whether this was the first step
             adept_scoring::RecordHit(userScoring, gamma2.trackId, gamma2.parentId, /*CreatorProcessId*/ short(2),
-                                     /* gamma*/ 2,                    // Particle type
-                                     0,                               // Step length
-                                     0,                               // Total Edep
-                                     gamma2.weight,                   // Track weight
-                                     navState,                        // Pre-step point navstate
-                                     gamma2.pos,                      // Pre-step point position
-                                     gamma2.dir,                      // Pre-step point momentum direction
-                                     gamma2.eKin,                     // Pre-step point kinetic energy
-                                     navState,                        // Post-step point navstate
-                                     gamma2.pos,                      // Post-step point position
-                                     gamma2.dir,                      // Post-step point momentum direction
-                                     gamma2.eKin,                     // Post-step point kinetic energy
-                                     globalTime,                      // global time
-                                     0.,                              // local time
+                                     /* gamma*/ 2,  // Particle type
+                                     0,             // Step length
+                                     0,             // Total Edep
+                                     gamma2.weight, // Track weight
+                                     navState,      // Pre-step point navstate
+                                     gamma2.pos,    // Pre-step point position
+                                     gamma2.dir,    // Pre-step point momentum direction
+                                     gamma2.eKin,   // Pre-step point kinetic energy
+                                     navState,      // Post-step point navstate
+                                     gamma2.pos,    // Post-step point position
+                                     gamma2.dir,    // Post-step point momentum direction
+                                     gamma2.eKin,   // Post-step point kinetic energy
+                                     globalTime,    // global time
+                                     0.,            // local time
+                                     globalTime, // global time at preStepPoint, for initializingStep its the globalTime
                                      gamma2.eventId, gamma2.threadId, // eventID and threadID
                                      false,                           // whether this was the last step
                                      gamma2.stepCounter);             // whether this was the first step
@@ -1016,6 +1027,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
                                eKin,                                        // Post-step point kinetic energy
                                globalTime,                                  // global time
                                localTime,                                   // local time
+                               preStepGlobalTime,                           // global time at preStepPoint
                                currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                isLastStep,                                  // whether this was the last step
                                currentTrack.stepCounter);                   // whether this was the first step

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -72,9 +72,10 @@ __global__ void ElectronHowFar(Track *electrons, G4HepEmElectronTrack *hepEMTrac
 
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID]; // FIXME unify VolAuxData
 
-    currentTrack.preStepEKin = currentTrack.eKin;
-    currentTrack.preStepPos  = currentTrack.pos;
-    currentTrack.preStepDir  = currentTrack.dir;
+    currentTrack.preStepEKin       = currentTrack.eKin;
+    currentTrack.preStepGlobalTime = currentTrack.globalTime;
+    currentTrack.preStepPos        = currentTrack.pos;
+    currentTrack.preStepDir        = currentTrack.dir;
     currentTrack.stepCounter++;
     bool printErrors = false;
     if (currentTrack.stepCounter >= maxSteps || currentTrack.zeroStepCounter > kStepsStuckKill) {
@@ -522,17 +523,20 @@ __global__ void ElectronSetupInteractions(Track *electrons, Track *leaks, G4HepE
                                  currentTrack.weight,                                   // Track weight
                                  currentTrack.navState,                                 // Pre-step point navstate
                                  currentTrack.preStepPos,                               // Pre-step point position
-                                 currentTrack.preStepDir,                     // Pre-step point momentum direction
-                                 currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                                 currentTrack.nextState,                      // Post-step point navstate
-                                 currentTrack.pos,                            // Post-step point position
-                                 currentTrack.dir,                            // Post-step point momentum direction
-                                 currentTrack.eKin,                           // Post-step point kinetic energy
-                                 currentTrack.globalTime,                     // global time
-                                 currentTrack.localTime,                      // local time
-                                 currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                                 isLastStep,                                  // whether this was the last step
-                                 currentTrack.stepCounter);                   // stepcounter
+                                 currentTrack.preStepDir,  // Pre-step point momentum direction
+                                 currentTrack.preStepEKin, // Pre-step point kinetic energy
+                                 currentTrack.nextState,   // Post-step point navstate
+                                 currentTrack.pos,         // Post-step point position
+                                 currentTrack.dir,         // Post-step point momentum direction
+                                 currentTrack.eKin,        // Post-step point kinetic energy
+                                 currentTrack.globalTime,  // global time
+                                 currentTrack.localTime,   // local time
+                                 currentTrack
+                                     .preStepGlobalTime // preStep global time
+                                         currentTrack.eventId,
+                                 currentTrack.threadId,     // eventID and threadID
+                                 isLastStep,                // whether this was the last step
+                                 currentTrack.stepCounter); // stepcounter
     }
   }
 }
@@ -633,26 +637,29 @@ __global__ void ElectronRelocation(Track *electrons, Track *leaks, G4HepEmElectr
     // Score
     if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep)
       adept_scoring::RecordHit(userScoring,
-                               currentTrack.trackId,                        // Track ID
-                               currentTrack.parentId,                       // parent Track ID
-                               static_cast<short>(/*transport*/ 10),        // step limiting process ID
-                               static_cast<char>(IsElectron ? 0 : 1),       // Particle type
-                               elTrack.GetPStepLength(),                    // Step length
-                               energyDeposit,                               // Total Edep
-                               currentTrack.weight,                         // Track weight
-                               currentTrack.navState,                       // Pre-step point navstate
-                               currentTrack.preStepPos,                     // Pre-step point position
-                               currentTrack.preStepDir,                     // Pre-step point momentum direction
-                               currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                               currentTrack.nextState,                      // Post-step point navstate
-                               currentTrack.pos,                            // Post-step point position
-                               currentTrack.dir,                            // Post-step point momentum direction
-                               currentTrack.eKin,                           // Post-step point kinetic energy
-                               currentTrack.globalTime,                     // global time
-                               currentTrack.localTime,                      // local time
-                               currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                               isLastStep,                                  // whether this was the last step
-                               currentTrack.stepCounter);                   // stepcounter
+                               currentTrack.trackId,                  // Track ID
+                               currentTrack.parentId,                 // parent Track ID
+                               static_cast<short>(/*transport*/ 10),  // step limiting process ID
+                               static_cast<char>(IsElectron ? 0 : 1), // Particle type
+                               elTrack.GetPStepLength(),              // Step length
+                               energyDeposit,                         // Total Edep
+                               currentTrack.weight,                   // Track weight
+                               currentTrack.navState,                 // Pre-step point navstate
+                               currentTrack.preStepPos,               // Pre-step point position
+                               currentTrack.preStepDir,               // Pre-step point momentum direction
+                               currentTrack.preStepEKin,              // Pre-step point kinetic energy
+                               currentTrack.nextState,                // Post-step point navstate
+                               currentTrack.pos,                      // Post-step point position
+                               currentTrack.dir,                      // Post-step point momentum direction
+                               currentTrack.eKin,                     // Post-step point kinetic energy
+                               currentTrack.globalTime,               // global time
+                               currentTrack.localTime,                // local time
+                               currentTrack
+                                   .preStepGlobalTime // preStep global time
+                                       currentTrack.eventId,
+                               currentTrack.threadId,     // eventID and threadID
+                               isLastStep,                // whether this was the last step
+                               currentTrack.stepCounter); // stepcounter
 
     if (cross_boundary) {
       // Move to the next boundary now that the Step is recorded
@@ -730,6 +737,7 @@ __device__ __forceinline__ void PerformStoppedAnnihilation(const int slot, Track
                                  gamma1.eKin,                     // Post-step point kinetic energy
                                  gamma1.globalTime,               // global time
                                  0.,                              // local time
+                                 gamma1.globalTime,               // preStep global time for initializing step
                                  gamma1.eventId, gamma1.threadId, // eventID and threadID
                                  false,                           // whether this was the last step
                                  gamma1.stepCounter);             // whether this was the first step
@@ -748,6 +756,7 @@ __device__ __forceinline__ void PerformStoppedAnnihilation(const int slot, Track
                                  gamma2.eKin,                     // Post-step point kinetic energy
                                  gamma2.globalTime,               // global time
                                  0.,                              // local time
+                                 gamma2.globalTime,               // preStep global time for initializing step
                                  gamma2.eventId, gamma2.threadId, // eventID and threadID
                                  false,                           // whether this was the last step
                                  gamma2.stepCounter);             // whether this was the first step
@@ -843,6 +852,7 @@ __global__ void ElectronIonization(Track *electrons, G4HepEmElectronTrack *hepEM
                                  secondary.eKin,                        // Post-step point kinetic energy
                                  secondary.globalTime,                  // global time
                                  0.,                                    // local time
+                                 secondary.globalTime,                  // preStep global time for initializing step
                                  secondary.eventId, secondary.threadId, // eventID and threadID
                                  false,                                 // whether this was the last step
                                  secondary.stepCounter);                // whether this was the first step
@@ -885,6 +895,7 @@ __global__ void ElectronIonization(Track *electrons, G4HepEmElectronTrack *hepEM
                                currentTrack.eKin,                           // Post-step point kinetic energy
                                currentTrack.globalTime,                     // global time
                                currentTrack.localTime,                      // local time
+                               currentTrack.preStepGlobalTime,              // preStep global time
                                currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                isLastStep,                                  // whether this was the last step
                                currentTrack.stepCounter);                   // stepcounter
@@ -976,6 +987,7 @@ __global__ void ElectronBremsstrahlung(Track *electrons, G4HepEmElectronTrack *h
                                  gamma.eKin,                    // Post-step point kinetic energy
                                  gamma.globalTime,              // global time
                                  0.,                            // local time
+                                 gamma.globalTime,              // preStep global time at initializing step
                                  gamma.eventId, gamma.threadId, // eventID and threadID
                                  false,                         // whether this was the last step
                                  gamma.stepCounter);            // whether this was the first step
@@ -1018,6 +1030,7 @@ __global__ void ElectronBremsstrahlung(Track *electrons, G4HepEmElectronTrack *h
                                currentTrack.eKin,                           // Post-step point kinetic energy
                                currentTrack.globalTime,                     // global time
                                currentTrack.localTime,                      // local time
+                               currentTrack.preStepGlobalTime,              // preStep global time
                                currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                isLastStep,                                  // whether this was the last step
                                currentTrack.stepCounter);                   // stepcounter
@@ -1106,6 +1119,7 @@ __global__ void PositronAnnihilation(Track *electrons, G4HepEmElectronTrack *hep
                                  gamma1.eKin,                     // Post-step point kinetic energy
                                  gamma1.globalTime,               // global time
                                  0.,                              // local time
+                                 gamma1.globalTime,               // preStep global time at initializing step
                                  gamma1.eventId, gamma1.threadId, // eventID and threadID
                                  false,                           // whether this was the last step
                                  gamma1.stepCounter);
@@ -1137,6 +1151,7 @@ __global__ void PositronAnnihilation(Track *electrons, G4HepEmElectronTrack *hep
                                  gamma2.eKin,                     // Post-step point kinetic energy
                                  gamma2.globalTime,               // global time
                                  0.,                              // local time
+                                 gamma2.globalTime,               // preStep global time at initializing step
                                  gamma2.eventId, gamma2.threadId, // eventID and threadID
                                  false,                           // whether this was the last step
                                  gamma2.stepCounter);
@@ -1166,6 +1181,7 @@ __global__ void PositronAnnihilation(Track *electrons, G4HepEmElectronTrack *hep
                                currentTrack.eKin,                           // Post-step point kinetic energy
                                currentTrack.globalTime,                     // global time
                                currentTrack.localTime,                      // local time
+                               currentTrack.preStepGlobalTime,              // preStep global time
                                currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                isLastStep,                                  // whether this was the last step
                                currentTrack.stepCounter);                   // stepcounter
@@ -1236,6 +1252,7 @@ __global__ void PositronStoppedAnnihilation(Track *electrons, G4HepEmElectronTra
                                currentTrack.eKin,                           // Post-step point kinetic energy
                                currentTrack.globalTime,                     // global time
                                currentTrack.localTime,                      // local time
+                               currentTrack.preStepGlobalTime,              // preStep global time
                                currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                isLastStep,                                  // whether this was the last step
                                currentTrack.stepCounter);                   // stepcounter

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -523,20 +523,18 @@ __global__ void ElectronSetupInteractions(Track *electrons, Track *leaks, G4HepE
                                  currentTrack.weight,                                   // Track weight
                                  currentTrack.navState,                                 // Pre-step point navstate
                                  currentTrack.preStepPos,                               // Pre-step point position
-                                 currentTrack.preStepDir,  // Pre-step point momentum direction
-                                 currentTrack.preStepEKin, // Pre-step point kinetic energy
-                                 currentTrack.nextState,   // Post-step point navstate
-                                 currentTrack.pos,         // Post-step point position
-                                 currentTrack.dir,         // Post-step point momentum direction
-                                 currentTrack.eKin,        // Post-step point kinetic energy
-                                 currentTrack.globalTime,  // global time
-                                 currentTrack.localTime,   // local time
-                                 currentTrack
-                                     .preStepGlobalTime // preStep global time
-                                         currentTrack.eventId,
-                                 currentTrack.threadId,     // eventID and threadID
-                                 isLastStep,                // whether this was the last step
-                                 currentTrack.stepCounter); // stepcounter
+                                 currentTrack.preStepDir,                     // Pre-step point momentum direction
+                                 currentTrack.preStepEKin,                    // Pre-step point kinetic energy
+                                 currentTrack.nextState,                      // Post-step point navstate
+                                 currentTrack.pos,                            // Post-step point position
+                                 currentTrack.dir,                            // Post-step point momentum direction
+                                 currentTrack.eKin,                           // Post-step point kinetic energy
+                                 currentTrack.globalTime,                     // global time
+                                 currentTrack.localTime,                      // local time
+                                 currentTrack.preStepGlobalTime,              // preStep global time
+                                 currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                 isLastStep,                                  // whether this was the last step
+                                 currentTrack.stepCounter);                   // stepcounter
     }
   }
 }
@@ -637,29 +635,27 @@ __global__ void ElectronRelocation(Track *electrons, Track *leaks, G4HepEmElectr
     // Score
     if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep)
       adept_scoring::RecordHit(userScoring,
-                               currentTrack.trackId,                  // Track ID
-                               currentTrack.parentId,                 // parent Track ID
-                               static_cast<short>(/*transport*/ 10),  // step limiting process ID
-                               static_cast<char>(IsElectron ? 0 : 1), // Particle type
-                               elTrack.GetPStepLength(),              // Step length
-                               energyDeposit,                         // Total Edep
-                               currentTrack.weight,                   // Track weight
-                               currentTrack.navState,                 // Pre-step point navstate
-                               currentTrack.preStepPos,               // Pre-step point position
-                               currentTrack.preStepDir,               // Pre-step point momentum direction
-                               currentTrack.preStepEKin,              // Pre-step point kinetic energy
-                               currentTrack.nextState,                // Post-step point navstate
-                               currentTrack.pos,                      // Post-step point position
-                               currentTrack.dir,                      // Post-step point momentum direction
-                               currentTrack.eKin,                     // Post-step point kinetic energy
-                               currentTrack.globalTime,               // global time
-                               currentTrack.localTime,                // local time
-                               currentTrack
-                                   .preStepGlobalTime // preStep global time
-                                       currentTrack.eventId,
-                               currentTrack.threadId,     // eventID and threadID
-                               isLastStep,                // whether this was the last step
-                               currentTrack.stepCounter); // stepcounter
+                               currentTrack.trackId,                        // Track ID
+                               currentTrack.parentId,                       // parent Track ID
+                               static_cast<short>(/*transport*/ 10),        // step limiting process ID
+                               static_cast<char>(IsElectron ? 0 : 1),       // Particle type
+                               elTrack.GetPStepLength(),                    // Step length
+                               energyDeposit,                               // Total Edep
+                               currentTrack.weight,                         // Track weight
+                               currentTrack.navState,                       // Pre-step point navstate
+                               currentTrack.preStepPos,                     // Pre-step point position
+                               currentTrack.preStepDir,                     // Pre-step point momentum direction
+                               currentTrack.preStepEKin,                    // Pre-step point kinetic energy
+                               currentTrack.nextState,                      // Post-step point navstate
+                               currentTrack.pos,                            // Post-step point position
+                               currentTrack.dir,                            // Post-step point momentum direction
+                               currentTrack.eKin,                           // Post-step point kinetic energy
+                               currentTrack.globalTime,                     // global time
+                               currentTrack.localTime,                      // local time
+                               currentTrack.preStepGlobalTime,              // preStep global time
+                               currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                               isLastStep,                                  // whether this was the last step
+                               currentTrack.stepCounter);                   // stepcounter
 
     if (cross_boundary) {
       // Move to the next boundary now that the Step is recorded

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -80,9 +80,10 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
     vecgeom::Vector3D<Precision> preStepPos(pos);
     auto dir = currentTrack.dir;
     vecgeom::Vector3D<Precision> preStepDir(dir);
-    double globalTime = currentTrack.globalTime;
-    double localTime  = currentTrack.localTime;
-    double properTime = currentTrack.properTime;
+    double globalTime        = currentTrack.globalTime;
+    double preStepGlobalTime = currentTrack.globalTime;
+    double localTime         = currentTrack.localTime;
+    double properTime        = currentTrack.properTime;
     vecgeom::NavigationState nextState;
     // the MCC vector is indexed by the logical volume id
 
@@ -337,20 +338,21 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
           if (returnLastStep) {
             adept_scoring::RecordHit(userScoring, electron.trackId, electron.parentId,
                                      /*CreatorProcessId*/ short(winnerProcessIndex),
-                                     /* electron*/ 0,                     // Particle type
-                                     0,                                   // Step length
-                                     0,                                   // Total Edep
-                                     electron.weight,                     // Track weight
-                                     navState,                            // Pre-step point navstate
-                                     electron.pos,                        // Pre-step point position
-                                     electron.dir,                        // Pre-step point momentum direction
-                                     electron.eKin,                       // Pre-step point kinetic energy
-                                     navState,                            // Post-step point navstate
-                                     electron.pos,                        // Post-step point position
-                                     electron.dir,                        // Post-step point momentum direction
-                                     electron.eKin,                       // Post-step point kinetic energy
-                                     globalTime,                          // global time
-                                     0.,                                  // local time
+                                     /* electron*/ 0, // Particle type
+                                     0,               // Step length
+                                     0,               // Total Edep
+                                     electron.weight, // Track weight
+                                     navState,        // Pre-step point navstate
+                                     electron.pos,    // Pre-step point position
+                                     electron.dir,    // Pre-step point momentum direction
+                                     electron.eKin,   // Pre-step point kinetic energy
+                                     navState,        // Post-step point navstate
+                                     electron.pos,    // Post-step point position
+                                     electron.dir,    // Post-step point momentum direction
+                                     electron.eKin,   // Post-step point kinetic energy
+                                     globalTime,      // global time
+                                     0.,              // local time
+                                     globalTime, // global time at preStepPoint, for initializingStep its the globalTime
                                      electron.eventId, electron.threadId, // eventID and threadID
                                      false,                               // whether this was the last step
                                      electron.stepCounter);               // whether this was the first step
@@ -381,20 +383,21 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
           if (returnLastStep) {
             adept_scoring::RecordHit(userScoring, positron.trackId, positron.parentId,
                                      /*CreatorProcessId*/ short(winnerProcessIndex),
-                                     /* positron*/ 1,                     // Particle type
-                                     0,                                   // Step length
-                                     0,                                   // Total Edep
-                                     positron.weight,                     // Track weight
-                                     navState,                            // Pre-step point navstate
-                                     positron.pos,                        // Pre-step point position
-                                     positron.dir,                        // Pre-step point momentum direction
-                                     positron.eKin,                       // Pre-step point kinetic energy
-                                     navState,                            // Post-step point navstate
-                                     positron.pos,                        // Post-step point position
-                                     positron.dir,                        // Post-step point momentum direction
-                                     positron.eKin,                       // Post-step point kinetic energy
-                                     globalTime,                          // global time
-                                     0.,                                  // local time
+                                     /* positron*/ 1, // Particle type
+                                     0,               // Step length
+                                     0,               // Total Edep
+                                     positron.weight, // Track weight
+                                     navState,        // Pre-step point navstate
+                                     positron.pos,    // Pre-step point position
+                                     positron.dir,    // Pre-step point momentum direction
+                                     positron.eKin,   // Pre-step point kinetic energy
+                                     navState,        // Post-step point navstate
+                                     positron.pos,    // Post-step point position
+                                     positron.dir,    // Post-step point momentum direction
+                                     positron.eKin,   // Post-step point kinetic energy
+                                     globalTime,      // global time
+                                     0.,              // local time
+                                     globalTime, // global time at preStepPoint, for initializingStep its the globalTime
                                      positron.eventId, positron.threadId, // eventID and threadID
                                      false,                               // whether this was the last step
                                      positron.stepCounter);               // whether this was the first step
@@ -448,20 +451,21 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
           if (returnLastStep) {
             adept_scoring::RecordHit(userScoring, electron.trackId, electron.parentId,
                                      /*CreatorProcessId*/ short(winnerProcessIndex),
-                                     /* electron*/ 0,                     // Particle type
-                                     0,                                   // Step length
-                                     0,                                   // Total Edep
-                                     electron.weight,                     // Track weight
-                                     navState,                            // Pre-step point navstate
-                                     electron.pos,                        // Pre-step point position
-                                     electron.dir,                        // Pre-step point momentum direction
-                                     electron.eKin,                       // Pre-step point kinetic energy
-                                     navState,                            // Post-step point navstate
-                                     electron.pos,                        // Post-step point position
-                                     electron.dir,                        // Post-step point momentum direction
-                                     electron.eKin,                       // Post-step point kinetic energy
-                                     globalTime,                          // global time
-                                     0.,                                  // local time
+                                     /* electron*/ 0, // Particle type
+                                     0,               // Step length
+                                     0,               // Total Edep
+                                     electron.weight, // Track weight
+                                     navState,        // Pre-step point navstate
+                                     electron.pos,    // Pre-step point position
+                                     electron.dir,    // Pre-step point momentum direction
+                                     electron.eKin,   // Pre-step point kinetic energy
+                                     navState,        // Post-step point navstate
+                                     electron.pos,    // Post-step point position
+                                     electron.dir,    // Post-step point momentum direction
+                                     electron.eKin,   // Post-step point kinetic energy
+                                     globalTime,      // global time
+                                     0.,              // local time
+                                     globalTime, // global time at preStepPoint, for initializingStep its the globalTime
                                      electron.eventId, electron.threadId, // eventID and threadID
                                      false,                               // whether this was the last step
                                      electron.stepCounter);               // whether this was the first step
@@ -523,20 +527,21 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
           if (returnLastStep) {
             adept_scoring::RecordHit(userScoring, electron.trackId, electron.parentId,
                                      /*CreatorProcessId*/ short(winnerProcessIndex),
-                                     /* electron*/ 0,                     // Particle type
-                                     0,                                   // Step length
-                                     0,                                   // Total Edep
-                                     electron.weight,                     // Track weight
-                                     navState,                            // Pre-step point navstate
-                                     electron.pos,                        // Pre-step point position
-                                     electron.dir,                        // Pre-step point momentum direction
-                                     electron.eKin,                       // Pre-step point kinetic energy
-                                     navState,                            // Post-step point navstate
-                                     electron.pos,                        // Post-step point position
-                                     electron.dir,                        // Post-step point momentum direction
-                                     electron.eKin,                       // Post-step point kinetic energy
-                                     globalTime,                          // global time
-                                     0.,                                  // local time
+                                     /* electron*/ 0, // Particle type
+                                     0,               // Step length
+                                     0,               // Total Edep
+                                     electron.weight, // Track weight
+                                     navState,        // Pre-step point navstate
+                                     electron.pos,    // Pre-step point position
+                                     electron.dir,    // Pre-step point momentum direction
+                                     electron.eKin,   // Pre-step point kinetic energy
+                                     navState,        // Post-step point navstate
+                                     electron.pos,    // Post-step point position
+                                     electron.dir,    // Post-step point momentum direction
+                                     electron.eKin,   // Post-step point kinetic energy
+                                     globalTime,      // global time
+                                     0.,              // local time
+                                     globalTime, // global time at preStepPoint, for initializingStep its the globalTime
                                      electron.eventId, electron.threadId, // eventID and threadID
                                      false,                               // whether this was the last step
                                      electron.stepCounter);               // whether this was the first step
@@ -622,6 +627,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
                                eKin,                                        // Post-step point kinetic energy
                                globalTime,                                  // global time
                                localTime,                                   // local time
+                               preStepGlobalTime,                           // global time at preStepPoint
                                currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                isLastStep,                // whether this is the last step of the track
                                currentTrack.stepCounter); // whether this is the first step

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -36,9 +36,10 @@ __global__ void GammaHowFar(Track *gammas, Track *leaks, G4HepEmGammaTrack *hepE
     int lvolID                = currentTrack.navState.GetLogicalId();
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID]; // FIXME unify VolAuxData
 
-    currentTrack.preStepEKin = currentTrack.eKin;
-    currentTrack.preStepPos  = currentTrack.pos;
-    currentTrack.preStepDir  = currentTrack.dir;
+    currentTrack.preStepEKin       = currentTrack.eKin;
+    currentTrack.preStepGlobalTime = currentTrack.globalTime;
+    currentTrack.preStepPos        = currentTrack.pos;
+    currentTrack.preStepDir        = currentTrack.dir;
     // the MCC vector is indexed by the logical volume id
 
     currentTrack.stepCounter++;
@@ -300,6 +301,7 @@ __global__ void GammaRelocation(Track *gammas, Track *leaks, G4HepEmGammaTrack *
                                  currentTrack.eKin,                           // Post-step point kinetic energy
                                  currentTrack.globalTime,                     // global time
                                  currentTrack.localTime,                      // local time
+                                 currentTrack.preStepGlobalTime,              // preStep global time
                                  currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                  false,                     // whether this is the last step of the track
                                  currentTrack.stepCounter); // stepcounter
@@ -343,6 +345,7 @@ __global__ void GammaRelocation(Track *gammas, Track *leaks, G4HepEmGammaTrack *
                                  currentTrack.eKin,                           // Post-step point kinetic energy
                                  currentTrack.globalTime,                     // global time
                                  currentTrack.localTime,                      // local time
+                                 currentTrack.preStepGlobalTime,              // preStep global time
                                  currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                  true,                      // whether this is the last step of the track
                                  currentTrack.stepCounter); // stepcounter
@@ -440,6 +443,7 @@ __global__ void GammaConversion(Track *gammas, G4HepEmGammaTrack *hepEMTracks, S
                                  electron.eKin,                       // Post-step point kinetic energy
                                  electron.globalTime,                 // global time
                                  0.,                                  // local time
+                                 electron.globalTime,                 // preStep global time at initializing step
                                  electron.eventId, electron.threadId, // eventID and threadID
                                  false,                               // whether this was the last step
                                  electron.stepCounter);               // whether this was the first step
@@ -473,6 +477,7 @@ __global__ void GammaConversion(Track *gammas, G4HepEmGammaTrack *hepEMTracks, S
                                  positron.eKin,                       // Post-step point kinetic energy
                                  positron.globalTime,                 // global time
                                  0.,                                  // local time
+                                 positron.globalTime,                 // preStep global time
                                  positron.eventId, positron.threadId, // eventID and threadID
                                  false,                               // whether this was the last step
                                  positron.stepCounter);               // whether this was the first step
@@ -504,6 +509,7 @@ __global__ void GammaConversion(Track *gammas, G4HepEmGammaTrack *hepEMTracks, S
                                newEnergyGamma,                              // Post-step point kinetic energy
                                currentTrack.globalTime,                     // global time
                                currentTrack.localTime,                      // local time
+                               currentTrack.preStepGlobalTime,              // preStep global time
                                currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                isLastStep,                // whether this is the last step of the track
                                currentTrack.stepCounter); // stepcounter
@@ -594,6 +600,7 @@ __global__ void GammaCompton(Track *gammas, G4HepEmGammaTrack *hepEMTracks, Seco
                                  electron.eKin,                       // Post-step point kinetic energy
                                  electron.globalTime,                 // global time
                                  0.,                                  // local time
+                                 electron.globalTime,                 // preStep global time at initializing step
                                  electron.eventId, electron.threadId, // eventID and threadID
                                  false,                               // whether this was the last step
                                  electron.stepCounter);               // whether this was the first step
@@ -639,6 +646,7 @@ __global__ void GammaCompton(Track *gammas, G4HepEmGammaTrack *hepEMTracks, Seco
                                newEnergyGamma,                              // Post-step point kinetic energy
                                currentTrack.globalTime,                     // global time
                                currentTrack.localTime,                      // local time
+                               currentTrack.preStepGlobalTime,              // preStep global time
                                currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                isLastStep, // whether this is the last step of the track
                                currentTrack.stepCounter);
@@ -727,6 +735,7 @@ __global__ void GammaPhotoelectric(Track *gammas, G4HepEmGammaTrack *hepEMTracks
                                  electron.eKin,                       // Post-step point kinetic energy
                                  electron.globalTime,                 // global time
                                  0.,                                  // local time
+                                 electron.globalTime,                 // preStep global time at initializing step
                                  electron.eventId, electron.threadId, // eventID and threadID
                                  false,                               // whether this was the last step
                                  electron.stepCounter);               // whether this was the first step
@@ -761,6 +770,7 @@ __global__ void GammaPhotoelectric(Track *gammas, G4HepEmGammaTrack *hepEMTracks
                                newEnergyGamma,                              // Post-step point kinetic energy
                                currentTrack.globalTime,                     // global time
                                currentTrack.localTime,                      // local time
+                               currentTrack.preStepGlobalTime,              // preStep global time
                                currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                isLastStep, // whether this is the last step of the track
                                currentTrack.stepCounter);

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -646,7 +646,7 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
   aPreStepPoint->SetPosition(G4ThreeVector(aGPUHit->fPreStepPoint.fPosition.x(), aGPUHit->fPreStepPoint.fPosition.y(),
                                            aGPUHit->fPreStepPoint.fPosition.z())); // Real data
   // aPreStepPoint->SetLocalTime(0);                                                                // Missing data
-  // aPreStepPoint->SetGlobalTime(0);                                                               // Missing data
+  aPreStepPoint->SetGlobalTime(aGPUHit->fPreGlobalTime); // Real data
   // aPreStepPoint->SetProperTime(0);                                                               // Missing data
   aPreStepPoint->SetMomentumDirection(G4ThreeVector(aGPUHit->fPreStepPoint.fMomentumDirection.x(),
                                                     aGPUHit->fPreStepPoint.fMomentumDirection.y(),


### PR DESCRIPTION
Previously only the `Track->globalTime` and the `postStepPoint->globalTime` was set. This PR also returns and sets the `preStepPoint->globalTime` as required by Athena, CMSSW, and Gauss. 