### PR TITLE
Add a PR template with a reminder to check physics results

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+It was verified that this PR
+- [] Changes physics results
+- [] Does not change physics results

--- a/.github/pull_request_template.md.license
+++ b/.github/pull_request_template.md.license
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2026 CERN
+# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Some changes may inadvertedly change physics results without throwing off the validation tests. In many cases, when a PR is not supposed to have an effect on the results this indicates some kind of error.

It is complicated to automatically check for changes in CI, since results will not be numerically identical across different hardware, and many PRs legitimately change results, which would require a cumbersome process of generating new results in the actual hardware where CI tests are run. Instead, we add a PR template with a reminder to check whether physics results are numerically identical to master, or explicitly specify otherwise.