### PR TITLE
Removed leftover setting of last exited state affecting relocation.

### DIFF
--- a/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
+++ b/include/AdePT/magneticfield/fieldPropagatorRungeKutta.h
@@ -344,9 +344,6 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
 
   propagated = found_end;
   itersDone += chordIters;
-  // If the track is not exiting the current volume, reset next_state.fLastExited because it may re-enter the same
-  // volume
-  if (next_state.GetLastExitedState() == current_state.GetLastExitedState()) next_state.SetLastExited();
 
   return stepDone;
 }


### PR DESCRIPTION
This removes a line probably left over during back-scattering debugging. I see no more stuck electrons in EMEC in a small test.