### PR TITLE
Changing vecgeom::Precision to double

### DIFF
--- a/include/AdePT/core/AdePTScoringTemplate.cuh
+++ b/include/AdePT/core/AdePTScoringTemplate.cuh
@@ -19,12 +19,12 @@ void FreeGPU(Scoring *scoring, Scoring *scoring_dev);
 template <typename Scoring>
 __device__ void RecordHit(Scoring *scoring_dev, uint64_t aTrackID, uint64_t aParentID, short stepLimProcessId,
                           char aParticleType, double aStepLength, double aTotalEnergyDeposit, float aTrackWeight,
-                          vecgeom::NavigationState const &aPreState, vecgeom::Vector3D<Precision> const &aPrePosition,
-                          vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin,
-                          vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
-                          vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                          double aGlobalTime, double aLocalTime, double aPreGlobalTime, unsigned int eventId,
-                          short threadId, bool isLastStep, unsigned short stepCounter);
+                          vecgeom::NavigationState const &aPreState, vecgeom::Vector3D<double> const &aPrePosition,
+                          vecgeom::Vector3D<double> const &aPreMomentumDirection, double aPreEKin,
+                          vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<double> const &aPostPosition,
+                          vecgeom::Vector3D<double> const &aPostMomentumDirection, double aPostEKin, double aGlobalTime,
+                          double aLocalTime, double aPreGlobalTime, unsigned int eventId, short threadId,
+                          bool isLastStep, unsigned short stepCounter);
 
 template <typename Scoring>
 __device__ void AccountProduced(Scoring *scoring_dev, int num_ele, int num_pos, int num_gam);

