### PR TITLE
remove origin navState from Track, keep it in hostTrackDataMapper

### DIFF
--- a/include/AdePT/core/AdePTTransport.cuh
+++ b/include/AdePT/core/AdePTTransport.cuh
@@ -211,9 +211,6 @@ __global__ void InitTracks(adeptint::TrackData *trackinfo, int ntracks, int star
 
     track.weight = trackinfo[i].weight;
 
-    track.originNavState.Clear();
-    track.originNavState = trackinfo[i].originNavState;
-
     // setting up the NavState
     track.navState.Clear();
     track.navState = trackinfo[i].navState;

--- a/include/AdePT/core/AdePTTransport.h
+++ b/include/AdePT/core/AdePTTransport.h
@@ -44,8 +44,7 @@ public:
   /// @brief Adds a track to the buffer
   void AddTrack(int pdg, uint64_t trackId, uint64_t parentId, double energy, double x, double y, double z, double dirx,
                 double diry, double dirz, double globalTime, double localTime, double properTime, float weight,
-                unsigned short stepCounter, int threadId, unsigned int eventId, vecgeom::NavigationState &&state,
-                vecgeom::NavigationState &&originState);
+                unsigned short stepCounter, int threadId, unsigned int eventId, vecgeom::NavigationState &&state);
 
   void SetTrackCapacity(size_t capacity) { fCapacity = capacity; }
   /// @brief Get the track capacity on GPU
@@ -67,6 +66,7 @@ public:
   /// @brief Set whether AdePT should transport particles across the whole geometry
   void SetTrackInAllRegions(bool trackInAllRegions) { fTrackInAllRegions = trackInAllRegions; }
   bool GetTrackInAllRegions() const { return fTrackInAllRegions; }
+  bool GetCallUserActions() const { return false; } // doesn't exist in sync AdePT
   /// @brief Set Geant4 region to which it applies
   void SetGPURegionNames(std::vector<std::string> const *regionNames) { fGPURegionNames = regionNames; }
   void SetCPURegionNames(std::vector<std::string> const *regionNames) { fCPURegionNames = regionNames; }

--- a/include/AdePT/core/AdePTTransport.icc
+++ b/include/AdePT/core/AdePTTransport.icc
@@ -64,11 +64,10 @@ void AdePTTransport<IntegrationLayer>::AddTrack(int pdg, uint64_t trackId, uint6
                                                 double y, double z, double dirx, double diry, double dirz,
                                                 double globalTime, double localTime, double properTime, float weight,
                                                 unsigned short stepCounter, int /*threadId*/, unsigned int eventId,
-                                                vecgeom::NavigationState &&state,
-                                                vecgeom::NavigationState &&originState)
+                                                vecgeom::NavigationState &&state)
 {
   fBuffer.toDevice.emplace_back(pdg, trackId, parentId, energy, x, y, z, dirx, diry, dirz, globalTime, localTime,
-                                properTime, weight, stepCounter, std::move(state), std::move(originState));
+                                properTime, weight, stepCounter, std::move(state));
   if (pdg == 11)
     fBuffer.nelectrons++;
   else if (pdg == -11)

--- a/include/AdePT/core/AdePTTransportInterface.hh
+++ b/include/AdePT/core/AdePTTransportInterface.hh
@@ -23,7 +23,7 @@ public:
   virtual void AddTrack(int pdg, uint64_t trackId, uint64_t parentId, double energy, double x, double y, double z,
                         double dirx, double diry, double dirz, double globalTime, double localTime, double properTime,
                         float weight, unsigned short stepCounter, int threadId, unsigned int eventId,
-                        vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState) = 0;
+                        vecgeom::NavigationState &&state) = 0;
 
   /// @brief Set capacity of on-GPU track buffer.
   virtual void SetTrackCapacity(size_t capacity) = 0;
@@ -41,6 +41,7 @@ public:
   virtual void SetTrackInAllRegions(bool trackInAllRegions) = 0;
   /// @brief Check whether AdePT should transport particles across the whole geometry
   virtual bool GetTrackInAllRegions() const = 0;
