### PR TITLE
reduce drift test statistics

### DIFF
--- a/test/regression/scripts/validation_drift_test.sh
+++ b/test/regression/scripts/validation_drift_test.sh
@@ -148,11 +148,11 @@ PR_SUPPORTS_ROOT="$(supports_truth_root "${PR_EXECUTABLE}")"
 MASTER_SUPPORTS_ROOT="$(supports_truth_root "${MASTER_EXECUTABLE}")"
 
 if [ "${PR_SUPPORTS_ROOT}" = "1" ] && [ "${MASTER_SUPPORTS_ROOT}" = "1" ]; then
-  # As the ROOT-enabled test can cover MT, the single-threaded 1 event 20 primaries
-  # is changed to 4 events with 5 primaries (using 4 threads), to cover  MT differences.
+  # Adjust the number of events and primaries, as the ROOT-enabled test is much heavier.
+  # Covering multi-threading by running with 4 threads.
   NUM_THREADS=4
   NUM_EVENTS=4
-  GUN_NUMBER=5
+  GUN_NUMBER=3
   CALL_USER_STEPPING_ACTION=True
   CALL_USER_TRACKING_ACTION=True
 fi

--- a/test/regression/scripts/validation_drift_test.sh
+++ b/test/regression/scripts/validation_drift_test.sh
@@ -148,11 +148,11 @@ PR_SUPPORTS_ROOT="$(supports_truth_root "${PR_EXECUTABLE}")"
 MASTER_SUPPORTS_ROOT="$(supports_truth_root "${MASTER_EXECUTABLE}")"
 
 if [ "${PR_SUPPORTS_ROOT}" = "1" ] && [ "${MASTER_SUPPORTS_ROOT}" = "1" ]; then
-  # The ROOT truth path remains exact in MT because it compares merged
-  # histogram populations, whereas the legacy CSV path still depends on the
-  # order of floating-point accumulation and is therefore kept single-threaded.
+  # As the ROOT-enabled test can cover MT, the single-threaded 1 event 20 primaries
+  # is changed to 4 events with 5 primaries (using 4 threads), to cover  MT differences.
   NUM_THREADS=4
-  NUM_EVENTS=8
+  NUM_EVENTS=4
+  GUN_NUMBER=5
   CALL_USER_STEPPING_ACTION=True
   CALL_USER_TRACKING_ACTION=True
 fi


### PR DESCRIPTION
The new drift test with MC truth introduced in #512 was taking only a bit longer on my local machine but much longer on the CI machine. Therefore, this PR is reducing the statistics such that the drift test is fast again (the new MC truth test is heavier, but also had much higher statistics). This PR puts back the old level of statistics.

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results