### PR TITLE
Fix for the surface model in the field propagator

### DIFF
--- a/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
+++ b/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
@@ -346,7 +346,7 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
   itersDone += chordIters;
   // If the track is not exiting the current volume, reset next_state.fLastExited because it may re-enter the same
   // volume
-  if (next_state.GetLastExited() == current_state.GetLastExited()) next_state.SetLastExited();
+  if (next_state.GetLastExitedState() == current_state.GetLastExitedState()) next_state.SetLastExited();
 
   return stepDone;
 }

--- a/include/AdePT/navigation/SurfNavigator.h
+++ b/include/AdePT/navigation/SurfNavigator.h
@@ -26,7 +26,7 @@ template <typename Real_t>
 class SurfNavigator {
 
 public:
-  using Vector3D = vecgeom::Vector3D<vecgeom::double>;
+  using Vector3D = vecgeom::Vector3D<double>;
   using SurfData = vgbrep::SurfData<Real_t>;
   using Real_b   = typename SurfData::Real_b;
 


### PR DESCRIPTION
The field propagator uses the `GetLastExited()` method from the navigation state. This doesn't work with the surface model as this method returns a PlacedVolume. With this fix the correct method is called, which also avoids a different call for solids and surfaces.