### PR TITLE
Fix setting of G4Touchable when giving track back to G4

### DIFF
--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -95,7 +95,8 @@ public:
 
 private:
   /// @brief Reconstruct G4TouchableHistory from a VecGeom Navigation index
-  void FillG4NavigationHistory(vecgeom::NavigationState aNavState, G4NavigationHistory &aG4NavigationHistory) const;
+  void FillG4NavigationHistory(const vecgeom::NavigationState &aNavState,
+                               G4NavigationHistory &aG4NavigationHistory) const;
 
   void FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step, G4TouchableHandle &aPreG4TouchableHandle,
                   G4TouchableHandle &aPostG4TouchableHandle, G4StepStatus aPreStepStatus, G4StepStatus aPostStepStatus,

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -332,8 +332,11 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
     fHepEmTrackingManager->SetFinishEventOnCPU(threadId, eventID);
   }
 
-  // setup touchable to be able to get region from GetNextVolume
-  steppingManager->SetInitialStep(aTrack);
+  // If this is the first step, set touchable and next touchable via SetInitialStep
+  // All other tracks should have a current and next touchable being set
+  if (aTrack->GetCurrentStepNumber() == 0) {
+    steppingManager->SetInitialStep(aTrack);
+  }
 
   // Track the particle Step-by-Step while it is alive
   while ((aTrack->GetTrackStatus() == fAlive) || (aTrack->GetTrackStatus() == fStopButAlive)) {


### PR DESCRIPTION
This small PR fixes the handling of the G4Touchable when tracks are returned to G4. 
As the UserStackingAction might check on the Touchable or NextTouchable, they must be set before giving it back to G4. This caused a crash in CMSSW.

At the same time, previously, every step was located in G4 when given to AdePT via `SetInitialStep` (see https://gitlab.cern.ch/geant4/geant4/-/blob/master/source/tracking/src/G4SteppingManager.cc?ref_type=heads#L309-L326). Now, this is called only for initial Steps (`step number == 0`).

This change slightly improves performance for offloading only the HCAL and ECAL in example1 using the CMS2018 geometry. 

Also a minor cleaning was done: the `FillG4NavigationHistory` now receives a const reference instead of by value.