### PR TITLE
[mini] remove passing of variables that are already captured

### DIFF
--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -153,7 +153,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     printErrors = !gTrackDebug.active || verbose;
 #endif
 
-    auto survive = [&](LeakStatus leakReason = LeakStatus::NoLeak) {
+    auto survive = [&]() {
       isLastStep              = false; // track survived, do not force return of step
       currentTrack.eKin       = eKin;
       currentTrack.pos        = pos;
@@ -533,7 +533,6 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
 #if ADEPT_DEBUG_TRACK > 0
         if (verbose) printf("| delta interaction\n");
 #endif
-        // survive();
         surviveFlag = true;
       } else {
         // Perform the discrete interaction, make sure the branched RNG state is
@@ -981,7 +980,7 @@ static __device__ __forceinline__ void TransportElectrons(adept::TrackManager<Tr
     __syncwarp(); // was found to be beneficial after divergent calls
 
     if (surviveFlag) {
-      survive(leakReason);
+      survive();
     } else {
       isLastStep = true;
       // particles that don't survive are killed by not enqueing them to the next queue and freeing the slot

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -91,7 +91,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
 #endif
 
     // Write local variables back into track and enqueue
-    auto survive = [&](LeakStatus leakReason = LeakStatus::NoLeak, bool enterWDTRegion = false) {
+    auto survive = [&]() {
       isLastStep = false; // set to false even for gamma nuclear, as the hostTrackData is deleted when invoking the
                           // reaction on CPU
       currentTrack.eKin       = eKin;
@@ -595,7 +595,7 @@ __global__ void TransportGammas(adept::TrackManager<Track> *gammas, Secondaries 
     __syncwarp();
 
     if (surviveFlag) {
-      survive(leakReason, enterWDTRegion);
+      survive();
     } else {
       isLastStep = true;
       // particles that don't survive are killed by not enqueing them to the next queue and freeing the slot

--- a/include/AdePT/kernels/gammasWDT.cuh
+++ b/include/AdePT/kernels/gammasWDT.cuh
@@ -65,6 +65,7 @@ __global__ void __launch_bounds__(256, 1)
 
     bool isLastStep       = returnLastStep;
     LeakStatus leakReason = LeakStatus::NoLeak;
+    bool leftWDTRegion    = false;
     // initialize nextState to current state
     vecgeom::NavigationState nextState = currentTrack.navState;
     double globalTime                  = currentTrack.globalTime;
@@ -74,7 +75,7 @@ __global__ void __launch_bounds__(256, 1)
     //
     // survive: decide whether to continue woodcock tracking or not:
     // Write local variables back into track and enqueue to correct queue
-    auto survive = [&](LeakStatus leakReason = LeakStatus::NoLeak, bool leftWDTRegion = false) {
+    auto survive = [&]() {
       isLastStep = false; // set to false even for gamma nuclear, as the hostTrackData is deleted when invoking the
                           // reaction on CPU
       currentTrack.eKin       = eKin;
@@ -354,7 +355,6 @@ __global__ void __launch_bounds__(256, 1)
 
     // helper variables needed for the processes
     bool surviveFlag           = false;
-    bool leftWDTRegion         = false;
     short stepDefinedProcessId = 10; // default for transportation
     double edep                = 0.;
     auto preStepEnergy         = eKin;
@@ -716,7 +716,7 @@ __global__ void __launch_bounds__(256, 1)
     }
 
     if (surviveFlag) {
-      survive(leakReason, leftWDTRegion);
+      survive();
     } else {
       isLastStep = true;
       // particles that don't survive are killed by not enqueing them to the next queue and freeing the slot


### PR DESCRIPTION
This small PR cleans the `survive` function in the monolithic kernels.

Variables were passed to `survive` but since it captures variables of the same name via `[&]` it was shadowing.
Before, it was functionally correct, but not clear. Now, just the captured variables are used.