### PR TITLE
[mini] fix track data == operator

### DIFF
--- a/include/AdePT/core/TrackData.h
+++ b/include/AdePT/core/TrackData.h
@@ -43,7 +43,7 @@ struct TrackData {
   }
 
   // fixme: add include navigation state in operators?
-  friend bool operator==(TrackData const &a, TrackData const &b) { return !(a < b && b < a); }
+  friend bool operator==(TrackData const &a, TrackData const &b) { return !(a < b) && !(b < a); }
   friend bool operator!=(TrackData const &a, TrackData const &b) { return !(a == b); }
   inline bool operator<(TrackData const &t) const
   {


### PR DESCRIPTION
Found thanks to static analysis by @dkonst13:

The == operator in the `TrackData` was bugged:

`!(a < b && b < a)` returns always true. In case of `a < b` (or `b < a`), it yields `!(true && false) -> !(false) -> true`

Correct is: `!(a < b) && !(b < a);`, which yields true only if `a == b`.