### PR TITLE
fix memory leak for data of UserTrackInfo

### DIFF
--- a/include/AdePT/integration/HostTrackDataMapper.hh
+++ b/include/AdePT/integration/HostTrackDataMapper.hh
@@ -161,7 +161,14 @@ public:
   {
     auto it = gpuToIndex.find(gpuId);
     if (it == gpuToIndex.end()) return; // already gone
-    int idx  = it->second;
+    int idx = it->second;
+
+    // As the data of the userTrackInfo is owned by AdePT, it has to be deleted here
+    if (hostDataVec[idx].userTrackInfo) {
+      delete hostDataVec[idx].userTrackInfo;
+      hostDataVec[idx].userTrackInfo = nullptr;
+    }
+
     int last = int(hostDataVec.size()) - 1;
 
     // unused g4 id


### PR DESCRIPTION
This PR fixes a memory leak with the G4UserTrackInfo in the HostTrackData:

When the track was given to AdePT, the G4UserTrackInfo pointer is set to null to avoid the deletion of the underlying data that AdePT still needs to access. However, that makes AdePT responsible for deleting the underlying data of the G4UserTrackInfo pointer. The deletion was missing and was added: Now, the data is deleted when the track is finished on GPU and the `removeTrack` of the HostTrackData is called. If the track is given back to CPU, the ownership of the data is transferred back to G4. In case of Gamma-nuclear, the leakedTrack can be deleted, as the gamma does not survive the process. Then, the underlying data also needs to be deleted, the pointer set to null and then, the track can be safely deleted to avoid double deletion.

Additional change: the `removeTrack` was called after the `PostUserTrackingAction` for a returned step that was flagged as the last step of a track, however, the `SensitiveDetector->Hit()` was called after. Thus, the `removeTrack` is moved to be called *after* the `SensitiveDetector->Hit()` is called.

This fixes a memory leak in CMSSW when MC truth is used.