### PR TITLE
remove LeakStatus from SteppingAction

### DIFF
--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -843,8 +843,8 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
         trackSurvives = false;
       } else {
         // call experiment-specific SteppingAction:
-        SteppingActionT::ElectronAction(trackSurvives, eKin, energyDeposit, leakReason, pos, globalTime,
-                                        auxData.fMCIndex, &g4HepEmData, params);
+        SteppingActionT::ElectronAction(trackSurvives, eKin, energyDeposit, pos, globalTime, auxData.fMCIndex,
+                                        &g4HepEmData, params);
       }
     }
 

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -495,8 +495,8 @@ __global__ void __launch_bounds__(256, 1)
         trackSurvives = false;
       } else {
         // call experiment-specific SteppingAction:
-        SteppingActionT::GammaAction(trackSurvives, eKin, edep, leakReason, pos, globalTime, auxData.fMCIndex,
-                                     &g4HepEmData, params);
+        SteppingActionT::GammaAction(trackSurvives, eKin, edep, pos, globalTime, auxData.fMCIndex, &g4HepEmData,
+                                     params);
       }
     }
 

--- a/include/AdePT/kernels/gammasWDT.cuh
+++ b/include/AdePT/kernels/gammasWDT.cuh
@@ -687,8 +687,7 @@ __global__ void __launch_bounds__(256, 1)
         trackSurvives = false;
       } else {
         // call experiment-specific SteppingAction:
-        SteppingActionT::GammaAction(trackSurvives, eKin, edep, leakReason, pos, globalTime, hepEmIMC, &g4HepEmData,
-                                     params);
+        SteppingActionT::GammaAction(trackSurvives, eKin, edep, pos, globalTime, hepEmIMC, &g4HepEmData, params);
       }
     }
 


### PR DESCRIPTION
This PR removes the LeakStatus from the SteppingAction. Initially, it was thought that the `LeakStatus::OutOfGPURegion` could mimic the `DeadMaterial` regions in CMS, but as the parametrized shower is unlikely to be done on the GPU in the near future, this is not a good option. Therefore, the DeadMaterial cut from CMS is deactivated (like it should have been already before, as the comment said), and the otherwise unused LeakStatus is removed from the interface.

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results