### PR TITLE
Refactor AdePT into 2 libraries 6: Refactor static geometry functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,6 +445,7 @@ endif()
 #----------------------------------------------------------------------------#
 set(ADEPT_G4_INTEGRATION_SRCS
   src/AdePTG4HepEmState.cpp
+  src/AdePTGeometryBridge.cpp
   src/G4HepEmTrackingManagerSpecialized.cc
   src/AdePTTrackingManager.cc
   src/G4EmStandardPhysics_AdePT.cc

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -17,10 +17,7 @@
 #include <G4EventManager.hh>
 #include <G4Event.hh>
 
-#include <unordered_map>
 #include <span>
-
-struct G4HepEmData;
 
 namespace AdePTGeant4Integration_detail {
 struct ScoringObjects;
@@ -39,31 +36,6 @@ public:
 
   AdePTGeant4Integration(AdePTGeant4Integration &&)            = default;
   AdePTGeant4Integration &operator=(AdePTGeant4Integration &&) = default;
-
-#ifdef VECGEOM_GDML_SUPPORT
-  /// @brief Initializes VecGeom geometry
-  /// @details Currently VecGeom geometry is initialized by loading it from a GDML file,
-  /// however ideally this function will call the G4 to VecGeom geometry converter
-  static void CreateVecGeomWorld(/*Temporary parameter*/ std::string filename);
-#endif
-
-  /// @brief Construct VecGeom geometry from Geant4 physical volume
-  /// @details This calls the G4VG converter
-  /// @throws std::runtime_error if input or output volumes are nullptr
-  static void CreateVecGeomWorld(G4VPhysicalVolume const *physvol);
-
-  /// @brief This function compares G4 and VecGeom geometries and reports any differences
-  static void CheckGeometry(G4HepEmData const *hepEmData);
-
-  /// @brief Fills the auxiliary data needed for AdePT
-  static void InitVolAuxData(adeptint::VolAuxData *volAuxData, G4HepEmData const *hepEmData,
-                             G4HepEmTrackingManagerSpecialized *hepEmTM, bool trackInAllRegions,
-                             std::vector<std::string> const *gpuRegionNames, adeptint::WDTHostRaw &wdtRaw);
-
-  /// @brief Returns a mapping of VecGeom placed volume IDs to Geant4 physical volumes and a mapping of VecGeom logical
-  /// volume IDs to Geant4 logical volumes
-  static void MapVecGeomToG4(std::vector<G4VPhysicalVolume const *> &vecgeomPvToG4Map,
-                             std::vector<G4LogicalVolume const *> &vecgeomLvToG4Map);
 
   /// @brief Reconstructs GPU hits on host and calls the user-defined sensitive detector code
   void ProcessGPUStep(std::span<const GPUHit> gpuSteps, bool const callUserSteppingAction = false,
@@ -127,8 +99,6 @@ private:
   // helper class to provide the CPU-only data for the returning GPU tracks
   std::unique_ptr<HostTrackDataMapper> fHostTrackDataMapper;
 
-  static std::vector<G4VPhysicalVolume const *> fglobal_vecgeom_pv_to_g4_map;
-  static std::vector<G4LogicalVolume const *> fglobal_vecgeom_lv_to_g4_map;
   std::unique_ptr<AdePTGeant4Integration_detail::ScoringObjects, AdePTGeant4Integration_detail::Deleter>
       fScoringObjects{nullptr};
 };

--- a/include/AdePT/integration/AdePTGeometryBridge.hh
+++ b/include/AdePT/integration/AdePTGeometryBridge.hh
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2026 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ADEPT_GEOMETRY_BRIDGE_HH
+#define ADEPT_GEOMETRY_BRIDGE_HH
+
+#include <AdePT/core/CommonStruct.h>
+#include <AdePT/integration/G4HepEmTrackingManagerSpecialized.hh>
+
+#include <VecGeom/base/Config.h>
+
+#include <string>
+#include <vector>
+
+class G4LogicalVolume;
+class G4VPhysicalVolume;
+struct G4HepEmData;
+
+/// @brief Global bridge between Geant4 host geometry and the VecGeom world used by AdePT.
+/// @details
+/// The geometry world and the VecGeom-to-Geant4 lookup tables are process-global,
+/// so this bridge provides the corresponding global services needed during setup and
+/// touchable reconstruction.
+class AdePTGeometryBridge {
+public:
+#ifdef VECGEOM_GDML_SUPPORT
+  /// @brief Initializes the VecGeom world from a GDML file.
+  /// @details
+  /// This is the temporary path used when a standalone VecGeom GDML description is
+  /// provided instead of converting the Geant4 world through G4VG.
+  static void CreateVecGeomWorld(std::string filename);
+#endif
+
+  /// @brief Converts the Geant4 world volume into the process-global VecGeom world.
+  /// @throws std::runtime_error if the input Geant4 world or resulting VecGeom world is null.
+  static void CreateVecGeomWorld(G4VPhysicalVolume const *physvol);
+
+  /// @brief Verifies that the Geant4 and VecGeom geometries match.
+  static void CheckGeometry(G4HepEmData const *hepEmData);
+
+  /// @brief Fills the auxiliary per-volume data needed by AdePT.
+  static void InitVolAuxData(adeptint::VolAuxData *volAuxData, G4HepEmData const *hepEmData,
+                             G4HepEmTrackingManagerSpecialized *hepEmTM, bool trackInAllRegions,
+                             std::vector<std::string> const *gpuRegionNames, adeptint::WDTHostRaw &wdtRaw);
+
+  /// @brief Returns the Geant4 placed volume matching a VecGeom placed volume.
+  /// @throws std::runtime_error if the VecGeom placed volume is not present in the global lookup table.
+  static G4VPhysicalVolume const *GetG4PhysicalVolume(vecgeom::VPlacedVolume const *placedVolume);
+
+private:
+  /// @brief Builds the lookup tables from VecGeom placed/logical volume ids to Geant4 volumes.
+  static void MapVecGeomToG4(std::vector<G4VPhysicalVolume const *> &vecgeomPvToG4Map,
+                             std::vector<G4LogicalVolume const *> &vecgeomLvToG4Map);
+
+  static std::vector<G4VPhysicalVolume const *> fGlobalVecGeomPvToG4Map;
+  static std::vector<G4LogicalVolume const *> fGlobalVecGeomLvToG4Map;
+};
+
+#endif

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -2,36 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <AdePT/integration/AdePTGeant4Integration.hh>
+#include <AdePT/integration/AdePTGeometryBridge.hh>
 
-#include <VecGeom/management/GeoManager.h>
-#ifdef VECGEOM_GDML_SUPPORT
-#include <VecGeom/gdml/Frontend.h>
-#endif
 #include <VecGeom/navigation/NavigationState.h>
 
 #include <G4ios.hh>
 #include <G4SystemOfUnits.hh>
-#include <G4GeometryManager.hh>
 #include <G4TransportationManager.hh>
-#include <G4MaterialCutsCouple.hh>
 #include <G4VSensitiveDetector.hh>
 #include <G4UniformMagField.hh>
 #include <G4FieldManager.hh>
-#include <G4RegionStore.hh>
 #include <G4TouchableHandle.hh>
-#include <G4PVReplica.hh>
-#include <G4ReplicaNavigation.hh>
 #include <G4StepStatus.hh>
 
-#include <G4HepEmData.hh>
-#include <G4HepEmMatCutData.hh>
 #include <G4HepEmNoProcess.hh>
 
 #include "G4Electron.hh"
 #include "G4Positron.hh"
 #include "G4Gamma.hh"
-
-#include <G4VG.hh>
 
 #include <new>
 #include <type_traits>
@@ -169,317 +157,7 @@ void Deleter::operator()(ScoringObjects *ptr)
 
 } // namespace AdePTGeant4Integration_detail
 
-std::vector<G4VPhysicalVolume const *> AdePTGeant4Integration::fglobal_vecgeom_pv_to_g4_map;
-std::vector<G4LogicalVolume const *> AdePTGeant4Integration::fglobal_vecgeom_lv_to_g4_map;
-
 AdePTGeant4Integration::~AdePTGeant4Integration() {}
-
-void AdePTGeant4Integration::MapVecGeomToG4(std::vector<G4VPhysicalVolume const *> &vecgeomPvToG4Map,
-                                            std::vector<G4LogicalVolume const *> &vecgeomLvToG4Map)
-{
-  const G4VPhysicalVolume *g4world =
-      G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
-  const vecgeom::VPlacedVolume *vecgeomWorld = vecgeom::GeoManager::Instance().GetWorld();
-
-  // recursive geometry visitor lambda matching one by one Geant4 and VecGeom logical volumes
-  typedef std::function<void(G4VPhysicalVolume const *, vecgeom::VPlacedVolume const *)> func_t;
-  func_t visitGeometry = [&](G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVolume const *vg_pvol) {
-    const auto g4_lvol = g4_pvol->GetLogicalVolume();
-    const auto vg_lvol = vg_pvol->GetLogicalVolume();
-
-    // Initialize mapping of Vecgeom PlacedVolume IDs to G4 PhysicalVolume*
-    vecgeomPvToG4Map.resize(std::max<std::size_t>(vecgeomPvToG4Map.size(), vg_pvol->id() + 1), nullptr);
-    vecgeomPvToG4Map[vg_pvol->id()] = g4_pvol;
-    // Initialize mapping of Vecgeom LogicalVolume IDs to G4 LogicalVolume*
-    vecgeomLvToG4Map.resize(std::max<std::size_t>(vecgeomLvToG4Map.size(), vg_lvol->id() + 1), nullptr);
-    vecgeomLvToG4Map[vg_lvol->id()] = g4_lvol;
-
-    // Now do the daughters
-    for (size_t id = 0; id < g4_lvol->GetNoDaughters(); ++id) {
-      auto g4pvol_d = g4_lvol->GetDaughter(id);
-      auto pvol_d   = vg_lvol->GetDaughters()[id];
-
-      visitGeometry(g4pvol_d, pvol_d);
-    }
-  };
-  visitGeometry(g4world, vecgeomWorld);
-}
-
-#ifdef VECGEOM_GDML_SUPPORT
-void AdePTGeant4Integration::CreateVecGeomWorld(std::string filename)
-{
-  // Import the gdml file into VecGeom
-  vecgeom::GeoManager::Instance().SetTransformationCacheDepth(0);
-  vgdml::Parser vgdmlParser;
-  auto middleWare = vgdmlParser.Load(filename, false, mm);
-  if (middleWare == nullptr) {
-    std::cerr << "Failed to read geometry from GDML file '" << filename << "'" << G4endl;
-    return;
-  }
-
-  // Generate the mapping of VecGeom volume IDs to Geant4 physical volumes
-  MapVecGeomToG4(fglobal_vecgeom_pv_to_g4_map, fglobal_vecgeom_lv_to_g4_map);
-
-  const vecgeom::VPlacedVolume *vecgeomWorld = vecgeom::GeoManager::Instance().GetWorld();
-  if (vecgeomWorld == nullptr) {
-    std::cerr << "GeoManager vecgeomWorld volume is nullptr" << G4endl;
-    return;
-  }
-}
-#endif
-
-void AdePTGeant4Integration::CreateVecGeomWorld(G4VPhysicalVolume const *physvol)
-{
-  // EXPECT: a non-null input volume
-  if (physvol == nullptr) {
-    throw std::runtime_error("AdePTGeant4Integration::CreateVecGeomWorld : Input Geant4 Physical Volume is nullptr");
-  }
-
-  vecgeom::GeoManager::Instance().SetTransformationCacheDepth(0);
-  g4vg::Options options;
-  options.reflection_factory = false;
-  auto conversion            = g4vg::convert(physvol, options);
-  vecgeom::GeoManager::Instance().SetWorldAndClose(conversion.world);
-
-  // Get the mapping of VecGeom volume IDs to Geant4 physical volumes from g4vg
-  fglobal_vecgeom_pv_to_g4_map = conversion.physical_volumes;
-  fglobal_vecgeom_lv_to_g4_map = conversion.logical_volumes;
-
-  // EXPECT: we finish with a non-null VecGeom host geometry
-  vecgeom::VPlacedVolume const *vecgeomWorld = vecgeom::GeoManager::Instance().GetWorld();
-  if (vecgeomWorld == nullptr) {
-    throw std::runtime_error("AdePTGeant4Integration::CreateVecGeomWorld : Output VecGeom Physical Volume is nullptr");
-  }
-}
-
-namespace {
-struct VisitContext {
-  const int *g4tohepmcindex;
-  std::size_t nvolumes;
-  G4HepEmData const *hepEmData;
-};
-
-/// Recursive geometry visitor matching one by one Geant4 and VecGeom logical volumes
-void visitGeometry(G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVolume const *vg_pvol, const VisitContext &context)
-{
-  const auto g4_lvol = g4_pvol->GetLogicalVolume();
-  const auto vg_lvol = vg_pvol->GetLogicalVolume();
-
-  // Geant4 Parameterised/Replica volumes are represented with direct placements in VecGeom
-  // To accurately compare the number of daughters, we need to sum multiplicity on Geant4 side
-  const size_t nd     = g4_lvol->GetNoDaughters();
-  size_t nd_converted = 0;
-  for (size_t daughter_id = 0; daughter_id < nd; ++daughter_id) {
-    const G4VPhysicalVolume *daughter_pvol = g4_lvol->GetDaughter(daughter_id);
-    nd_converted += daughter_pvol->GetMultiplicity();
-  }
-
-  const auto daughters = vg_lvol->GetDaughters();
-
-  if (nd_converted != daughters.size())
-    throw std::runtime_error("Fatal: CheckGeometry: Mismatch in number of daughters");
-
-  // Check if transformations are matching
-  // As above, with Parameterized/Replica volumes, we need to compare the transforms between
-  // the VG direct placement and that for the Parameterised/Replicated volume given the same copy
-  // number as that of the VG physical volume.
-  // NOTE:
-  // 1. Nasty const_cast as currently known way to get transform is to directly transform the
-  //    Geant4 phys vol before extracting, which is non-const....
-  // 2. ...this does modify the physical volume, but this is _probably_ o.k. as actual navigation
-  //    will reset things o.k.
-  if (G4VPVParameterisation *param = g4_pvol->GetParameterisation()) {
-    param->ComputeTransformation(vg_pvol->GetCopyNo(), const_cast<G4VPhysicalVolume *>(g4_pvol));
-  } else if (auto *replica = dynamic_cast<G4PVReplica *>(const_cast<G4VPhysicalVolume *>(g4_pvol))) {
-    G4ReplicaNavigation nav;
-    nav.ComputeTransformation(vg_pvol->GetCopyNo(), replica);
-  }
-
-  const auto g4trans            = g4_pvol->GetTranslation();
-  const G4RotationMatrix *g4rot = g4_pvol->GetRotation();
-  G4RotationMatrix idrot;
-  const auto vgtransformation = vg_pvol->GetTransformation();
-  constexpr double epsil      = 1.e-8;
-
-  for (int i = 0; i < 3; ++i) {
-    if (std::abs(g4trans[i] - vgtransformation->Translation(i)) > epsil)
-      throw std::runtime_error(
-          std::string("Fatal: CheckGeometry: Mismatch between Geant4 translation for physical volume") +
-          vg_pvol->GetName());
-  }
-
-  // check if VecGeom and Geant4 (local) transformations are matching. Not optimized, this will re-check
-  // already checked placed volumes when re-visiting the same volumes in different branches
-  if (!g4rot) g4rot = &idrot;
-  for (int row = 0; row < 3; ++row) {
-    for (int col = 0; col < 3; ++col) {
-      int i = row + 3 * col;
-      if (std::abs((*g4rot)(row, col) - vgtransformation->Rotation(i)) > epsil)
-        throw std::runtime_error(
-            std::string("Fatal: CheckGeometry: Mismatch between Geant4 rotation for physical volume") +
-            vg_pvol->GetName());
-    }
-  }
-
-  // Check the couples
-  if (g4_lvol->GetMaterialCutsCouple() == nullptr)
-    throw std::runtime_error("Fatal: CheckGeometry: G4LogicalVolume " + std::string(g4_lvol->GetName()) +
-                             std::string(" has no material-cuts couple"));
-  const int g4mcindex    = g4_lvol->GetMaterialCutsCouple()->GetIndex();
-  const int hepemmcindex = context.g4tohepmcindex[g4mcindex];
-  // Check consistency with G4HepEm data
-  if (context.hepEmData->fTheMatCutData->fMatCutData[hepemmcindex].fG4MatCutIndex != g4mcindex)
-    throw std::runtime_error("Fatal: CheckGeometry: Mismatch between Geant4 mcindex and corresponding G4HepEm index");
-  if (vg_lvol->id() >= context.nvolumes)
-    throw std::runtime_error("Fatal: CheckGeometry: Volume id larger than number of volumes");
-
-  // Now do the daughters
-  for (size_t id = 0; id < g4_lvol->GetNoDaughters(); ++id) {
-    const auto g4pvol_d = g4_lvol->GetDaughter(id);
-    const auto pvol_d   = vg_lvol->GetDaughters()[id];
-
-    visitGeometry(g4pvol_d, pvol_d, context);
-  }
-}
-} // namespace
-
-void AdePTGeant4Integration::CheckGeometry(G4HepEmData const *hepEmData)
-{
-  const G4VPhysicalVolume *g4world =
-      G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
-  const vecgeom::VPlacedVolume *vecgeomWorld = vecgeom::GeoManager::Instance().GetWorld();
-  const int *g4tohepmcindex                  = hepEmData->fTheMatCutData->fG4MCIndexToHepEmMCIndex;
-  const auto nvolumes                        = vecgeom::GeoManager::Instance().GetRegisteredVolumesCount();
-
-  std::cout << "Visiting geometry ...\n";
-  const VisitContext context{g4tohepmcindex, nvolumes, hepEmData};
-  visitGeometry(g4world, vecgeomWorld, context);
-  std::cout << "Visiting geometry done\n";
-}
-
-void AdePTGeant4Integration::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4HepEmData const *hepEmData,
-                                            G4HepEmTrackingManagerSpecialized *hepEmTM, bool trackInAllRegions,
-                                            std::vector<std::string> const *gpuRegionNames,
-                                            adeptint::WDTHostRaw &wdtRaw)
-{
-
-  // Note: the hepEmTM must be passed as an argument despite the member fHepEmTrackingManager,
-  // as InitVolAuxData is a static function and cannot call member variables
-  wdtRaw.ekinMin = (float)hepEmTM->GetWDTKineticEnergyLimit();
-
-  const G4VPhysicalVolume *g4world =
-      G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
-  const vecgeom::VPlacedVolume *vecgeomWorld = vecgeom::GeoManager::Instance().GetWorld();
-  const int *g4tohepmcindex                  = hepEmData->fTheMatCutData->fG4MCIndexToHepEmMCIndex;
-
-  // We need to go from region names to G4Region
-  std::vector<G4Region *> gpuRegions{};
-  if (!trackInAllRegions) {
-    for (std::string regionName : *(gpuRegionNames)) {
-      G4Region *region = G4RegionStore::GetInstance()->GetRegion(regionName);
-      gpuRegions.push_back(region);
-    }
-  }
-
-  // recursive geometry visitor lambda matching one by one Geant4 and VecGeom logical volumes
-  typedef std::function<void(G4VPhysicalVolume const *, vecgeom::VPlacedVolume const *, vecgeom::NavigationState)>
-      func_t;
-  func_t visitGeometry = [&](G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVolume const *vg_pvol,
-                             vecgeom::NavigationState currentNavState) {
-    const auto g4_lvol = g4_pvol->GetLogicalVolume();
-    const auto vg_lvol = vg_pvol->GetLogicalVolume();
-
-    // Push this placed volume into the running NavState
-    currentNavState.Push(vg_pvol);
-    currentNavState.SetBoundaryState(false);
-
-    // Fill the MCC index in the array
-    int g4mcindex                      = g4_lvol->GetMaterialCutsCouple()->GetIndex();
-    int hepemmcindex                   = g4tohepmcindex[g4mcindex];
-    volAuxData[vg_lvol->id()].fMCIndex = hepemmcindex;
-
-    const int regionId = g4_lvol->GetRegion()->GetInstanceID();
-
-    // Check if the region is a Woodcock tracking region in G4HepEm
-    if (hepEmTM->IsWDTRegion(regionId)) {
-      // check if this logical volume is one of the declared WDT root LVs for this region
-      const int rootIMC = hepEmTM->GetWDTCoupleHepEmIndex(regionId, g4_lvol->GetInstanceID());
-      if (rootIMC >= 0) {
-        // this placed volume belongs to a WDT root LV -> record a WDTRoot
-        int idx = (int)wdtRaw.roots.size();
-        wdtRaw.roots.push_back(adeptint::WDTRoot{currentNavState, rootIMC});
-        wdtRaw.regionToRootIndices[regionId].push_back(idx);
-      }
-    }
-
-    // Check if the volume belongs to a GPU region
-    if (!trackInAllRegions) {
-      for (G4Region *gpuRegion : gpuRegions) {
-        if (g4_lvol->GetRegion() == gpuRegion) {
-          volAuxData[vg_lvol->id()].fGPUregionId = g4_lvol->GetRegion()->GetInstanceID();
-        }
-      }
-    } else {
-      volAuxData[vg_lvol->id()].fGPUregionId = g4_lvol->GetRegion()->GetInstanceID();
-    }
-
-    if (g4_lvol->GetSensitiveDetector() != nullptr) {
-      if (volAuxData[vg_lvol->id()].fSensIndex < 0) {
-        G4cout << "VecGeom: Making " << vg_lvol->GetName() << " sensitive" << G4endl;
-      }
-      volAuxData[vg_lvol->id()].fSensIndex = 1;
-    }
-    // Now do the daughters
-    for (size_t id = 0; id < g4_lvol->GetNoDaughters(); ++id) {
-      auto g4pvol_d = g4_lvol->GetDaughter(id);
-      auto pvol_d   = vg_lvol->GetDaughters()[id];
-
-      visitGeometry(g4pvol_d, pvol_d, currentNavState);
-    }
-
-    // Pop NavState before before returning
-    currentNavState.Pop();
-  };
-
-  // Initialize root NavState
-  vecgeom::NavigationState rootNavState;
-
-  visitGeometry(g4world, vecgeomWorld, rootNavState);
-
-  auto findRegionName = [](int rid) -> std::string {
-    for (auto *r : *G4RegionStore::GetInstance()) {
-      if (r && r->GetInstanceID() == rid) return r->GetName();
-    }
-    return std::string("<unknown>");
-  };
-
-  std::cout << "\n=== Woodcock tracking summary (host) ===\n";
-  std::cout << "KineticEnergyLimit = " << wdtRaw.ekinMin << " [G4 units]\n";
-  std::cout << "Total WDT roots found: " << wdtRaw.roots.size() << std::endl;
-  std::cout << "Regions with WDT: " << wdtRaw.regionToRootIndices.size() << std::endl;
-
-  if (wdtRaw.regionToRootIndices.empty()) {
-    std::cout << "  (none)\n";
-  } else {
-    for (const auto &kv : wdtRaw.regionToRootIndices) {
-      const int rid    = kv.first;
-      const auto &idxs = kv.second;
-      std::cout << "\nRegionID " << rid << "  (" << findRegionName(rid) << "): " << idxs.size()
-                << " root placed-volume(s)\n";
-
-      for (size_t i = 0; i < idxs.size(); ++i) {
-        const int rootIdx = idxs[i];
-        const auto &root  = wdtRaw.roots[rootIdx];
-
-        std::cout << "  [" << i << "] hepemIMC=" << root.hepemIMC << "\n";
-        std::cout << "      NavState (level=" << root.root.GetLevel() << "):\n";
-        // vecgeom::NavigationState::Print() prints the full stack
-        root.root.Print();
-      }
-    }
-  }
-  std::cout << "=== End Woodcock tracking summary ===\n\n";
-}
 
 G4Track *AdePTGeant4Integration::ConstructSecondaryTrackInPlace(GPUHit const *secHit) const
 {
@@ -696,7 +374,7 @@ void AdePTGeant4Integration::FillG4NavigationHistory(const vecgeom::NavigationSt
     // While we are in levels shallower than the history depth, it may be that we already
     // have the correct volume in the history
     assert(aNavState.At(aLevel));
-    pnewvol = const_cast<G4VPhysicalVolume *>(fglobal_vecgeom_pv_to_g4_map[aNavState.At(aLevel)->id()]);
+    pnewvol = const_cast<G4VPhysicalVolume *>(AdePTGeometryBridge::GetG4PhysicalVolume(aNavState.At(aLevel)));
     assert(pnewvol != nullptr);
     if (!pnewvol) throw std::runtime_error("VecGeom volume not found in G4 mapping!");
 

--- a/src/AdePTGeometryBridge.cpp
+++ b/src/AdePTGeometryBridge.cpp
@@ -1,0 +1,349 @@
+// SPDX-FileCopyrightText: 2026 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include <AdePT/integration/AdePTGeometryBridge.hh>
+
+#include <VecGeom/management/GeoManager.h>
+#ifdef VECGEOM_GDML_SUPPORT
+#include <VecGeom/gdml/Frontend.h>
+#endif
+#include <VecGeom/navigation/NavigationState.h>
+
+#include <G4HepEmData.hh>
+#include <G4HepEmMatCutData.hh>
+#include <G4LogicalVolume.hh>
+#include <G4MaterialCutsCouple.hh>
+#include <G4PVReplica.hh>
+#include <G4RegionStore.hh>
+#include <G4ReplicaNavigation.hh>
+#include <G4SystemOfUnits.hh>
+#include <G4TransportationManager.hh>
+#include <G4VG.hh>
+#include <G4VSensitiveDetector.hh>
+#include <G4ios.hh>
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <stdexcept>
+
+std::vector<G4VPhysicalVolume const *> AdePTGeometryBridge::fGlobalVecGeomPvToG4Map;
+std::vector<G4LogicalVolume const *> AdePTGeometryBridge::fGlobalVecGeomLvToG4Map;
+
+void AdePTGeometryBridge::MapVecGeomToG4(std::vector<G4VPhysicalVolume const *> &vecgeomPvToG4Map,
+                                         std::vector<G4LogicalVolume const *> &vecgeomLvToG4Map)
+{
+  const G4VPhysicalVolume *g4world =
+      G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
+  const vecgeom::VPlacedVolume *vecgeomWorld = vecgeom::GeoManager::Instance().GetWorld();
+
+  // Recursive geometry visitor lambda matching one by one Geant4 and VecGeom logical volumes.
+  using VisitFn         = std::function<void(G4VPhysicalVolume const *, vecgeom::VPlacedVolume const *)>;
+  VisitFn visitGeometry = [&](G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVolume const *vg_pvol) {
+    const auto g4_lvol = g4_pvol->GetLogicalVolume();
+    const auto vg_lvol = vg_pvol->GetLogicalVolume();
+
+    // Initialize mapping of VecGeom placed-volume ids to Geant4 physical volumes.
+    vecgeomPvToG4Map.resize(std::max<std::size_t>(vecgeomPvToG4Map.size(), vg_pvol->id() + 1), nullptr);
+    vecgeomPvToG4Map[vg_pvol->id()] = g4_pvol;
+
+    // Initialize mapping of VecGeom logical-volume ids to Geant4 logical volumes.
+    vecgeomLvToG4Map.resize(std::max<std::size_t>(vecgeomLvToG4Map.size(), vg_lvol->id() + 1), nullptr);
+    vecgeomLvToG4Map[vg_lvol->id()] = g4_lvol;
+
+    // Now do the daughters.
+    for (size_t id = 0; id < g4_lvol->GetNoDaughters(); ++id) {
+      visitGeometry(g4_lvol->GetDaughter(id), vg_lvol->GetDaughters()[id]);
+    }
+  };
+
+  visitGeometry(g4world, vecgeomWorld);
+}
+
+#ifdef VECGEOM_GDML_SUPPORT
+/// @brief Initialize the process-global VecGeom world from a GDML file.
+void AdePTGeometryBridge::CreateVecGeomWorld(std::string filename)
+{
+  // Import the GDML file into VecGeom.
+  vecgeom::GeoManager::Instance().SetTransformationCacheDepth(0);
+  vgdml::Parser vgdmlParser;
+  auto middleWare = vgdmlParser.Load(filename, false, mm);
+  if (middleWare == nullptr) {
+    std::cerr << "Failed to read geometry from GDML file '" << filename << "'" << G4endl;
+    return;
+  }
+
+  // Generate the mapping of VecGeom volume ids to Geant4 physical volumes.
+  MapVecGeomToG4(fGlobalVecGeomPvToG4Map, fGlobalVecGeomLvToG4Map);
+
+  const vecgeom::VPlacedVolume *vecgeomWorld = vecgeom::GeoManager::Instance().GetWorld();
+  if (vecgeomWorld == nullptr) {
+    std::cerr << "GeoManager vecgeomWorld volume is nullptr" << G4endl;
+    return;
+  }
+}
+#endif
+
+/// @brief Convert the Geant4 world into the process-global VecGeom world via G4VG.
+void AdePTGeometryBridge::CreateVecGeomWorld(G4VPhysicalVolume const *physvol)
+{
+  // EXPECT: a non-null input volume.
+  if (physvol == nullptr) {
+    throw std::runtime_error("AdePTGeometryBridge::CreateVecGeomWorld: Input Geant4 physical volume is nullptr");
+  }
+
+  vecgeom::GeoManager::Instance().SetTransformationCacheDepth(0);
+  g4vg::Options options;
+  options.reflection_factory = false;
+  auto conversion            = g4vg::convert(physvol, options);
+  vecgeom::GeoManager::Instance().SetWorldAndClose(conversion.world);
+
+  // Get the mapping of VecGeom volume ids to Geant4 physical volumes from G4VG.
+  fGlobalVecGeomPvToG4Map = conversion.physical_volumes;
+  fGlobalVecGeomLvToG4Map = conversion.logical_volumes;
+
+  // EXPECT: we finish with a non-null VecGeom host geometry.
+  if (vecgeom::GeoManager::Instance().GetWorld() == nullptr) {
+    throw std::runtime_error("AdePTGeometryBridge::CreateVecGeomWorld: Output VecGeom world is nullptr");
+  }
+}
+
+namespace {
+struct VisitContext {
+  const int *g4tohepmcindex;
+  std::size_t nvolumes;
+  G4HepEmData const *hepEmData;
+};
+
+/// @brief Recursively compare the Geant4 and VecGeom geometry trees.
+void VisitGeometryForChecks(G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVolume const *vg_pvol,
+                            const VisitContext &context)
+{
+  const auto g4_lvol = g4_pvol->GetLogicalVolume();
+  const auto vg_lvol = vg_pvol->GetLogicalVolume();
+
+  // Geant4 parameterised/replica volumes are represented with direct placements in VecGeom.
+  // To accurately compare the number of daughters, sum multiplicity on the Geant4 side.
+  const size_t nd     = g4_lvol->GetNoDaughters();
+  size_t nd_converted = 0;
+  for (size_t daughter_id = 0; daughter_id < nd; ++daughter_id) {
+    nd_converted += g4_lvol->GetDaughter(daughter_id)->GetMultiplicity();
+  }
+
+  const auto daughters = vg_lvol->GetDaughters();
+  if (nd_converted != daughters.size()) {
+    throw std::runtime_error("Fatal: CheckGeometry: Mismatch in number of daughters");
+  }
+
+  // Check whether transformations are matching.
+  // As above, with parameterized/replica volumes we need to compare the transforms between
+  // the VecGeom direct placement and that for the parameterised/replicated volume given the
+  // same copy number as that of the VecGeom physical volume.
+  // NOTE:
+  // 1. This needs a const_cast because the current Geant4 API computes the transform by
+  //    mutating the physical volume.
+  // 2. This does modify the physical volume, but navigation will reset things afterwards.
+  if (G4VPVParameterisation *param = g4_pvol->GetParameterisation()) {
+    param->ComputeTransformation(vg_pvol->GetCopyNo(), const_cast<G4VPhysicalVolume *>(g4_pvol));
+  } else if (auto *replica = dynamic_cast<G4PVReplica *>(const_cast<G4VPhysicalVolume *>(g4_pvol))) {
+    G4ReplicaNavigation nav;
+    nav.ComputeTransformation(vg_pvol->GetCopyNo(), replica);
+  }
+
+  const auto g4trans            = g4_pvol->GetTranslation();
+  const G4RotationMatrix *g4rot = g4_pvol->GetRotation();
+  G4RotationMatrix idrot;
+  const auto vgtransformation = vg_pvol->GetTransformation();
+  constexpr double epsil      = 1.e-8;
+
+  for (int i = 0; i < 3; ++i) {
+    if (std::abs(g4trans[i] - vgtransformation->Translation(i)) > epsil) {
+      throw std::runtime_error(
+          std::string("Fatal: CheckGeometry: Mismatch between Geant4 translation for physical volume") +
+          vg_pvol->GetName());
+    }
+  }
+
+  // Check if VecGeom and Geant4 local transformations are matching.
+  // This is not optimized and will re-check already-checked placed volumes when
+  // revisiting the same volumes in different branches.
+  if (!g4rot) g4rot = &idrot;
+  for (int row = 0; row < 3; ++row) {
+    for (int col = 0; col < 3; ++col) {
+      int i = row + 3 * col;
+      if (std::abs((*g4rot)(row, col) - vgtransformation->Rotation(i)) > epsil) {
+        throw std::runtime_error(
+            std::string("Fatal: CheckGeometry: Mismatch between Geant4 rotation for physical volume") +
+            vg_pvol->GetName());
+      }
+    }
+  }
+
+  if (g4_lvol->GetMaterialCutsCouple() == nullptr) {
+    throw std::runtime_error("Fatal: CheckGeometry: G4LogicalVolume " + std::string(g4_lvol->GetName()) +
+                             std::string(" has no material-cuts couple"));
+  }
+  const int g4mcindex    = g4_lvol->GetMaterialCutsCouple()->GetIndex();
+  const int hepemmcindex = context.g4tohepmcindex[g4mcindex];
+  // Check consistency with G4HepEm data.
+  if (context.hepEmData->fTheMatCutData->fMatCutData[hepemmcindex].fG4MatCutIndex != g4mcindex) {
+    throw std::runtime_error("Fatal: CheckGeometry: Mismatch between Geant4 mcindex and corresponding G4HepEm index");
+  }
+  if (vg_lvol->id() >= context.nvolumes) {
+    throw std::runtime_error("Fatal: CheckGeometry: Volume id larger than number of volumes");
+  }
+
+  // Now do the daughters.
+  for (size_t id = 0; id < g4_lvol->GetNoDaughters(); ++id) {
+    VisitGeometryForChecks(g4_lvol->GetDaughter(id), vg_lvol->GetDaughters()[id], context);
+  }
+}
+} // namespace
+
+/// @brief Compare the Geant4 and VecGeom host geometries for consistency.
+void AdePTGeometryBridge::CheckGeometry(G4HepEmData const *hepEmData)
+{
+  const G4VPhysicalVolume *g4world =
+      G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
+  const vecgeom::VPlacedVolume *vecgeomWorld = vecgeom::GeoManager::Instance().GetWorld();
+  const int *g4tohepmcindex                  = hepEmData->fTheMatCutData->fG4MCIndexToHepEmMCIndex;
+  const auto nvolumes                        = vecgeom::GeoManager::Instance().GetRegisteredVolumesCount();
+
+  std::cout << "Visiting geometry ...\n";
+  const VisitContext context{g4tohepmcindex, nvolumes, hepEmData};
+  VisitGeometryForChecks(g4world, vecgeomWorld, context);
+  std::cout << "Visiting geometry done\n";
+}
+
+/// @brief Fill the auxiliary per-volume transport metadata used by AdePT.
+void AdePTGeometryBridge::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4HepEmData const *hepEmData,
+                                         G4HepEmTrackingManagerSpecialized *hepEmTM, bool trackInAllRegions,
+                                         std::vector<std::string> const *gpuRegionNames, adeptint::WDTHostRaw &wdtRaw)
+{
+  // Note: the hepEmTM must be passed explicitly here, since this is now a stateless
+  // global bridge helper and therefore cannot reach any per-thread integration members.
+  wdtRaw.ekinMin = (float)hepEmTM->GetWDTKineticEnergyLimit();
+
+  const G4VPhysicalVolume *g4world =
+      G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
+  const vecgeom::VPlacedVolume *vecgeomWorld = vecgeom::GeoManager::Instance().GetWorld();
+  const int *g4tohepmcindex                  = hepEmData->fTheMatCutData->fG4MCIndexToHepEmMCIndex;
+
+  // We need to go from region names to G4Region objects.
+  std::vector<G4Region *> gpuRegions{};
+  if (!trackInAllRegions) {
+    for (const std::string &regionName : *gpuRegionNames) {
+      gpuRegions.push_back(G4RegionStore::GetInstance()->GetRegion(regionName));
+    }
+  }
+
+  // Recursive geometry visitor lambda matching one by one Geant4 and VecGeom logical volumes.
+  using VisitFn =
+      std::function<void(G4VPhysicalVolume const *, vecgeom::VPlacedVolume const *, vecgeom::NavigationState)>;
+  VisitFn visitGeometry = [&](G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVolume const *vg_pvol,
+                              vecgeom::NavigationState currentNavState) {
+    const auto g4_lvol = g4_pvol->GetLogicalVolume();
+    const auto vg_lvol = vg_pvol->GetLogicalVolume();
+
+    // Push this placed volume into the running navigation state.
+    currentNavState.Push(vg_pvol);
+    currentNavState.SetBoundaryState(false);
+
+    // Fill the material-cuts-couple index in the auxiliary array.
+    int g4mcindex                      = g4_lvol->GetMaterialCutsCouple()->GetIndex();
+    int hepemmcindex                   = g4tohepmcindex[g4mcindex];
+    volAuxData[vg_lvol->id()].fMCIndex = hepemmcindex;
+
+    const int regionId = g4_lvol->GetRegion()->GetInstanceID();
+    // Check if the region is a Woodcock tracking region in G4HepEm.
+    if (hepEmTM->IsWDTRegion(regionId)) {
+      // Check if this logical volume is one of the declared WDT root LVs for this region.
+      const int rootIMC = hepEmTM->GetWDTCoupleHepEmIndex(regionId, g4_lvol->GetInstanceID());
+      if (rootIMC >= 0) {
+        // This placed volume belongs to a WDT root LV, so record a WDTRoot.
+        int idx = (int)wdtRaw.roots.size();
+        wdtRaw.roots.push_back(adeptint::WDTRoot{currentNavState, rootIMC});
+        wdtRaw.regionToRootIndices[regionId].push_back(idx);
+      }
+    }
+
+    // Check if the volume belongs to a GPU region.
+    if (!trackInAllRegions) {
+      for (G4Region *gpuRegion : gpuRegions) {
+        if (g4_lvol->GetRegion() == gpuRegion) {
+          volAuxData[vg_lvol->id()].fGPUregionId = g4_lvol->GetRegion()->GetInstanceID();
+        }
+      }
+    } else {
+      volAuxData[vg_lvol->id()].fGPUregionId = g4_lvol->GetRegion()->GetInstanceID();
+    }
+
+    if (g4_lvol->GetSensitiveDetector() != nullptr) {
+      if (volAuxData[vg_lvol->id()].fSensIndex < 0) {
+        G4cout << "VecGeom: Making " << vg_lvol->GetName() << " sensitive" << G4endl;
+      }
+      volAuxData[vg_lvol->id()].fSensIndex = 1;
+    }
+
+    // Now do the daughters.
+    for (size_t id = 0; id < g4_lvol->GetNoDaughters(); ++id) {
+      visitGeometry(g4_lvol->GetDaughter(id), vg_lvol->GetDaughters()[id], currentNavState);
+    }
+
+    // Pop the navigation state before returning.
+    currentNavState.Pop();
+  };
+
+  // Initialize the root navigation state.
+  vecgeom::NavigationState rootNavState;
+  visitGeometry(g4world, vecgeomWorld, rootNavState);
+
+  auto findRegionName = [](int rid) -> std::string {
+    for (auto *r : *G4RegionStore::GetInstance()) {
+      if (r && r->GetInstanceID() == rid) return r->GetName();
+    }
+    return std::string("<unknown>");
+  };
+
+  std::cout << "\n=== Woodcock tracking summary (host) ===\n";
+  std::cout << "KineticEnergyLimit = " << wdtRaw.ekinMin << " [G4 units]\n";
+  std::cout << "Total WDT roots found: " << wdtRaw.roots.size() << std::endl;
+  std::cout << "Regions with WDT: " << wdtRaw.regionToRootIndices.size() << std::endl;
+
+  if (wdtRaw.regionToRootIndices.empty()) {
+    std::cout << "  (none)\n";
+  } else {
+    for (const auto &[regionId, indices] : wdtRaw.regionToRootIndices) {
+      std::cout << "\nRegionID " << regionId << "  (" << findRegionName(regionId) << "): " << indices.size()
+                << " root placed-volume(s)\n";
+
+      for (std::size_t i = 0; i < indices.size(); ++i) {
+        const auto &root = wdtRaw.roots[indices[i]];
+        std::cout << "  [" << i << "] hepemIMC=" << root.hepemIMC << "\n";
+        std::cout << "      NavState (level=" << root.root.GetLevel() << "):\n";
+        // vecgeom::NavigationState::Print() prints the full stack.
+        root.root.Print();
+      }
+    }
+  }
+  std::cout << "=== End Woodcock tracking summary ===\n\n";
+}
+
+/// @brief Resolve the Geant4 placed volume associated with a VecGeom placed volume.
+G4VPhysicalVolume const *AdePTGeometryBridge::GetG4PhysicalVolume(vecgeom::VPlacedVolume const *placedVolume)
+{
+  if (placedVolume == nullptr) {
+    throw std::runtime_error("AdePTGeometryBridge::GetG4PhysicalVolume: Input VecGeom placed volume is nullptr");
+  }
+  if (placedVolume->id() >= fGlobalVecGeomPvToG4Map.size()) {
+    throw std::runtime_error(
+        "AdePTGeometryBridge::GetG4PhysicalVolume: VecGeom placed volume id is outside the lookup table");
+  }
+
+  auto *g4Volume = fGlobalVecGeomPvToG4Map[placedVolume->id()];
+  if (g4Volume == nullptr) {
+    throw std::runtime_error(
+        "AdePTGeometryBridge::GetG4PhysicalVolume: VecGeom placed volume not found in Geant4 mapping");
+  }
+  return g4Volume;
+}

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <AdePT/integration/AdePTTrackingManager.hh>
+#include <AdePT/integration/AdePTGeometryBridge.hh>
 
 #include "G4Threading.hh"
 #include "G4Track.hh"
@@ -103,14 +104,14 @@ void AdePTTrackingManager::InitializeSharedAdePTTransport()
   auto adeptG4HepEmState        = std::make_unique<AsyncAdePT::AdePTG4HepEmState>(fHepEmTrackingManager->GetConfig());
 
   // Check VecGeom geometry matches Geant4 before deriving any geometry metadata for transport.
-  fGeant4Integration.CheckGeometry(adeptG4HepEmState->GetData());
+  AdePTGeometryBridge::CheckGeometry(adeptG4HepEmState->GetData());
 
   // Initialize auxiliary per-LV data and collect the raw WDT metadata on the Geant4 side.
   auto *auxData = new adeptint::VolAuxData[vecgeom::GeoManager::Instance().GetRegisteredVolumesCount()];
   adeptint::WDTHostRaw wdtRaw;
-  fGeant4Integration.InitVolAuxData(auxData, adeptG4HepEmState->GetData(), fHepEmTrackingManager.get(),
-                                    fAdePTConfiguration->GetTrackInAllRegions(),
-                                    fAdePTConfiguration->GetGPURegionNames(), wdtRaw);
+  AdePTGeometryBridge::InitVolAuxData(auxData, adeptG4HepEmState->GetData(), fHepEmTrackingManager.get(),
+                                      fAdePTConfiguration->GetTrackInAllRegions(),
+                                      fAdePTConfiguration->GetGPURegionNames(), wdtRaw);
   adeptint::WDTHostPacked wdtPacked = adeptint::PackWDT(wdtRaw);
 
   // Move the fully prepared host-side package into the shared transport. The
@@ -165,11 +166,11 @@ void AdePTTrackingManager::InitializeAdePT()
       auto *tman  = G4TransportationManager::GetTransportationManager();
       auto *world = tman->GetNavigatorForTracking()->GetWorldVolume();
       std::cout << "Loading geometry via G4VG\n";
-      AdePTGeant4Integration::CreateVecGeomWorld(world);
+      AdePTGeometryBridge::CreateVecGeomWorld(world);
     } else {
 #ifdef VECGEOM_GDML_SUPPORT
       std::cout << "Loading geometry via VGDML\n";
-      AdePTGeant4Integration::CreateVecGeomWorld(fAdePTConfiguration->GetVecGeomGDML());
+      AdePTGeometryBridge::CreateVecGeomWorld(fAdePTConfiguration->GetVecGeomGDML());
 #endif
     }
 


### PR DESCRIPTION
This PR belongs to the refactor of AdePT described in https://github.com/apt-sim/AdePT/issues/516.
This PR is based on https://github.com/apt-sim/AdePT/pull/520 and should not be reviewed before that one is merged.

This PR extracts the static geometry setup and mapping logic out of `AdePTGeant4Integration` into a dedicated `AdePTGeometryBridge`.

The goal is to separate the global geometry bridge responsibilities from the per-thread Geant4 integration object.

Before `AdePTGeant4Integration` did both:
- per-thread Geant4 reconstruction and track return
- global geometry conversion and lookup

This PR factors out the global geometry conversion and lookup into a separate helper. This makes the intended architecture clearer, without changing behavior.

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results