### PR TITLE
Add a test compiling AdePT with ADEPT_USE_EXT_BFIELD=ON

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -134,11 +134,20 @@ def buildAndTest() {
     set -x
     export CUDA_CAPABILITY=${CUDA_CAPABILITY}
     env | sort | sed 's/:/:?     /g' | tr '?' '\n'
+    export CMAKE_BINARY_DIR=BUILD_ASYNC_ON
+    export ExtraCMakeOptions="-DADEPT_ASYNC_MODE=ON -DADEPT_BUILD_TESTING=ON"
+    ctest -V --output-on-failure --timeout 2400 -S AdePT/jenkins/adept-ctest.cmake,$MODEL
+    export CMAKE_BINARY_DIR=BUILD_SPLIT_ON
+    export ExtraCMakeOptions="-DADEPT_ASYNC_MODE=ON -DADEPT_USE_SPLIT_KERNELS=ON -DADEPT_BUILD_TESTING=ON"
+    ctest -V --output-on-failure --timeout 2400 -R testEm3_validation -S AdePT/jenkins/adept-ctest.cmake,$MODEL
+    export CMAKE_BINARY_DIR=BUILD_ASYNC_OFF
+    export ExtraCMakeOptions="-DADEPT_ASYNC_MODE=OFF -DADEPT_USE_SPLIT_KERNELS=OFF -DADEPT_BUILD_TESTING=ON"
+    ctest -V --output-on-failure --timeout 2400 -S AdePT/jenkins/adept-ctest.cmake,$MODEL
     export CMAKE_BINARY_DIR=BUILD_MIXED_PRECISION
     export ExtraCMakeOptions="-DADEPT_ASYNC_MODE=ON -DADEPT_MIXED_PRECISION=ON -DADEPT_BUILD_TESTING=ON"
     ctest -V --output-on-failure --timeout 2400 -R run_only_test -S AdePT/jenkins/adept-ctest.cmake,$MODEL
     export CMAKE_BINARY_DIR=BUILD_EXT_BFIELD
     export ExtraCMakeOptions="-DADEPT_ASYNC_MODE=ON -DADEPT_USE_EXT_BFIELD=ON -DADEPT_BUILD_TESTING=ON"
-    ctest -V --output-on-failure --timeout 2400 -S AdePT/jenkins/adept-ctest.cmake,$MODEL -N
+    ctest -V --output-on-failure --timeout 2400 -R run_only_test -S AdePT/jenkins/adept-ctest.cmake,$MODEL
   """
 }


### PR DESCRIPTION
A CI test ensuring that AdePT compiles correctly when using a external bfield was missing. With this change we will compile async mode AdePT with `ADEPT_USE_EXT_BFIELD=ON`