### PR TITLE
store origin navState instead of G4TouchableHandle in HostTrackData

### DIFF
--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -57,8 +57,11 @@ private:
   /// @brief Get the corresponding VecGeom NavigationState from the track's G4NavigationHistory, and set the boundary
   /// status based on the track's state
   /// @param aG4Track The G4Track from which to extract the NavigationState
+  /// @param aG4NavigationHistory Navigation history that is used to define the navState. If not provided, it will
+  /// default to aG4Track.GetNextTouchableHandle()->GetHistory()
   /// @return The corresponding vecgeom::NavigationState
-  const vecgeom::NavigationState GetVecGeomFromG4State(const G4Track &aG4Track);
+  const vecgeom::NavigationState GetVecGeomFromG4State(const G4Track &aG4Track,
+                                                       const G4NavigationHistory *aG4NavigationHistory = nullptr);
 
   std::unique_ptr<G4HepEmTrackingManagerSpecialized> fHepEmTrackingManager;
   static inline int fNumThreads{0};

--- a/include/AdePT/integration/HostTrackDataMapper.hh
+++ b/include/AdePT/integration/HostTrackDataMapper.hh
@@ -6,7 +6,8 @@
 
 #include "G4VUserTrackInformation.hh"
 #include "G4VProcess.hh"
-#include "G4TouchableHandle.hh"
+
+#include <VecGeom/navigation/NavigationState.h>
 
 #include <unordered_map>
 #include <cstdint>
@@ -28,7 +29,7 @@ struct HostTrackData {
   G4LogicalVolume *logicalVolumeAtVertex = nullptr;
   G4ThreeVector vertexPosition;
   G4ThreeVector vertexMomentumDirection;
-  std::unique_ptr<G4TouchableHandle> originTouchableHandle;
+  vecgeom::NavigationState originNavState;
   G4double vertexKineticEnergy = 0.0;
   unsigned char particleType;
 

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -662,10 +662,7 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step,
           G4ThreeVector{aGPUHit->fPostStepPoint.fMomentumDirection.x(), aGPUHit->fPostStepPoint.fMomentumDirection.y(),
                         aGPUHit->fPostStepPoint.fMomentumDirection.z()};
       hostTData.vertexKineticEnergy = aGPUHit->fPostStepPoint.fEKin;
-      if (hostTData.originTouchableHandle) {
-        hostTData.originTouchableHandle =
-            std::make_unique<G4TouchableHandle>(MakeTouchableFromNavState(aGPUHit->fPostStepPoint.fNavigationState));
-      }
+      hostTData.originNavState      = aGPUHit->fPostStepPoint.fNavigationState;
 
       // For the initializing step, the step defining process ID is the creator process
       const int stepId = aGPUHit->fStepLimProcessId;
@@ -906,8 +903,9 @@ void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsig
   leakedTrack->SetVertexMomentumDirection(hostTData.vertexMomentumDirection);
   leakedTrack->SetVertexKineticEnergy(hostTData.vertexKineticEnergy);
   leakedTrack->SetLogicalVolumeAtVertex(hostTData.logicalVolumeAtVertex);
-  if (hostTData.originTouchableHandle) {
-    leakedTrack->SetOriginTouchableHandle(*hostTData.originTouchableHandle);
+  if (callUserActions) {
+    auto originTouchableHandle = MakeTouchableFromNavState(hostTData.originNavState);
+    leakedTrack->SetOriginTouchableHandle(originTouchableHandle);
   }
 
   // ------ Handle leaked tracks according to their status, if not LeakStatus::OutOfGPURegion ---------


### PR DESCRIPTION
This PR fixes the origin Touchable handling in the HostTrackData Mapper. 

Before, there was a `!` missing in this if-Statement:
```c++
  if (hostTData.originTouchableHandle) {
    leakedTrack->SetOriginTouchableHandle(*hostTData.originTouchableHandle);
}
```
Thus, the originTouchableHandle was never set. Fixing it, a major run time regression was found.
Indeed creating `G4TouchableHandle` is very expensive.
Therefore, now the `vecgeom::NavState` is stored in the hostTrackData and the `G4TouchableHandle` is only created when the track is returned to G4 from the GPU and not already per step.

This mitigates the impact significantly. In the extreme case of testEm3 where each second layer is a GPU region, the overhead was drastically reduced, in normal cases it was fully mitigated.

As the origin Touchable so far is only needed by ATLAS, one might see if it should be guarded as a compile time option.


| Example        | Master (with origin touchable) | No origin touchable | PR (with origin touchable) |
|---------------|--------------------------------|----------------------|----------------------------|
| Em3 Regions   | 142.28                         | 89.9975              | 95.486                     |
| Em3           | 191.196                        | 116.307              | 116.413                    |


It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results