### PR TITLE
Initialize NavState directly in constructor

### DIFF
--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -206,13 +206,12 @@ __global__ void InitTracks(AsyncAdePT::TrackDataWithIDs *trackinfo, int ntracks,
     // we need to scramble the initial seed with some more trackinfo to generate a unique seed.
     // otherwise, if a particle returns from the device and is injected again (i.e., via lepton nuclear), it would have
     // the same random number state, causing collisions in the track IDs
-    auto seed    = GenerateSeedFromTrackInfo(trackInfo, initialSeed);
-    Track &track = speciesTM->InitTrack(
-        slot, seed, trackInfo.eKin, trackInfo.globalTime, static_cast<float>(trackInfo.localTime),
-        static_cast<float>(trackInfo.properTime), trackInfo.weight, trackInfo.position, trackInfo.direction,
-        trackInfo.eventId, trackInfo.trackId, trackInfo.parentId, trackInfo.threadId, trackInfo.stepCounter);
-    track.navState.Clear();
-    track.navState = trackinfo[i].navState;
+    auto seed = GenerateSeedFromTrackInfo(trackInfo, initialSeed);
+    Track &track =
+        speciesTM->InitTrack(slot, seed, trackInfo.eKin, trackInfo.globalTime, static_cast<float>(trackInfo.localTime),
+                             static_cast<float>(trackInfo.properTime), trackInfo.weight, trackInfo.position,
+                             trackInfo.direction, trackinfo[i].navState, trackInfo.eventId, trackInfo.trackId,
+                             trackInfo.parentId, trackInfo.threadId, trackInfo.stepCounter);
     toBeEnqueued->push_back(QueueIndexPair{slot, queueIndex});
   }
 }

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -80,13 +80,13 @@ struct Track {
   __host__ __device__ Track &operator=(const Track &) = default;
 
   /// Construct a new track for GPU transport.
-  /// NB: The navState remains uninitialised.
   __device__ Track(uint64_t rngSeed, double eKin, double globalTime, float localTime, float properTime, float weight,
-                   double const position[3], double const direction[3], unsigned int eventId, uint64_t trackId,
-                   uint64_t parentId, short threadId, unsigned short stepCounter)
+                   double const position[3], double const direction[3], const vecgeom::NavigationState &newNavState,
+                   unsigned int eventId, uint64_t trackId, uint64_t parentId, short threadId,
+                   unsigned short stepCounter)
       : eKin{eKin}, weight{weight}, globalTime{globalTime}, localTime{localTime}, properTime{properTime},
-        eventId{eventId}, trackId{trackId}, parentId{parentId}, threadId{threadId}, stepCounter{stepCounter},
-        looperCounter{0}, zeroStepCounter{0}
+        navState{newNavState}, eventId{eventId}, trackId{trackId}, parentId{parentId}, threadId{threadId},
+        stepCounter{stepCounter}, looperCounter{0}, zeroStepCounter{0}
   {
     rngState.SetSeed(rngSeed);
     pos        = {position[0], position[1], position[2]};


### PR DESCRIPTION
This cleans a leftover of the track init, when a track is pushed to the GPU. A longer time ago, the navigation state was set via a separate Localize-call. By now, it is directly generated from the G4 navigation history. Thus, the NavState can now be directly initialized in the constructor.

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results