+  virtual bool GetCallUserActions() const   = 0;
   /// @brief Set Geant4 region which are run on GPU
   virtual void SetGPURegionNames(std::vector<std::string> const *regionNames) = 0;
   /// @brief Set Geant4 region which are run on CPU

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -212,8 +212,7 @@ __global__ void InitTracks(AsyncAdePT::TrackDataWithIDs *trackinfo, int ntracks,
         static_cast<float>(trackInfo.properTime), trackInfo.weight, trackInfo.position, trackInfo.direction,
         trackInfo.eventId, trackInfo.trackId, trackInfo.parentId, trackInfo.threadId, trackInfo.stepCounter);
     track.navState.Clear();
-    track.navState       = trackinfo[i].navState;
-    track.originNavState = trackinfo[i].originNavState;
+    track.navState = trackinfo[i].navState;
     toBeEnqueued->push_back(QueueIndexPair{slot, queueIndex});
   }
 }
@@ -281,26 +280,25 @@ __global__ void FillFromDeviceBuffer(AllLeaked all, AsyncAdePT::TrackDataWithIDs
     // NOTE: Sync transport copies data into trackData structs during transport.
     // Async transport stores the slots and copies to trackdata structs for transfer to
     // host here. These approaches should be unified.
-    fromDevice[idx].position[0]    = track->pos[0];
-    fromDevice[idx].position[1]    = track->pos[1];
-    fromDevice[idx].position[2]    = track->pos[2];
-    fromDevice[idx].direction[0]   = track->dir[0];
-    fromDevice[idx].direction[1]   = track->dir[1];
-    fromDevice[idx].direction[2]   = track->dir[2];
-    fromDevice[idx].eKin           = track->eKin;
-    fromDevice[idx].globalTime     = track->globalTime;
-    fromDevice[idx].localTime      = track->localTime;
-    fromDevice[idx].properTime     = track->properTime;
-    fromDevice[idx].weight         = track->weight;
-    fromDevice[idx].pdg            = pdg;
-    fromDevice[idx].eventId        = track->eventId;
-    fromDevice[idx].threadId       = track->threadId;
-    fromDevice[idx].navState       = track->navState;
-    fromDevice[idx].originNavState = track->originNavState;
-    fromDevice[idx].leakStatus     = track->leakStatus;
-    fromDevice[idx].parentId       = track->parentId;
-    fromDevice[idx].trackId        = track->trackId;
-    fromDevice[idx].stepCounter    = track->stepCounter;
+    fromDevice[idx].position[0]  = track->pos[0];
+    fromDevice[idx].position[1]  = track->pos[1];
+    fromDevice[idx].position[2]  = track->pos[2];
+    fromDevice[idx].direction[0] = track->dir[0];
+    fromDevice[idx].direction[1] = track->dir[1];
+    fromDevice[idx].direction[2] = track->dir[2];
+    fromDevice[idx].eKin         = track->eKin;
+    fromDevice[idx].globalTime   = track->globalTime;
+    fromDevice[idx].localTime    = track->localTime;
+    fromDevice[idx].properTime   = track->properTime;
+    fromDevice[idx].weight       = track->weight;
+    fromDevice[idx].pdg          = pdg;
+    fromDevice[idx].eventId      = track->eventId;
+    fromDevice[idx].threadId     = track->threadId;
+    fromDevice[idx].navState     = track->navState;
+    fromDevice[idx].leakStatus   = track->leakStatus;
+    fromDevice[idx].parentId     = track->parentId;
+    fromDevice[idx].trackId      = track->trackId;
+    fromDevice[idx].stepCounter  = track->stepCounter;
 
     leakedTracks->fSlotManager->MarkSlotForFreeing(trackSlot);
   }

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -92,8 +92,8 @@ public:
   /// @brief Adds a track to the buffer
   void AddTrack(int pdg, uint64_t trackId, uint64_t parentId, double energy, double x, double y, double z, double dirx,
                 double diry, double dirz, double globalTime, double localTime, double properTime, float weight,
-                unsigned short stepCounter, int threadId, unsigned int eventId, vecgeom::NavigationState &&state,
-                vecgeom::NavigationState &&originState) override;
+                unsigned short stepCounter, int threadId, unsigned int eventId,
+                vecgeom::NavigationState &&state) override;
   /// @brief Set track capacity on GPU
   void SetTrackCapacity(size_t capacity) override { fTrackCapacity = capacity; }
   /// @brief Set leak capacity on GPU
