### PR TITLE
[mini] increment stepcounter in the beginning of the step

### DIFF
--- a/include/AdePT/kernels/gammasWDT.cuh
+++ b/include/AdePT/kernels/gammasWDT.cuh
@@ -54,6 +54,8 @@ __global__ void __launch_bounds__(256, 1)
     }
 #endif
 
+    currentTrack.stepCounter++;
+
     // Local variables that are needed:
     // get global point from track
     auto pos = currentTrack.pos;
@@ -355,8 +357,6 @@ __global__ void __launch_bounds__(256, 1)
     short stepDefinedProcessId = 10; // default for transportation
     double edep                = 0.;
     auto preStepEnergy         = eKin;
-
-    currentTrack.stepCounter++;
 
     // nextAuxData is needed for either finding the correct GPU region for relocation, or the sensitive detector code,
     // as the initial auxData is obsolete after WDT

--- a/include/AdePT/kernels/gammasWDT_split.cuh
+++ b/include/AdePT/kernels/gammasWDT_split.cuh
@@ -66,6 +66,7 @@ __global__ void __launch_bounds__(256, 1)
     currentTrack.preStepGlobalTime = currentTrack.globalTime;
     currentTrack.preStepPos        = currentTrack.pos;
     currentTrack.preStepDir        = currentTrack.dir;
+    currentTrack.stepCounter++;
 
     bool leftWDTRegion = false;
 
@@ -430,8 +431,6 @@ __global__ void __launch_bounds__(256, 1)
 
     // helper variables needed for the processes
     bool reached_interaction = true;
-
-    currentTrack.stepCounter++;
 
     if (currentTrack.looperCounter > 0) {
       // Case 1: fake interaction, give particle back to WDT gammas unless it did more fake interactions than allowed,


### PR DESCRIPTION
This PR moves the incrementing of the step counter in Woodcock tracking to the beginning of the step.
In fact, in the split kernels, when gamma tracks were finished on the CPU, they were sent back to the CPU before incrementing the counter in the Woodcock tracking kernel, leading to mayhem if the stepcounter was 0, as this is then flagged as initializing step.

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results