### PR TITLE
fix timing to not include initialization time

### DIFF
--- a/examples/AsyncExample/include/RunAction.hh
+++ b/examples/AsyncExample/include/RunAction.hh
@@ -29,7 +29,7 @@
 #define RUNACTION_HH
 
 #include "G4UserRunAction.hh"
-#include <VecGeom/base/Stopwatch.h>
+#include "G4Timer.hh"
 class G4Run;
 
 /**
@@ -53,7 +53,7 @@ public:
   virtual void EndOfRunAction(const G4Run *) final;
 
 private:
-  vecgeom::Stopwatch fTimer;
+  G4Timer fTimer;
 };
 
 #endif /* RUNACTION_HH */

--- a/examples/AsyncExample/src/RunAction.cc
+++ b/examples/AsyncExample/src/RunAction.cc
@@ -49,7 +49,8 @@ void RunAction::BeginOfRunAction(const G4Run *)
 void RunAction::EndOfRunAction(const G4Run *)
 {
   static std::mutex print_mutex;
-  auto time = fTimer.Stop();
+  fTimer.Stop();
+  auto time = fTimer.GetRealElapsed();
   auto tid  = G4Threading::G4GetThreadId();
   // Just protect the printout to avoid interlacing text
   const std::scoped_lock<std::mutex> lock(print_mutex);

--- a/examples/Example1/include/EventAction.hh
+++ b/examples/Example1/include/EventAction.hh
@@ -29,7 +29,7 @@
 #define EVENTACTION_HH
 
 #include "G4UserEventAction.hh"
-#include "G4Timer.hh"
+#include "G4Types.hh"
 
 class DetectorConstruction;
 class EventActionMessenger;
@@ -60,8 +60,6 @@ private:
   G4int fVerbosity{0};
   /// ID of a hit collection to analyse
   G4int fHitCollectionID;
-  /// Timer measurement
-  G4Timer fTimer;
   /// Messenger for this
   EventActionMessenger *fMessenger{nullptr};
 };

--- a/examples/Example1/include/RunAction.hh
+++ b/examples/Example1/include/RunAction.hh
@@ -29,8 +29,9 @@
 #define RUNACTION_HH
 
 #include "G4UserRunAction.hh"
-#include <VecGeom/base/Stopwatch.h>
 #include "G4String.hh"
+#include "G4Timer.hh"
+#include <mutex>
 
 class G4Run;
 class Run;
@@ -55,10 +56,15 @@ public:
   /// Write and close the file
   virtual void EndOfRunAction(const G4Run *) final;
 
+  // Start/stop the run wall-time timer around actual event processing only.
+  static void StartRunTimerFromFirstEvent();
+
 private:
-  /// Pointer to detector construction to retrieve the detector dimensions to
-  /// setup the histograms
-  vecgeom::Stopwatch fTimer;
+  static double StopRunTimerOnMaster();
+
+  static G4Timer fgRunTimer;
+  static std::mutex fgRunTimerMutex;
+  static bool fgRunTimerStarted;
 };
 
 #endif /* RUNACTION_HH */

--- a/examples/Example1/src/EventAction.cc
+++ b/examples/Example1/src/EventAction.cc
@@ -27,6 +27,7 @@
 //
 #include "EventAction.hh"
 #include "EventActionMessenger.hh"
+#include "RunAction.hh"
 #include "SimpleHit.hh"
 
 #include "G4SDManager.hh"
@@ -37,7 +38,7 @@
 #include "G4PhysicalVolumeStore.hh"
 #include "G4SystemOfUnits.hh"
 
-EventAction::EventAction() : G4UserEventAction(), fHitCollectionID(-1), fTimer()
+EventAction::EventAction() : G4UserEventAction(), fHitCollectionID(-1)
 {
   fMessenger = new EventActionMessenger(this);
 }