@@ -108,6 +108,7 @@ public:
   void SetDebugLevel(int level) override { fDebugLevel = level; }
   void SetTrackInAllRegions(bool trackInAllRegions) override { fTrackInAllRegions = trackInAllRegions; }
   bool GetTrackInAllRegions() const override { return fTrackInAllRegions; }
+  bool GetCallUserActions() const { return fReturnFirstAndLastStep; }
   void SetGPURegionNames(std::vector<std::string> const *regionNames) override { fGPURegionNames = regionNames; }
   void SetCPURegionNames(std::vector<std::string> const *regionNames) override { fCPURegionNames = regionNames; }
   /// @brief Set path to covfie Bfield file

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -124,35 +124,27 @@ void AsyncAdePTTransport<IntegrationLayer>::SetHepEmTrackingManagerForThread(int
 }
 
 template <typename IntegrationLayer>
-void AsyncAdePTTransport<IntegrationLayer>::AddTrack(
-    int pdg, uint64_t trackId, uint64_t parentId, double energy, double x, double y, double z, double dirx, double diry,
-    double dirz, double globalTime, double localTime, double properTime, float weight, unsigned short stepCounter,
-    int threadId, unsigned int eventId, vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState)
+void AsyncAdePTTransport<IntegrationLayer>::AddTrack(int pdg, uint64_t trackId, uint64_t parentId, double energy,
+                                                     double x, double y, double z, double dirx, double diry,
+                                                     double dirz, double globalTime, double localTime,
+                                                     double properTime, float weight, unsigned short stepCounter,
+                                                     int threadId, unsigned int eventId,
+                                                     vecgeom::NavigationState &&state)
 {
   if (pdg != 11 && pdg != -11 && pdg != 22) {
     G4cerr << __FILE__ << ":" << __LINE__ << ": Only supporting EM tracks. Got pdgID=" << pdg << "\n";
     return;
   }
 
-  TrackDataWithIDs track{pdg,
-                         trackId,
-                         parentId,
-                         energy,
-                         x,
-                         y,
-                         z,
-                         dirx,
-                         diry,
-                         dirz,
-                         globalTime,
-                         localTime,
-                         properTime,
-                         weight,
-                         stepCounter,
-                         std::move(state),
-                         std::move(originState),
-                         eventId,
-                         static_cast<short>(threadId)};
+  TrackDataWithIDs track{pdg,         trackId,
+                         parentId,    energy,
+                         x,           y,
+                         z,           dirx,
+                         diry,        dirz,
+                         globalTime,  localTime,
+                         properTime,  weight,
+                         stepCounter, std::move(state),
+                         eventId,     static_cast<short>(threadId)};
   if (fDebugLevel >= 2) {
     fGPUNetEnergy[threadId] += energy;
     if (fDebugLevel >= 8) {

--- a/include/AdePT/core/CommonStruct.h
+++ b/include/AdePT/core/CommonStruct.h
@@ -187,25 +187,10 @@ struct TrackDataWithIDs : public adeptint::TrackData {
 
   TrackDataWithIDs(int pdg_id, uint64_t trackId, uint64_t parentId, double ene, double x, double y, double z,
                    double dirx, double diry, double dirz, double gTime, double lTime, double pTime, float weight,
-                   unsigned short stepCounter, vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState,
-                   unsigned int eventId = 0, short threadId = -1)
-      : TrackData{pdg_id,
-                  trackId,
-                  parentId,
-                  ene,
-                  x,
-                  y,
-                  z,
-                  dirx,
-                  diry,
-                  dirz,
-                  gTime,
-                  lTime,
-                  pTime,
-                  weight,
-                  stepCounter,
-                  std::move(state),
-                  std::move(originState)},
+                   unsigned short stepCounter, vecgeom::NavigationState &&state, unsigned int eventId = 0,
+                   short threadId = -1)
+      : TrackData{pdg_id, trackId, parentId, ene,   x,     y,      z,           dirx,
+                  diry,   dirz,    gTime,    lTime, pTime, weight, stepCounter, std::move(state)},
         eventId{eventId}, threadId{threadId}
   {
   }

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -39,9 +39,8 @@ struct Track {
   vecgeom::Vector3D<float> safetyPos; ///< last position where the safety was computed
   // TODO: For better clarity in the split kernels, rename this to "stored safety" as opposed to the
   // safety we get from GetSafety(), which is computed in the moment
-  float safety{0.f};                       ///< last computed safety value
-  vecgeom::NavigationState navState;       ///< current navigation state
-  vecgeom::NavigationState originNavState; ///< navigation state where the vertex was created
+  float safety{0.f};                 ///< last computed safety value
+  vecgeom::NavigationState navState; ///< current navigation state
 
 #ifdef ADEPT_USE_SPLIT_KERNELS
   // Variables used to store track info needed for scoring
@@ -101,7 +100,7 @@ struct Track {
                    const vecgeom::Vector3D<double> &newDirection, const vecgeom::NavigationState &newNavState,
                    const Track &parentTrack, const double globalTime)
       : rngState{rng_state}, eKin{eKin}, globalTime{globalTime}, pos{parentPos}, dir{newDirection},
-        navState{newNavState}, originNavState{newNavState}, trackId{rngState.IntRndm64()}, eventId{parentTrack.eventId},
+        navState{newNavState}, trackId{rngState.IntRndm64()}, eventId{parentTrack.eventId},
         parentId{parentTrack.trackId}, threadId{parentTrack.threadId}, weight{parentTrack.weight}, stepCounter{0},
         looperCounter{0}, zeroStepCounter{0}, leakStatus{LeakStatus::NoLeak}
   {
@@ -169,9 +168,6 @@ struct Track {
     this->safety   = 0.0f;
     this->navState = parentNavState;
 
-    // Set the origin for this track
-    this->originNavState = parentNavState;
-
     // Caller is responsible to set the weight of the track
 
     // The global time is inherited from the parent
@@ -188,24 +184,23 @@ struct Track {
 
   __host__ __device__ void CopyTo(adeptint::TrackData &tdata, int pdg)
   {
-    tdata.pdg            = pdg;
-    tdata.trackId        = trackId;
-    tdata.parentId       = parentId;
-    tdata.position[0]    = pos[0];
-    tdata.position[1]    = pos[1];
-    tdata.position[2]    = pos[2];
-    tdata.direction[0]   = dir[0];
-    tdata.direction[1]   = dir[1];
-    tdata.direction[2]   = dir[2];
-    tdata.eKin           = eKin;
-    tdata.globalTime     = globalTime;
-    tdata.localTime      = localTime;
-    tdata.properTime     = properTime;
-    tdata.navState       = navState;
-    tdata.originNavState = originNavState;
-    tdata.weight         = weight;
-    tdata.leakStatus     = leakStatus;
-    tdata.stepCounter    = stepCounter;
+    tdata.pdg          = pdg;
+    tdata.trackId      = trackId;
+    tdata.parentId     = parentId;
+    tdata.position[0]  = pos[0];
+    tdata.position[1]  = pos[1];
+    tdata.position[2]  = pos[2];
+    tdata.direction[0] = dir[0];
+    tdata.direction[1] = dir[1];
+    tdata.direction[2] = dir[2];
+    tdata.eKin         = eKin;
+    tdata.globalTime   = globalTime;
+    tdata.localTime    = localTime;
+    tdata.properTime   = properTime;
+    tdata.navState     = navState;
+    tdata.weight       = weight;
+    tdata.leakStatus   = leakStatus;
+    tdata.stepCounter  = stepCounter;
   }
 };
 #endif

--- a/include/AdePT/core/TrackData.h
+++ b/include/AdePT/core/TrackData.h
@@ -17,7 +17,6 @@ namespace adeptint {
 /// the destination, and used to reconstruct the track
 struct TrackData {
   vecgeom::NavigationState navState;
-  vecgeom::NavigationState originNavState;
   double position[3];
   double direction[3];
   double eKin{0};
@@ -35,10 +34,10 @@ struct TrackData {
   TrackData() = default;
   TrackData(int pdg_id, uint64_t trackId, uint64_t parentId, double ene, double x, double y, double z, double dirx,
             double diry, double dirz, double gTime, double lTime, double pTime, float weight,
-            unsigned short stepCounter, vecgeom::NavigationState &&state, vecgeom::NavigationState &&originState)
-      : navState{std::move(state)}, originNavState{std::move(originState)}, position{x, y, z},
-        direction{dirx, diry, dirz}, eKin{ene}, globalTime{gTime}, localTime{lTime}, properTime{pTime}, weight{weight},
-        pdg{pdg_id}, trackId{trackId}, parentId{parentId}, stepCounter{stepCounter}
+            unsigned short stepCounter, vecgeom::NavigationState &&state)
+      : navState{std::move(state)}, position{x, y, z}, direction{dirx, diry, dirz}, eKin{ene}, globalTime{gTime},
+        localTime{lTime}, properTime{pTime}, weight{weight}, pdg{pdg_id}, trackId{trackId}, parentId{parentId},
+        stepCounter{stepCounter}
   {
   }
 

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -98,6 +98,8 @@ private:
   void FillG4NavigationHistory(const vecgeom::NavigationState &aNavState,
                                G4NavigationHistory &aG4NavigationHistory) const;
 
+  G4TouchableHandle MakeTouchableFromNavState(vecgeom::NavigationState const &navState) const;
+
   void FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step, G4TouchableHandle &aPreG4TouchableHandle,
                   G4TouchableHandle &aPostG4TouchableHandle, G4StepStatus aPreStepStatus, G4StepStatus aPostStepStatus,
                   bool callUserTrackingAction, bool callUserSteppingAction) const;

--- a/include/AdePT/integration/HostTrackDataMapper.hh
+++ b/include/AdePT/integration/HostTrackDataMapper.hh
@@ -6,6 +6,7 @@
 
 #include "G4VUserTrackInformation.hh"
 #include "G4VProcess.hh"
+#include "G4TouchableHandle.hh"
 
 #include <unordered_map>
 #include <cstdint>
@@ -27,6 +28,7 @@ struct HostTrackData {
   G4LogicalVolume *logicalVolumeAtVertex = nullptr;
   G4ThreeVector vertexPosition;
   G4ThreeVector vertexMomentumDirection;
+  std::unique_ptr<G4TouchableHandle> originTouchableHandle;
   G4double vertexKineticEnergy = 0.0;
   unsigned char particleType;
 


### PR DESCRIPTION
This PR removes the `originNavState` from the GPU track. Instead, the originTouchableHandle (which is in the end what is needed to be set for the G4Track), is directly stored as a smart pointer in the hostTrackData. This removes the necessity to convert a G4TouchableHistory into a VecGeom state, that is brought along to the GPU, only then to be transformed into a G4TouchableHistory again.
This also reduces the track size on the GPU, and consequently the data transfer size for leaked tracks.

In the TestEm3 region example, this gives a ~3% speedup.

Now, the G4OriginTouchableHandle is only available in the MC truth if `callTrackingAction` is set to true (just like all the other advanced MC truth options as well).