### PR TITLE
Async AdePT initialization cleanup

### DIFF
--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -91,7 +91,7 @@ public:
   /// @brief Setup function used only in async AdePT
   /// @param threadId thread Id
   /// @param hepEmTM specialized G4HepEmTrackingManager
-  void SetIntegrationLayerForThread(int threadId, G4HepEmTrackingManagerSpecialized *hepEmTM) override {};
+  void SetHepEmTrackingManagerForThread(int threadId, G4HepEmTrackingManagerSpecialized *hepEmTM) override {};
   IntegrationLayer &GetIntegrationLayer(int /*threadId*/) { return fIntegrationLayer; }
 
 private:

--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -44,7 +44,6 @@ void ShowerGPU(IntegrationLayer &integration, int event, TrackBuffer &buffer, GP
 template <typename IntegrationLayer>
 AdePTTransport<IntegrationLayer>::AdePTTransport(AdePTConfiguration &configuration,
                                                  G4HepEmTrackingManagerSpecialized *hepEmTM)
-    : fIntegrationLayer(hepEmTM)
 {
   fDebugLevel        = configuration.GetVerbosity();
   fBufferThreshold   = configuration.GetTransportBufferThreshold();
@@ -58,6 +57,7 @@ AdePTTransport<IntegrationLayer>::AdePTTransport(AdePTConfiguration &configurati
   fBfieldFile        = configuration.GetCovfieBfieldFile();
   fCapacity          = 1024 * 1024 * configuration.GetMillionsOfTrackSlots() / configuration.GetNumThreads();
   fHitBufferCapacity = 1024 * 1024 * configuration.GetMillionsOfHitSlots() / configuration.GetNumThreads();
+  fIntegrationLayer.SetHepEmTrackingManager(hepEmTM);
 
   printf("AdePT Allocated track capacity: %d tracks\n", fCapacity);
   printf("AdePT Allocated step buffer capacity: %d tracks\n", fHitBufferCapacity);

--- a/include/AdePT/core/AdePTTransportInterface.hh
+++ b/include/AdePT/core/AdePTTransportInterface.hh
@@ -60,10 +60,10 @@ public:
   virtual void Shower(int event, int threadId)            = 0;
   virtual void Cleanup(bool commonInitThread)             = 0;
   virtual void ProcessGPUSteps(int threadId, int eventId) = 0;
-  /// @brief Setup function for the G4HepEmtrackingManager in the integratin layer -  used only in async AdePT
+  /// @brief Setup function for the G4HepEmtrackingManager in the integration layer - used only in async AdePT
   /// @param threadId thread Id
   /// @param hepEmTM specialized G4HepEmTrackingManager
-  virtual void SetIntegrationLayerForThread(int threadId, G4HepEmTrackingManagerSpecialized *hepEmTM) = 0;
+  virtual void SetHepEmTrackingManagerForThread(int threadId, G4HepEmTrackingManagerSpecialized *hepEmTM) = 0;
 };
 
 #endif

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -55,9 +55,9 @@ private:
   unsigned short fLastNParticlesOnCPU{0}; ///< Number N of last N particles that are finished on CPU
   // note: std::optional is used here as the AdePTGeant4Integration has no default constructor and we need to
   // resize the vector to the number of threads, and then each worker has to construct its entry at its given slot
-  std::vector<std::optional<IntegrationLayer>> fIntegrationLayerObjects; //< vector of integration layers per thread
-  std::unique_ptr<GPUstate, GPUstateDeleter> fGPUstate{nullptr};         ///< CUDA state placeholder
-  std::vector<AdePTScoring> fScoring;                                    ///< User scoring objects per G4 worker
+  std::vector<IntegrationLayer> fIntegrationLayerObjects;        //< vector of integration layers per thread
+  std::unique_ptr<GPUstate, GPUstateDeleter> fGPUstate{nullptr}; ///< CUDA state placeholder
+  std::vector<AdePTScoring> fScoring;                            ///< User scoring objects per G4 worker
   std::unique_ptr<TrackBuffer> fBuffer{nullptr};     ///< Buffers for transferring tracks between host and device
   std::unique_ptr<G4HepEmState> fg4hepem_state;      ///< The HepEm state singleton
   std::thread fGPUWorker;                            ///< Thread to manage GPU
@@ -79,6 +79,7 @@ private:
   ///< G4workers
   double fCPUCopyFraction{0.5};
 
+  void Initialize(G4HepEmConfig *hepEmConfig);
   void InitBVH();
   bool InitializeBField();
   bool InitializeBField(UniformMagneticField &Bfield);
@@ -86,7 +87,7 @@ private:
   bool InitializePhysics(G4HepEmConfig *hepEmConfig);
 
 public:
-  AsyncAdePTTransport(AdePTConfiguration &configuration, G4HepEmTrackingManagerSpecialized *hepEmTM);
+  AsyncAdePTTransport(AdePTConfiguration &configuration, G4HepEmConfig *hepEmConfig);
   AsyncAdePTTransport(const AsyncAdePTTransport &other) = delete;
   ~AsyncAdePTTransport();
 
@@ -120,7 +121,6 @@ public:
   std::vector<std::string> const *GetCPURegionNames() override { return fCPURegionNames; }
   /// No effect
   void Initialize(G4HepEmConfig *hepEmConfig, bool) override {}
-  void Initialize(G4HepEmTrackingManagerSpecialized *hepEmTM, int threadId);
   /// @brief Finish GPU transport, bring hits and tracks to host
   /// @details The shower call exists to maintain the same interface as the
   /// synchronous AdePT mode, since in this case the transport loop is always
@@ -134,8 +134,8 @@ public:
   /// @brief Setup function used only in async AdePT
   /// @param threadId thread Id
   /// @param hepEmTM specialized G4HepEmTrackingManager
-  void SetIntegrationLayerForThread(int threadId, G4HepEmTrackingManagerSpecialized *hepEmTM) override;
-  IntegrationLayer &GetIntegrationLayer(int threadId) { return fIntegrationLayerObjects[threadId].value(); }
+  void SetHepEmTrackingManagerForThread(int threadId, G4HepEmTrackingManagerSpecialized *hepEmTM) override;
+  IntegrationLayer &GetIntegrationLayer(int threadId) { return fIntegrationLayerObjects[threadId]; }
 };
 
 } // namespace AsyncAdePT

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -85,16 +85,16 @@ std::ostream &operator<<(std::ostream &stream, TrackDataWithIDs const &track)
 
 template <typename IntegrationLayer>
 AsyncAdePTTransport<IntegrationLayer>::AsyncAdePTTransport(AdePTConfiguration &configuration,
-                                                           G4HepEmTrackingManagerSpecialized *hepEmTM)
+                                                           G4HepEmConfig *hepEmConfig)
     : fAdePTSeed{configuration.GetAdePTSeed()}, fNThread{(ushort)configuration.GetNumThreads()},
       fTrackCapacity{(uint)(1024 * 1024 * configuration.GetMillionsOfTrackSlots())},
       fLeakCapacity{(uint)(1024 * 1024 * configuration.GetMillionsOfLeakSlots())},
       fScoringCapacity{(uint)(1024 * 1024 * configuration.GetMillionsOfHitSlots())},
       fDebugLevel{configuration.GetVerbosity()}, fCUDAStackLimit{configuration.GetCUDAStackLimit()},
       fCUDAHeapLimit{configuration.GetCUDAHeapLimit()}, fLastNParticlesOnCPU{configuration.GetLastNParticlesOnCPU()},
