### PR TITLE
fetch and fill secondary initializing step together with parent step

### DIFF
--- a/include/AdePT/core/AdePTScoringTemplate.cuh
+++ b/include/AdePT/core/AdePTScoringTemplate.cuh
@@ -24,7 +24,8 @@ __device__ void RecordHit(Scoring *scoring_dev, uint64_t aTrackID, uint64_t aPar
                           vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<double> const &aPostPosition,
                           vecgeom::Vector3D<double> const &aPostMomentumDirection, double aPostEKin, double aGlobalTime,
                           double aLocalTime, double aPreGlobalTime, unsigned int eventId, short threadId,
-                          bool isLastStep, unsigned short stepCounter);
+                          bool isLastStep, unsigned short stepCounter, SecondaryInitData const *secondaryData,
+                          unsigned int nSecondaries);
 
 template <typename Scoring>
 __device__ void AccountProduced(Scoring *scoring_dev, int num_ele, int num_pos, int num_gam);

--- a/include/AdePT/core/ScoringCommons.hh
+++ b/include/AdePT/core/ScoringCommons.hh
@@ -40,6 +40,15 @@ struct GPUHit {
   char fParticleType{0}; // Particle type ID
 };
 
+/// @brief Minimal data struct that is needed along with the parent track to provide the initial track information that
+/// is sent back to the CPU
+struct SecondaryInitData {
+  uint64_t trackId;
+  vecgeom::Vector3D<double> dir;
+  double eKin;
+  char particleType{0};
+};
+
 /// @brief Stores information used for comparison with Geant4 (Number of steps, Number of produced particles, etc)
 struct GlobalCounters {
   double energyDeposit;

--- a/include/AdePT/kernels/gammasWDT_split.cuh
+++ b/include/AdePT/kernels/gammasWDT_split.cuh
@@ -167,7 +167,9 @@ __global__ void __launch_bounds__(256, 1)
                                    currentTrack.preStepGlobalTime,              // preStep global time
                                    currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                    true,                                        // whether this was the last step
-                                   currentTrack.stepCounter);                   // stepcounter
+                                   currentTrack.stepCounter,                    // stepcounter
+                                   nullptr,                                     // pointer to secondary init data
+                                   0);                                          // number of secondaries
         }
         continue; // track is killed, can stop here
       }


### PR DESCRIPTION

This PR is the preparation for enabling the secondary vector in the returned steps for the MC truth.

Before, each initializing step for a secondary was calling `RecordHit` itself with the initial data. Now, instead the data that is truly needed for the secondary (direction, energy, particle type, track id) is passed to the final `RecordHit` of the parent particle.

Then, instead of doing single atomic adds in RecordHit, it immediately allocates all slots for the parent track + all secondaries.
Therefore, it must be ensured that if there are secondaries created, the parent step is calling RecordHit.

In the next step, on the host side, the connection between the parent and the secondaries can be made.

This PR also slightly accelerates both the split and the monolithic kernels (if returnLastStep is true), as less atomic calls are needed.
| Configuration         | Runtime [s] |
|----------------------|------------:|
| Split (PR)           |     116.477 |
| Split (origin)       |     122.959 |
| Monolithic (PR)      |     117.661 |
| Monolithic (origin)  |     119.321 |

It was verified that this PR
- [x] Changes physics results. Note: this is caused by the different ordering, it does not really change the physics. In debug mode, the result is exactly the same as before
- [ ] Does not change physics results