### PR TITLE
Refactor AdePT into 2 libraries 11:  move packing of Woodcock data to GeometryBridge

### DIFF
--- a/include/AdePT/core/CommonStruct.h
+++ b/include/AdePT/core/CommonStruct.h
@@ -12,9 +12,6 @@
 
 #include <G4HepEmRandomEngine.hh>
 
-#include "G4RegionStore.hh"
-#include "G4Region.hh"
-
 #include <atomic>
 #include <array>
 #include <mutex>
@@ -142,40 +139,6 @@ struct WDTDeviceBuffers {
   WDTRegion *d_regions = nullptr;
   int *d_map           = nullptr;
 };
-
-/// @brief This packs the Woodcock data from the original map to arrays that can be copied to the GPU
-/// @param raw raw WDT data, stored in a map
-/// @return packed, dense WDT data, ready to be copied to the GPU
-inline WDTHostPacked PackWDT(const WDTHostRaw &raw)
-{
-  WDTHostPacked packed;
-
-  // Build dense regionId -> bucket index
-  int maxRegionId = -1;
-  for (auto *r : *G4RegionStore::GetInstance())
-    if (r) maxRegionId = std::max(maxRegionId, r->GetInstanceID());
-
-  packed.regionToWDT.assign(maxRegionId + 1, -1);
-
-  packed.roots.reserve(raw.roots.size());
-  packed.regions.reserve(raw.regionToRootIndices.size());
-
-  int runningOffset = 0;
-  for (const auto &kv : raw.regionToRootIndices) {
-    const int rid    = kv.first;
-    const auto &idxs = kv.second;
-
-    packed.regionToWDT[rid] = (int)packed.regions.size();
-    packed.regions.push_back(WDTRegion{runningOffset, (int)idxs.size(), raw.ekinMin});
-
-    for (int idx : idxs) {
-      packed.roots.push_back(raw.roots[idx]); // preserve order per region
-    }
-    runningOffset += (int)idxs.size();
-  }
-
-  return packed;
-}
 
 } // end namespace adeptint
 

--- a/include/AdePT/integration/AdePTGeometryBridge.hh
+++ b/include/AdePT/integration/AdePTGeometryBridge.hh
@@ -43,6 +43,11 @@ public:
                              G4HepEmTrackingManagerSpecialized *hepEmTM, bool trackInAllRegions,
                              std::vector<std::string> const *gpuRegionNames, adeptint::WDTHostRaw &wdtRaw);
 
+  /// @brief Pack the Woodcock tracking data from the sparse host-side map into arrays that can be copied to the GPU.
+  /// @param wdtRaw Raw WDT data collected during geometry traversal.
+  /// @return Packed, dense WDT data ready to be handed to the transport for device upload.
+  static adeptint::WDTHostPacked PackWDT(adeptint::WDTHostRaw const &wdtRaw);
+
   /// @brief Returns the Geant4 placed volume matching a VecGeom placed volume.
   /// @throws std::runtime_error if the VecGeom placed volume is not present in the global lookup table.
   static G4VPhysicalVolume const *GetG4PhysicalVolume(vecgeom::VPlacedVolume const *placedVolume);

--- a/src/AdePTGeometryBridge.cpp
+++ b/src/AdePTGeometryBridge.cpp
@@ -329,6 +329,33 @@ void AdePTGeometryBridge::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4Hep
   std::cout << "=== End Woodcock tracking summary ===\n\n";
 }
 
+adeptint::WDTHostPacked AdePTGeometryBridge::PackWDT(adeptint::WDTHostRaw const &wdtRaw)
+{
+  adeptint::WDTHostPacked packed;
+
+  int maxRegionId = -1;
+  for (auto *region : *G4RegionStore::GetInstance())
+    if (region) maxRegionId = std::max(maxRegionId, region->GetInstanceID());
+
+  packed.regionToWDT.assign(maxRegionId + 1, -1);
+
+  packed.roots.reserve(wdtRaw.roots.size());
+  packed.regions.reserve(wdtRaw.regionToRootIndices.size());
+
+  int runningOffset = 0;
+  for (auto const &[regionId, rootIndices] : wdtRaw.regionToRootIndices) {
+    packed.regionToWDT[regionId] = static_cast<int>(packed.regions.size());
+    packed.regions.push_back(adeptint::WDTRegion{runningOffset, static_cast<int>(rootIndices.size()), wdtRaw.ekinMin});
+
+    for (int index : rootIndices) {
+      packed.roots.push_back(wdtRaw.roots[index]);
+    }
+    runningOffset += static_cast<int>(rootIndices.size());
+  }
+
+  return packed;
+}
+
 /// @brief Resolve the Geant4 placed volume associated with a VecGeom placed volume.
 G4VPhysicalVolume const *AdePTGeometryBridge::GetG4PhysicalVolume(vecgeom::VPlacedVolume const *placedVolume)
 {

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -113,7 +113,7 @@ void AdePTTrackingManager::InitializeSharedAdePTTransport()
   AdePTGeometryBridge::InitVolAuxData(auxData, adeptG4HepEmState->GetData(), fHepEmTrackingManager.get(),
                                       fAdePTConfiguration->GetTrackInAllRegions(),
                                       fAdePTConfiguration->GetGPURegionNames(), wdtRaw);
-  adeptint::WDTHostPacked wdtPacked = adeptint::PackWDT(wdtRaw);
+  adeptint::WDTHostPacked wdtPacked = AdePTGeometryBridge::PackWDT(wdtRaw);
 
   // Move the fully prepared host-side package into the shared transport. The
   // first worker creates the transport here; later workers only retrieve the


### PR DESCRIPTION
This PR belongs to the refactor of AdePT described in https://github.com/apt-sim/AdePT/issues/516.

This small PR fixes a leftover that is needed to split AdePT into two libraries:

The initialization of the Woodcock tracking geometry data was done in the `CommonStruct`, which will belong to the `AdePT::core`, but it was relying on the `G4RegionStore`. This PR moves it into the GeometryBridge, which will live in the g4integration.

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results