### PR TITLE
Refactor AdePT into 2 libraries 10: Remove leftover G4-dependency from AdePTTransport

### DIFF
--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2024 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-/// The The Geant4 AdePT integration service. This provides the interfaces for:
-/// - initializing the geometry and physics on the AdePT size
+/// The AdePT transport service. This provides the interfaces for:
+/// - initializing geometry and physics on the AdePT side
 /// - filling the buffer with tracks to be transported on the GPU
-/// - Calling the Shower method transporting a buffer on the GPU
+/// - driving the GPU transport worker
 
 #ifndef ASYNC_ADEPT_TRANSPORT_HH
 #define ASYNC_ADEPT_TRANSPORT_HH
@@ -25,9 +25,6 @@
 #include <thread>
 #include <unordered_map>
 #include <optional>
-
-class G4Region;
-class G4VPhysicalVolume;
 namespace AsyncAdePT {
 struct TrackBuffer;
 struct GPUstate;

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -9,21 +9,11 @@
 #include <VecGeom/surfaces/BrepHelper.h>
 #endif
 
-#include <G4Timer.hh>
-#include <G4RunManager.hh>
-#include <G4Threading.hh>
-#include <G4Proton.hh>
-#include <G4Region.hh>
-#include <G4SDManager.hh>
-#include <G4VFastSimSensitiveDetector.hh>
-#include <G4MaterialCutsCouple.hh>
-#include <G4ProductionCutsTable.hh>
-#include <G4TransportationManager.hh>
-
 #include <G4HepEmData.hh>
 #include <G4HepEmParameters.hh>
-#include <G4LogicalVolumeStore.hh>
 
+#include <chrono>
+#include <iostream>
 /// Forward declarations
 namespace async_adept_impl {
 void setDeviceLimits(int stackLimit = 0, int heapLimit = 0);
@@ -88,7 +78,7 @@ inline void AsyncAdePTTransport::AddTrack(int pdg, uint64_t trackId, uint64_t pa
                                           int threadId, unsigned int eventId, vecgeom::NavigationState &&state)
 {
   if (pdg != 11 && pdg != -11 && pdg != 22) {
-    G4cerr << __FILE__ << ":" << __LINE__ << ": Only supporting EM tracks. Got pdgID=" << pdg << "\n";
+    std::cerr << __FILE__ << ":" << __LINE__ << ": Only supporting EM tracks. Got pdgID=" << pdg << "\n";
     return;
   }
 
@@ -128,12 +118,11 @@ inline bool AsyncAdePTTransport::InitializeGeometry(const vecgeom::cxx::VPlacedV
   using SurfData   = vgbrep::SurfData<double>;
   using BrepHelper = vgbrep::BrepHelper<double>;
 #endif
-  G4Timer timer;
-  timer.Start();
+  auto start = std::chrono::steady_clock::now();
   if (!BrepHelper::Instance().Convert()) return 1;
   BrepHelper::Instance().PrintSurfData();
-  timer.Stop();
-  std::cout << "== Conversion to surface model done in " << timer.GetRealElapsed() << " [s]\n";
+  auto elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - start);
+  std::cout << "== Conversion to surface model done in " << elapsed.count() << " [s]\n";
   // Upload only navigation table to the GPU
   cudaManager.SynchronizeNavigationTable();
   async_adept_impl::CopySurfaceModelToGPU();
@@ -166,7 +155,7 @@ inline void AsyncAdePTTransport::Initialize(adeptint::VolAuxData *auxData, const
   if (vecgeom::GeoManager::Instance().GetRegisteredVolumesCount() == 0)
     throw std::runtime_error("AsyncAdePTTransport::Initialize: Number of geometry volumes is zero.");
 
-  G4cout << "=== AsyncAdePTTransport: initializing geometry and physics\n";
+  std::cout << "=== AsyncAdePTTransport: initializing geometry and physics\n";
   // Initialize geometry on device
   if (!vecgeom::GeoManager::Instance().IsClosed())
     throw std::runtime_error("AsyncAdePTTransport::Initialize: VecGeom geometry not closed.");
@@ -198,8 +187,8 @@ inline void AsyncAdePTTransport::Initialize(adeptint::VolAuxData *auxData, const
   // NOTE: Increasing the size of the leak buffer size can probably improve performance
   // Allocate buffers to transport particles to/from device. Scale the size of the staging area
   // with the number of threads.
-  G4cout << "\nAllocating " << 4 * 8192 * fNThread << " To-device buffer slots" << G4endl;
-  G4cout << "\nAllocating " << 2048 * fNThread << " From-device buffer slots" << G4endl;
+  std::cout << "\nAllocating " << 4 * 8192 * fNThread << " To-device buffer slots\n";
+  std::cout << "\nAllocating " << 2048 * fNThread << " From-device buffer slots\n";
   fBuffer = std::make_unique<TrackBuffer>(4 * 8192 * fNThread, 2048 * fNThread, fNThread);
 
   assert(fBuffer != nullptr);
@@ -267,7 +256,6 @@ inline std::vector<TrackDataWithIDs> AsyncAdePTTransport::TakeReturnedTracks(int
   tracks.swap(handle.tracks);
   return tracks;
 }
-
 inline void AsyncAdePTTransport::MarkLeakedTracksRetrieved(int threadId)
 {
   fEventStates[threadId].store(EventState::LeakedTracksRetrieved, std::memory_order_release);


### PR DESCRIPTION
This PR belongs to the refactor of AdePT described in https://github.com/apt-sim/AdePT/issues/516.
This PR is based on https://github.com/apt-sim/AdePT/pull/525 and should not be reviewed before that one is merged.

This small cleanup PR removes the remaining G4 dependency from the AdePTTransport: usage of G4Timer or G4Cout. 

Now, the AdePTTransport does not depend on G4 anymore and can be separated in the next PR.


It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results