### PR TITLE
List all failing ROOT histograms in drift test check

### DIFF
--- a/test/regression/scripts/python_scripts/check_root_histograms.py
+++ b/test/regression/scripts/python_scripts/check_root_histograms.py
@@ -65,6 +65,10 @@ def compare_single_histogram(name, hist1, hist2, root1, root2, abs_tol, rel_tol)
     metadata2 = load_value_metadata(root2, name)
     label_metadata1 = load_label_metadata(root1, name)
     label_metadata2 = load_label_metadata(root2, name)
+    values1 = metadata1.splitlines() if metadata1 is not None else None
+    values2 = metadata2.splitlines() if metadata2 is not None else None
+    labels1 = label_metadata1.splitlines() if label_metadata1 is not None else None
+    labels2 = label_metadata2.splitlines() if label_metadata2 is not None else None
 
     # For exact-value histograms we first compare the metadata that defines
     # which floating-point value each bin corresponds to, and only then the
@@ -73,8 +77,6 @@ def compare_single_histogram(name, hist1, hist2, root1, root2, abs_tol, rel_tol)
         return f"Histogram '{name}' differs: exact-value metadata is missing in one file."
 
     if metadata1 is not None and metadata1 != metadata2:
-        values1 = metadata1.splitlines()
-        values2 = metadata2.splitlines()
         for index, (value1, value2) in enumerate(zip(values1, values2), start=1):
             if value1 != value2:
                 return f"Histogram '{name}' differs at bin {index}: value '{value1}' != '{value2}'"
@@ -87,8 +89,6 @@ def compare_single_histogram(name, hist1, hist2, root1, root2, abs_tol, rel_tol)
         return f"Histogram '{name}' differs: label metadata is missing in one file."
 
     if label_metadata1 is not None and label_metadata1 != label_metadata2:
-        labels1 = label_metadata1.splitlines()
-        labels2 = label_metadata2.splitlines()
         for index, (label1, label2) in enumerate(zip(labels1, labels2), start=1):
             if label1 != label2:
                 return f"Histogram '{name}' differs at bin {index}: label '{label1}' != '{label2}'"
@@ -98,15 +98,17 @@ def compare_single_histogram(name, hist1, hist2, root1, root2, abs_tol, rel_tol)
         )
 
     for bin_index in range(1, hist1.GetNbinsX() + 1):
-        label1 = ""
-        if label_metadata1 is not None:
-            label1 = label_metadata1.splitlines()[bin_index - 1]
+        if values1 is not None:
+            label1 = values1[bin_index - 1]
+        elif labels1 is not None:
+            label1 = labels1[bin_index - 1]
         else:
             label1 = hist1.GetXaxis().GetBinLabel(bin_index)
 
-        label2 = ""
-        if label_metadata2 is not None:
-            label2 = label_metadata2.splitlines()[bin_index - 1]
+        if values2 is not None:
+            label2 = values2[bin_index - 1]
+        elif labels2 is not None:
+            label2 = labels2[bin_index - 1]
         else:
             label2 = hist2.GetXaxis().GetBinLabel(bin_index)
 
@@ -116,9 +118,7 @@ def compare_single_histogram(name, hist1, hist2, root1, root2, abs_tol, rel_tol)
         value1 = hist1.GetBinContent(bin_index)
         value2 = hist2.GetBinContent(bin_index)
         if not math.isclose(value1, value2, rel_tol=rel_tol, abs_tol=abs_tol):
