### PR TITLE
[mini] avoid download of gdmls in unit tests, instead reuse existing one

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -23,17 +23,8 @@ endmacro()
 #----------------------------------------------------------------------------#
 # Common Data
 #----------------------------------------------------------------------------#
-set(TESTING_GDML "${PROJECT_BINARY_DIR}/trackML.gdml")
-file(DOWNLOAD https://gitlab.cern.ch/VecGeom/VecGeom/raw/v1.2.0/persistency/gdml/gdmls/trackML.gdml
-  "${TESTING_GDML}"
-  EXPECTED_HASH SHA256=2c53e0f2f4673c61f8679702532647bf71ec64c1613aae330fa835e7d7087064
-)
-
-set(CMS2018_GDML "${PROJECT_BINARY_DIR}/cms2018.gdml")
-file(DOWNLOAD https://gitlab.cern.ch/VecGeom/VecGeom/raw/v1.2.0/persistency/gdml/gdmls/cms2018.gdml
-  "${CMS2018_GDML}"
-  EXPECTED_HASH SHA256=a6538d8f196fbfe4c14e806df3439d5a0d7050d538d364faabe882c750970e63
-)
+# Keep unit tests aligned with regression tests by using the in-repo geometry.
+configure_file(${PROJECT_SOURCE_DIR}/examples/data/cms2018_sd.gdml ${PROJECT_BINARY_DIR}/cms2018_sd.gdml)
 
 #----------------------------------------------------------------------------#
 # Detailed tests

--- a/test/unit/testField/CMakeLists.txt
+++ b/test/unit/testField/CMakeLists.txt
@@ -56,5 +56,5 @@ endif()
 
 # Tests
 add_test(NAME testField
-  COMMAND $<TARGET_FILE:testField> -gdml_file ${PROJECT_BINARY_DIR}/cms2018.gdml
+  COMMAND $<TARGET_FILE:testField> -gdml_file ${PROJECT_BINARY_DIR}/cms2018_sd.gdml
 )

--- a/test/unit/testField/README.md
+++ b/test/unit/testField/README.md
@@ -14,7 +14,7 @@ New feature is
    - fixed accuracy of integration (constant in source)
 
 The features carried over from Example13 are:
- * arbitrary geometry via gdml file (tested with cms2018.gdml from VecGeom persistency/gdml/gdmls folder) and optionally a magnetic field with constant Bz,
+ * arbitrary geometry via gdml file (tested with the in-repo `cms2018_sd.gdml`) and optionally a magnetic field with constant Bz,
  * geometry read as Geant4 geometry, reading in regions and cuts, to initialize G4HepEm data
  * geometry read then into VecGeom, and synchronized to GPU
  * G4HepEm material-cuts couple indices mapped to VecGeom logical volume id's

--- a/test/unit/testField/testField.cpp
+++ b/test/unit/testField/testField.cpp
@@ -195,8 +195,8 @@ int main(int argc, char *argv[])
 {
   // Only outputs are the data file(s)
   // Separate for now, but will want to unify
-  OPTION_STRING(gdml_file, "cms2018.gdml"); //  "trackML.gdml"); //  "cms2018.gdml");
-  OPTION_INT(cache_depth, 0);               // 0 = full depth
+  OPTION_STRING(gdml_file, "cms2018_sd.gdml");
+  OPTION_INT(cache_depth, 0); // 0 = full depth
   OPTION_INT(particles, 100);
   OPTION_DOUBLE(energy, 10); // entered in GeV
   energy *= copcore::units::GeV;


### PR DESCRIPTION
This PR avoids downloading gdmls from VecGeom, and instead re-uses the one that is already in the AdePT repository and used for the regression tests.

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results