### PR TITLE
Fix creator process for stopped annihilation

### DIFF
--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -737,7 +737,8 @@ __device__ void RecordHit(AsyncAdePT::PerEventScoring * /*scoring*/, uint64_t aT
   for (unsigned int i = 0; i < nSecondaries; ++i) {
     // The index is the startIndex + 1 (for the parent) + i for the current secondary
     GPUHit &secondaryStep = AsyncAdePT::gHitScoringBuffer_dev.GetSlot(threadID, slotStartIndex + 1u + i);
-    FillHit(secondaryStep, secondaryData[i].trackId, aTrackID, stepLimProcessId, secondaryData[i].particleType,
+    FillHit(secondaryStep, secondaryData[i].trackId, aTrackID, secondaryData[i].creatorProcessId,
+            secondaryData[i].particleType,
             /*steplength*/ 0., /*energydeposit*/ 0., aTrackWeight, aPostState, aPostPosition, secondaryData[i].dir,
             secondaryData[i].eKin, aPostState, aPostPosition, secondaryData[i].dir, secondaryData[i].eKin, aGlobalTime,
             /*localTime*/ 0., aGlobalTime, eventID, threadID, /*isLastStep*/ false, /*stepCounter*/ 0,

--- a/include/AdePT/core/ScoringCommons.hh
+++ b/include/AdePT/core/ScoringCommons.hh
@@ -46,6 +46,7 @@ struct SecondaryInitData {
   uint64_t trackId;
   vecgeom::Vector3D<double> dir;
   double eKin;
+  short creatorProcessId{-1};
   char particleType{0};
 };
 

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -532,6 +532,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
             // if tracking or stepping action is called, return initial step
             if (returnLastStep) {
               secondaryData[nSecondaries++] = {secondary.trackId, secondary.dir, secondary.eKin,
+                                               /*creator process*/ short(winnerProcessIndex),
                                                /*particle type*/ char(0)};
             }
           }
@@ -587,7 +588,9 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
 
             // if tracking or stepping action is called, return initial step
             if (returnLastStep) {
-              secondaryData[nSecondaries++] = {gamma.trackId, gamma.dir, gamma.eKin, /*particle type*/ char(2)};
+              secondaryData[nSecondaries++] = {gamma.trackId, gamma.dir, gamma.eKin,
+                                               /*creator process*/ short(winnerProcessIndex),
+                                               /*particle type*/ char(2)};
             }
           }
 
@@ -639,7 +642,9 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
                                            navState, currentTrack, globalTime);
             // if tracking or stepping action is called, return initial step
             if (returnLastStep) {
-              secondaryData[nSecondaries++] = {gamma1.trackId, gamma1.dir, gamma1.eKin, /*particle type*/ char(2)};
+              secondaryData[nSecondaries++] = {gamma1.trackId, gamma1.dir, gamma1.eKin,
+                                               /*creator process*/ short(winnerProcessIndex),
+                                               /*particle type*/ char(2)};
             }
           }
           if (ApplyCuts && (theGamma2Ekin < theGammaCut)) {
@@ -655,7 +660,9 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
                                            navState, currentTrack, globalTime);
             // if tracking or stepping action is called, return initial step
             if (returnLastStep) {
-              secondaryData[nSecondaries++] = {gamma2.trackId, gamma2.dir, gamma2.eKin, /*particle type*/ char(2)};
+              secondaryData[nSecondaries++] = {gamma2.trackId, gamma2.dir, gamma2.eKin,
+                                               /*creator process*/ short(winnerProcessIndex),
+                                               /*particle type*/ char(2)};
             }
           }
           break;
@@ -708,8 +715,10 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
 
           // if tracking or stepping action is called, return initial step
           if (returnLastStep) {
-            secondaryData[nSecondaries++] = {gamma1.trackId, gamma1.dir, gamma1.eKin, /*particle type*/ char(2)};
-            secondaryData[nSecondaries++] = {gamma2.trackId, gamma2.dir, gamma2.eKin, /*particle type*/ char(2)};
+            secondaryData[nSecondaries++] = {gamma1.trackId, gamma1.dir, gamma1.eKin,
+                                             /*creator process: annihilation*/ short(2), /*particle type*/ char(2)};
+            secondaryData[nSecondaries++] = {gamma2.trackId, gamma2.dir, gamma2.eKin,
+                                             /*creator process: annihilation*/ short(2), /*particle type*/ char(2)};
           }
         }
       }

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -733,8 +733,10 @@ __device__ __forceinline__ void PerformStoppedAnnihilation(const int slot, Track
 
     // if tracking or stepping action is called, return initial step
     if (returnLastStep) {
-      secondaryData[nSecondaries++] = {gamma1.trackId, gamma1.dir, gamma1.eKin, /*particle type*/ char(2)};
-      secondaryData[nSecondaries++] = {gamma2.trackId, gamma2.dir, gamma2.eKin, /*particle type*/ char(2)};
+      secondaryData[nSecondaries++] = {gamma1.trackId, gamma1.dir, gamma1.eKin, /*creator process*/ short(2),
+                                       /*particle type*/ char(2)};
+      secondaryData[nSecondaries++] = {gamma2.trackId, gamma2.dir, gamma2.eKin, /*creator process*/ short(2),
+                                       /*particle type*/ char(2)};
     }
   }
 }
