### PR TITLE
Make VecGeom::gdml optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,10 +214,15 @@ endif()
 
 ### end version check for VecGeom
 
-# Make sure VecGeom::vgdml is enabled
-if(NOT TARGET VecGeom::vgdml)
-  message(FATAL_ERROR "AdePT requires VecGeom compiled with GDML support")
+# Check whether VecGeom::vgdml is enabled
+if(TARGET VecGeom::vgdml)
+  set(VECGEOM_GDML_SUPPORT TRUE)
+  add_compile_definitions(VECGEOM_GDML_SUPPORT)
+else()
+  set(VECGEOM_GDML_SUPPORT FALSE)
+  message(STATUS "VecGeom was compiled without GDML support, only in-memory geometry conversion via g4vg will be available")
 endif()
+
 # Run split kernels
 if (ADEPT_USE_SPLIT_KERNELS)
   add_compile_definitions(ADEPT_USE_SPLIT_KERNELS)
@@ -435,7 +440,7 @@ cuda_rdc_target_link_libraries(AdePT_G4_integration
   PUBLIC
     CopCore
     VecGeom::vecgeom
-    VecGeom::vgdml
+    $<$<BOOL:${VECGEOM_GDML_SUPPORT}>:VecGeom::vgdml>
     ${Geant4_LIBRARIES}
     G4HepEm::g4HepEm
     G4HepEm::g4HepEmData

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -40,10 +40,12 @@ public:
   AdePTGeant4Integration(AdePTGeant4Integration &&)            = default;
   AdePTGeant4Integration &operator=(AdePTGeant4Integration &&) = default;
 
+#ifdef VECGEOM_GDML_SUPPORT
   /// @brief Initializes VecGeom geometry
   /// @details Currently VecGeom geometry is initialized by loading it from a GDML file,
   /// however ideally this function will call the G4 to VecGeom geometry converter
   static void CreateVecGeomWorld(/*Temporary parameter*/ std::string filename);
+#endif
 
   /// @brief Construct VecGeom geometry from Geant4 physical volume
   /// @details This calls the G4VG converter

--- a/src/AdePTConfigurationMessenger.cc
+++ b/src/AdePTConfigurationMessenger.cc
@@ -183,7 +183,12 @@ void AdePTConfigurationMessenger::SetNewValue(G4UIcommand *command, G4String new
   } else if (command == fSetHitBufferSafetyFactorCmd.get()) {
     fAdePTConfiguration->SetHitBufferSafetyFactor(fSetHitBufferSafetyFactorCmd->GetNewDoubleValue(newValue));
   } else if (command == fSetGDMLCmd.get()) {
+#ifdef VECGEOM_GDML_SUPPORT
     fAdePTConfiguration->SetVecGeomGDML(newValue);
+#else
+    throw std::runtime_error("Attempting to load geometry via VGDML, but VecGeom was compiled without GDML support, "
+                             "unset /adept/setVecGeomGDML to load via g4vg");
+#endif
   } else if (command == fSetCovfieFileCmd.get()) {
     fAdePTConfiguration->SetCovfieBfieldFile(newValue);
   } else if (command == fSetCUDAStackLimitCmd.get()) {

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -4,7 +4,9 @@
 #include <AdePT/integration/AdePTGeant4Integration.hh>
 
 #include <VecGeom/management/GeoManager.h>
+#ifdef VECGEOM_GDML_SUPPORT
 #include <VecGeom/gdml/Frontend.h>
+#endif
 #include <VecGeom/navigation/NavigationState.h>
 
 #include <G4ios.hh>
@@ -204,6 +206,7 @@ void AdePTGeant4Integration::MapVecGeomToG4(std::vector<G4VPhysicalVolume const 
   visitGeometry(g4world, vecgeomWorld);
 }
 
+#ifdef VECGEOM_GDML_SUPPORT
 void AdePTGeant4Integration::CreateVecGeomWorld(std::string filename)
 {
   // Import the gdml file into VecGeom
@@ -224,6 +227,7 @@ void AdePTGeant4Integration::CreateVecGeomWorld(std::string filename)
     return;
   }
 }
+#endif
 
 void AdePTGeant4Integration::CreateVecGeomWorld(G4VPhysicalVolume const *physvol)
 {

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -96,8 +96,10 @@ void AdePTTrackingManager::InitializeAdePT()
       std::cout << "Loading geometry via G4VG\n";
       AdePTGeant4Integration::CreateVecGeomWorld(world);
     } else {
+#ifdef VECGEOM_GDML_SUPPORT
       std::cout << "Loading geometry via VGDML\n";
       AdePTGeant4Integration::CreateVecGeomWorld(fAdePTConfiguration->GetVecGeomGDML());
+#endif
     }
 
 #ifdef ADEPT_USE_EXT_BFIELD

--- a/test/unit/testField/CMakeLists.txt
+++ b/test/unit/testField/CMakeLists.txt
@@ -35,9 +35,10 @@ cuda_rdc_target_link_libraries(testField
   PRIVATE
     CopCore
     VecGeom::vecgeom
-    VecGeom::vgdml
+    $<$<BOOL:${VECGEOM_GDML_SUPPORT}>:VecGeom::vgdml>
     ${Geant4_LIBRARIES}
     ${G4HepEm_LIBRARIES}
+    G4VG::g4vg
 )
 if(ADEPT_USE_EXT_BFIELD)
   # link covfie if external magnetic field usage is enabled

--- a/test/unit/testField/testField.cpp
+++ b/test/unit/testField/testField.cpp
@@ -26,14 +26,19 @@
 #include <G4Timer.hh>
 #include <VecGeom/management/GeoManager.h>
 #include <VecGeom/management/BVHManager.h>
+#ifdef VECGEOM_GDML_SUPPORT
 #include <VecGeom/gdml/Frontend.h>
+#endif
 #include <VecGeom/management/CudaManager.h>
 #ifdef ADEPT_USE_SURF
 #include <VecGeom/surfaces/BrepHelper.h>
 #endif
 
+#include <G4VG.hh>
+
 #include <AdePT/copcore/SystemOfUnits.h>
 #include <AdePT/base/ArgParser.h>
+#include <AdePT/integration/AdePTGeant4Integration.hh>
 
 static constexpr double DefaultCut = 0.7 * mm;
 
@@ -98,6 +103,7 @@ const G4VPhysicalVolume *InitGeant4(const std::string &gdml_file)
 
 const vecgeom::cxx::VPlacedVolume *InitVecGeom(const std::string &gdml_file, int cache_depth)
 {
+#ifdef VECGEOM_GDML_SUPPORT
   // Import the gdml file into VecGeom
   vecgeom::GeoManager::Instance().SetTransformationCacheDepth(cache_depth);
   vgdml::Parser vgdmlParser;
@@ -106,6 +112,17 @@ const vecgeom::cxx::VPlacedVolume *InitVecGeom(const std::string &gdml_file, int
     std::cerr << "Failed to read geometry from GDML file '" << gdml_file << "'" << std::endl;
     return nullptr;
   }
+#else
+  // Use the functionality in AdePTGeant4Integration to load the geometry via vgdml
+  auto *tman    = G4TransportationManager::GetTransportationManager();
+  auto *g4world = tman->GetNavigatorForTracking()->GetWorldVolume();
+  std::cout << "Loading geometry via G4VG\n";
+  vecgeom::GeoManager::Instance().SetTransformationCacheDepth(0);
+  g4vg::Options options;
+  options.reflection_factory = false;
+  auto conversion            = g4vg::convert(g4world, options);
+  vecgeom::GeoManager::Instance().SetWorldAndClose(conversion.world);
+#endif
 
   const vecgeom::VPlacedVolume *world = vecgeom::GeoManager::Instance().GetWorld();
   if (world == nullptr) {


### PR DESCRIPTION
Removes the requirement for VecGeom to be compiled with GDML support. If GDML support is not detected, the functionality to load from file will be disabled.

It was verified that this PR
- [] Changes physics results
- [] Does not change physics results