@@ -50,7 +51,7 @@ EventAction::~EventAction() {}
 
 void EventAction::BeginOfEventAction(const G4Event *)
 {
-  fTimer.Start();
+  RunAction::StartRunTimerFromFirstEvent();
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -58,8 +59,6 @@ void EventAction::BeginOfEventAction(const G4Event *)
 void EventAction::EndOfEventAction(const G4Event *aEvent)
 {
   auto eventId = G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID();
-
-  fTimer.Stop();
 
   // Get hits collection ID (only once)
   if (fHitCollectionID == -1) {

--- a/examples/Example1/src/RunAction.cc
+++ b/examples/Example1/src/RunAction.cc
@@ -27,8 +27,11 @@
 #include "RunAction.hh"
 #include "G4Threading.hh"
 
-#include <thread>
 #include <mutex>
+
+G4Timer RunAction::fgRunTimer{};
+std::mutex RunAction::fgRunTimerMutex{};
+bool RunAction::fgRunTimerStarted = false;
 
 RunAction::RunAction() : G4UserRunAction() {}
 
@@ -41,7 +44,11 @@ RunAction::~RunAction() {}
 void RunAction::BeginOfRunAction(const G4Run *)
 {
   std::cout << "### Starting run ###\n";
-  fTimer.Start();
+  auto tid = G4Threading::G4GetThreadId();
+  if (tid < 0) {
+    std::lock_guard<std::mutex> lock(fgRunTimerMutex);
+    fgRunTimerStarted = false;
+  }
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -49,12 +56,32 @@ void RunAction::BeginOfRunAction(const G4Run *)
 void RunAction::EndOfRunAction(const G4Run *)
 {
   static std::mutex print_mutex;
-  auto time = fTimer.Stop();
-  auto tid  = G4Threading::G4GetThreadId();
+  auto tid = G4Threading::G4GetThreadId();
   // Just protect the printout to avoid interlacing text
   const std::lock_guard<std::mutex> lock(print_mutex);
   // Print timer just for the master thread since this is called when all workers are done
   if (tid < 0) {
+    const auto time = StopRunTimerOnMaster();
     std::cout << "Run time: " << time << "\n";
   }
+}
+
+void RunAction::StartRunTimerFromFirstEvent()
+{
+  std::lock_guard<std::mutex> lock(fgRunTimerMutex);
+  if (!fgRunTimerStarted) {
+    fgRunTimer.Start();
+    fgRunTimerStarted = true;
+  }
+}
+
+double RunAction::StopRunTimerOnMaster()
+{
+  std::lock_guard<std::mutex> lock(fgRunTimerMutex);
+  if (!fgRunTimerStarted) return 0.0;
+
+  fgRunTimer.Stop();
+  auto time         = fgRunTimer.GetRealElapsed();
+  fgRunTimerStarted = false;
+  return time;
 }

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -5,13 +5,13 @@
 
 #include <AdePT/integration/AdePTGeant4Integration.hh>
 
-#include <VecGeom/base/Stopwatch.h>
 #include <VecGeom/management/BVHManager.h>
 #include <VecGeom/management/GeoManager.h>
 #ifdef ADEPT_USE_SURF
 #include <VecGeom/surfaces/BrepHelper.h>
 #endif
 
+#include <G4Timer.hh>
 #include <G4RunManager.hh>
 #include <G4Threading.hh>
 #include <G4Proton.hh>
@@ -184,11 +184,12 @@ bool AsyncAdePTTransport<IntegrationLayer>::InitializeGeometry(const vecgeom::cx
   using SurfData   = vgbrep::SurfData<double>;
   using BrepHelper = vgbrep::BrepHelper<double>;
 #endif
-  vecgeom::Stopwatch timer;
+  G4Timer timer;
   timer.Start();
   if (!BrepHelper::Instance().Convert()) return 1;
   BrepHelper::Instance().PrintSurfData();
-  std::cout << "== Conversion to surface model done in " << timer.Stop() << " [s]\n";
+  timer.Stop();
+  std::cout << "== Conversion to surface model done in " << timer.GetRealElapsed() << " [s]\n";
   // Upload only navigation table to the GPU
   cudaManager.SynchronizeNavigationTable();
   async_adept_impl::CopySurfaceModelToGPU();

--- a/test/regression/IntegrationTest/include/EventAction.hh
+++ b/test/regression/IntegrationTest/include/EventAction.hh
@@ -29,7 +29,7 @@
 #define EVENTACTION_HH
 
 #include "G4UserEventAction.hh"
-#include "G4Timer.hh"
+#include "G4Types.hh"
 
 #include "RunAction.hh"
 
@@ -67,8 +67,6 @@ private:
   G4int fVerbosity{0};
   /// ID of a hit collection to analyse
   G4int fHitCollectionID;
-  /// Timer measurement
-  G4Timer fTimer;
   /// Messenger for this
   EventActionMessenger *fMessenger{nullptr};
   RunAction *fRunAction{nullptr};

--- a/test/regression/IntegrationTest/include/RunAction.hh
+++ b/test/regression/IntegrationTest/include/RunAction.hh
@@ -29,8 +29,9 @@
 #define RUNACTION_HH
 
 #include "G4UserRunAction.hh"
-#include <VecGeom/base/Stopwatch.h>
 #include "G4String.hh"
+#include "G4Timer.hh"
+#include <mutex>
 
 class G4Run;
 class Run;
@@ -59,6 +60,9 @@ public:
 
   G4Run *GenerateRun() override;
 
+  // Start/stop the run wall-time timer around actual event processing only.
+  static void StartRunTimerFromFirstEvent();
+
   bool &GetDoBenchmark() { return fDoBenchmark; };
   bool &GetDoValidation() { return fDoValidation; };
   bool &GetDoAccumulatedEvents() { return fDoAccumulatedEvents; };
@@ -73,7 +77,11 @@ private:
   bool fDoBenchmark;
   bool fDoValidation;
   bool fDoAccumulatedEvents;
-  vecgeom::Stopwatch fTimer;
+  static double StopRunTimerOnMaster();
+
+  static G4Timer fgRunTimer;
+  static std::mutex fgRunTimerMutex;
+  static bool fgRunTimerStarted;
   Run *fRun;
 };
 

--- a/test/regression/IntegrationTest/src/EventAction.cc
+++ b/test/regression/IntegrationTest/src/EventAction.cc
@@ -41,8 +41,7 @@
 #include <AdePT/benchmarking/TestManagerStore.h>
 #include "Run.hh"
 
-EventAction::EventAction(RunAction *aRunAction)
-    : G4UserEventAction(), fHitCollectionID(-1), fTimer(), fRunAction(aRunAction)
+EventAction::EventAction(RunAction *aRunAction) : G4UserEventAction(), fHitCollectionID(-1), fRunAction(aRunAction)
 {
   fMessenger = new EventActionMessenger(this);
 }
@@ -55,7 +54,7 @@ EventAction::~EventAction() {}
 
 void EventAction::BeginOfEventAction(const G4Event *)
 {
-  fTimer.Start();
+  RunAction::StartRunTimerFromFirstEvent();
 
   // Get the Run object associated to this thread and start the timer for this event
   Run *currentRun = static_cast<Run *>(G4RunManager::GetRunManager()->GetNonConstCurrentRun());
@@ -74,8 +73,6 @@ void EventAction::BeginOfEventAction(const G4Event *)
 void EventAction::EndOfEventAction(const G4Event *aEvent)
 {
   auto eventId = G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID();
-
-  fTimer.Stop();
 
   // Get the Run object associated to this thread and stop the timer for this event
   Run *currentRun   = static_cast<Run *>(G4RunManager::GetRunManager()->GetNonConstCurrentRun());
@@ -108,7 +105,6 @@ void EventAction::EndOfEventAction(const G4Event *aEvent)
     G4cout << "EndOfEventAction " << eventId << ": positrons " << number_positrons << G4endl;
     G4cout << "EndOfEventAction " << eventId << ": gammas    " << number_gammas << G4endl;
     G4cout << "EndOfEventAction " << eventId << ": killed    " << number_killed << G4endl;
-    G4cout << "EndOfEventAction " << eventId << ": real time " << fTimer.GetRealElapsed() << G4endl;
   }
 
   // Store the original IO precission and width

--- a/test/regression/IntegrationTest/src/RunAction.cc
+++ b/test/regression/IntegrationTest/src/RunAction.cc
@@ -30,8 +30,11 @@
 #include "G4Threading.hh"
 #include <AdePT/benchmarking/TestManager.h>
 
-#include <thread>
 #include <mutex>
+
+G4Timer RunAction::fgRunTimer{};
+std::mutex RunAction::fgRunTimerMutex{};
+bool RunAction::fgRunTimerStarted = false;
 
 RunAction::RunAction() : G4UserRunAction(), fOutputDirectory(""), fOutputFilename("") {}
 
@@ -50,9 +53,12 @@ RunAction::~RunAction() {}
 
 void RunAction::BeginOfRunAction(const G4Run *)
 {
-  fTimer.Start();
   auto tid = G4Threading::G4GetThreadId();
   if (tid < 0) {
+    {
+      std::lock_guard<std::mutex> lock(fgRunTimerMutex);
+      fgRunTimerStarted = false;
+    }
     if (fDoBenchmark) {
       fRun->GetTestManager()->timerStart(Run::timers::TOTAL);
     }
@@ -64,8 +70,7 @@ void RunAction::BeginOfRunAction(const G4Run *)
 void RunAction::EndOfRunAction(const G4Run *)
 {
   static std::mutex print_mutex;
-  auto time = fTimer.Stop();
-  auto tid  = G4Threading::G4GetThreadId();
+  auto tid = G4Threading::G4GetThreadId();
   // Just protect the printout to avoid interlacing text
   const std::lock_guard<std::mutex> lock(print_mutex);
 
@@ -76,6 +81,7 @@ void RunAction::EndOfRunAction(const G4Run *)
 
   // Print timer just for the master thread since this is called when all workers are done
   if (tid < 0) {
+    const auto time = StopRunTimerOnMaster();
     std::cout << "Run time: " << time << "\n";
     if (fDoBenchmark) {
       fRun->GetTestManager()->timerStop(Run::timers::TOTAL);
@@ -90,4 +96,24 @@ G4Run *RunAction::GenerateRun()
 {
   fRun = new Run(this);
   return fRun;
+}
+
+void RunAction::StartRunTimerFromFirstEvent()
+{
+  std::lock_guard<std::mutex> lock(fgRunTimerMutex);
+  if (!fgRunTimerStarted) {
+    fgRunTimer.Start();
+    fgRunTimerStarted = true;
+  }
+}
+
+double RunAction::StopRunTimerOnMaster()
+{
+  std::lock_guard<std::mutex> lock(fgRunTimerMutex);
+  if (!fgRunTimerStarted) return 0.0;
+
+  fgRunTimer.Stop();
+  auto time         = fgRunTimer.GetRealElapsed();
+  fgRunTimerStarted = false;
+  return time;
 }

--- a/test/unit/testField/testField.cpp
+++ b/test/unit/testField/testField.cpp
@@ -23,7 +23,7 @@
 #include <G4HepEmParameters.hh>
 #include <G4HepEmMatCutData.hh>
 
-#include <VecGeom/base/Stopwatch.h>
+#include <G4Timer.hh>
 #include <VecGeom/management/GeoManager.h>
 #include <VecGeom/management/BVHManager.h>
 #include <VecGeom/gdml/Frontend.h>
@@ -217,7 +217,7 @@ int main(int argc, char *argv[])
     exit(EXIT_FAILURE);
   }
 
-  vecgeom::Stopwatch timer;
+  G4Timer timer;
   timer.Start();
 
   // Initialize Geant4
@@ -267,7 +267,8 @@ int main(int argc, char *argv[])
 #endif
   InitBVH();
 
-  auto time_cpu = timer.Stop();
+  timer.Stop();
+  auto time_cpu = timer.GetRealElapsed();
   std::cout << "Initialization took: " << time_cpu << " sec\n";
 
   int NumVolumes = vecgeom::GeoManager::Instance().GetRegisteredVolumesCount();

--- a/test/unit/testField/testField.cu
+++ b/test/unit/testField/testField.cu
@@ -13,7 +13,7 @@
 #include <AdePT/copcore/Ranluxpp.h>
 
 #include <VecGeom/base/Config.h>
-#include <VecGeom/base/Stopwatch.h>
+#include <G4Timer.hh>
 #include <VecGeom/management/GeoManager.h>
 #ifdef VECGEOM_ENABLE_CUDA
 #include <VecGeom/backend/cuda/Interface.h>
@@ -346,7 +346,7 @@ void testField(int numParticles, double energy, int batch, const int *MCIndex_ho
   SetBzFieldPtr<<<1, 1>>>(BzFieldValue_dev);
   COPCORE_CUDA_CHECK(cudaStreamSynchronize(stream));
 
-  vecgeom::Stopwatch timer;
+  G4Timer timer;
   timer.Start();
 
   std::cout << "Entering loop to simulate " << numParticles << " particles. " << std::flush;
@@ -516,7 +516,8 @@ void testField(int numParticles, double energy, int batch, const int *MCIndex_ho
   }
   std::cout << "\ndone!" << std::endl;
 
-  auto time = timer.Stop();
+  timer.Stop();
+  auto time = timer.GetRealElapsed();
   std::cout << "Run time: " << time << "\n";
 
   // Transfer back scoring.


### PR DESCRIPTION
This PR fixes the timing output in example1 and the integrationBenchmark:

Since the initialization of AdePT is done on the worker, and the timer started on the master thread, the initialization time of AdePT was included.
This is removed by starting the timer by the first worker who reaches the BeginOfEventAction and is stopped by the master in the EndOfRunAction. This unfortunately has to be done with a mutex to avoid race conditions.

The unused event timer was removed. All usage of the VecGeom::stopwatch was removed, which is a copy paste of the stopwatch of TBB. Instead, to stay consistent, the G4Timer is used.

With this PR, the timing is correct again. For very short runs, e.g., one gets:

testEm3 example:
```
G4WT9 > EndOfEventAction 0 Total energy deposited: 984360 MeV
Run time: 2.53373
```

cms2026:
```
G4WT0 > EndOfEventAction 0 Total energy deposited: 0 MeV
Run time: 0.167516
```

On the master, this included the init time:
testEm3 example:
```
G4WT29 > EndOfEventAction 0 Total energy deposited: 984360 MeV
Run time: 13.3144
```

cms2026
```
G4WT0 > EndOfEventAction 0 Total energy deposited: 0 MeV
Run time: 41.8007
```

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results