### PR TITLE
Refactor AdePT into 2 libraries 9: Move flushing of an event to AdePTTrackingManager

### DIFF
--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -57,7 +57,6 @@ private:
   std::condition_variable fCV_G4Workers;             ///< Communicate with G4 workers
   std::mutex fMutex_G4Workers;                       ///< Mutex associated to the condition variable
   std::vector<std::atomic<EventState>> fEventStates; ///< State machine for each G4 worker
-  std::vector<double> fGPUNetEnergy;
   bool fTrackInAllRegions = false;
   bool fHasWDTRegions     = false;
   std::vector<std::string> const *fGPURegionNames;
@@ -116,10 +115,6 @@ public:
   bool IsDeviceFlushed(int threadId) const;
   /// @brief Take the leaked-track batch returned by transport for the given worker.
   std::vector<TrackDataWithIDs> TakeReturnedTracks(int threadId);
-  /// @brief Sort and account for a returned-track batch after transport hands it to the host.
-  /// @details This keeps the bookkeeping in the AdePTTransport even though
-  /// the flush is now triggered from the AdePTTrackingManager.
-  void PrepareReturnedTracks(int threadId, int eventId, std::vector<TrackDataWithIDs> &tracks);
   /// @brief Mark the returned-track batch for the given worker as consumed.
   void MarkLeakedTracksRetrieved(int threadId);
 };

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -24,8 +24,6 @@
 #include <G4HepEmParameters.hh>
 #include <G4LogicalVolumeStore.hh>
 
