### PR TITLE
reintroduce timeout for CI tests

### DIFF
--- a/jenkins/adept-ctest-ci.cmake
+++ b/jenkins/adept-ctest-ci.cmake
@@ -61,6 +61,11 @@ message("CI test dashboard script configuration:\n${vars}\n")
 include("${CTEST_SOURCE_DIRECTORY}/CTestConfig.cmake")
 
 set(ENV{CTEST_OUTPUT_ON_FAILURE} 1)
+if(DEFINED ENV{CTEST_TEST_TIMEOUT} AND NOT "$ENV{CTEST_TEST_TIMEOUT}" STREQUAL "")
+  set(CTEST_TEST_TIMEOUT "$ENV{CTEST_TEST_TIMEOUT}")
+else()
+  set(CTEST_TEST_TIMEOUT 2400)
+endif()
 
 ctest_start(${CTEST_MODEL} TRACK ${CTEST_MODEL})
 ctest_test(BUILD ${CTEST_BINARY_DIRECTORY}


### PR DESCRIPTION
The timeout for the CI tests was removed in #494, as it was assumed that the default is 1500, which should have been enough.
However, in our setup it is 600, which we can break for some tests on the CI machines. Therefore, it is set back in to the previous value of 2400.

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results