-      fEventStates(fNThread), fGPUNetEnergy(fNThread, 0.0), fTrackInAllRegions{configuration.GetTrackInAllRegions()},
-      fGPURegionNames{configuration.GetGPURegionNames()}, fCPURegionNames{configuration.GetCPURegionNames()},
-      fReturnAllSteps{configuration.GetCallUserSteppingAction()},
+      fIntegrationLayerObjects(fNThread), fEventStates(fNThread), fGPUNetEnergy(fNThread, 0.0),
+      fTrackInAllRegions{configuration.GetTrackInAllRegions()}, fGPURegionNames{configuration.GetGPURegionNames()},
+      fCPURegionNames{configuration.GetCPURegionNames()}, fReturnAllSteps{configuration.GetCallUserSteppingAction()},
       fReturnFirstAndLastStep{configuration.GetCallUserTrackingAction() || configuration.GetCallUserSteppingAction()},
       fBfieldFile{configuration.GetCovfieBfieldFile()}, fCPUCapacityFactor{configuration.GetCPUCapacityFactor()},
       fCPUCopyFraction{configuration.GetHitBufferFlushThreshold()}
@@ -106,12 +106,7 @@ AsyncAdePTTransport<IntegrationLayer>::AsyncAdePTTransport(AdePTConfiguration &c
     std::atomic_init(&eventState, EventState::ScoringRetrieved);
   }
 
