### PR TITLE
Make CI builds actually use Debug

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
     CMAKE_BINARY_DIR     = 'build'
     CMAKE_INSTALL_PREFIX = 'install'
     CUDA_CAPABILITY      = '75'
-    BUILDTYPE            = params.BUILDTYPE
+    BUILDTYPE            = "${params.BUILDTYPE}"
   }
 
   agent none


### PR DESCRIPTION
I think this should make Debug show up here then

https://github.com/apt-sim/AdePT/blob/a79bb718b137e08f08fc27b0c0af655b11470843/jenkins/adept-ctest-build.cmake#L45-L49