### PR TITLE
add correct energy deposition if loopers are killed

### DIFF
--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -835,12 +835,20 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
                  eKin, currentTrack.eventId, currentTrack.trackId, currentTrack.looperCounter, energyDeposit,
                  geometryStepLength, geometricalStepLengthFromPhysics, safety);
         trackSurvives = false;
+        // For electrons, simply deposit the kinetic energy, for positrons also the 2 m_e that would be added from
+        // annihilation at rest
+        energyDeposit += IsElectron ? eKin : eKin + 2 * copcore::units::kElectronMassC2;
+        eKin = 0.;
       } else if (currentTrack.stepCounter >= maxSteps || currentTrack.zeroStepCounter > kStepsStuckKill) {
         if (printErrors)
           printf("Killing e-/+ event %d track %lu E=%f lvol=%d after %d steps with zeroStepCounter %u\n",
                  currentTrack.eventId, currentTrack.trackId, eKin, lvolID, currentTrack.stepCounter,
                  currentTrack.zeroStepCounter);
         trackSurvives = false;
+        // For electrons, simply deposit the kinetic energy, for positrons also the 2 m_e that would be added from
+        // annihilation at rest
+        energyDeposit += IsElectron ? eKin : eKin + 2 * copcore::units::kElectronMassC2;
+        eKin = 0.;
       } else {
         // call experiment-specific SteppingAction:
         SteppingActionT::ElectronAction(trackSurvives, eKin, energyDeposit, leakReason, pos, globalTime,

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -493,6 +493,8 @@ __global__ void __launch_bounds__(256, 1)
               currentTrack.eventId, currentTrack.trackId, eKin, lvolID, currentTrack.stepCounter,
               currentTrack.zeroStepCounter);
         trackSurvives = false;
+        edep += eKin;
+        eKin = 0.;
       } else {
         // call experiment-specific SteppingAction:
         SteppingActionT::GammaAction(trackSurvives, eKin, edep, leakReason, pos, globalTime, auxData.fMCIndex,

--- a/include/AdePT/kernels/gammasWDT.cuh
+++ b/include/AdePT/kernels/gammasWDT.cuh
@@ -685,6 +685,8 @@ __global__ void __launch_bounds__(256, 1)
                  "stuck particle!\n",
                  currentTrack.eventId, currentTrack.trackId, eKin, lvolID, currentTrack.stepCounter);
         trackSurvives = false;
+        edep += eKin;
+        eKin = 0.;
       } else {
         // call experiment-specific SteppingAction:
         SteppingActionT::GammaAction(trackSurvives, eKin, edep, leakReason, pos, globalTime, hepEmIMC, &g4HepEmData,


### PR DESCRIPTION
For the AdePT internal killing of loopers, the kinetic energy of the particles was neglected. This PR adds them to the energy deposition (and also the 2x rest mass of the electron in case of positrons).

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results. Note: This PR **does** change physics results, but not for testEm3 in the CI, as there are no loopers being killed.