### PR TITLE
[mini] Fix proper time

### DIFF
--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -454,7 +454,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     double deltaTime = elTrack.GetPStepLength() / GetVelocity(eKin);
     globalTime += deltaTime;
     localTime += deltaTime;
-    properTime += deltaTime * (restMass / eKin);
+    properTime += deltaTime * (restMass / (restMass + eKin));
 
     // Collect the charged step length (might be changed by MSC). Collect the changes in energy and deposit.
     eKin                 = theTrack->GetEKin();

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -363,7 +363,7 @@ __global__ void ElectronMSC(Track *electrons, G4HepEmElectronTrack *hepEMTracks,
     double deltaTime = elTrack.GetPStepLength() / GetVelocity(currentTrack.eKin);
     currentTrack.globalTime += deltaTime;
     currentTrack.localTime += deltaTime;
-    currentTrack.properTime += deltaTime * (restMass / currentTrack.eKin);
+    currentTrack.properTime += deltaTime * (restMass / (restMass + currentTrack.eKin));
   }
 }
 


### PR DESCRIPTION
Reported by @dkonst13 :

The proper time was not calculated correctly in AdePT:

It should be  $t_{proper} += \Delta_t * m_e / E_{tot}$ with $E_{tot} = m_e + E_{kin}$.
See also in G4 [here](https://gitlab.cern.ch/geant4/geant4/-/blob/master/source/processes/transportation/src/G4Transportation.cc?ref_type=heads#L553) 