--- a/include/AdePT/core/AsyncAdePTTransportStruct.cuh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.cuh
@@ -78,8 +78,8 @@ struct LeakedTracks {
 //     double PEmxSec; // Only used for photoelectric process
 //     unsigned int slot;
 //     vecgeom::NavigationState preStepNavState;
-//     vecgeom::Vector3D<Precision> preStepPos;
-//     vecgeom::Vector3D<Precision> preStepDir;
+//     vecgeom::Vector3D<double> preStepPos;
+//     vecgeom::Vector3D<double> preStepDir;
 //     double preStepEnergy;
 //   };
 //   adept::MParrayT<Data> *queues[Interaction::NInt];

--- a/include/AdePT/core/HostScoringImpl.cuh
+++ b/include/AdePT/core/HostScoringImpl.cuh
@@ -151,12 +151,12 @@ void FreeGPU(HostScoring *hostScoring, HostScoring *hostScoring_dev)
 template <>
 __device__ void RecordHit(HostScoring *hostScoring_dev, uint64_t aTrackID, uint64_t aParentID, short stepLimProcessId,
                           char aParticleType, double aStepLength, double aTotalEnergyDeposit, float aTrackWeight,
-                          vecgeom::NavigationState const &aPreState, vecgeom::Vector3D<Precision> const &aPrePosition,
-                          vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin,
-                          vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
-                          vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                          double aGlobalTime, double aLocalTime, double aPreGlobalTime, unsigned int eventID,
-                          short threadID, bool isLastStep, unsigned short stepCounter)
+                          vecgeom::NavigationState const &aPreState, vecgeom::Vector3D<double> const &aPrePosition,
+                          vecgeom::Vector3D<double> const &aPreMomentumDirection, double aPreEKin,
+                          vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<double> const &aPostPosition,
+                          vecgeom::Vector3D<double> const &aPostMomentumDirection, double aPostEKin, double aGlobalTime,
+                          double aLocalTime, double aPreGlobalTime, unsigned int eventID, short threadID,
+                          bool isLastStep, unsigned short stepCounter)
 {
   // Acquire a hit slot
   GPUHit &aGPUHit = *GetNextFreeHit(hostScoring_dev);

--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -702,12 +702,12 @@ template <>
 __device__ void RecordHit(AsyncAdePT::PerEventScoring * /*scoring*/, uint64_t aTrackID, uint64_t aParentID,
                           short stepLimProcessId, char aParticleType, double aStepLength, double aTotalEnergyDeposit,
                           float aTrackWeight, vecgeom::NavigationState const &aPreState,
-                          vecgeom::Vector3D<Precision> const &aPrePosition,
-                          vecgeom::Vector3D<Precision> const &aPreMomentumDirection, double aPreEKin,
-                          vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
-                          vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin,
-                          double aGlobalTime, double aLocalTime, double aPreGlobalTime, unsigned int eventID,
-                          short threadID, bool isLastStep, unsigned short stepCounter)
+                          vecgeom::Vector3D<double> const &aPrePosition,
+                          vecgeom::Vector3D<double> const &aPreMomentumDirection, double aPreEKin,
+                          vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<double> const &aPostPosition,
+                          vecgeom::Vector3D<double> const &aPostMomentumDirection, double aPostEKin, double aGlobalTime,
+                          double aLocalTime, double aPreGlobalTime, unsigned int eventID, short threadID,
+                          bool isLastStep, unsigned short stepCounter)
 {
   // Acquire a hit slot
   GPUHit &aGPUHit = AsyncAdePT::gHitScoringBuffer_dev.GetNextSlot(threadID);

--- a/include/AdePT/core/ScoringCommons.hh
+++ b/include/AdePT/core/ScoringCommons.hh
@@ -9,8 +9,8 @@
 #include "VecGeom/navigation/NavigationState.h"
 
 struct GPUStepPoint {
-  vecgeom::Vector3D<Precision> fPosition;
-  vecgeom::Vector3D<Precision> fMomentumDirection;
+  vecgeom::Vector3D<double> fPosition;
+  vecgeom::Vector3D<double> fMomentumDirection;
   double fEKin;
   // Data needed to reconstruct G4 Touchable history
   vecgeom::NavigationState fNavigationState{0}; // VecGeom navigation state, used to identify the touchable
@@ -62,8 +62,8 @@ struct GlobalCounters {
 };
 
 /// @brief Utility function to copy a 3D vector, used for filling the Step Points
-__device__ __forceinline__ void Copy3DVector(vecgeom::Vector3D<Precision> const &source,
-                                             vecgeom::Vector3D<Precision> &destination)
+__device__ __forceinline__ void Copy3DVector(vecgeom::Vector3D<double> const &source,
+                                             vecgeom::Vector3D<double> &destination)
 {
   destination.x() = source.x();
   destination.y() = source.y();
@@ -74,9 +74,9 @@ __device__ __forceinline__ void Copy3DVector(vecgeom::Vector3D<Precision> const 
 __device__ __forceinline__ void FillHit(
     GPUHit &aGPUHit, uint64_t aTrackID, uint64_t aParentID, short aStepLimProcessId, char aParticleType,
     double aStepLength, double aTotalEnergyDeposit, float aTrackWeight, vecgeom::NavigationState const &aPreState,
-    vecgeom::Vector3D<Precision> const &aPrePosition, vecgeom::Vector3D<Precision> const &aPreMomentumDirection,
-    double aPreEKin, vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<Precision> const &aPostPosition,
-    vecgeom::Vector3D<Precision> const &aPostMomentumDirection, double aPostEKin, double aGlobalTime, double aLocalTime,
+    vecgeom::Vector3D<double> const &aPrePosition, vecgeom::Vector3D<double> const &aPreMomentumDirection,
+    double aPreEKin, vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<double> const &aPostPosition,
+    vecgeom::Vector3D<double> const &aPostMomentumDirection, double aPostEKin, double aGlobalTime, double aLocalTime,
     double aPreGlobalTime, unsigned int eventID, short threadID, bool isLastStep, unsigned short stepCounter)
 {
   aGPUHit.fEventId = eventID;

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -18,8 +18,6 @@
 // A data structure to represent a particle track. The particle type is implicit
 // by the queue and not stored in memory.
 struct Track {
-  using Precision = vecgeom::Precision;
-
   RanluxppDouble rngState;
   double eKin{0.};
   double globalTime{0.};
@@ -36,8 +34,8 @@ struct Track {
   float localTime{0.f};
   float properTime{0.f};
 
-  vecgeom::Vector3D<Precision> pos;   ///< track position
-  vecgeom::Vector3D<Precision> dir;   ///< track direction
+  vecgeom::Vector3D<double> pos;      ///< track position
+  vecgeom::Vector3D<double> dir;      ///< track direction
   vecgeom::Vector3D<float> safetyPos; ///< last position where the safety was computed
   // TODO: For better clarity in the split kernels, rename this to "stored safety" as opposed to the
   // safety we get from GetSafety(), which is computed in the moment
@@ -49,8 +47,8 @@ struct Track {
   // Variables used to store track info needed for scoring
   vecgeom::NavigationState nextState;
   vecgeom::NavigationState preStepNavState;
-  vecgeom::Vector3D<Precision> preStepPos;
-  vecgeom::Vector3D<Precision> preStepDir;
+  vecgeom::Vector3D<double> preStepPos;
+  vecgeom::Vector3D<double> preStepDir;
   double preStepEKin{0};
   double preStepGlobalTime{0.};
   // Variables used to store navigation results
@@ -96,8 +94,8 @@ struct Track {
 
   /// Construct a secondary from a parent track.
   /// NB: The caller is responsible to branch a new RNG state.
-  __device__ Track(RanluxppDouble const &rng_state, double eKin, const vecgeom::Vector3D<Precision> &parentPos,
-                   const vecgeom::Vector3D<Precision> &newDirection, const vecgeom::NavigationState &newNavState,
+  __device__ Track(RanluxppDouble const &rng_state, double eKin, const vecgeom::Vector3D<double> &parentPos,
+                   const vecgeom::Vector3D<double> &newDirection, const vecgeom::NavigationState &newNavState,
                    const Track &parentTrack, const double globalTime)
       : rngState{rng_state}, eKin{eKin}, globalTime{globalTime}, pos{parentPos}, dir{newDirection},
         navState{newNavState}, originNavState{newNavState}, trackId{rngState.IntRndm64()}, eventId{parentTrack.eventId},
@@ -126,7 +124,7 @@ struct Track {
   /// @param new_pos Track position
   /// @param accurate_limit Only return non-zero if the recomputed safety if larger than the accurate_limit
   /// @return Recomputed safety.
-  __host__ __device__ VECGEOM_FORCE_INLINE float GetSafety(vecgeom::Vector3D<Precision> const &new_pos,
+  __host__ __device__ VECGEOM_FORCE_INLINE float GetSafety(vecgeom::Vector3D<double> const &new_pos,
                                                            float accurate_limit = 0.f) const
   {
     float dsafe = safety - accurate_limit;
@@ -139,7 +137,7 @@ struct Track {
   /// @brief Set Safety value computed in a new point
   /// @param new_pos Position where the safety is computed
   /// @param safe Safety value
-  __host__ __device__ VECGEOM_FORCE_INLINE void SetSafety(vecgeom::Vector3D<Precision> const &new_pos, float safe)
+  __host__ __device__ VECGEOM_FORCE_INLINE void SetSafety(vecgeom::Vector3D<double> const &new_pos, float safe)
   {
     safetyPos.Set(static_cast<float>(new_pos[0]), static_cast<float>(new_pos[1]), static_cast<float>(new_pos[2]));
     safety = vecCore::math::Max(safe, 0.f);
@@ -147,7 +145,7 @@ struct Track {
 
   __host__ __device__ double Uniform() { return rngState.Rndm(); }
 
-  __host__ __device__ void InitAsSecondary(const vecgeom::Vector3D<Precision> &parentPos,
+  __host__ __device__ void InitAsSecondary(const vecgeom::Vector3D<double> &parentPos,
                                            const vecgeom::NavigationState &parentNavState, double gTime)
   {
 #ifndef USE_SPLIT_KERNELS

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -53,7 +53,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, Trac
                                                           AllowFinishOffEventArray allowFinishOffEvent,
                                                           const bool returnAllSteps, const bool returnLastStep)
 {
-  constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
+  constexpr double kPushDistance    = 1000 * vecgeom::kTolerance;
   constexpr unsigned short maxSteps = 10'000;
   constexpr int Charge              = IsElectron ? -1 : 1;
   constexpr double restMass         = copcore::units::kElectronMassC2;
@@ -96,7 +96,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
   using namespace adept_impl;
   constexpr bool returnAllSteps     = false;
   constexpr bool returnLastStep     = false;
-  constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
+  constexpr double kPushDistance    = 1000 * vecgeom::kTolerance;
   constexpr unsigned short maxSteps = 10'000;
   constexpr int Charge              = IsElectron ? -1 : 1;
   constexpr double restMass         = copcore::units::kElectronMassC2;
@@ -134,15 +134,15 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     bool isLastStep                          = returnLastStep;
     bool surviveFlag                         = false;
     LeakStatus leakReason                    = LeakStatus::NoLeak;
-    constexpr Precision kPushStuck           = 100 * vecgeom::kTolerance;
+    constexpr double kPushStuck              = 100 * vecgeom::kTolerance;
     constexpr unsigned short kStepsStuckPush = 5;
     constexpr unsigned short kStepsStuckKill = 25;
     auto eKin                                = currentTrack.eKin;
     auto preStepEnergy                       = eKin;
     auto pos                                 = currentTrack.pos;
-    vecgeom::Vector3D<Precision> preStepPos(pos);
+    vecgeom::Vector3D<double> preStepPos(pos);
     auto dir = currentTrack.dir;
-    vecgeom::Vector3D<Precision> preStepDir(dir);
+    vecgeom::Vector3D<double> preStepDir(dir);
     double globalTime        = currentTrack.globalTime;
     double preStepGlobalTime = currentTrack.globalTime;
     double localTime         = currentTrack.localTime;
@@ -150,7 +150,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     vecgeom::NavigationState nextState;
 
     currentTrack.stepCounter++;
-    bool printErrors = false;
+    bool printErrors = true;
     bool verbose     = false;
 #if ADEPT_DEBUG_TRACK > 0
     const char *pname[2] = {"e+", "e-"};
@@ -409,7 +409,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 
     if (!nextState.IsOnBoundary()) {
       const double *mscDisplacement = mscData->GetDisplacement();
-      vecgeom::Vector3D<Precision> displacement(mscDisplacement[0], mscDisplacement[1], mscDisplacement[2]);
+      vecgeom::Vector3D<double> displacement(mscDisplacement[0], mscDisplacement[1], mscDisplacement[2]);
       const double dLength2            = displacement.Length2();
       constexpr double kGeomMinLength  = 5 * copcore::units::nm;          // 0.05 [nm]
       constexpr double kGeomMinLength2 = kGeomMinLength * kGeomMinLength; // (0.05 [nm])^2
@@ -605,7 +605,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
           } else {
 #ifdef ASYNC_MODE
             Track &secondary = secondaries.electrons.NextTrack(
-                newRNG, deltaEkin, pos, vecgeom::Vector3D<Precision>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
+                newRNG, deltaEkin, pos, vecgeom::Vector3D<double>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
                 navState, currentTrack, globalTime);
 #else
             Track &secondary = secondaries.electrons->NextTrack();
@@ -687,7 +687,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
           } else {
 #ifdef ASYNC_MODE
             Track &gamma = secondaries.gammas.NextTrack(
-                newRNG, deltaEkin, pos, vecgeom::Vector3D<Precision>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
+                newRNG, deltaEkin, pos, vecgeom::Vector3D<double>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
                 navState, currentTrack, globalTime);
 #else
             Track &gamma = secondaries.gammas->NextTrack();
@@ -767,7 +767,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 #ifdef ASYNC_MODE
             Track &gamma1 = secondaries.gammas.NextTrack(
                 newRNG, theGamma1Ekin, pos,
-                vecgeom::Vector3D<Precision>{theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]}, navState, currentTrack,
+                vecgeom::Vector3D<double>{theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]}, navState, currentTrack,
                 globalTime);
 #else
             Track &gamma1 = secondaries.gammas->NextTrack();
@@ -811,7 +811,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 #ifdef ASYNC_MODE
             Track &gamma2 = secondaries.gammas.NextTrack(
                 currentTrack.rngState, theGamma2Ekin, pos,
-                vecgeom::Vector3D<Precision>{theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]}, navState, currentTrack,
+                vecgeom::Vector3D<double>{theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]}, navState, currentTrack,
                 globalTime);
 #else
             Track &gamma2 = secondaries.gammas->NextTrack();
@@ -888,7 +888,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 
 #ifdef ASYNC_MODE
           Track &gamma1 = secondaries.gammas.NextTrack(newRNG2, double{copcore::units::kElectronMassC2}, pos,
-                                                       vecgeom::Vector3D<Precision>{sint * cosPhi, sint * sinPhi, cost},
+                                                       vecgeom::Vector3D<double>{sint * cosPhi, sint * sinPhi, cost},
                                                        navState, currentTrack, globalTime);
 
           // Reuse the RNG state of the dying track.

--- a/include/AdePT/kernels/electrons_async.cuh
+++ b/include/AdePT/kernels/electrons_async.cuh
@@ -47,16 +47,12 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
                                                           Secondaries &secondaries, adept::MParray *activeQueue,
                                                           adept::MParray *leakedQueue, Scoring *userScoring)
 {
-  using VolAuxData = adeptint::VolAuxData;
-#ifdef VECGEOM_FLOAT_PRECISION
-  const Precision kPush = 10 * vecgeom::kTolerance;
-#else
-  const Precision kPush = 0.;
-#endif
-  constexpr Precision kPushOutRegion = 10 * vecgeom::kTolerance;
-  constexpr int Charge               = IsElectron ? -1 : 1;
-  constexpr double restMass          = copcore::units::kElectronMassC2;
-  constexpr unsigned short maxSteps  = 10000; // 20'000;
+  using VolAuxData                  = adeptint::VolAuxData;
+  const double kPush                = 0.;
+  constexpr double kPushOutRegion   = 10 * vecgeom::kTolerance;
+  constexpr int Charge              = IsElectron ? -1 : 1;
+  constexpr double restMass         = copcore::units::kElectronMassC2;
+  constexpr unsigned short maxSteps = 10000; // 20'000;
   fieldPropagatorConstBz fieldPropagatorBz(BzFieldValue);
 
   const int activeSize = active->size();
@@ -69,7 +65,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     auto pos                 = currentTrack.pos;
     const auto preStepPos{pos};
     auto dir = currentTrack.dir;
-    vecgeom::Vector3D<Precision> preStepDir(dir);
+    vecgeom::Vector3D<double> preStepDir(dir);
     auto navState     = currentTrack.navState;
     const auto volume = navState.Top();
     // the MCC vector is indexed by the logical volume id
@@ -220,7 +216,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
     dir.Set(direction[0], direction[1], direction[2]);
     if (!nextState.IsOnBoundary()) {
       const double *mscDisplacement = mscData->GetDisplacement();
-      vecgeom::Vector3D<Precision> displacement(mscDisplacement[0], mscDisplacement[1], mscDisplacement[2]);
+      vecgeom::Vector3D<double> displacement(mscDisplacement[0], mscDisplacement[1], mscDisplacement[2]);
       const double dLength2            = displacement.Length2();
       constexpr double kGeomMinLength  = 5 * copcore::units::nm;          // 0.05 [nm]
       constexpr double kGeomMinLength2 = kGeomMinLength * kGeomMinLength; // (0.05 [nm])^2
@@ -314,7 +310,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
 
         newRNG.Advance();
         Track &gamma1 = secondaries.gammas.NextTrack(newRNG, double{copcore::units::kElectronMassC2}, pos,
-                                                     vecgeom::Vector3D<Precision>{sint * cosPhi, sint * sinPhi, cost},
+                                                     vecgeom::Vector3D<double>{sint * cosPhi, sint * sinPhi, cost},
                                                      navState, currentTrack);
 
         // Reuse the RNG state of the dying track.
@@ -460,7 +456,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       G4HepEmElectronInteractionIoni::SampleDirections(eKin, deltaEkin, dirSecondary, dirPrimary, &rnge);
 
       Track &secondary = secondaries.electrons.NextTrack(
-          newRNG, deltaEkin, pos, vecgeom::Vector3D<Precision>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
+          newRNG, deltaEkin, pos, vecgeom::Vector3D<double>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
           navState, currentTrack);
 
       adept_scoring::AccountProduced(userScoring + currentTrack.threadId, /*numElectrons*/ 1, /*numPositrons*/ 0,
@@ -488,7 +484,7 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
                                      /*numGammas*/ 1);
 
       secondaries.gammas.NextTrack(newRNG, deltaEkin, pos,
-                                   vecgeom::Vector3D<Precision>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
+                                   vecgeom::Vector3D<double>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
                                    navState, currentTrack);
 
       eKin -= deltaEkin;
@@ -508,11 +504,11 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
                                      /*numGammas*/ 2);
 
       secondaries.gammas.NextTrack(newRNG, theGamma1Ekin, pos,
-                                   vecgeom::Vector3D<Precision>{theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]},
+                                   vecgeom::Vector3D<double>{theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]},
                                    navState, currentTrack);
       // Reuse the RNG state of the dying track.
       secondaries.gammas.NextTrack(currentTrack.rngState, theGamma2Ekin, pos,
-                                   vecgeom::Vector3D<Precision>{theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]},
+                                   vecgeom::Vector3D<double>{theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]},
                                    navState, currentTrack);
 
       // The current track is killed by not enqueuing into the next activeQueue.

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -202,12 +202,12 @@ template <bool IsElectron>
 __global__ void ElectronPropagation(Track *electrons, G4HepEmElectronTrack *hepEMTracks, const adept::MParray *active,
                                     adept::MParray *leakedQueue)
 {
-  constexpr Precision kPushDistance        = 1000 * vecgeom::kTolerance;
+  constexpr double kPushDistance           = 1000 * vecgeom::kTolerance;
   constexpr int Charge                     = IsElectron ? -1 : 1;
   constexpr double restMass                = copcore::units::kElectronMassC2;
   constexpr int Nvar                       = 6;
   constexpr int max_iterations             = 10;
-  constexpr Precision kPushStuck           = 100 * vecgeom::kTolerance;
+  constexpr double kPushStuck              = 100 * vecgeom::kTolerance;
   constexpr unsigned short kStepsStuckPush = 5;
 
 #ifdef ADEPT_USE_EXT_BFIELD
@@ -319,7 +319,7 @@ __global__ void ElectronMSC(Track *electrons, G4HepEmElectronTrack *hepEMTracks,
     currentTrack.dir.Set(direction[0], direction[1], direction[2]);
     if (!currentTrack.nextState.IsOnBoundary()) {
       const double *mscDisplacement = mscData->GetDisplacement();
-      vecgeom::Vector3D<Precision> displacement(mscDisplacement[0], mscDisplacement[1], mscDisplacement[2]);
+      vecgeom::Vector3D<double> displacement(mscDisplacement[0], mscDisplacement[1], mscDisplacement[2]);
       const double dLength2            = displacement.Length2();
       constexpr double kGeomMinLength  = 5 * copcore::units::nm;          // 0.05 [nm]
       constexpr double kGeomMinLength2 = kGeomMinLength * kGeomMinLength; // (0.05 [nm])^2
@@ -545,8 +545,8 @@ __global__ void ElectronRelocation(Track *electrons, Track *leaks, G4HepEmElectr
                                    adept::MParray *relocatingQueue, adept::MParray *leakedQueue, Scoring *userScoring,
                                    const bool returnAllSteps, const bool returnLastStep)
 {
-  constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
-  int activeSize                    = relocatingQueue->size();
+  constexpr double kPushDistance = 1000 * vecgeom::kTolerance;
+  int activeSize                 = relocatingQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot           = (*relocatingQueue)[i];
     SlotManager &slotManager = IsElectron ? *secondaries.electrons.fSlotManager : *secondaries.positrons.fSlotManager;
@@ -708,7 +708,7 @@ __device__ __forceinline__ void PerformStoppedAnnihilation(const int slot, Track
       RanluxppDouble newRNG(currentTrack.rngState.Branch());
 
       Track &gamma1 = secondaries.gammas.NextTrack(newRNG, double{copcore::units::kElectronMassC2}, currentTrack.pos,
-                                                   vecgeom::Vector3D<Precision>{sint * cosPhi, sint * sinPhi, cost},
+                                                   vecgeom::Vector3D<double>{sint * cosPhi, sint * sinPhi, cost},
                                                    currentTrack.navState, currentTrack, currentTrack.globalTime);
 
       // Reuse the RNG state of the dying track.
@@ -825,10 +825,10 @@ __global__ void ElectronIonization(Track *electrons, G4HepEmElectronTrack *hepEM
       energyDeposit += deltaEkin;
 
     } else {
-      Track &secondary = secondaries.electrons.NextTrack(
-          newRNG, deltaEkin, currentTrack.pos,
-          vecgeom::Vector3D<Precision>{dirSecondary[0], dirSecondary[1], dirSecondary[2]}, currentTrack.navState,
-          currentTrack, currentTrack.globalTime);
+      Track &secondary =
+          secondaries.electrons.NextTrack(newRNG, deltaEkin, currentTrack.pos,
+                                          vecgeom::Vector3D<double>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
+                                          currentTrack.navState, currentTrack, currentTrack.globalTime);
 
       // if tracking or stepping action is called, return initial step
       if (returnLastStep) {
@@ -964,7 +964,7 @@ __global__ void ElectronBremsstrahlung(Track *electrons, G4HepEmElectronTrack *h
     } else {
       Track &gamma =
           secondaries.gammas.NextTrack(newRNG, deltaEkin, currentTrack.pos,
-                                       vecgeom::Vector3D<Precision>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
+                                       vecgeom::Vector3D<double>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
                                        currentTrack.navState, currentTrack, currentTrack.globalTime);
       // if tracking or stepping action is called, return initial step
       if (returnLastStep) {
@@ -1096,7 +1096,7 @@ __global__ void PositronAnnihilation(Track *electrons, G4HepEmElectronTrack *hep
     } else {
       Track &gamma1 =
           secondaries.gammas.NextTrack(newRNG, theGamma1Ekin, currentTrack.pos,
-                                       vecgeom::Vector3D<Precision>{theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]},
+                                       vecgeom::Vector3D<double>{theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]},
                                        currentTrack.navState, currentTrack, currentTrack.globalTime);
       // if tracking or stepping action is called, return initial step
       if (returnLastStep) {
@@ -1128,7 +1128,7 @@ __global__ void PositronAnnihilation(Track *electrons, G4HepEmElectronTrack *hep
     } else {
       Track &gamma2 =
           secondaries.gammas.NextTrack(currentTrack.rngState, theGamma2Ekin, currentTrack.pos,
-                                       vecgeom::Vector3D<Precision>{theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]},
+                                       vecgeom::Vector3D<double>{theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]},
                                        currentTrack.navState, currentTrack, currentTrack.globalTime);
       // if tracking or stepping action is called, return initial step
       if (returnLastStep) {

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -30,7 +30,7 @@ __global__ void __launch_bounds__(256, 1)
                     Stats *InFlightStats, AllowFinishOffEventArray allowFinishOffEvent, const bool returnAllSteps,
                     const bool returnLastStep)
 {
-  constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
+  constexpr double kPushDistance    = 1000 * vecgeom::kTolerance;
   constexpr unsigned short maxSteps = 10'000;
   int activeSize                    = active->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
@@ -51,7 +51,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
   using namespace adept_impl;
   constexpr bool returnAllSteps     = false;
   constexpr bool returnLastStep     = false;
-  constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
+  constexpr double kPushDistance    = 1000 * vecgeom::kTolerance;
   constexpr unsigned short maxSteps = 10'000;
   constexpr int Pdg                 = 22;
   int activeSize                    = gammas->fActiveTracks->size();
@@ -71,15 +71,15 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
     LeakStatus leakReason                    = LeakStatus::NoLeak;
     short stepDefinedProcessId               = 10; // default for transportation
     double edep                              = 0.;
-    constexpr Precision kPushStuck           = 100 * vecgeom::kTolerance;
+    constexpr double kPushStuck              = 100 * vecgeom::kTolerance;
     constexpr unsigned short kStepsStuckPush = 5;
     constexpr unsigned short kStepsStuckKill = 25;
     auto eKin                                = currentTrack.eKin;
     auto preStepEnergy                       = eKin;
     auto pos                                 = currentTrack.pos;
-    vecgeom::Vector3D<Precision> preStepPos(pos);
+    vecgeom::Vector3D<double> preStepPos(pos);
     auto dir = currentTrack.dir;
-    vecgeom::Vector3D<Precision> preStepDir(dir);
+    vecgeom::Vector3D<double> preStepDir(dir);
     double globalTime        = currentTrack.globalTime;
     double preStepGlobalTime = currentTrack.globalTime;
     double localTime         = currentTrack.localTime;
@@ -88,7 +88,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
     // the MCC vector is indexed by the logical volume id
 
     currentTrack.stepCounter++;
-    bool printErrors = false;
+    bool printErrors = true;
 #if ADEPT_DEBUG_TRACK > 0
     bool verbose = false;
     if (gTrackDebug.active) {
@@ -322,7 +322,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
 #ifdef ASYNC_MODE
           Track &electron = secondaries.electrons.NextTrack(
               newRNG, elKinEnergy, pos,
-              vecgeom::Vector3D<Precision>{dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]}, navState,
+              vecgeom::Vector3D<double>{dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]}, navState,
               currentTrack, globalTime);
 #else
           Track &electron = secondaries.electrons->NextTrack();
@@ -366,7 +366,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
 #ifdef ASYNC_MODE
           Track &positron = secondaries.positrons.NextTrack(
               currentTrack.rngState, posKinEnergy, pos,
-              vecgeom::Vector3D<Precision>{dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]}, navState,
+              vecgeom::Vector3D<double>{dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]}, navState,
               currentTrack, globalTime);
 #else
           Track &positron = secondaries.positrons->NextTrack();
@@ -511,7 +511,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
           // Create a secondary electron and sample directions.
 #ifdef ASYNC_MODE
           Track &electron = secondaries.electrons.NextTrack(
-              newRNG, photoElecE, pos, vecgeom::Vector3D<Precision>{dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]},
+              newRNG, photoElecE, pos, vecgeom::Vector3D<double>{dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]},
               navState, currentTrack, globalTime);
 #else
           Track &electron = secondaries.electrons->NextTrack();

--- a/include/AdePT/kernels/gammas_async.cuh
+++ b/include/AdePT/kernels/gammas_async.cuh
@@ -26,14 +26,10 @@ __global__ void __launch_bounds__(256, 1)
     TransportGammas(Track *gammas, const adept::MParray *active, Secondaries secondaries, adept::MParray *activeQueue,
                     adept::MParray *leakedQueue, Scoring *userScoring, GammaInteractions gammaInteractions)
 {
-  using VolAuxData = adeptint::VolAuxData;
-#ifdef VECGEOM_FLOAT_PRECISION
-  constexpr Precision kPush = 10 * vecgeom::kTolerance;
-#else
-  constexpr Precision kPush = 0.;
-#endif
-  constexpr Precision kPushOutRegion = 10 * vecgeom::kTolerance;
-  const int activeSize               = active->size();
+  using VolAuxData                = adeptint::VolAuxData;
+  constexpr double kPush          = 0.;
+  constexpr double kPushOutRegion = 10 * vecgeom::kTolerance;
+  const int activeSize            = active->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot           = (*active)[i];
     Track &currentTrack      = gammas[slot];
@@ -216,12 +212,12 @@ __global__ void __launch_bounds__(256, 1)
 
         secondaries.electrons.NextTrack(
             newRNG, elKinEnergy, currentTrack.pos,
-            vecgeom::Vector3D<Precision>{dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]},
-            currentTrack.navState, currentTrack);
+            vecgeom::Vector3D<double>{dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]}, currentTrack.navState,
+            currentTrack);
         // Reuse the RNG state of the dying track.
         secondaries.positrons.NextTrack(
             currentTrack.rngState, posKinEnergy, currentTrack.pos,
-            vecgeom::Vector3D<Precision>{dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]},
+            vecgeom::Vector3D<double>{dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]},
             currentTrack.navState, currentTrack);
 
         // Kill the original track.
@@ -320,10 +316,9 @@ __global__ void __launch_bounds__(256, 1)
           double dirPhotoElec[3];
           G4HepEmGammaInteractionPhotoelectric::SamplePhotoElectronDirection(photoElecE, dirGamma, dirPhotoElec, &rnge);
 
-          secondaries.electrons.NextTrack(
-              newRNG, photoElecE, currentTrack.pos,
-              vecgeom::Vector3D<Precision>{dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]}, currentTrack.navState,
-              currentTrack);
+          secondaries.electrons.NextTrack(newRNG, photoElecE, currentTrack.pos,
+                                          vecgeom::Vector3D<double>{dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]},
+                                          currentTrack.navState, currentTrack);
         } else {
           edep = eKin;
         }

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -107,8 +107,8 @@ __global__ void GammaHowFar(Track *gammas, Track *leaks, G4HepEmGammaTrack *hepE
 
 __global__ void GammaPropagation(Track *gammas, G4HepEmGammaTrack *hepEMTracks, const adept::MParray *active)
 {
-  constexpr Precision kPushDistance        = 1000 * vecgeom::kTolerance;
-  constexpr Precision kPushStuck           = 100 * vecgeom::kTolerance;
+  constexpr double kPushDistance           = 1000 * vecgeom::kTolerance;
+  constexpr double kPushStuck              = 100 * vecgeom::kTolerance;
   constexpr unsigned short kStepsStuckPush = 5;
 
   int activeSize = active->size();
@@ -232,8 +232,8 @@ __global__ void GammaRelocation(Track *gammas, Track *leaks, G4HepEmGammaTrack *
                                 adept::MParray *leakedQueue, Scoring *userScoring, const bool returnAllSteps,
                                 const bool returnLastStep)
 {
-  constexpr Precision kPushDistance = 1000 * vecgeom::kTolerance;
-  int activeSize                    = relocatingQueue->size();
+  constexpr double kPushDistance = 1000 * vecgeom::kTolerance;
+  int activeSize                 = relocatingQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot      = (*relocatingQueue)[i];
     auto &slotManager   = *secondaries.gammas.fSlotManager;
@@ -423,7 +423,7 @@ __global__ void GammaConversion(Track *gammas, G4HepEmGammaTrack *hepEMTracks, S
     } else {
       Track &electron = secondaries.electrons.NextTrack(
           newRNG, elKinEnergy, currentTrack.pos,
-          vecgeom::Vector3D<Precision>{dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]}, currentTrack.navState,
+          vecgeom::Vector3D<double>{dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]}, currentTrack.navState,
           currentTrack, currentTrack.globalTime);
 
       // if tracking or stepping action is called, return initial step
@@ -457,8 +457,8 @@ __global__ void GammaConversion(Track *gammas, G4HepEmGammaTrack *hepEMTracks, S
     } else {
       Track &positron = secondaries.positrons.NextTrack(
           currentTrack.rngState, posKinEnergy, currentTrack.pos,
-          vecgeom::Vector3D<Precision>{dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]},
-          currentTrack.navState, currentTrack, currentTrack.globalTime);
+          vecgeom::Vector3D<double>{dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]}, currentTrack.navState,
+          currentTrack, currentTrack.globalTime);
 
       // if tracking or stepping action is called, return initial step
       if (returnLastStep) {
@@ -713,10 +713,10 @@ __global__ void GammaPhotoelectric(Track *gammas, G4HepEmGammaTrack *hepEMTracks
       G4HepEmGammaInteractionPhotoelectric::SamplePhotoElectronDirection(photoElecE, dirGamma, dirPhotoElec, &rnge);
 
       // Create a secondary electron and sample directions.
-      Track &electron = secondaries.electrons.NextTrack(
-          newRNG, photoElecE, currentTrack.pos,
-          vecgeom::Vector3D<Precision>{dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]}, currentTrack.navState,
-          currentTrack, currentTrack.globalTime);
+      Track &electron =
+          secondaries.electrons.NextTrack(newRNG, photoElecE, currentTrack.pos,
+                                          vecgeom::Vector3D<double>{dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]},
+                                          currentTrack.navState, currentTrack, currentTrack.globalTime);
 
       // if tracking or stepping action is called, return initial step
       if (returnLastStep) {

--- a/include/AdePT/magneticfield/CompareResponses.h
+++ b/include/AdePT/magneticfield/CompareResponses.h
@@ -9,19 +9,19 @@
 #include <VecGeom/base/Vector3D.h>
 
 static __device__ __host__ bool CompareResponseVector3D(
-    int id, vecgeom::Vector3D<Precision> const &originalVec, vecgeom::Vector3D<Precision> const &baselineVec,
-    vecgeom::Vector3D<Precision> const &resultVec, // Output of new method
+    int id, vecgeom::Vector3D<double> const &originalVec, vecgeom::Vector3D<double> const &baselineVec,
+    vecgeom::Vector3D<double> const &resultVec, // Output of new method
     const char *vecName,
-    Precision thresholdRel // fraction difference allowed
+    double thresholdRel // fraction difference allowed
 )
 // Returns 'true' if values are 'bad'...
 {
-  bool bad                              = false; // Good ..
-  Precision magOrig                     = originalVec.Mag();
-  vecgeom::Vector3D<Precision> moveBase = baselineVec - originalVec;
-  vecgeom::Vector3D<Precision> moveRes  = resultVec - originalVec;
-  Precision magMoveBase                 = moveBase.Mag();
-  Precision magDiffRes                  = moveRes.Mag();
+  bool bad                           = false; // Good ..
+  double magOrig                     = originalVec.Mag();
+  vecgeom::Vector3D<double> moveBase = baselineVec - originalVec;
+  vecgeom::Vector3D<double> moveRes  = resultVec - originalVec;
+  double magMoveBase                 = moveBase.Mag();
+  double magDiffRes                  = moveRes.Mag();
 
   if (std::fabs(magDiffRes / magMoveBase) - 1.0 > thresholdRel ||
       (resultVec - baselineVec).Mag() > thresholdRel * magMoveBase) {
@@ -42,9 +42,8 @@ static __device__ __host__ bool CompareResponseVector3D(
   return bad;
 };
 
-static __device__ __host__ void ReportSameMoveVector3D(int id, vecgeom::Vector3D<Precision> const &originalVec,
-                                                       vecgeom::Vector3D<Precision> const &resultVec,
-                                                       const char *vecName)
+static __device__ __host__ void ReportSameMoveVector3D(int id, vecgeom::Vector3D<double> const &originalVec,
+                                                       vecgeom::Vector3D<double> const &resultVec, const char *vecName)
 {
   printf(" id %3d - Same %s: "
          " mv/base: 3v= %14.9f %14.9f %14.9f (mag= %9.4g)"

--- a/include/AdePT/magneticfield/ConstBzFieldStepper.h
+++ b/include/AdePT/magneticfield/ConstBzFieldStepper.h
@@ -26,18 +26,17 @@
  * This class is roughly equivalent to TGeoHelix in ROOT
  */
 class ConstBzFieldStepper {
-  using Precision = vecgeom::Precision;
 
 private:
-  Precision fBz;
+  double fBz;
 
 public:
   __host__ __device__ ConstBzFieldStepper(float Bz = 0.) : fBz(Bz) {}
 
-  void SetBz(Precision Bz) { fBz = Bz; }
-  Precision GetBz() const { return fBz; }
+  void SetBz(double Bz) { fBz = Bz; }
+  double GetBz() const { return fBz; }
 
-  // static constexpr Precision kB2C =
+  // static constexpr double kB2C =
   //    -0.299792458 * (copcore::units::GeV / (copcore::units::tesla * copcore::units::meter));
 
   /*
@@ -90,7 +89,7 @@ inline __attribute__((always_inline)) void ConstBzFieldStepper::DoStep(
     BaseDType const &dz0, BaseIType const &charge, BaseDType const &momentum, BaseDType const &step, BaseDType &x,
     BaseDType &y, BaseDType &z, BaseDType &dx, BaseDType &dy, BaseDType &dz) const
 {
-  const Precision kSmall = 1.E-30;
+  const double kSmall = 1.E-30;
   // could do a fast square root here
   BaseDType dt      = sqrt((dx0 * dx0) + (dy0 * dy0)) + kSmall;
   BaseDType invnorm = 1. / dt;

--- a/include/AdePT/magneticfield/ConstFieldHelixStepper.h
+++ b/include/AdePT/magneticfield/ConstFieldHelixStepper.h
@@ -24,7 +24,6 @@
  *   ( not just along the z-axis-- for that there is ConstBzFieldHelixStepper )
  */
 class ConstFieldHelixStepper {
-  using Precision = vecgeom::Precision;
 
   template <typename T>
   using Vector3D = vecgeom::Vector3D<T>;
@@ -33,20 +32,20 @@ public:
   // __host__ __device__
   // ConstFieldHelixStepper(); // For default initialisation only
 
-  __host__ __device__ ConstFieldHelixStepper(Precision Bx, Precision By, Precision Bz);
+  __host__ __device__ ConstFieldHelixStepper(double Bx, double By, double Bz);
 
-  __host__ __device__ ConstFieldHelixStepper(Precision Bfield[3]);
+  __host__ __device__ ConstFieldHelixStepper(double Bfield[3]);
 
-  __host__ __device__ ConstFieldHelixStepper(Vector3D<Precision> const &Bfield);
+  __host__ __device__ ConstFieldHelixStepper(Vector3D<double> const &Bfield);
 
-  void __host__ __device__ SetB(Precision Bx, Precision By, Precision Bz)
+  void __host__ __device__ SetB(double Bx, double By, double Bz)
   {
     // fB.Set(Bx, By, Bz);
-    Vector3D<Precision> Bfield(Bx, By, Bz);
+    Vector3D<double> Bfield(Bx, By, Bz);
     CalculateDerived(Bfield);
   }
 
-  __host__ __device__ Vector3D<Precision> const GetFieldVec() const { return fBmag * fUnit; }
+  __host__ __device__ Vector3D<double> const GetFieldVec() const { return fBmag * fUnit; }
 
   /*
   template<typename RT, typename Vector3D>
@@ -86,39 +85,39 @@ public:
                  vecgeom::Vector3D<Real_t> &endPosition, vecgeom::Vector3D<Real_t> &endDirection) const;
 
 protected:
-  inline __host__ __device__ void CalculateDerived(Vector3D<Precision> Bvec);
+  inline __host__ __device__ void CalculateDerived(Vector3D<double> Bvec);
 
   template <typename Real_t>
   inline __host__ __device__ bool CheckModulus(Real_t &newdirX_v, Real_t &newdirY_v, Real_t &newdirZ_v) const;
 
 private:
   // Values below used for speed, code simplicity
-  Vector3D<Precision> fUnit{1, 0, 0}; // direction
-  Precision fBmag = 0;                // magnitude
+  Vector3D<double> fUnit{1, 0, 0}; // direction
+  double fBmag = 0;                // magnitude
 
 }; // end class declaration
 
-inline __host__ __device__ void ConstFieldHelixStepper::CalculateDerived(Vector3D<Precision> Bvec)
+inline __host__ __device__ void ConstFieldHelixStepper::CalculateDerived(Vector3D<double> Bvec)
 {
-  fBmag             = Bvec.Mag();
-  Precision bMagInv = (1 / fBmag);
-  fUnit             = {1, 0, 0};
+  fBmag          = Bvec.Mag();
+  double bMagInv = (1 / fBmag);
+  fUnit          = {1, 0, 0};
   if (fBmag > 0) fUnit = bMagInv * Bvec;
 }
 
-inline __host__ __device__ ConstFieldHelixStepper::ConstFieldHelixStepper(Precision Bx, Precision By,
-                                                                          Precision Bz) // : fB(Bx, By, gBz)
+inline __host__ __device__ ConstFieldHelixStepper::ConstFieldHelixStepper(double Bx, double By,
+                                                                          double Bz) // : fB(Bx, By, gBz)
 {
   CalculateDerived({Bx, By, Bz});
 }
 
-inline __host__ __device__ ConstFieldHelixStepper::ConstFieldHelixStepper(Precision B[3]) // : fB(B[0], B[1], B[2])
+inline __host__ __device__ ConstFieldHelixStepper::ConstFieldHelixStepper(double B[3]) // : fB(B[0], B[1], B[2])
 {
   CalculateDerived({B[0], B[1], B[2]});
 }
 
 inline __host__ __device__
-ConstFieldHelixStepper::ConstFieldHelixStepper(Vector3D<Precision> const &Bfield) // : fB(Bfield)
+ConstFieldHelixStepper::ConstFieldHelixStepper(Vector3D<double> const &Bfield) // : fB(Bfield)
 {
   CalculateDerived(Bfield);
 }
@@ -219,7 +218,7 @@ inline __host__ __device__ void ConstFieldHelixStepper::DoStep(vecgeom::Vector3D
 template <typename Real_t>
 bool ConstFieldHelixStepper::CheckModulus(Real_t &newdirX_v, Real_t &newdirY_v, Real_t &newdirZ_v) const
 {
-  constexpr Precision perMillion = 1.0e-6;
+  constexpr double perMillion = 1.0e-6;
 
   Real_t modulusDir = newdirX_v * newdirX_v + newdirY_v * newdirY_v + newdirZ_v * newdirZ_v;
   typename vecCore::Mask<Real_t> goodDir;

--- a/include/AdePT/magneticfield/fieldPropagatorConstBany.h
+++ b/include/AdePT/magneticfield/fieldPropagatorConstBany.h
@@ -12,31 +12,29 @@
 #include <AdePT/magneticfield/ConstFieldHelixStepper.h>
 
 class fieldPropagatorConstBany {
-  using Precision = vecgeom::Precision;
 
 public:
   inline __host__ __device__ void stepInField(ConstFieldHelixStepper &helixAnyB, double kinE, double mass, int charge,
-                                              Precision step, vecgeom::Vector3D<vecgeom::Precision> &position,
-                                              vecgeom::Vector3D<vecgeom::Precision> &direction);
+                                              double step, vecgeom::Vector3D<vecgeom::double> &position,
+                                              vecgeom::Vector3D<vecgeom::double> &direction);
 };
 
 // ----------------------------------------------------------------------------
 
 inline __host__ __device__ void fieldPropagatorConstBany::stepInField(ConstFieldHelixStepper &helixAnyB, double kinE,
-                                                                      double mass, int charge, Precision step,
-                                                                      vecgeom::Vector3D<vecgeom::Precision> &position,
-                                                                      vecgeom::Vector3D<vecgeom::Precision> &direction)
+                                                                      double mass, int charge, double step,
+                                                                      vecgeom::Vector3D<vecgeom::double> &position,
+                                                                      vecgeom::Vector3D<vecgeom::double> &direction)
 {
-  using Precision = vecgeom::Precision;
   if (charge != 0) {
-    Precision momentumMag = sqrt(kinE * (kinE + 2.0 * mass));
+    double momentumMag = sqrt(kinE * (kinE + 2.0 * mass));
 
     // For now all particles ( e-, e+, gamma ) can be propagated using this
     //   for gammas  charge = 0 works, and ensures that it goes straight.
 
-    vecgeom::Vector3D<Precision> endPosition  = position;
-    vecgeom::Vector3D<Precision> endDirection = direction;
-    helixAnyB.DoStep<Precision, int>(position, direction, charge, momentumMag, step, endPosition, endDirection);
+    vecgeom::Vector3D<double> endPosition  = position;
+    vecgeom::Vector3D<double> endDirection = direction;
+    helixAnyB.DoStep<double, int>(position, direction, charge, momentumMag, step, endPosition, endDirection);
     position  = endPosition;
     direction = endDirection;
   } else {

--- a/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
+++ b/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
@@ -59,13 +59,8 @@ public:
 protected:
   static constexpr unsigned int fMaxTrials = 100;
   static constexpr unsigned int Nvar       = 6; // For position (3) and momentum (3) -- invariant
-
-#ifdef VECGEOM_FLOAT_PRECISION
-  static constexpr Real_t kPush = 10 * vecgeom::kTolerance;
-#else
-  static constexpr Real_t kPush = 0.;
-#endif
-  static constexpr Real_t kDistCheckPush = kPush + Navigator::kBoundaryPush;
+  static constexpr Real_t kPush            = 0.;
+  static constexpr Real_t kDistCheckPush   = kPush + Navigator::kBoundaryPush;
   // Cannot change the energy (or momentum magnitude) -- currently usable only for pure magnetic fields
 };
 
@@ -161,8 +156,8 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
   //  Locate the intersection of the curved trajectory and the boundaries of the current
   //    volume (including daughters).
   do {
-    static constexpr Precision ReduceFactor = 0.1; ///< Factor to reduce the first step in case of crossing
-    static constexpr int ReduceIters        = 6;   ///< Number of reduced step trials to move away from the boundary
+    static constexpr Real_t ReduceFactor = 0.1; ///< Factor to reduce the first step in case of crossing
+    static constexpr int ReduceIters     = 6;   ///< Number of reduced step trials to move away from the boundary
 
     // Position and momentum at the end of the current arc
     vecgeom::Vector3D<double> endPosition    = position;
@@ -186,7 +181,7 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
     endDirection.Normalize();
 
     // Subtract from the existing safety after the move
-    Precision currentSafety = safety - (endPosition - safetyOrigin).Length();
+    Real_t currentSafety = safety - (endPosition - safetyOrigin).Length();
 #if ADEPT_DEBUG_TRACK > 0
     if (verbose) {
       if (chordIters > 0)

--- a/include/AdePT/navigation/SurfNavigator.h
+++ b/include/AdePT/navigation/SurfNavigator.h
@@ -26,12 +26,11 @@ template <typename Real_t>
 class SurfNavigator {
 
 public:
-  using Precision = vecgeom::Precision;
-  using Vector3D  = vecgeom::Vector3D<vecgeom::Precision>;
-  using SurfData  = vgbrep::SurfData<Real_t>;
-  using Real_b    = typename SurfData::Real_b;
+  using Vector3D = vecgeom::Vector3D<vecgeom::double>;
+  using SurfData = vgbrep::SurfData<Real_t>;
+  using Real_b   = typename SurfData::Real_b;
 
-  static constexpr Precision kBoundaryPush = 10 * vecgeom::kTolerance;
+  static constexpr double kBoundaryPush = 10 * vecgeom::kTolerance;
 
   /// @brief Locates the point in the geometry volume tree
   /// @param pvol_id Placed volume id to be checked first
@@ -51,8 +50,8 @@ public:
   /// @param state Path where to compute safety
   /// @param limit Limit to which safety should be computed accurately
   /// @return Isotropic safe distance
-  __host__ __device__ static Precision ComputeSafety(Vector3D const &globalpoint, vecgeom::NavigationState const &state,
-                                                     Precision limit = vecgeom::InfinityLength<Real_t>())
+  __host__ __device__ static double ComputeSafety(Vector3D const &globalpoint, vecgeom::NavigationState const &state,
+                                                  double limit = vecgeom::InfinityLength<Real_t>())
   {
     auto safety = vgbrep::protonav::BVHSurfNavigator<Real_t>::ComputeSafety(globalpoint, state, limit);
     return safety;
@@ -64,11 +63,11 @@ public:
   // the next volume.
   //
   // The surface model does automatic relocation, so this function does it as well.
-  __host__ __device__ static Precision ComputeStepAndNextVolume(Vector3D const &globalpoint, Vector3D const &globaldir,
-                                                                Precision step_limit,
-                                                                vecgeom::NavigationState const &in_state,
-                                                                vecgeom::NavigationState &out_state,
-                                                                long &hitsurf_index, Precision push = 0)
+  __host__ __device__ static double ComputeStepAndNextVolume(Vector3D const &globalpoint, Vector3D const &globaldir,
+                                                             double step_limit,
+                                                             vecgeom::NavigationState const &in_state,
+                                                             vecgeom::NavigationState &out_state, long &hitsurf_index,
+                                                             double push = 0)
   {
     if (step_limit <= 0) {
       in_state.CopyTo(&out_state);
@@ -85,11 +84,11 @@ public:
   // function calls out_state.SetBoundaryState(true) and relocates the state to
   // the next volume.
 
-  __host__ __device__ static Precision ComputeStepAndPropagatedState(Vector3D const &globalpoint,
-                                                                     Vector3D const &globaldir, Precision step_limit,
-                                                                     vecgeom::NavigationState const &in_state,
-                                                                     vecgeom::NavigationState &out_state,
-                                                                     long &hitsurf_index, Precision push = 0)
+  __host__ __device__ static double ComputeStepAndPropagatedState(Vector3D const &globalpoint,
+                                                                  Vector3D const &globaldir, double step_limit,
+                                                                  vecgeom::NavigationState const &in_state,
+                                                                  vecgeom::NavigationState &out_state,
+                                                                  long &hitsurf_index, double push = 0)
   {
     return ComputeStepAndNextVolume(globalpoint, globaldir, step_limit, in_state, out_state, hitsurf_index, push);
   }
@@ -100,8 +99,8 @@ public:
                                                        long hitsurf_index, vecgeom::NavigationState &out_state)
   {
     vgbrep::CrossedSurface crossed_surf;
-    vgbrep::protonav::BVHSurfNavigator<Real_t>::RelocateToNextVolume(globalpoint, globaldir, Precision(0),
-                                                                     hitsurf_index, out_state, crossed_surf);
+    vgbrep::protonav::BVHSurfNavigator<Real_t>::RelocateToNextVolume(globalpoint, globaldir, double(0), hitsurf_index,
+                                                                     out_state, crossed_surf);
   }
 };
 

--- a/test/unit/testField/gammas.cu
+++ b/test/unit/testField/gammas.cu
@@ -23,12 +23,8 @@ __global__ void TransportGammas(Track *gammas, const adept::MParray *active, Sec
                                 adept::MParray *activeQueue, GlobalScoring *globalScoring,
                                 ScoringPerVolume *scoringPerVolume)
 {
-#ifdef VECGEOM_FLOAT_PRECISION
-  const Precision kPush = 10 * vecgeom::kTolerance;
-#else
-  const Precision kPush = 0.;
-#endif
-  int activeSize = active->size();
+  const double kPush = 0.;
+  int activeSize     = active->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot      = (*active)[i];
     Track &currentTrack = gammas[slot];

--- a/test/unit/testField/testField.cu
+++ b/test/unit/testField/testField.cu
@@ -132,9 +132,9 @@ __global__ void InitPrimaries(ParticleGenerator generator, int startEvent, int n
       // simulate.
       const double phi = 2. * M_PI * track.rngState.Rndm();
       const double eta = -5. + 10. * track.rngState.Rndm();
-      track.dir.x()    = static_cast<vecgeom::Precision>(cos(phi) / cosh(eta));
-      track.dir.y()    = static_cast<vecgeom::Precision>(sin(phi) / cosh(eta));
-      track.dir.z()    = static_cast<vecgeom::Precision>(tanh(eta));
+      track.dir.x()    = static_cast<double>(cos(phi) / cosh(eta));
+      track.dir.y()    = static_cast<double>(sin(phi) / cosh(eta));
+      track.dir.z()    = static_cast<double>(tanh(eta));
     } else {
       track.dir = {1.0, 0, 0};
     }

--- a/test/unit/testField/testField.cuh
+++ b/test/unit/testField/testField.cuh
@@ -20,7 +20,6 @@
 // A data structure to represent a particle track. The particle type is implicit
 // by the queue and not stored in memory.
 struct Track {
-  using Precision = vecgeom::Precision;
   RanluxppDouble rngState;
   double energy;
   double numIALeft[3];
@@ -28,13 +27,13 @@ struct Track {
   double dynamicRangeFactor;
   double tlimitMin;
 
-  vecgeom::Vector3D<Precision> pos;
-  vecgeom::Vector3D<Precision> dir;
+  vecgeom::Vector3D<double> pos;
+  vecgeom::Vector3D<double> dir;
   vecgeom::NavigationState navState;
 
   __host__ __device__ double Uniform() { return rngState.Rndm(); }
 
-  __host__ __device__ void InitAsSecondary(const vecgeom::Vector3D<Precision> &parentPos,
+  __host__ __device__ void InitAsSecondary(const vecgeom::Vector3D<double> &parentPos,
                                            const vecgeom::NavigationState &parentNavState)
   {
     // The caller is responsible to branch a new RNG state and to set the energy.

--- a/test/unit/test_Bfield_step_debugger.cpp
+++ b/test/unit/test_Bfield_step_debugger.cpp
@@ -23,8 +23,8 @@ template <typename T>
 using Vector3D = vecgeom::Vector3D<T>;
 
 using Equation_t = MagneticFieldEquation<Field_t>;
-using Stepper_t  = DormandPrinceRK45<Equation_t, Field_t, 6, vecgeom::Precision>;
-using RkDriver_t = RkIntegrationDriver<Stepper_t, vecgeom::Precision, int, Equation_t, Field_t>;
+using Stepper_t  = DormandPrinceRK45<Equation_t, Field_t, 6, double>;
+using RkDriver_t = RkIntegrationDriver<Stepper_t, double, int, Equation_t, Field_t>;
 
 #include <iostream>
 


### PR DESCRIPTION
Drop the usage of VECGEOM_FLOAT_PRECISION (Precision=float) and replace Precision<->double.

This prepares for the `v2` release of VecGeom where `Precision` lives only in `vecgeom` namespace and will break the compilation of AdePT. The change of Precision->double will preserve the capability to run also with older VecGeom. VECGEOM_FLOAT_PRECISION was an experimental feature known to have big limitations for realistic setups anyway.