### PR TITLE
Fix handling of lepton nuclear steps in split kernels

### DIFF
--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -471,7 +471,7 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
       if (trackSurvives) {
 
         // possible hook to SteppingAction here
-        
+
         // Lepton nuclear needs to be handled by Geant4 directly, passing track back to CPU
         auto leakReason = winnerProcessIndex == 3 ? LeakStatus::LeptonNuclear : LeakStatus::NoLeak;
 
@@ -486,9 +486,8 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
       }
 
       // Only non-interacting, non-relocating tracks score here
-      // Note: In this kernel returnLastStep is only true for particles that left the world
       // Score the edep for particles that didn't reach the interaction
-      if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep  )
+      if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || (returnLastStep && !trackSurvives))
         adept_scoring::RecordHit(userScoring,
                                  currentTrack.trackId,                        // Track ID
                                  currentTrack.parentId,                       // parent Track ID


### PR DESCRIPTION
This PR cleans and fixes the handling of steps from lepton nuclear reactions in the split kernels:

Before, tracks that underwent lepton nuclear would be marked as `reached_interaction` and therefore did not return their steps. Thereby, their energy deposition due to continuous energy loss was lost.
This is now fixed. Note that the other small changes do not change the physics output. That was verified by having all changes and then excluding the steps from lepton nuclear again, which yielded the same results as before.

For the other small changes, they are in preparation for a SteppingAction as it is available in the monolithic kernels.
- the same trackSurvives flag as in the monolithic kernels is used
- survive is called only once, allowing for one SteppingAction. The lambda is dismantled, as it would have to be moved around due to shadowing parameters. As it is called only once, no need to define an extra lambda.
- the winner process index is queried once and then reused. It is not written back to the track (that was not necessary).
- the return of the last step returned every step as `returnLastStep` is not changed within the kernel anymore. This was fixed in the monolithic kernels but apparently not backported to the split kernels.

It was verified that this PR
- [x] Changes physics results
- [ ] Does not change physics results