@@ -812,7 +814,8 @@ __global__ void ElectronIonization(G4HepEmElectronTrack *hepEMTracks, ParticleMa
 
       // if tracking or stepping action is called, return initial step
       if (returnLastStep) {
-        secondaryData[nSecondaries++] = {secondary.trackId, secondary.dir, secondary.eKin, /*particle type*/ char(0)};
+        secondaryData[nSecondaries++] = {secondary.trackId, secondary.dir, secondary.eKin, /*creator process*/ short(0),
+                                         /*particle type*/ char(0)};
       }
     }
 
@@ -943,7 +946,8 @@ __global__ void ElectronBremsstrahlung(G4HepEmElectronTrack *hepEMTracks, Partic
                                      currentTrack.navState, currentTrack, currentTrack.globalTime);
       // if tracking or stepping action is called, return initial step
       if (returnLastStep) {
-        secondaryData[nSecondaries++] = {gamma.trackId, gamma.dir, gamma.eKin, /*particle type*/ char(2)};
+        secondaryData[nSecondaries++] = {gamma.trackId, gamma.dir, gamma.eKin, /*creator process*/ short(1),
+                                         /*particle type*/ char(2)};
       }
     }
 
@@ -1065,7 +1069,8 @@ __global__ void PositronAnnihilation(G4HepEmElectronTrack *hepEMTracks, Particle
                                      currentTrack.navState, currentTrack, currentTrack.globalTime);
       // if tracking or stepping action is called, return initial step
       if (returnLastStep) {
-        secondaryData[nSecondaries++] = {gamma1.trackId, gamma1.dir, gamma1.eKin, /*particle type*/ char(2)};
+        secondaryData[nSecondaries++] = {gamma1.trackId, gamma1.dir, gamma1.eKin, /*creator process*/ short(2),
+                                         /*particle type*/ char(2)};
       }
     }
     if (ApplyCuts && (theGamma2Ekin < theGammaCut)) {
@@ -1081,7 +1086,8 @@ __global__ void PositronAnnihilation(G4HepEmElectronTrack *hepEMTracks, Particle
                                      currentTrack.navState, currentTrack, currentTrack.globalTime);
       // if tracking or stepping action is called, return initial step
       if (returnLastStep) {
-        secondaryData[nSecondaries++] = {gamma2.trackId, gamma2.dir, gamma2.eKin, /*particle type*/ char(2)};
+        secondaryData[nSecondaries++] = {gamma2.trackId, gamma2.dir, gamma2.eKin, /*creator process*/ short(2),
+                                         /*particle type*/ char(2)};
       }
     }
 

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -290,7 +290,8 @@ __global__ void __launch_bounds__(256, 1)
 
           // if tracking or stepping action is called, return initial step
           if (returnLastStep) {
-            secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin, /*particle type*/ char(0)};
+            secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin,
+                                             /*creator process*/ short(winnerProcessIndex), /*particle type*/ char(0)};
           }
         }
 
@@ -305,7 +306,8 @@ __global__ void __launch_bounds__(256, 1)
 
           // if tracking or stepping action is called, return initial step
           if (returnLastStep) {
-            secondaryData[nSecondaries++] = {positron.trackId, positron.dir, positron.eKin, /*particle type*/ char(1)};
+            secondaryData[nSecondaries++] = {positron.trackId, positron.dir, positron.eKin,
+                                             /*creator process*/ short(winnerProcessIndex), /*particle type*/ char(1)};
           }
         }
         eKin = 0.;
