### PR TITLE
Refactor AdePT into 2 libraries 4: Fix transport lifetime ownership and shutdown

### DIFF
--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -1016,6 +1016,13 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
       using namespace std::chrono_literals;
       std::this_thread::sleep_for(10ms);
     }
+    // Shutdown can wake the dedicated GPU steering thread out of the idle wait
+    // even when all event states are already LeakedTracksRetrieved. In that
+    // case, one Geant4 worker has entered FreeGPU() and flipped runTransport.
+    // The outer while-condition is only re-checked at the next iteration
+    // boundary, so we must exit explicitly before this current iteration
+    // touches the CUDA stream again during teardown.
+    if (!gpuState.runTransport) break;
 
     if (debugLevel > 2) {
       G4cout << "GPU transport starting" << std::endl;

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -26,14 +26,42 @@
 
 namespace {
 using AdePTTransport = AdePTTrackingManager::AdePTTransport;
+
+// Store only a weak reference here so the transport lifetime is still owned by
+// the thread-local AdePTTrackingManager instances. A static owning shared_ptr
+// would keep the transport alive until very late process teardown.
+std::weak_ptr<AdePTTransport> &SharedAdePTTransportStorage()
+{
+  static std::weak_ptr<AdePTTransport> transport;
+  return transport;
 }
 
-std::shared_ptr<AdePTTransport> GetSharedAdePTTransport(AdePTConfiguration &conf,
-                                                        G4HepEmTrackingManagerSpecialized *hepEmTM)
+std::shared_ptr<AdePTTransport> CreateSharedAdePTTransport(AdePTConfiguration &conf,
+                                                           G4HepEmTrackingManagerSpecialized *hepEmTM)
 {
-  static std::shared_ptr<AdePTTransport> AdePT{new AdePTTransport(conf, hepEmTM->GetConfig())};
-  return AdePT;
+  auto &transport = SharedAdePTTransportStorage();
+  // weak_ptr::lock() promotes the stored weak reference to a shared_ptr if the
+  // shared transport is still alive. This is not a mutex lock.
+  if (auto existing = transport.lock()) {
+    return existing;
+  }
+
+  auto created = std::make_shared<AdePTTransport>(conf, hepEmTM->GetConfig());
+  transport    = created;
+  return created;
 }
+
+std::shared_ptr<AdePTTransport> GetSharedAdePTTransport()
+{
+  // weak_ptr::lock() promotes the weak reference held in static storage. The
+  // actual ownership remains with the AdePTTrackingManager instances.
+  auto transport = SharedAdePTTransportStorage().lock();
+  if (!transport) {
+    throw std::runtime_error("Shared AdePT transport is not available.");
+  }
+  return transport;
+}
+} // namespace
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
@@ -65,7 +93,7 @@ void AdePTTrackingManager::InitializeSharedAdePTTransport()
   const auto uniformFieldValues = fGeant4Integration.GetUniformField();
 
   // Create the shared AdePT transport engine on the first worker thread.
-  fAdeptTransport = GetSharedAdePTTransport(*fAdePTConfiguration, fHepEmTrackingManager.get());
+  fAdeptTransport = CreateSharedAdePTTransport(*fAdePTConfiguration, fHepEmTrackingManager.get());
 
   // Check VecGeom geometry matches Geant4 before deriving any geometry metadata for transport.
   fGeant4Integration.CheckGeometry(fAdeptTransport->GetHepEmState());
@@ -155,7 +183,7 @@ void AdePTTrackingManager::InitializeAdePT()
 
   // The shared AdePT transport was already created and initialized by the first worker.
   // The remaining workers only retrieve the shared pointer here.
-  fAdeptTransport = GetSharedAdePTTransport(*fAdePTConfiguration, fHepEmTrackingManager.get());
+  fAdeptTransport = GetSharedAdePTTransport();
 
   // Initialize the GPU region list
   if (!fAdePTConfiguration->GetTrackInAllRegions()) {


### PR DESCRIPTION

This PR cleans up the lifetime of the shared `AdePTTransport`:

Instead of keeping the transport alive through a static owning `shared_ptr`, the static storage now only keeps a `weak_ptr`, while the real ownership remains with the `AdePTTrackingManager` instances.

This avoids destroying the transport very late during process teardown, where CUDA stream cleanup can already be in an invalid shutdown state.

Another explicit guard was added in the AsyncAdePTTransport:
In this wait loop for work of the G4 workers:
```c++
    while (gpuState.runTransport && std::none_of(eventStates.begin(), eventStates.end(), needTransport)) {
      using namespace std::chrono_literals;
      std::this_thread::sleep_for(10ms);
    }
```
The GPU steering thread can enter the sleep at shutdown, because the needTransport is already false, but the runTransport is not yet switched to false in the `AsyncAdePTDestructor`. If it is then switched to false by the worker in the shutdown, then one more iteration is run, while CUDA might already be in teardown, leading to a crash. This is prevented by a simple guard.

This PR is needed for upcoming restructuring, which exposed this life-time-management problem

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results