-#include <iomanip>
-
 /// Forward declarations
 namespace async_adept_impl {
 void setDeviceLimits(int stackLimit = 0, int heapLimit = 0);
@@ -48,25 +46,6 @@ void FreeGPU(std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> 
 
 namespace AsyncAdePT {
 
-namespace {
-template <typename T>
-std::size_t countTracks(int pdgToSelect, T const &container)
-{
-  return std::count_if(container.begin(), container.end(),
-                       [pdgToSelect](TrackDataWithIDs const &track) { return track.pdg == pdgToSelect; });
-}
-
-std::ostream &operator<<(std::ostream &stream, TrackDataWithIDs const &track)
-{
-  const auto flags = stream.flags();
-  stream << std::setw(5) << track.pdg << std::scientific << std::setw(15) << std::setprecision(6) << track.eKin << " ("
-         << std::setprecision(2) << std::setw(9) << track.position[0] << std::setw(9) << track.position[1]
-         << std::setw(9) << track.position[2] << ")";
-  stream.flags(flags);
-  return stream;
-}
-} // namespace
-
 // These definitions live in a header-included .icc file, so they must remain
 // inline to avoid multiple definitions across translation units.
 inline AsyncAdePTTransport::AsyncAdePTTransport(AdePTConfiguration &configuration,
@@ -80,7 +59,7 @@ inline AsyncAdePTTransport::AsyncAdePTTransport(AdePTConfiguration &configuratio
       fDebugLevel{configuration.GetVerbosity()}, fCUDAStackLimit{configuration.GetCUDAStackLimit()},
       fCUDAHeapLimit{configuration.GetCUDAHeapLimit()}, fLastNParticlesOnCPU{configuration.GetLastNParticlesOnCPU()},
       fMaxWDTIter{configuration.GetMaxWDTIter()}, fAdePTG4HepEmState(std::move(adeptG4HepEmState)),
-      fEventStates(fNThread), fGPUNetEnergy(fNThread, 0.0), fTrackInAllRegions{configuration.GetTrackInAllRegions()},
+      fEventStates(fNThread), fTrackInAllRegions{configuration.GetTrackInAllRegions()},
       fGPURegionNames{configuration.GetGPURegionNames()}, fCPURegionNames{configuration.GetCPURegionNames()},
       fReturnAllSteps{configuration.GetCallUserSteppingAction()},
       fReturnFirstAndLastStep{configuration.GetCallUserTrackingAction() || configuration.GetCallUserSteppingAction()},
@@ -122,13 +101,6 @@ inline void AsyncAdePTTransport::AddTrack(int pdg, uint64_t trackId, uint64_t pa
                          properTime,  weight,
                          stepCounter, std::move(state),
                          eventId,     static_cast<short>(threadId)};
-  if (fDebugLevel >= 2) {
-    fGPUNetEnergy[threadId] += energy;
-    if (fDebugLevel >= 8) {
-      G4cout << "\n[_in," << eventId << "," << trackId << "]: " << track << "\tGPU net energy " << std::setprecision(6)
-             << fGPUNetEnergy[threadId] << G4endl;
-    }
-  }
 
   // Lock buffer and emplace the track
   {
@@ -294,49 +266,6 @@ inline std::vector<TrackDataWithIDs> AsyncAdePTTransport::TakeReturnedTracks(int
   auto handle = fBuffer->getTracksFromDevice(threadId);
   tracks.swap(handle.tracks);
   return tracks;
-}
-
-inline void AsyncAdePTTransport::PrepareReturnedTracks(int threadId, int eventId, std::vector<TrackDataWithIDs> &tracks)
-{
-  // TODO: Sort tracks on device?
-#ifndef NDEBUG
-  for (auto const &track : tracks) {
-    bool error = false;
-    if (track.threadId != threadId || track.eventId != static_cast<unsigned int>(eventId)) error = true;
-    if (!(track.pdg == -11 || track.pdg == 11 || track.pdg == 22)) error = true;
-    if (error)
-      std::cerr << "Error in returning track: threadId=" << track.threadId << " eventId=" << track.eventId
-                << " pdg=" << track.pdg << "\n";
-    assert(!error);
-  }
-#endif
-
-  // Sort the tracks coming from device by energy. This is necessary to ensure reproducibility
-  std::sort(tracks.begin(), tracks.end());
-
-  const auto oldEnergyTransferred = fGPUNetEnergy[threadId];
-  if (fDebugLevel >= 2) {
-    unsigned int trackId = 0;
-    for (const auto &track : tracks) {
-
-      fGPUNetEnergy[threadId] -= track.eKin;
-      if (fDebugLevel >= 8) {
-        G4cout << "\n[out," << track.eventId << "," << trackId++ << "]: " << track << "\tGPU net energy "
-               << std::setprecision(6) << fGPUNetEnergy[threadId] << G4endl;
-      }
-    }
-  }
-
-  if (fDebugLevel >= 2) {
-    std::stringstream str;
-    str << "\n[" << eventId << "]: Pushed " << tracks.size() << " tracks to G4";
-    str << "\tEnergy back to G4: " << std::setprecision(6)
-        << (oldEnergyTransferred - fGPUNetEnergy[threadId]) / CLHEP::GeV << "\tGPU net energy " << std::setprecision(6)
-        << fGPUNetEnergy[threadId] / CLHEP::GeV << " GeV";
-    str << "\t(" << countTracks(11, tracks) << ", " << countTracks(-11, tracks) << ", " << countTracks(22, tracks)
-        << ")";
-    G4cout << str.str() << G4endl;
-  }
 }
 
 inline void AsyncAdePTTransport::MarkLeakedTracksRetrieved(int threadId)

--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -83,6 +83,9 @@ private:
   /// each batch.
   void ProcessReturnedGPUHits(int threadId, int eventId);
 
+  /// @brief Validate and sort returned tracks before reinjecting them into Geant4.
+  void PrepareReturnedTracksForGeant4(int threadId, int eventId, std::vector<AsyncAdePT::TrackDataWithIDs> &tracks);
+
   std::unique_ptr<G4HepEmTrackingManagerSpecialized> fHepEmTrackingManager;
   AdePTGeant4Integration fGeant4Integration;
   static inline int fNumThreads{0};

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -20,6 +20,7 @@
 #include <VecGeom/management/GeoManager.h>
 
 #include <algorithm>
+#include <cassert>
 
 #ifdef ENABLE_POWER_METER
 #include <power_meter.hh>
@@ -342,9 +343,28 @@ void AdePTTrackingManager::FlushEvent()
   // transport and hand it back to Geant4 on the host side.
   std::vector<AsyncAdePT::TrackDataWithIDs> tracks = fAdeptTransport->TakeReturnedTracks(threadId);
   fAdeptTransport->MarkLeakedTracksRetrieved(threadId);
-  fAdeptTransport->PrepareReturnedTracks(threadId, eventId, tracks);
+  PrepareReturnedTracksForGeant4(threadId, eventId, tracks);
   fGeant4Integration.ReturnTracks(tracks.begin(), tracks.end(), fAdeptTransport->GetDebugLevel(),
                                   fAdeptTransport->GetReturnFirstAndLastStep());
+}
+
+void AdePTTrackingManager::PrepareReturnedTracksForGeant4(int threadId, int eventId,
+                                                          std::vector<AsyncAdePT::TrackDataWithIDs> &tracks)
+{
+#ifndef NDEBUG
+  for (auto const &track : tracks) {
+    bool error = false;
+    if (track.threadId != threadId || track.eventId != static_cast<unsigned int>(eventId)) error = true;
+    if (!(track.pdg == -11 || track.pdg == 11 || track.pdg == 22)) error = true;
+    if (error)
+      std::cerr << "Error in returning track: threadId=" << track.threadId << " eventId=" << track.eventId
+                << " pdg=" << track.pdg << "\n";
+    assert(!error);
+  }
+#endif
+
+  // Sort the tracks coming from device by energy. This is necessary to ensure reproducibility.
+  std::sort(tracks.begin(), tracks.end());
 }
 
 void AdePTTrackingManager::ProcessReturnedGPUHits(int threadId, int eventId)


### PR DESCRIPTION
This PR belongs to the refactor of AdePT described in https://github.com/apt-sim/AdePT/issues/516.
This PR is based on https://github.com/apt-sim/AdePT/pull/524 and should not be reviewed before that one is merged.

This PR uses the new AdePTTransport functions introduced in #524 to trigger the flush from within the AdePTTrackingManager. 
This is the final bigger step to move the dependency of the AdePTTransport on the AdePTGeant5Integration layer. 

Next step will be to actually separate the two libraries.

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results