@@ -343,7 +345,8 @@ __global__ void __launch_bounds__(256, 1)
 
           // if tracking or stepping action is called, return initial step
           if (returnLastStep) {
-            secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin, /*particle type*/ char(0)};
+            secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin,
+                                             /*creator process*/ short(winnerProcessIndex), /*particle type*/ char(0)};
           }
         } else {
           edep = energyEl;
@@ -390,7 +393,8 @@ __global__ void __launch_bounds__(256, 1)
 
           // if tracking or stepping action is called, return initial step
           if (returnLastStep) {
-            secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin, /*particle type*/ char(0)};
+            secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin,
+                                             /*creator process*/ short(winnerProcessIndex), /*particle type*/ char(0)};
           }
         } else {
           // If the secondary electron is cut, deposit all the energy of the gamma in this volume

--- a/include/AdePT/kernels/gammasWDT.cuh
+++ b/include/AdePT/kernels/gammasWDT.cuh
@@ -484,7 +484,8 @@ __global__ void __launch_bounds__(256, 1)
 
           // if tracking or stepping action is called, return initial step
           if (returnLastStep) {
-            secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin, /*particle type*/ char(0)};
+            secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin,
+                                             /*creator process*/ short(winnerProcessIndex), /*particle type*/ char(0)};
           }
         }
 
@@ -499,7 +500,8 @@ __global__ void __launch_bounds__(256, 1)
 
           // if tracking or stepping action is called, return initial step
           if (returnLastStep) {
-            secondaryData[nSecondaries++] = {positron.trackId, positron.dir, positron.eKin, /*particle type*/ char(1)};
+            secondaryData[nSecondaries++] = {positron.trackId, positron.dir, positron.eKin,
+                                             /*creator process*/ short(winnerProcessIndex), /*particle type*/ char(1)};
           }
         }
         eKin = 0.;
@@ -537,7 +539,8 @@ __global__ void __launch_bounds__(256, 1)
 
           // if tracking or stepping action is called, return initial step
           if (returnLastStep) {
-            secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin, /*particle type*/ char(0)};
+            secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin,
+                                             /*creator process*/ short(winnerProcessIndex), /*particle type*/ char(0)};
           }
         } else {
           edep = energyEl;
@@ -584,7 +587,8 @@ __global__ void __launch_bounds__(256, 1)
 
           // if tracking or stepping action is called, return initial step
           if (returnLastStep) {
-            secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin, /*particle type*/ char(0)};
+            secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin,
+                                             /*creator process*/ short(winnerProcessIndex), /*particle type*/ char(0)};
           }
         } else {
           // If the secondary electron is cut, deposit all the energy of the gamma in this volume

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -501,7 +501,8 @@ __global__ void GammaConversion(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
 
       // if tracking or stepping action is called, return initial step
       if (returnLastStep) {
-        secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin, /*particle type*/ char(0)};
+        secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin, /*creator process*/ short(0),
+                                         /*particle type*/ char(0)};
       }
     }
 
@@ -516,7 +517,8 @@ __global__ void GammaConversion(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
 
       // if tracking or stepping action is called, return initial step
       if (returnLastStep) {
-        secondaryData[nSecondaries++] = {positron.trackId, positron.dir, positron.eKin, /*particle type*/ char(1)};
+        secondaryData[nSecondaries++] = {positron.trackId, positron.dir, positron.eKin, /*creator process*/ short(0),
+                                         /*particle type*/ char(1)};
       }
     }
 
@@ -630,7 +632,8 @@ __global__ void GammaCompton(G4HepEmGammaTrack *hepEMTracks, ParticleManager par
 
       // if tracking or stepping action is called, return initial step
       if (returnLastStep) {
-        secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin, /*particle type*/ char(0)};
+        secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin, /*creator process*/ short(1),
+                                         /*particle type*/ char(0)};
       }
 
     } else {
@@ -747,7 +750,8 @@ __global__ void GammaPhotoelectric(G4HepEmGammaTrack *hepEMTracks, ParticleManag
 
       // if tracking or stepping action is called, return initial step
       if (returnLastStep) {
-        secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin, /*particle type*/ char(0)};
+        secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin, /*creator process*/ short(2),
+                                         /*particle type*/ char(0)};
       }
 
     } else {

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -775,7 +775,8 @@ void AdePTGeant4Integration::InitSecondaryHostTrackDataFromParent(GPUHit const *
 
   // For the initializing step, the step defining process ID is the creator process
   const int stepId = secHit->fStepLimProcessId;
-  const int ptype  = static_cast<int>(secTData.particleType);
+  assert(stepId >= 0);
+  const int ptype = static_cast<int>(secTData.particleType);
   if (ptype == 0 || ptype == 1) {
     secTData.creatorProcess = fHepEmTrackingManager->GetElectronNoProcessVector()[stepId];
   } else if (ptype == 2) {


### PR DESCRIPTION
Before, the creator process was always set to be the step limiting process of the parent. However, this is not true for positrons that are stopped due to continuous energy loss:
The emerging gammas should have the creator process of stopped annihilation, not MSC. Therefore, both variables are separated and the creator process is set  properly.

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results