### PR TITLE
dont create hostTrackData if advanced MC truth is not enabled

### DIFF
--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -333,35 +333,40 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
       // is created (by casting the int G4 id into a uint64 GPU id) Then, the existing hostTrackData is returned or a
       // new one is created in case it either never existed or was retired after the track left the GPU region
       uint64_t gpuTrackID;
-      bool entryExists             = trackMapper.getGPUId(aTrack->GetTrackID(), gpuTrackID);
-      HostTrackData &hostTrackData = trackMapper.activateForGPU(gpuTrackID, aTrack->GetTrackID(), entryExists);
+      HostTrackData dummy; // default constructed dummy if no advanced information is available
+      bool entryExists = trackMapper.getGPUId(aTrack->GetTrackID(), gpuTrackID);
+      HostTrackData &hostTrackData =
+          callUserActions ? trackMapper.activateForGPU(gpuTrackID, aTrack->GetTrackID(), entryExists) : dummy;
 
-      // set pointers and G4 parent id
-      hostTrackData.primary        = aTrack->GetDynamicParticle()->GetPrimaryParticle();
-      hostTrackData.creatorProcess = const_cast<G4VProcess *>(aTrack->GetCreatorProcess());
-      hostTrackData.g4parentid     = aTrack->GetParentID();
+      // fill hostTracKData if being used:
+      if (callUserActions) {
+        // set pointers and G4 parent id
+        hostTrackData.primary        = aTrack->GetDynamicParticle()->GetPrimaryParticle();
+        hostTrackData.creatorProcess = const_cast<G4VProcess *>(aTrack->GetCreatorProcess());
+        hostTrackData.g4parentid     = aTrack->GetParentID();
 
-      // Set the vertex information
-      if (aTrack->GetCurrentStepNumber() == 0) {
-        // If it's the first step of the track these values are not set
-        hostTrackData.vertexPosition          = aTrack->GetPosition();
-        hostTrackData.vertexMomentumDirection = aTrack->GetMomentumDirection();
-        hostTrackData.vertexKineticEnergy     = aTrack->GetKineticEnergy();
-        hostTrackData.logicalVolumeAtVertex   = aTrack->GetTouchableHandle()->GetVolume()->GetLogicalVolume();
-      } else {
-        hostTrackData.vertexPosition          = aTrack->GetVertexPosition();
-        hostTrackData.vertexMomentumDirection = aTrack->GetVertexMomentumDirection();
-        hostTrackData.vertexKineticEnergy     = aTrack->GetVertexKineticEnergy();
-        hostTrackData.logicalVolumeAtVertex   = const_cast<G4LogicalVolume *>(aTrack->GetLogicalVolumeAtVertex());
-      }
+        // Set the vertex information
+        if (aTrack->GetCurrentStepNumber() == 0) {
+          // If it's the first step of the track these values are not set
+          hostTrackData.vertexPosition          = aTrack->GetPosition();
+          hostTrackData.vertexMomentumDirection = aTrack->GetMomentumDirection();
+          hostTrackData.vertexKineticEnergy     = aTrack->GetKineticEnergy();
+          hostTrackData.logicalVolumeAtVertex   = aTrack->GetTouchableHandle()->GetVolume()->GetLogicalVolume();
+        } else {
+          hostTrackData.vertexPosition          = aTrack->GetVertexPosition();
+          hostTrackData.vertexMomentumDirection = aTrack->GetVertexMomentumDirection();
+          hostTrackData.vertexKineticEnergy     = aTrack->GetVertexKineticEnergy();
+          hostTrackData.logicalVolumeAtVertex   = const_cast<G4LogicalVolume *>(aTrack->GetLogicalVolumeAtVertex());
+        }
 
-      // set the particle type
-      if (pdg == 11) {
-        hostTrackData.particleType = ParticleType::Electron;
-      } else if (pdg == -11) {
-        hostTrackData.particleType = ParticleType::Positron;
-      } else if (pdg == 22) {
-        hostTrackData.particleType = ParticleType::Gamma;
+        // set the particle type
+        if (pdg == 11) {
+          hostTrackData.particleType = ParticleType::Electron;
+        } else if (pdg == -11) {
+          hostTrackData.particleType = ParticleType::Positron;
+        } else if (pdg == 22) {
+          hostTrackData.particleType = ParticleType::Gamma;
+        }
       }
 
       // if there has been no step, call PreUserTrackingAction and try to attach UserInformation


### PR DESCRIPTION
This PR fixes an issue with the HostTrackData mapper:

When running without advanced MCTruth info, the hostTrackData was still generated for particles that were being offloaded to the GPU. That was only deleted at the end of the event, causing potential crashes in ttbar events in CMS example1.

The fix is to not create the hostTrackData mapper if no advanced MCTruth info is used, as it won't be deleted when the track finishes.

Note: currently, the advanced MC truth info + hostTrackData is entangled with `/adept/CallUserTrackingAction` or `/adept/CallUserSteppingAction`. This will be separated for clarity in a separate PR.

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results