-  // Initialize integration layers:
-  // the worker thread that initializes the GPU transport must initialize the integration layer for itself first
-  fIntegrationLayerObjects.resize(fNThread);
-  auto tid = G4Threading::G4GetThreadId();
-  SetIntegrationLayerForThread(tid, hepEmTM);
-  AsyncAdePTTransport::Initialize(hepEmTM, tid);
+  AsyncAdePTTransport::Initialize(hepEmConfig);
 }
 
 template <typename IntegrationLayer>
@@ -121,19 +116,10 @@ AsyncAdePTTransport<IntegrationLayer>::~AsyncAdePTTransport()
 }
 
 template <typename IntegrationLayer>
-void AsyncAdePTTransport<IntegrationLayer>::SetIntegrationLayerForThread(int threadId,
-                                                                         G4HepEmTrackingManagerSpecialized *hepEmTM)
+void AsyncAdePTTransport<IntegrationLayer>::SetHepEmTrackingManagerForThread(int threadId,
+                                                                             G4HepEmTrackingManagerSpecialized *hepEmTM)
 {
-
-  if (threadId >= fNThread) {
-    throw std::runtime_error("Invalid thread ID: exceeds configured thread count");
-  }
-  if (fIntegrationLayerObjects[threadId].has_value()) {
-    // Integration layer already initialized
-    return;
-  }
-  fIntegrationLayerObjects[threadId].emplace(hepEmTM);
-  return;
+  fIntegrationLayerObjects[threadId].SetHepEmTrackingManager(hepEmTM);
 }
 
 template <typename IntegrationLayer>
@@ -264,7 +250,7 @@ bool AsyncAdePTTransport<IntegrationLayer>::InitializePhysics(G4HepEmConfig *hep
 }
 
 template <typename IntegrationLayer>
