### PR TITLE
always return last step in WDT kernel

### DIFF
--- a/include/AdePT/kernels/gammasWDT.cuh
+++ b/include/AdePT/kernels/gammasWDT.cuh
@@ -656,8 +656,7 @@ __global__ void __launch_bounds__(256, 1)
 
     assert(nSecondaries <= 3);
 
-    // If there is some edep from cutting particles, record the step
-    // Note: record only real steps that either interacted or hit a boundary
+    // If there is some edep from cutting particles or if it is the last step, record the step
     if ((edep > 0 && nextauxData.fSensIndex >= 0) || returnAllSteps ||
         (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
       adept_scoring::RecordHit(userScoring,


### PR DESCRIPTION
There was a logic error in the monolithic WDT kernel:

It was assumed that only realSteps (not fake interaction steps) can return steps. However, in case of a SteppingAction, even the fake interaction step can be killed. In that case, the step info must be returned, otherwise there is a missing link in the HostTrackData. It is important to always return the last step, such that the HostTrackData mapper entry can be deleted.

More information is added to the per-track debug printout.

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results