### PR TITLE
Refactor AdePT into 2 libraries 8: Refactor transport flush

### DIFF
--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -107,6 +107,16 @@ public:
   /// reconstructs Geant4 steps from the returned GPU hits.
   template <typename Callback>
   void HandleReturnedGPUHitBatchesWith(int threadId, int eventId, Callback &&callback);
+  /// @brief Request that the device flush all pending work for the given worker.
+  void RequestFlush(int threadId);
+  /// @brief Wait until the transport threads make further flush progress.
+  void WaitForFlushProgress();
+  /// @brief Check whether the device side has completed flushing for the given worker.
+  bool IsDeviceFlushed(int threadId) const;
+  /// @brief Take the leaked-track batch returned by transport for the given worker.
+  std::vector<TrackDataWithIDs> TakeReturnedTracks(int threadId);
+  /// @brief Mark the returned-track batch for the given worker as consumed.
+  void MarkLeakedTracksRetrieved(int threadId);
   /// Block until transport of the given event is done.
   void Flush(int threadId, int eventId, AdePTGeant4Integration &g4Integration);
 };

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -271,21 +271,46 @@ inline void AsyncAdePTTransport::HandleReturnedGPUHitBatchesWith(int threadId, i
   }
 }
 
+inline void AsyncAdePTTransport::RequestFlush(int threadId)
+{
+  assert(static_cast<unsigned int>(threadId) < fBuffer->fromDeviceBuffers.size());
+  fEventStates[threadId].store(EventState::G4RequestsFlush, std::memory_order_release);
+}
+
+inline void AsyncAdePTTransport::WaitForFlushProgress()
+{
+  std::unique_lock lock{fMutex_G4Workers};
+  fCV_G4Workers.wait(lock);
+}
+
+inline bool AsyncAdePTTransport::IsDeviceFlushed(int threadId) const
+{
+  return fEventStates[threadId].load(std::memory_order_acquire) >= EventState::DeviceFlushed;
+}
+
+inline std::vector<TrackDataWithIDs> AsyncAdePTTransport::TakeReturnedTracks(int threadId)
+{
+  std::vector<TrackDataWithIDs> tracks;
+  auto handle = fBuffer->getTracksFromDevice(threadId);
+  tracks.swap(handle.tracks);
+  return tracks;
+}
+
+inline void AsyncAdePTTransport::MarkLeakedTracksRetrieved(int threadId)
+{
+  fEventStates[threadId].store(EventState::LeakedTracksRetrieved, std::memory_order_release);
+}
+
 inline void AsyncAdePTTransport::Flush(G4int threadId, G4int eventId, AdePTGeant4Integration &g4Integration)
 {
   if (fDebugLevel >= 3) {
     G4cout << "\nFlushing AdePT for event " << eventId << G4endl;
   }
 
-  assert(static_cast<unsigned int>(threadId) < fBuffer->fromDeviceBuffers.size());
-  fEventStates[threadId].store(EventState::G4RequestsFlush, std::memory_order_release);
+  RequestFlush(threadId);
 
-  while (fEventStates[threadId].load(std::memory_order_acquire) < EventState::DeviceFlushed) {
-
-    {
-      std::unique_lock lock{fMutex_G4Workers};
-      fCV_G4Workers.wait(lock);
-    }
+  while (!IsDeviceFlushed(threadId)) {
+    WaitForFlushProgress();
 
     HandleReturnedGPUHitBatchesWith(threadId, eventId, [&](std::span<const GPUHit> gpuSteps) {
       // The returned GPU steps are ordered like this:
@@ -313,12 +338,8 @@ inline void AsyncAdePTTransport::Flush(G4int threadId, G4int eventId, AdePTGeant
   }
 
   // Now device should be flushed, so retrieve the tracks:
-  std::vector<TrackDataWithIDs> tracks;
-  {
-    auto handle = fBuffer->getTracksFromDevice(threadId);
-    tracks.swap(handle.tracks);
-    fEventStates[threadId].store(EventState::LeakedTracksRetrieved, std::memory_order_release);
-  }
+  std::vector<TrackDataWithIDs> tracks = TakeReturnedTracks(threadId);
+  MarkLeakedTracksRetrieved(threadId);
 
   // TODO: Sort tracks on device?
 #ifndef NDEBUG


### PR DESCRIPTION
This PR belongs to the refactor of AdePT described in https://github.com/apt-sim/AdePT/issues/516.
This PR is based on https://github.com/apt-sim/AdePT/pull/523 and should not be reviewed before that one is merged.

This PR is a preparation to move out the event flush from the AsyncAdePTTransport. It introduces transport-side flush functions (RequestFlush, WaitForFlushProgress, IsDeviceFlushed, TakeReturnedTracks, and MarkLeakedTracksRetrieved) and refactors Flush(...) to use them internally while preserving the current behavior. 
In the next step, those functions will be called from the AdePTTrackingManager.

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results