### PR TITLE
[mini] use correct type to avoid compiler warning

### DIFF
--- a/examples/AsyncExample/include/SensitiveDetector.hh
+++ b/examples/AsyncExample/include/SensitiveDetector.hh
@@ -70,7 +70,7 @@ private:
   /// ID of collection of hits
   G4int fHitCollectionID = -1;
   /// Number of sensitive detectors
-  G4int fNumSensitive{0};
+  std::size_t fNumSensitive{0};
 };
 
 #endif /* SENSITIVEDETECTOR_HH */

--- a/examples/AsyncExample/src/SensitiveDetector.cc
+++ b/examples/AsyncExample/src/SensitiveDetector.cc
@@ -88,7 +88,7 @@ G4bool SensitiveDetector::ProcessHits(G4Step *aStep, G4TouchableHistory *)
 
 SimpleHit *SensitiveDetector::RetrieveAndSetupHit(std::size_t hitID)
 {
-  assert(hitID < static_cast<std::size_t>(fNumSensitive));
+  assert(hitID < fNumSensitive);
 
   if (hitID >= fHitsCollection->entries()) {
     G4Exception("SensitiveDetector::RetrieveAndSetupHit()", "InvalidSetup", FatalException,

--- a/examples/Example1/include/SensitiveDetector.hh
+++ b/examples/Example1/include/SensitiveDetector.hh
@@ -70,7 +70,7 @@ private:
   /// ID of collection of hits
   G4int fHitCollectionID = -1;
   /// Number of sensitive detectors
-  G4int fNumSensitive{0};
+  std::size_t fNumSensitive{0};
 };
 
 #endif /* SENSITIVEDETECTOR_HH */

--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -102,7 +102,6 @@ private:
   int fNthreads{0};                                    ///< Number of cpu threads
   int fMaxBatch{0};                                    ///< Max batch size for allocating GPU memory
   int fNumVolumes{0};                                  ///< Total number of active logical volumes
-  int fNumSensitive{0};                                ///< Total number of sensitive volumes
   size_t fBufferThreshold{20};                         ///< Buffer threshold for flushing AdePT transport buffer
   int fDebugLevel{1};                                  ///< Debug level
   int fCUDAStackLimit{0};                              ///< CUDA device stack limit

--- a/test/regression/IntegrationTest/include/SensitiveDetector.hh
+++ b/test/regression/IntegrationTest/include/SensitiveDetector.hh
@@ -72,7 +72,7 @@ private:
   /// ID of collection of hits
   G4int fHitCollectionID = -1;
   /// Number of sensitive detectors
-  G4int fNumSensitive{0};
+  std::size_t fNumSensitive{0};
 };
 
 #endif /* SENSITIVEDETECTOR_HH */


### PR DESCRIPTION
This mini PR fixes the size of the fNumSensitive to be `size_t` instead of `G4int`, which fixes the compiler warning in debug mode:

```
AdePT/test/regression/IntegrationTest/src/SensitiveDetector.cc: In member function ‘SimpleHit* SensitiveDetector::RetrieveAndSetupHit(std::size_t)’:
/AdePT/test/regression/IntegrationTest/src/SensitiveDetector.cc:94:16: warning: comparison of integer expressions of different signedness: ‘std::size_t’ {aka ‘long unsigned int’} and ‘G4int’ {aka ‘int’} [-Wsign-compare]
   94 |   assert(hitID < fNumSensitive);
      |          ~~~~~~^~~~~~~~~~~~~~~
```