### PR TITLE
use propagation queue in ElectronPropagation kernel

### DIFF
--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -1149,8 +1149,8 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
         ElectronHowFar<true, PerEventScoring, SteppingAction><<<blocks, threads, 0, electrons.stream>>>(
             particleManager, gpuState.hepEmBuffers_d.electronsHepEm, electrons.queues.propagation, gpuState.stats_dev,
             steppingActionParams, gpuState.fScoring_dev, allowFinishOffEvent, returnAllSteps, returnLastStep);
-        ElectronPropagation<true>
-            <<<blocks, threads, 0, electrons.stream>>>(particleManager, gpuState.hepEmBuffers_d.electronsHepEm);
+        ElectronPropagation<true><<<blocks, threads, 0, electrons.stream>>>(
+            electrons.tracks, gpuState.hepEmBuffers_d.electronsHepEm, electrons.queues.propagation);
         ElectronMSC<true><<<blocks, threads, 0, electrons.stream>>>(
             electrons.tracks, gpuState.hepEmBuffers_d.electronsHepEm, electrons.queues.propagation);
         ElectronSetupInteractions<true, PerEventScoring><<<blocks, threads, 0, electrons.stream>>>(
@@ -1185,8 +1185,8 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
         ElectronHowFar<false, PerEventScoring, SteppingAction><<<blocks, threads, 0, positrons.stream>>>(
             particleManager, gpuState.hepEmBuffers_d.positronsHepEm, positrons.queues.propagation, gpuState.stats_dev,
             steppingActionParams, gpuState.fScoring_dev, allowFinishOffEvent, returnAllSteps, returnLastStep);
-        ElectronPropagation<false>
-            <<<blocks, threads, 0, positrons.stream>>>(particleManager, gpuState.hepEmBuffers_d.positronsHepEm);
+        ElectronPropagation<false><<<blocks, threads, 0, positrons.stream>>>(
+            positrons.tracks, gpuState.hepEmBuffers_d.positronsHepEm, positrons.queues.propagation);
         ElectronMSC<false><<<blocks, threads, 0, positrons.stream>>>(
             positrons.tracks, gpuState.hepEmBuffers_d.positronsHepEm, positrons.queues.propagation);
         ElectronSetupInteractions<false, PerEventScoring><<<blocks, threads, 0, positrons.stream>>>(

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -263,7 +263,8 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
 }
 
 template <bool IsElectron>
-__global__ void ElectronPropagation(ParticleManager particleManager, G4HepEmElectronTrack *hepEMTracks)
+__global__ void ElectronPropagation(Track *electronsOrPositrons, G4HepEmElectronTrack *hepEMTracks,
+                                    const adept::MParray *propagationQueue)
 {
   constexpr double kPushDistance           = 1000 * vecgeom::kTolerance;
   constexpr int Charge                     = IsElectron ? -1 : 1;
@@ -284,12 +285,10 @@ __global__ void ElectronPropagation(ParticleManager particleManager, G4HepEmElec
 
   auto &magneticField = *gMagneticField;
 
-  auto &electronsOrPositrons = (IsElectron ? particleManager.electrons : particleManager.positrons);
-
-  const int activeSize = electronsOrPositrons.ActiveSize();
+  int activeSize = propagationQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
-    const auto slot     = electronsOrPositrons.ActiveAt(i);
-    Track &currentTrack = electronsOrPositrons.TrackAt(slot);
+    const int slot      = (*propagationQueue)[i];
+    Track &currentTrack = electronsOrPositrons[slot];
     // the MCC vector is indexed by the logical volume id
     const int lvolID = currentTrack.navState.GetLogicalId();
 


### PR DESCRIPTION
Before, the `ElectronPropagation` kernel was not using the electron or positron queue, but the full queue.

In case the SteppingAction killed a particle in `ElectronHowFar`, this empty slot would then be processed inside the `ElectronPropagation` leading to a crash.

This PR fixes that behaviour by using the correct queue.

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results