-            if metadata1 is not None:
-                label1 = metadata1.splitlines()[bin_index - 1]
-            elif not label1:
+            if not label1:
                 label1 = f"bin={bin_index}"
             return (
                 f"Histogram '{name}' differs at bin {bin_index} ('{label1}'): "

--- a/test/regression/scripts/python_scripts/check_root_histograms.py
+++ b/test/regression/scripts/python_scripts/check_root_histograms.py
@@ -57,6 +57,77 @@ def load_label_metadata(root_file, histogram_name):
     return metadata.GetString().Data()
 
 
+def compare_single_histogram(name, hist1, hist2, root1, root2, abs_tol, rel_tol):
+    if hist1.GetNbinsX() != hist2.GetNbinsX():
+        return f"Histogram '{name}' differs: bin count {hist1.GetNbinsX()} != {hist2.GetNbinsX()}"
+
+    metadata1 = load_value_metadata(root1, name)
+    metadata2 = load_value_metadata(root2, name)
+    label_metadata1 = load_label_metadata(root1, name)
+    label_metadata2 = load_label_metadata(root2, name)
+
+    # For exact-value histograms we first compare the metadata that defines
+    # which floating-point value each bin corresponds to, and only then the
+    # counts stored in those bins.
+    if (metadata1 is None) != (metadata2 is None):
+        return f"Histogram '{name}' differs: exact-value metadata is missing in one file."
+
+    if metadata1 is not None and metadata1 != metadata2:
+        values1 = metadata1.splitlines()
+        values2 = metadata2.splitlines()
+        for index, (value1, value2) in enumerate(zip(values1, values2), start=1):
+            if value1 != value2:
+                return f"Histogram '{name}' differs at bin {index}: value '{value1}' != '{value2}'"
+        return (
+            f"Histogram '{name}' differs: exact-value metadata length "
+            f"{len(values1)} != {len(values2)}"
+        )
+
+    if (label_metadata1 is None) != (label_metadata2 is None):
+        return f"Histogram '{name}' differs: label metadata is missing in one file."
+
+    if label_metadata1 is not None and label_metadata1 != label_metadata2:
+        labels1 = label_metadata1.splitlines()
+        labels2 = label_metadata2.splitlines()
+        for index, (label1, label2) in enumerate(zip(labels1, labels2), start=1):
+            if label1 != label2:
+                return f"Histogram '{name}' differs at bin {index}: label '{label1}' != '{label2}'"
+        return (
+            f"Histogram '{name}' differs: label metadata length "
+            f"{len(labels1)} != {len(labels2)}"
+        )
+
+    for bin_index in range(1, hist1.GetNbinsX() + 1):
+        label1 = ""
+        if label_metadata1 is not None:
+            label1 = label_metadata1.splitlines()[bin_index - 1]
+        else:
+            label1 = hist1.GetXaxis().GetBinLabel(bin_index)
+
+        label2 = ""
+        if label_metadata2 is not None:
+            label2 = label_metadata2.splitlines()[bin_index - 1]
+        else:
+            label2 = hist2.GetXaxis().GetBinLabel(bin_index)
+
+        if label1 != label2:
+            return f"Histogram '{name}' differs at bin {bin_index}: label '{label1}' != '{label2}'"
+
+        value1 = hist1.GetBinContent(bin_index)
+        value2 = hist2.GetBinContent(bin_index)
+        if not math.isclose(value1, value2, rel_tol=rel_tol, abs_tol=abs_tol):
+            if metadata1 is not None:
+                label1 = metadata1.splitlines()[bin_index - 1]
+            elif not label1:
+                label1 = f"bin={bin_index}"
+            return (
+                f"Histogram '{name}' differs at bin {bin_index} ('{label1}'): "
+                f"file1={value1} file2={value2}"
+            )
+
+    return None
+
+
 def compare_histograms(file1, file2, abs_tol, rel_tol):
     ROOT = load_root()
     root1 = ROOT.TFile.Open(file1, "READ")
@@ -74,92 +145,34 @@ def compare_histograms(file1, file2, abs_tol, rel_tol):
 
     names1 = sorted(histograms1.keys())
     names2 = sorted(histograms2.keys())
+    mismatches = []
     if names1 != names2:
-        print("Histogram inventories differ.")
-        print(f"Only in file1: {sorted(set(names1) - set(names2))}")
-        print(f"Only in file2: {sorted(set(names2) - set(names1))}")
+        only_in_file1 = sorted(set(names1) - set(names2))
+        only_in_file2 = sorted(set(names2) - set(names1))
+        if only_in_file1:
+            mismatches.append(f"Histogram inventory differs: only in file1: {only_in_file1}")
+        if only_in_file2:
+            mismatches.append(f"Histogram inventory differs: only in file2: {only_in_file2}")
+
+    common_names = sorted(set(names1) & set(names2))
+    for name in common_names:
+        mismatch = compare_single_histogram(name, histograms1[name], histograms2[name], root1, root2, abs_tol, rel_tol)
+        if mismatch is not None:
+            mismatches.append(mismatch)
+
+    if mismatches:
+        print(
+            "ROOT histogram comparison found mismatches: "
+            f"{len(mismatches)} failing checks across {len(common_names)} common histograms."
+        )
+        for mismatch in mismatches:
+            print(f"- {mismatch}")
         sys.exit(1)
-
-    for name in names1:
-        hist1 = histograms1[name]
-        hist2 = histograms2[name]
-
-        if hist1.GetNbinsX() != hist2.GetNbinsX():
-            print(f"Histogram '{name}' differs: bin count {hist1.GetNbinsX()} != {hist2.GetNbinsX()}")
-            sys.exit(1)
-
-        metadata1 = load_value_metadata(root1, name)
-        metadata2 = load_value_metadata(root2, name)
-        label_metadata1 = load_label_metadata(root1, name)
-        label_metadata2 = load_label_metadata(root2, name)
-        # For exact-value histograms we first compare the metadata that defines
-        # which floating-point value each bin corresponds to, and only then the
-        # counts stored in those bins.
-        if (metadata1 is None) != (metadata2 is None):
-            print(f"Histogram '{name}' differs: exact-value metadata is missing in one file.")
-            sys.exit(1)
-        if metadata1 is not None and metadata1 != metadata2:
-            values1 = metadata1.splitlines()
-            values2 = metadata2.splitlines()
-            for index, (value1, value2) in enumerate(zip(values1, values2), start=1):
-                if value1 != value2:
-                    print(f"Histogram '{name}' differs at bin {index}: value '{value1}' != '{value2}'")
-                    sys.exit(1)
-            print(
-                f"Histogram '{name}' differs: exact-value metadata length "
-                f"{len(values1)} != {len(values2)}"
-            )
-            sys.exit(1)
-
-        if (label_metadata1 is None) != (label_metadata2 is None):
-            print(f"Histogram '{name}' differs: label metadata is missing in one file.")
-            sys.exit(1)
-        if label_metadata1 is not None and label_metadata1 != label_metadata2:
-            labels1 = label_metadata1.splitlines()
-            labels2 = label_metadata2.splitlines()
-            for index, (label1, label2) in enumerate(zip(labels1, labels2), start=1):
-                if label1 != label2:
-                    print(f"Histogram '{name}' differs at bin {index}: label '{label1}' != '{label2}'")
-                    sys.exit(1)
-            print(
-                f"Histogram '{name}' differs: label metadata length "
-                f"{len(labels1)} != {len(labels2)}"
-            )
-            sys.exit(1)
-
-        for bin_index in range(1, hist1.GetNbinsX() + 1):
-            label1 = ""
-            if label_metadata1 is not None:
-                label1 = label_metadata1.splitlines()[bin_index - 1]
-            else:
-                label1 = hist1.GetXaxis().GetBinLabel(bin_index)
-
-            label2 = ""
-            if label_metadata2 is not None:
-                label2 = label_metadata2.splitlines()[bin_index - 1]
-            else:
-                label2 = hist2.GetXaxis().GetBinLabel(bin_index)
-
-            if label1 != label2:
-                print(f"Histogram '{name}' differs at bin {bin_index}: label '{label1}' != '{label2}'")
-                sys.exit(1)
-
-            value1 = hist1.GetBinContent(bin_index)
-            value2 = hist2.GetBinContent(bin_index)
-            if not math.isclose(value1, value2, rel_tol=rel_tol, abs_tol=abs_tol):
-                if metadata1 is not None:
-                    label1 = metadata1.splitlines()[bin_index - 1]
-                elif not label1:
-                    label1 = f"bin={bin_index}"
-                print(
-                    f"Histogram '{name}' differs at bin {bin_index} ('{label1}'): "
-                    f"file1={value1} file2={value2}"
-                )
-                sys.exit(1)
 
     print(
         "ROOT histogram outputs match within the configured tolerances: "
-        f"abs_tol={abs_tol:g}, rel_tol={rel_tol:g}"
+        f"abs_tol={abs_tol:g}, rel_tol={rel_tol:g}; "
+        f"checked {len(common_names)} common histograms."
     )
 
 


### PR DESCRIPTION
This PR improves the output of the ROOT histogram checker:

Before, it would stop and fail at the first mismatch, e.g.:

```
Histogram 'creator_process_counts' differs: bin count 6 != 11
```

Now, it will always compare all histograms and lists the differences:

```
ROOT histogram comparison found mismatches: 35 failing checks across 42 common histograms.
- Histogram 'creator_process_counts' differs: bin count 6 != 11
- Histogram 'edep_by_volume' differs at bin 2 ('1:G4_lA'): file1=40.780903516103535 file2=40.78090351610354
- Histogram 'final_dir_x' differs: bin count 87046 != 87435
- Histogram 'final_dir_y' differs: bin count 87046 != 87435
- Histogram 'final_dir_z' differs: bin count 87046 != 87435
- Histogram 'final_ekin' differs: bin count 2516 != 2573
- Histogram 'final_global_time' differs: bin count 87046 != 87435
- Histogram 'final_local_time' differs: bin count 87042 != 87431
- Histogram 'final_num_secondaries' differs: bin count 3 != 12
- Histogram 'final_proper_time' differs: bin count 1 != 110
- Histogram 'final_step_length' differs: bin count 87042 != 87431
- Histogram 'final_total_edep' differs: bin count 74387 != 74688
- Histogram 'final_volume_counts' differs at bin 1 ('0:G4_Pb'): file1=49.0 file2=53.0
- Histogram 'final_x' differs: bin count 86614 != 86980
- Histogram 'final_y' differs: bin count 86949 != 87323
- Histogram 'final_z' differs: bin count 86951 != 87331
- Histogram 'generation_population' differs at bin 5 ('bin=5'): file1=4302.0 file2=4357.0
``` 

This is important to understand differences in the drift test, as one can see if only one histogram (e.g., the time at vertex) differs or the full physics output changed (e.g., also the energy deposition and all kinds of other histograms).

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results