### PR TITLE
Refactor AdePT into 2 libraries 2: Pass B field directly to AdePTTransport

### DIFF
--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -73,7 +73,8 @@ private:
   ///< Needed to stall the GPU, in case the nPartInFlight * fHitBufferSafetyFactor > available HitSlots
   double fHitBufferSafetyFactor{1.5};
 
-  void Initialize(G4HepEmTrackingManagerSpecialized *hepEmTM, AdePTGeant4Integration &g4Integration);
+  void Initialize(G4HepEmTrackingManagerSpecialized *hepEmTM, AdePTGeant4Integration &g4Integration,
+                  const std::vector<float> &uniformFieldValues);
   void InitBVH();
   bool InitializeGeometry(const vecgeom::cxx::VPlacedVolume *world);
   bool InitializePhysics(G4HepEmConfig *hepEmConfig);
@@ -81,7 +82,7 @@ private:
 
 public:
   AsyncAdePTTransport(AdePTConfiguration &configuration, G4HepEmTrackingManagerSpecialized *hepEmTM,
-                      AdePTGeant4Integration &g4Integration);
+                      AdePTGeant4Integration &g4Integration, const std::vector<float> &uniformFieldValues);
   AsyncAdePTTransport(const AsyncAdePTTransport &other) = delete;
   ~AsyncAdePTTransport();
 

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -74,7 +74,8 @@ std::ostream &operator<<(std::ostream &stream, TrackDataWithIDs const &track)
 // inline to avoid multiple definitions across translation units.
 inline AsyncAdePTTransport::AsyncAdePTTransport(AdePTConfiguration &configuration,
                                                 G4HepEmTrackingManagerSpecialized *hepEmTM,
-                                                AdePTGeant4Integration &g4Integration)
+                                                AdePTGeant4Integration &g4Integration,
+                                                const std::vector<float> &uniformFieldValues)
     : fAdePTSeed{configuration.GetAdePTSeed()}, fNThread{(ushort)configuration.GetNumThreads()},
       fTrackCapacity{(uint)(1024 * 1024 * configuration.GetMillionsOfTrackSlots())},
       fLeakCapacity{(uint)(1024 * 1024 * configuration.GetMillionsOfLeakSlots())},
@@ -96,7 +97,7 @@ inline AsyncAdePTTransport::AsyncAdePTTransport(AdePTConfiguration &configuratio
     std::atomic_init(&eventState, EventState::LeakedTracksRetrieved);
   }
 
-  AsyncAdePTTransport::Initialize(hepEmTM, g4Integration);
+  AsyncAdePTTransport::Initialize(hepEmTM, g4Integration, uniformFieldValues);
 }
 
 inline AsyncAdePTTransport::~AsyncAdePTTransport()
@@ -185,7 +186,8 @@ inline bool AsyncAdePTTransport::InitializePhysics(G4HepEmConfig *hepEmConfig)
 }
 
 inline void AsyncAdePTTransport::Initialize(G4HepEmTrackingManagerSpecialized *hepEmTM,
-                                            AdePTGeant4Integration &g4Integration)
+                                            AdePTGeant4Integration &g4Integration,
+                                            const std::vector<float> &uniformFieldValues)
 {
   const auto numVolumes = vecgeom::GeoManager::Instance().GetRegisteredVolumesCount();
   if (numVolumes == 0) throw std::runtime_error("AsyncAdePTTransport::Initialize: Number of geometry volumes is zero.");
@@ -235,8 +237,7 @@ inline void AsyncAdePTTransport::Initialize(G4HepEmTrackingManagerSpecialized *h
   assert(fBuffer != nullptr);
 
   fGPUstate  = async_adept_impl::InitializeGPU(fTrackCapacity, fLeakCapacity, fScoringCapacity, fNThread, *fBuffer,
-                                               fCPUCapacityFactor, fCPUCopyFraction, fBfieldFile,
-                                               g4Integration.GetUniformField());
+                                               fCPUCapacityFactor, fCPUCopyFraction, fBfieldFile, uniformFieldValues);
   fGPUWorker = async_adept_impl::LaunchGPUWorker(fTrackCapacity, fLeakCapacity, fScoringCapacity, fNThread, *fBuffer,
                                                  *fGPUstate, fEventStates, fCV_G4Workers, fAdePTSeed, fDebugLevel,
                                                  fReturnAllSteps, fReturnFirstAndLastStep, fLastNParticlesOnCPU,

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -27,9 +27,10 @@ using AdePTTransport = AdePTTrackingManager::AdePTTransport;
 }
 
 std::shared_ptr<AdePTTransport> InstantiateAdePT(AdePTConfiguration &conf, G4HepEmTrackingManagerSpecialized *hepEmTM,
-                                                 AdePTGeant4Integration &g4Integration)
+                                                 AdePTGeant4Integration &g4Integration,
+                                                 const std::vector<float> &uniformFieldValues)
 {
-  static std::shared_ptr<AdePTTransport> AdePT{new AdePTTransport(conf, hepEmTM, g4Integration)};
+  static std::shared_ptr<AdePTTransport> AdePT{new AdePTTransport(conf, hepEmTM, g4Integration, uniformFieldValues)};
   return AdePT;
 }
 
@@ -110,10 +111,12 @@ void AdePTTrackingManager::InitializeAdePT()
               << std::endl;
     if (fAdePTConfiguration->GetCovfieBfieldFile() == "") std::cout << "No magnetic field file provided!" << std::endl;
 #endif
+    const auto uniformFieldValues = fGeant4Integration.GetUniformField();
 
     // Create an instance of an AdePT transport engine. This can either be one engine per thread or a shared engine for
     // all threads.
-    fAdeptTransport = InstantiateAdePT(*fAdePTConfiguration, fHepEmTrackingManager.get(), fGeant4Integration);
+    fAdeptTransport =
+        InstantiateAdePT(*fAdePTConfiguration, fHepEmTrackingManager.get(), fGeant4Integration, uniformFieldValues);
 
     // common init done, can notify other workers to proceed their initialization
     {
@@ -134,7 +137,8 @@ void AdePTTrackingManager::InitializeAdePT()
   fAdePTConfiguration->SetNumThreads(fNumThreads);
 
   // AdePTTransport was already initialized by the first G4 worker. The other workers get its pointer here
-  fAdeptTransport = InstantiateAdePT(*fAdePTConfiguration, fHepEmTrackingManager.get(), fGeant4Integration);
+  fAdeptTransport = InstantiateAdePT(*fAdePTConfiguration, fHepEmTrackingManager.get(), fGeant4Integration,
+                                     fGeant4Integration.GetUniformField());
 
   // Initialize the GPU region list
   if (!fAdePTConfiguration->GetTrackInAllRegions()) {


### PR DESCRIPTION
This PR belongs the the refactor of AdePT described in #516.
It is based on #517 and should not be reviewed before that one is merged.

In this PR, the B field is passed directly to the AdePTTransport, such that it does not rely on the AdePTGeant4Integration to get the B field value. In the end, the goal is to not pass the AdePTGeant4Integration to AdePTTransport, to be able to separate the libraries.

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results