### PR TITLE
[mini] fix minor warnings found via clang-tidy

### DIFF
--- a/include/AdePT/copcore/VariableSizeObj.h
+++ b/include/AdePT/copcore/VariableSizeObj.h
@@ -171,6 +171,7 @@ public:
     // Copy data content using memcpy, limited by the respective size
     // of the the object.  If this is smaller there is data truncation,
     // if this is larger the extra datum are zero to zero.
+    if (this == &rhs) return *this;
 
     if (rhs.fN == fN) {
       memcpy(GetValues(), rhs.GetValues(), rhs.fN * sizeof(V));

--- a/include/AdePT/integration/HostTrackDataMapper.hh
+++ b/include/AdePT/integration/HostTrackDataMapper.hh
@@ -28,7 +28,7 @@ struct HostTrackData {
   G4ThreeVector vertexPosition;
   G4ThreeVector vertexMomentumDirection;
   G4double vertexKineticEnergy = 0.0;
-  char particleType;
+  unsigned char particleType;
 
   HostTrackData() = default;
 

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -466,6 +466,10 @@ void AdePTGeant4Integration::ProcessGPUStep(GPUHit const &hit, bool const callUs
   case 2:
     fScoringObjects->fG4Step->SetTrack(fScoringObjects->fGammaTrack);
     break;
+  default:
+    std::cerr << "Error: unknown particle type " << static_cast<int>(static_cast<unsigned char>(hit.fParticleType))
+              << "\n";
+    std::abort();
   }
   FillG4Step(&hit, fScoringObjects->fG4Step, *fScoringObjects->fPreG4TouchableHistoryHandle,
              *fScoringObjects->fPostG4TouchableHistoryHandle, preStepStatus, postStepStatus, callUserTrackingAction,


### PR DESCRIPTION
This mini PR fixes a few warnings reported by clang tidy for 
```
bugprone-signed-char-misuse
bugprone-unhandled-self-assignment
bugprone-switch-missing-default-case
```