### PR TITLE
Fix minor issues in ranluxpp

### DIFF
--- a/include/AdePT/copcore/Ranluxpp.h
+++ b/include/AdePT/copcore/Ranluxpp.h
@@ -126,8 +126,8 @@ public:
 
     n -= left;
     // Need to advance and possibly skip over blocks.
-    int nPerState = kMaxPos / w;
-    int skip      = (n / nPerState);
+    const uint64_t nPerState = static_cast<uint64_t>(kMaxPos / w);
+    const uint64_t skip      = n / nPerState;
 
     uint64_t a_skip[9];
     powermod(kA, a_skip, skip + 1);
@@ -138,7 +138,8 @@ public:
     to_ranlux(lcg, fState, fCarry);
 
     // Potentially skip numbers in the freshly generated block.
-    int remaining = n - skip * nPerState;
+    // 'remaining' is in [0, nPerState), so it safely fits in int.
+    const int remaining = static_cast<int>(n - skip * nPerState);
     assert(remaining >= 0 && "should not end up at a negative position!");
     fPosition = remaining * w;
     assert(fPosition <= kMaxPos && "position out of range!");

--- a/include/AdePT/copcore/ranluxpp/ranlux_lcg.h
+++ b/include/AdePT/copcore/ranluxpp/ranlux_lcg.h
@@ -76,6 +76,7 @@ __host__ __device__ static void to_ranlux(const uint64_t *lcg, uint64_t *ranlux,
     uint64_t ranlux_i = ranlux[i];
     ranlux_i          = add_overflow(ranlux_i, carry, carry);
     ranlux_i          = add_carry(ranlux_i, c1, carry);
+    ranlux[i]         = ranlux_i;
   }
 
   c_out = carry;


### PR DESCRIPTION
This small PR fixes two issues in Ranluxpp which were reported by clang-tidy via `clang-analyzer-deadcode.DeadStores` and `bugprone-implicit-widening-of-multiplication-result`:

1. the temporary variable `ranlux_i` was not writing back the results.
2. As the input of the skip method takes `uint64` there was an implicit widening in a multiplication reported. This is fixed by propagating uint64 until it is safe to cast back into int. This is the case because `remaining = n - skip * nPerState` with `skip      = n / nPerState` being an integer division, gives `remaining = n % nPerState`. As `nPerState` is smaller than int by definition, the cast back to int is safe.  