-void AsyncAdePTTransport<IntegrationLayer>::Initialize(G4HepEmTrackingManagerSpecialized *hepEmTM, int threadId)
+void AsyncAdePTTransport<IntegrationLayer>::Initialize(G4HepEmConfig *hepEmConfig)
 {
   const auto numVolumes = vecgeom::GeoManager::Instance().GetRegisteredVolumesCount();
   if (numVolumes == 0) throw std::runtime_error("AsyncAdePTTransport::Initialize: Number of geometry volumes is zero.");
@@ -274,21 +260,12 @@ void AsyncAdePTTransport<IntegrationLayer>::Initialize(G4HepEmTrackingManagerSpe
   if (!vecgeom::GeoManager::Instance().IsClosed())
     throw std::runtime_error("AsyncAdePTTransport::Initialize: VecGeom geometry not closed.");
 
-  // initialize the G4HepEmTrackingManager per thread - this is needed for the nuclear processes,
-  // as the HepEmTM carries a pointer to the thread-local hadronic physics model
-  if (threadId >= fNThread) {
-    throw std::runtime_error("Invalid thread ID: exceeds configured thread count");
-  }
-  if (!(fIntegrationLayerObjects[threadId].has_value())) {
-    fIntegrationLayerObjects[threadId].emplace(hepEmTM);
-  }
-
   const vecgeom::cxx::VPlacedVolume *world = vecgeom::GeoManager::Instance().GetWorld();
   if (!InitializeGeometry(world))
     throw std::runtime_error("AsyncAdePTTransport::Initialize: Cannot initialize geometry on GPU");
 
   // Initialize G4HepEm
-  if (!InitializePhysics(hepEmTM->GetConfig()))
+  if (!InitializePhysics(hepEmConfig))
     throw std::runtime_error("AsyncAdePTTransport::Initialize cannot initialize physics on GPU");
 
   // Initialize field
@@ -299,19 +276,17 @@ void AsyncAdePTTransport<IntegrationLayer>::Initialize(G4HepEmTrackingManagerSpe
         "AdePTTransport<IntegrationLayer>::Initialize cannot initialize GeneralMagneticField on GPU");
   }
 #else
-  auto field_values = fIntegrationLayerObjects[threadId]
-                          .value()
-                          .GetUniformField(); // Get the field value from one of the worker threads
+  auto field_values =
+      fIntegrationLayerObjects.front().GetUniformField(); // Get the field value from one of the worker threads
   std::unique_ptr<UniformMagneticField> Bfield = std::make_unique<UniformMagneticField>(field_values);
   if (!InitializeBField(*Bfield))
     throw std::runtime_error("AdePTTransport<IntegrationLayer>::Initialize cannot initialize field on GPU");
 #endif
 
   // Check VecGeom geometry matches Geant4. Initialize auxiliary per-LV data. Initialize scoring map.
-  fIntegrationLayerObjects[threadId].value().CheckGeometry(fg4hepem_state.get());
+  fIntegrationLayerObjects.front().CheckGeometry(fg4hepem_state.get());
   adeptint::VolAuxData *auxData = new adeptint::VolAuxData[vecgeom::GeoManager::Instance().GetRegisteredVolumesCount()];
-  fIntegrationLayerObjects[threadId].value().InitVolAuxData(auxData, fg4hepem_state.get(), fTrackInAllRegions,
-                                                            fGPURegionNames);
+  fIntegrationLayerObjects.front().InitVolAuxData(auxData, fg4hepem_state.get(), fTrackInAllRegions, fGPURegionNames);
 
   // Initialize volume auxiliary data on device
   auto &volAuxArray       = adeptint::VolAuxArray::GetInstance();
@@ -347,7 +322,7 @@ template <typename IntegrationLayer>
 void AsyncAdePTTransport<IntegrationLayer>::ProcessGPUSteps(int threadId, int eventId)
 {
 
-  AdePTGeant4Integration &integrationInstance = fIntegrationLayerObjects[threadId].value();
+  AdePTGeant4Integration &integrationInstance = fIntegrationLayerObjects[threadId];
   std::pair<GPUHit *, GPUHit *> range;
   bool dataOnBuffer;
 
@@ -382,7 +357,7 @@ void AsyncAdePTTransport<IntegrationLayer>::Flush(G4int threadId, G4int eventId)
   assert(static_cast<unsigned int>(threadId) < fBuffer->fromDeviceBuffers.size());
   fEventStates[threadId].store(EventState::G4RequestsFlush, std::memory_order_release);
 
-  AdePTGeant4Integration &integrationInstance = fIntegrationLayerObjects[threadId].value();
+  AdePTGeant4Integration &integrationInstance = fIntegrationLayerObjects[threadId];
 
   while (fEventStates[threadId].load(std::memory_order_acquire) < EventState::DeviceFlushed) {
 

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -30,10 +30,7 @@ struct Deleter {
 
 class AdePTGeant4Integration {
 public:
-  explicit AdePTGeant4Integration(G4HepEmTrackingManagerSpecialized *hepEmTM)
-      : fHepEmTrackingManager(hepEmTM), fHostTrackDataMapper(std::make_unique<HostTrackDataMapper>())
-  {
-  }
+  explicit AdePTGeant4Integration() : fHostTrackDataMapper(std::make_unique<HostTrackDataMapper>()) {}
   ~AdePTGeant4Integration();
 
   AdePTGeant4Integration(const AdePTGeant4Integration &)            = delete;
@@ -90,6 +87,11 @@ public:
 
   HostTrackDataMapper &GetHostTrackDataMapper() { return *fHostTrackDataMapper; }
 
+  void SetHepEmTrackingManager(G4HepEmTrackingManagerSpecialized *hepEmTrackingManager)
+  {
+    fHepEmTrackingManager = hepEmTrackingManager;
+  }
+
 private:
   /// @brief Reconstruct G4TouchableHistory from a VecGeom Navigation index
   void FillG4NavigationHistory(vecgeom::NavigationState aNavState, G4NavigationHistory &aG4NavigationHistory) const;
@@ -103,7 +105,7 @@ private:
 
   // pointer to specialized G4HepEmTrackingManager. Owned by AdePTTrackingManager,
   // this is just a reference to handle gamma-/lepton-nuclear reactions
-  G4HepEmTrackingManagerSpecialized *fHepEmTrackingManager;
+  G4HepEmTrackingManagerSpecialized *fHepEmTrackingManager{nullptr};
 
   // helper class to provide the CPU-only data for the returning GPU tracks
   std::unique_ptr<HostTrackDataMapper> fHostTrackDataMapper;


### PR DESCRIPTION
Due to the nuclear processes, we need each integration layer object to hold a reference to the thread's HepEmTrackingManager. This was achieved by initializing each integration object per thread after the AdePT common initialization. However, the code gave the impression that this was happening in the AsyncAdePTTransport constructor, while in reality this is called only once per run, by the first thread that runs the initialization.

With these changes, the unneeded code is removed from the constructor, and the integration objects are default constructed, rather than being created at AdePT initialization. Each thread stores its HepEmTrackingManager on the corresponding integration object with a call after retrieving the pointer to the common AsyncAdePTTransport.