### PR TITLE
[mini] initialize (empty) secondary vector

### DIFF
--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -413,6 +413,9 @@ void AdePTGeant4Integration::ProcessGPUStep(GPUHit const &hit, bool const callUs
   if (aSensitiveDetector != nullptr && hit.fStepCounter != 0) {
     aSensitiveDetector->Hit(fScoringObjects->fG4Step);
   }
+
+  // cleanup of the secondary vector that is created in FillG4Step above
+  fScoringObjects->fG4Step->DeleteSecondaryVector();
 }
 
 void AdePTGeant4Integration::FillG4NavigationHistory(vecgeom::NavigationState aNavState,
@@ -488,6 +491,7 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
   if (aGPUHit->fLastStepOfTrack) aG4Step->SetLastStepFlag();   // Real data
   // aG4Step->SetPointerToVectorOfAuxiliaryPoints(nullptr);        // Missing data
   // initialize secondary vector (although it is empty for now)
+  // Note: we own this vector, we are responsible for deleting it!
   aG4Step->NewSecondaryVector();
   // aG4Step->SetSecondary(nullptr);                               // Missing data
 


### PR DESCRIPTION
This initializes an empty secondary vector when returning a GPU step to the CPU. This is needed such that the access to the secondary does not crash:
```
  const std::vector<const G4Track*>  *secondaryVector = aStep->GetSecondaryInCurrentStep();
  secondaryVector->size(); <- currently crashes as it is a nullPtr
```
With this PR the secondary vector is available, just empty.

This PR is needed to run Athena with the `Sim_tf` transform.