### PR TITLE
Fix handling of MC truth for tracks undergoing nuclear reactions

### DIFF
--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -12,12 +12,15 @@
 #include <AdePT/core/ScoringCommons.hh>
 #include <AdePT/core/TrackData.h>
 #include <AdePT/integration/G4HepEmTrackingManagerSpecialized.hh>
+#include <AdePT/core/ReturnedTrackData.hh>
 #include <AdePT/integration/HostTrackDataMapper.hh>
 
 #include <G4EventManager.hh>
 #include <G4Event.hh>
+#include <G4Track.hh>
 
 #include <span>
+#include <vector>
 
 namespace AdePTGeant4Integration_detail {
 struct ScoringObjects;
@@ -28,6 +31,15 @@ struct Deleter {
 
 class AdePTGeant4Integration {
 public:
+  /// @brief Stored work for a returned gamma/lepton nuclear step.
+  /// @details
+  /// These steps are handled later in the same sorted return order as ordinary
+  /// leaked tracks, so the Geant4 nuclear process always runs in a fixed order.
+  struct DeferredNuclearStep {
+    adeptint::TrackData returnedTrack{};
+    std::vector<GPUHit> hits{};
+  };
+
   explicit AdePTGeant4Integration() : fHostTrackDataMapper(std::make_unique<HostTrackDataMapper>()) {}
   ~AdePTGeant4Integration();
 
@@ -63,6 +75,18 @@ public:
 
   HostTrackDataMapper &GetHostTrackDataMapper() { return *fHostTrackDataMapper; }
 
+  /// @brief Defer a returned nuclear step for later sorted replay on the host.
+  void QueueDeferredNuclearStep(std::span<const GPUHit> gpuSteps);
+
+  /// @brief Transfer ownership of the currently queued deferred nuclear steps.
+  /// @details
+  /// This drains the integration-local queue into a temporary vector without
+  /// copying the stored GPU-hit blocks.
+  std::vector<DeferredNuclearStep> TakeDeferredNuclearSteps();
+
+  void ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex, int debugLevel,
+                   bool callUserActions = false) const;
+
   void SetHepEmTrackingManager(G4HepEmTrackingManagerSpecialized *hepEmTrackingManager)
   {
     fHepEmTrackingManager = hepEmTrackingManager;
@@ -89,8 +113,17 @@ private:
                   G4StepStatus aPreStepStatus, G4StepStatus aPostStepStatus, bool callUserTrackingAction,
                   bool callUserSteppingAction) const;
 
-  void ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex, int debugLevel,
-                   bool callUserActions = false) const;
+  /// @brief Build the ordering key for a deferred nuclear step.
+  adeptint::TrackData MakeReturnedTrackFromGPUHit(GPUHit const &gpuHit) const;
+
+  /// @brief Create a heap-owned track that can be pushed onto the Geant4 stack.
+  /// @details
+  /// This is only used as a fallback for gamma/lepton nuclear when no Geant4
+  /// nuclear process is attached. In that case there is no temporary nuclear
+  /// replay track to continue on the CPU, and the visible reconstructed track
+  /// cannot be handed to the stack manager because it is reused integration
+  /// storage.
+  G4Track *MakeTrackForCPUStacking(const G4Track &track) const;
 
   // pointer to specialized G4HepEmTrackingManager. Owned by AdePTTrackingManager,
   // this is just a reference to handle gamma-/lepton-nuclear reactions
@@ -101,6 +134,8 @@ private:
 
   std::unique_ptr<AdePTGeant4Integration_detail::ScoringObjects, AdePTGeant4Integration_detail::Deleter>
       fScoringObjects{nullptr};
+
+  std::vector<DeferredNuclearStep> fDeferredNuclearSteps;
 };
 
 #endif

--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -83,9 +83,6 @@ private:
   /// each batch.
   void ProcessReturnedGPUHits(int threadId, int eventId);
 
-  /// @brief Validate and sort returned tracks before reinjecting them into Geant4.
-  void PrepareReturnedTracksForGeant4(int threadId, int eventId, std::vector<AsyncAdePT::TrackDataWithIDs> &tracks);
-
   std::unique_ptr<G4HepEmTrackingManagerSpecialized> fHepEmTrackingManager;
   AdePTGeant4Integration fGeant4Integration;
   static inline int fNumThreads{0};

--- a/include/AdePT/integration/HostTrackDataMapper.hh
+++ b/include/AdePT/integration/HostTrackDataMapper.hh
@@ -21,9 +21,12 @@ class G4PrimaryParticle;
 
 /// @brief A helper struct to store the data that is stored exclusively on the CPU
 struct HostTrackData {
-  int g4id                               = 0; // the Geant4 track ID
-  int g4parentid                         = 0; // the Geant4 parent ID
-  uint64_t gpuId                         = 0; // the GPU’s 64-bit track ID
+  int g4id       = 0; // the Geant4 track ID
+  int g4parentid = 0; // the Geant4 parent ID
+  uint64_t gpuId = 0; // the GPU’s 64-bit track ID
+  // Deferred nuclear replay still needs this metadata even after the GPU track
+  // has finished, so removal/retirement must wait while this flag is set.
+  bool pendingNuclearReaction            = false;
   G4PrimaryParticle *primary             = nullptr;
   G4VProcess *creatorProcess             = nullptr;
   G4VUserTrackInformation *userTrackInfo = nullptr;
@@ -147,6 +150,26 @@ public:
     return d;
   }
 
+  /// @brief Mark whether a deferred nuclear reaction still needs this host-side metadata.
+  /// @param gpuId GPU track id of the entry to update.
+  /// @param pending Whether deferred nuclear replay is still outstanding for this track.
+  void SetPendingNuclearReaction(uint64_t gpuId, bool pending)
+  {
+    auto it = gpuToIndex.find(gpuId);
+    if (it == gpuToIndex.end()) return;
+    hostDataVec[it->second].pendingNuclearReaction = pending;
+  }
+
+  /// @brief Finish a deferred nuclear reaction and perform the final ownership transition.
+  /// @param gpuId GPU track id of the entry to finalize.
+  /// @param continueOnCPU If true, retire the metadata to CPU ownership; otherwise remove it completely.
+  void FinalizePendingNuclearReaction(uint64_t gpuId, bool continueOnCPU)
+  {
+    auto it = gpuToIndex.find(gpuId);
+    if (it == gpuToIndex.end()) return;
+    eraseHostTrackData(it, /*keepReverseMap=*/continueOnCPU, /*deleteUserTrackInfo=*/!continueOnCPU);
+  }
+
   /// @brief Sets the gpuid by reference and returns whether the entry already existed
   /// @param g4id int G4 id that is checked
   /// @param gpuid uint64 gpu id that is returned
@@ -169,26 +192,8 @@ public:
     if (it == gpuToIndex.end()) return; // already gone
     int idx = it->second;
 
-    // As the data of the userTrackInfo is owned by AdePT, it has to be deleted here
-    if (hostDataVec[idx].userTrackInfo) {
-      delete hostDataVec[idx].userTrackInfo;
-      hostDataVec[idx].userTrackInfo = nullptr;
-    }
-
-    int last = int(hostDataVec.size()) - 1;
-
-    // unused g4 id
-    const int g4idToErase = hostDataVec[idx].g4id;
-    if (idx != last) {
-      // move last element into idx
-      std::swap(hostDataVec[idx], hostDataVec[last]);
-      // update its map entry
-      gpuToIndex[hostDataVec[idx].gpuId] = idx;
-    }
-    hostDataVec.pop_back();
-    gpuToIndex.erase(it);
-    // second part of deletion of g4 ids
-    g4idToGpuId.erase(g4idToErase);
+    if (hostDataVec[idx].pendingNuclearReaction) return;
+    eraseHostTrackData(it, /*keepReverseMap=*/false, /*deleteUserTrackInfo=*/true);
   }
 
   // Free the big struct + index, keep g4id->gpuId for possible future reuse
@@ -199,16 +204,10 @@ public:
   {
     auto it = gpuToIndex.find(gpuId);
     if (it == gpuToIndex.end()) return;
-    int idx  = it->second;
-    int last = int(hostDataVec.size()) - 1;
+    int idx = it->second;
 
-    if (idx != last) {
-      std::swap(hostDataVec[idx], hostDataVec[last]);
-      gpuToIndex[hostDataVec[idx].gpuId] = idx;
-    }
-    hostDataVec.pop_back();
-    gpuToIndex.erase(it);
-    // NOTE: intentionally *do not* erase g4idToGpuId here
+    if (hostDataVec[idx].pendingNuclearReaction) return;
+    eraseHostTrackData(it, /*keepReverseMap=*/true, /*deleteUserTrackInfo=*/false);
   }
 
   /// @brief Whether an entry exists in the GPU to Index map for the given GPU id
@@ -217,6 +216,28 @@ public:
   bool contains(uint64_t gpuId) const { return gpuToIndex.find(gpuId) != gpuToIndex.end(); }
 
 private:
+  using GpuToIndexMap = std::unordered_map<uint64_t, int>;
+
+  void eraseHostTrackData(GpuToIndexMap::iterator it, bool keepReverseMap, bool deleteUserTrackInfo)
+  {
+    int idx = it->second;
+
+    if (deleteUserTrackInfo && hostDataVec[idx].userTrackInfo) {
+      delete hostDataVec[idx].userTrackInfo;
+      hostDataVec[idx].userTrackInfo = nullptr;
+    }
+
+    const int g4idToErase = hostDataVec[idx].g4id;
+    const int last        = int(hostDataVec.size()) - 1;
+    if (idx != last) {
+      std::swap(hostDataVec[idx], hostDataVec[last]);
+      gpuToIndex[hostDataVec[idx].gpuId] = idx;
+    }
+    hostDataVec.pop_back();
+    gpuToIndex.erase(it);
+    if (!keepReverseMap) g4idToGpuId.erase(g4idToErase);
+  }
+
   std::unordered_map<uint64_t, int> gpuToIndex;  // key→slot in hostDataVec
   std::unordered_map<int, uint64_t> g4idToGpuId; // geant4 id to GPU id, needed for reverse lookup
   std::vector<HostTrackData> hostDataVec;        // contiguous array of all data

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -100,6 +100,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     double localTime         = currentTrack.localTime;
     double properTime        = currentTrack.properTime;
     vecgeom::NavigationState nextState;
+    bool continuesOnCPU = false;
 
     currentTrack.stepCounter++;
     bool printErrors = true;
@@ -692,9 +693,10 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
           break;
         }
         case 3: {
-          // Lepton nuclear needs to be handled by Geant4 directly, passing track back to CPU
-          trackSurvives = true;
-          leakReason    = LeakStatus::LeptonNuclear;
+          // Lepton nuclear is handled on the host from the returned step only.
+          // The GPU-side track dies here, but the parent continues on CPU later.
+          trackSurvives  = false;
+          continuesOnCPU = true;
           break;
         }
         }
@@ -803,7 +805,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     assert(nSecondaries <= 3);
 
     // Record the step. Edep includes the continuous energy loss and edep from secondaries which were cut
-    if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps ||
+    if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU ||
         (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
       adept_scoring::RecordHit(currentTrack.trackId, currentTrack.parentId, short(winnerProcessIndex),
                                IsElectron ? ParticleType::Electron : ParticleType::Positron,
@@ -822,7 +824,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
                                localTime,                                   // local time
                                preStepGlobalTime,                           // global time at preStepPoint
                                currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                               !trackSurvives,                              // whether this was the last step
+                               !trackSurvives && !continuesOnCPU,           // whether this was the last step
                                currentTrack.stepCounter,                    // stepcounter
                                secondaryData,                               // pointer to secondary init data
                                nSecondaries);                               // number of secondaries

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -505,8 +505,9 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
       }
     }
 
-    // Now push the particles that reached their interaction into the per-interaction queues,
-    // except for lepton nuclear (winnerProcessIndex == 3), which is sent back to the CPU
+    // Now push the particles that reached their interaction into the
+    // per-interaction queues. Lepton nuclear (winnerProcessIndex == 3) is
+    // handled on the host from the returned step only.
     if (reached_interaction && winnerProcessIndex != 3) {
       // reset Looper counter if limited by discrete interaction or MSC
       currentTrack.looperCounter = 0;
@@ -524,27 +525,29 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
 
     } else {
 
+      const bool continuesOnCPU = reached_interaction && winnerProcessIndex == 3;
+
+      if (continuesOnCPU) {
+        // The returned hit is sufficient to reconstruct the step and later
+        // continue the parent on the CPU in sorted order.
+        trackSurvives = false;
+        slotManager.MarkSlotForFreeing(slot);
+      }
+
       // if not already dead, check for SteppingAction and survive
       if (trackSurvives) {
 
         // possible hook to SteppingAction here
 
-        // Lepton nuclear needs to be handled by Geant4 directly, passing track back to CPU
-        auto leakReason = winnerProcessIndex == 3 ? LeakStatus::LeptonNuclear : LeakStatus::NoLeak;
-
         // --- Survive --- //
-        currentTrack.leakStatus = leakReason;
-        if (leakReason == LeakStatus::LeptonNuclear) {
-          // Copy track at slot to the leaked tracks
-          electronsOrPositrons.CopyTrackToLeaked(slot);
-        } else {
-          electronsOrPositrons.EnqueueNext(slot);
-        }
+        currentTrack.leakStatus = LeakStatus::NoLeak;
+        electronsOrPositrons.EnqueueNext(slot);
       }
 
       // Only non-interacting, non-relocating tracks score here
       // Score the edep for particles that didn't reach the interaction
-      if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || (returnLastStep && !trackSurvives)) {
+      if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU ||
+          (returnLastStep && (!trackSurvives || continuesOnCPU))) {
         adept_scoring::RecordHit(currentTrack.trackId,                                         // Track ID
                                  currentTrack.parentId,                                        // parent Track ID
                                  static_cast<short>(winnerProcessIndex),                       // step defining process
@@ -564,7 +567,7 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
                                  currentTrack.localTime,                      // local time
                                  currentTrack.preStepGlobalTime,              // preStep global time
                                  currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                                 !trackSurvives,                              // whether this was the last step
+                                 !trackSurvives && !continuesOnCPU,           // whether this was the last step
                                  currentTrack.stepCounter,                    // stepcounter
                                  nullptr,                                     // pointer to secondary init data
                                  0);                                          // number of secondaries

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -401,8 +401,8 @@ __global__ void __launch_bounds__(256, 1)
 #if ADEPT_DEBUG_TRACK > 0
         if (verbose) printf("| GAMMA-NUCLEAR ");
 #endif
-        // Gamma nuclear needs to be handled by Geant4 directly, passing track back to CPU
-        leakReason = LeakStatus::GammaNuclear;
+        // Gamma nuclear is handled on the host from the returned step only.
+        trackSurvives = false;
       }
       } // end switch (winnerProcessIndex)
 
@@ -440,10 +440,10 @@ __global__ void __launch_bounds__(256, 1)
 
     __syncwarp();
 
-    // A track that survives must be enqueued to the leaks or the next queue.
-    // Note: gamma nuclear does not survive but must still be leaked to the CPU, which is done
-    // inside survive()
-    if (trackSurvives || leakReason == LeakStatus::GammaNuclear) {
+    // A surviving track must be enqueued to the leak buffer or the next queue.
+    // Gamma-nuclear is handled from the returned step only, so the GPU-side
+    // track simply dies after recording that step.
+    if (trackSurvives) {
       survive();
     } else {
       // particles that don't survive are killed by not enqueing them to the next queue and freeing the slot
@@ -453,7 +453,7 @@ __global__ void __launch_bounds__(256, 1)
     assert(nSecondaries <= 3);
 
     // If there is some edep from cutting particles, record the step
-    if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps ||
+    if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps || winnerProcessIndex == 3 ||
         (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
       adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
                                currentTrack.parentId,                       // parent Track ID

--- a/include/AdePT/kernels/gammasWDT.cuh
+++ b/include/AdePT/kernels/gammasWDT.cuh
@@ -597,8 +597,8 @@ __global__ void __launch_bounds__(256, 1)
 #if ADEPT_DEBUG_TRACK > 0
         if (verbose) printf("| GAMMA-NUCLEAR ");
 #endif
-        // Gamma nuclear needs to be handled by Geant4 directly, passing track back to CPU
-        leakReason = LeakStatus::GammaNuclear;
+        // Gamma nuclear is handled on the host from the returned step only.
+        trackSurvives = false;
       }
       } // end switch (winnerProcessIndex)
 
@@ -638,10 +638,10 @@ __global__ void __launch_bounds__(256, 1)
       leftWDTRegion = true;
     }
 
-    // A track that survives must be enqueued to the leaks or the next queue.
-    // Note: gamma nuclear does not survive but must still be leaked to the CPU, which is done
-    // inside survive()
-    if (trackSurvives || leakReason == LeakStatus::GammaNuclear) {
+    // A surviving track must be enqueued to the leak buffer or the next queue.
+    // Gamma-nuclear is handled from the returned step only, so the GPU-side
+    // track simply dies after recording that terminal step.
+    if (trackSurvives) {
       survive();
     } else {
       // particles that don't survive are killed by not enqueing them to the next queue and freeing the slot
@@ -651,7 +651,7 @@ __global__ void __launch_bounds__(256, 1)
     assert(nSecondaries <= 3);
 
     // If there is some edep from cutting particles or if it is the last step, record the step
-    if ((edep > 0 && nextauxData.fSensIndex >= 0) || returnAllSteps ||
+    if ((edep > 0 && nextauxData.fSensIndex >= 0) || returnAllSteps || winnerProcessIndex == 3 ||
         (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
       adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
                                currentTrack.parentId,                       // parent Track ID

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -210,23 +210,13 @@ __global__ void GammaSetupInteractions(G4HepEmGammaTrack *hepEMTracks, const ade
                                        ParticleManager particleManager, AllInteractionQueues interactionQueues,
                                        const bool returnAllSteps, const bool returnLastStep)
 {
-  int activeSize = propagationQueue->size();
+  auto &slotManager = *particleManager.gammas.fSlotManager;
+  int activeSize    = propagationQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot      = (*propagationQueue)[i];
     Track &currentTrack = particleManager.gammas.TrackAt(slot);
 
     int lvolID = currentTrack.navState.GetLogicalId();
-
-    // Write local variables back into track and enqueue
-    auto survive = [&](LeakStatus leakReason = LeakStatus::NoLeak) {
-      currentTrack.leakStatus = leakReason;
-      if (leakReason != LeakStatus::NoLeak) {
-        // Copy track at slot to the leaked tracks
-        particleManager.gammas.CopyTrackToLeaked(slot);
-      } else {
-        particleManager.gammas.EnqueueNext(slot);
-      }
-    };
 
     G4HepEmGammaTrack &gammaTrack = hepEMTracks[slot];
     G4HepEmTrack *theTrack        = gammaTrack.GetTrack();
@@ -247,36 +237,34 @@ __global__ void GammaSetupInteractions(G4HepEmGammaTrack *hepEMTracks, const ade
       if (theTrack->GetWinnerProcessIndex() < 3) {
         interactionQueues.queues[theTrack->GetWinnerProcessIndex()]->push_back(slot);
       } else {
-        // Gamma nuclear needs to be handled by Geant4 directly, passing track back to CPU
-        survive(LeakStatus::GammaNuclear);
+        // Gamma nuclear is handled on the host from the returned step only.
+        slotManager.MarkSlotForFreeing(slot);
 
-        // Record last step to enable UserPostTrackingAction to be called
-        if (returnAllSteps || returnLastStep) {
-          adept_scoring::RecordHit(
-              currentTrack.trackId,                        // Track ID
-              currentTrack.parentId,                       // parent Track ID
-              static_cast<short>(3),                       // step defining process ID
-              ParticleType::Gamma,                         // Particle type
-              theTrack->GetGStepLength(),                  // Step length
-              0,                                           // Total Edep
-              currentTrack.weight,                         // Track weight
-              currentTrack.navState,                       // Pre-step point navstate
-              currentTrack.preStepPos,                     // Pre-step point position
-              currentTrack.preStepDir,                     // Pre-step point momentum direction
-              currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-              currentTrack.nextState,                      // Post-step point navstate
-              currentTrack.pos,                            // Post-step point position
-              currentTrack.dir,                            // Post-step point momentum direction
-              0,                                           // Post-step point kinetic energy
-              currentTrack.globalTime,                     // global time
-              currentTrack.localTime,                      // local time
-              currentTrack.preStepGlobalTime,              // preStep global time
-              currentTrack.eventId, currentTrack.threadId, // event and thread ID
-              true, // whether this is the last step of the track: true as gamma nuclear kills the gamma
-              currentTrack.stepCounter, // stepcounter
-              nullptr,                  // pointer to secondary init data
-              0);                       // number of secondaries
-        }
+        // Gamma-nuclear must always return the step so the host can replay the
+        // interaction even when user callbacks are disabled.
+        adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
+                                 currentTrack.parentId,                       // parent Track ID
+                                 static_cast<short>(3),                       // step defining process ID
+                                 ParticleType::Gamma,                         // Particle type
+                                 theTrack->GetGStepLength(),                  // Step length
+                                 0,                                           // Total Edep
+                                 currentTrack.weight,                         // Track weight
+                                 currentTrack.navState,                       // Pre-step point navstate
+                                 currentTrack.preStepPos,                     // Pre-step point position
+                                 currentTrack.preStepDir,                     // Pre-step point momentum direction
+                                 currentTrack.preStepEKin,                    // Pre-step point kinetic energy
+                                 currentTrack.nextState,                      // Post-step point navstate
+                                 currentTrack.pos,                            // Post-step point position
+                                 currentTrack.dir,                            // Post-step point momentum direction
+                                 currentTrack.eKin,                           // Post-step point kinetic energy
+                                 currentTrack.globalTime,                     // global time
+                                 currentTrack.localTime,                      // local time
+                                 currentTrack.preStepGlobalTime,              // preStep global time
+                                 currentTrack.eventId, currentTrack.threadId, // event and thread ID
+                                 true,                                        // gamma nuclear kills the parent
+                                 currentTrack.stepCounter,                    // stepcounter
+                                 nullptr,                                     // pointer to secondary init data
+                                 0);                                          // number of secondaries
       }
     }
   }

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -157,7 +157,113 @@ void Deleter::operator()(ScoringObjects *ptr)
 
 } // namespace AdePTGeant4Integration_detail
 
+namespace {
+
+void MergeNuclearReplayIntoVisibleStep(const G4Track &scratchTrack, const G4Step &scratchStep, G4Step &visibleStep,
+                                       bool isLeptonNuclearStep)
+{
+  G4Track *visibleTrack             = visibleStep.GetTrack();
+  G4StepPoint *visiblePostStepPoint = visibleStep.GetPostStepPoint();
+  const G4StepPoint *scratchPost    = scratchStep.GetPostStepPoint();
+
+  visibleTrack->SetTrackStatus(scratchTrack.GetTrackStatus());
+  visibleTrack->SetKineticEnergy(scratchTrack.GetKineticEnergy());
+  visiblePostStepPoint->SetKineticEnergy(scratchPost->GetKineticEnergy());
+  visiblePostStepPoint->SetVelocity(scratchPost->GetVelocity());
+  visiblePostStepPoint->SetStepStatus(scratchPost->GetStepStatus());
+
+  if (isLeptonNuclearStep) {
+    visibleTrack->SetMomentumDirection(scratchTrack.GetMomentumDirection());
+    visibleTrack->SetVelocity(scratchTrack.GetVelocity());
+    visiblePostStepPoint->SetMomentumDirection(scratchPost->GetMomentumDirection());
+  }
+}
+
+} // namespace
+
 AdePTGeant4Integration::~AdePTGeant4Integration() {}
+
+void AdePTGeant4Integration::QueueDeferredNuclearStep(std::span<const GPUHit> gpuSteps)
+{
+  if (gpuSteps.empty()) return;
+
+  fHostTrackDataMapper->SetPendingNuclearReaction(gpuSteps.front().fTrackID, true);
+
+  // Keep the returned GPU-hit block together with the ordering key that
+  // places it in the same return order as an ordinary leaked track.
+  DeferredNuclearStep deferred;
+  deferred.returnedTrack = MakeReturnedTrackFromGPUHit(gpuSteps.front());
+  deferred.hits.assign(gpuSteps.begin(), gpuSteps.end());
+  fDeferredNuclearSteps.push_back(std::move(deferred));
+}
+
+std::vector<AdePTGeant4Integration::DeferredNuclearStep> AdePTGeant4Integration::TakeDeferredNuclearSteps()
+{
+  // Swap with an empty vector so ownership of the queued work moves out
+  // without copying the stored GPU-hit payloads.
+  std::vector<DeferredNuclearStep> deferred;
+  deferred.swap(fDeferredNuclearSteps);
+  return deferred;
+}
+
+adeptint::TrackData AdePTGeant4Integration::MakeReturnedTrackFromGPUHit(GPUHit const &gpuHit) const
+{
+  adeptint::TrackData returnedTrack;
+
+  switch (gpuHit.fParticleType) {
+  case ParticleType::Electron:
+    returnedTrack.pdg = 11;
+    break;
+  case ParticleType::Positron:
+    returnedTrack.pdg = -11;
+    break;
+  case ParticleType::Gamma:
+    returnedTrack.pdg = 22;
+    break;
+  default:
+    throw std::runtime_error("Unknown particle type in MakeReturnedTrackFromGPUHit");
+  }
+
+  returnedTrack.eKin         = gpuHit.fPostStepPoint.fEKin;
+  returnedTrack.position[0]  = gpuHit.fPostStepPoint.fPosition.x();
+  returnedTrack.position[1]  = gpuHit.fPostStepPoint.fPosition.y();
+  returnedTrack.position[2]  = gpuHit.fPostStepPoint.fPosition.z();
+  returnedTrack.direction[0] = gpuHit.fPostStepPoint.fMomentumDirection.x();
+  returnedTrack.direction[1] = gpuHit.fPostStepPoint.fMomentumDirection.y();
+  returnedTrack.direction[2] = gpuHit.fPostStepPoint.fMomentumDirection.z();
+
+  return returnedTrack;
+}
+
+G4Track *AdePTGeant4Integration::MakeTrackForCPUStacking(const G4Track &track) const
+{
+  auto *dynamic =
+      new G4DynamicParticle(track.GetParticleDefinition(), track.GetMomentumDirection(), track.GetKineticEnergy());
+  dynamic->SetPrimaryParticle(track.GetDynamicParticle()->GetPrimaryParticle());
+
+  auto *clone = new G4Track(dynamic, track.GetGlobalTime(), track.GetPosition());
+  clone->IncrementCurrentStepNumber();
+  clone->SetTrackID(track.GetTrackID());
+  clone->SetParentID(track.GetParentID());
+  clone->SetLocalTime(track.GetLocalTime());
+  clone->SetProperTime(track.GetProperTime());
+  clone->SetWeight(track.GetWeight());
+  clone->SetCreatorProcess(track.GetCreatorProcess());
+  clone->SetStepLength(track.GetStepLength());
+  clone->SetMomentumDirection(track.GetMomentumDirection());
+  clone->SetVertexPosition(track.GetVertexPosition());
+  clone->SetVertexMomentumDirection(track.GetVertexMomentumDirection());
+  clone->SetVertexKineticEnergy(track.GetVertexKineticEnergy());
+  clone->SetLogicalVolumeAtVertex(const_cast<G4LogicalVolume *>(track.GetLogicalVolumeAtVertex()));
+  clone->SetTouchableHandle(track.GetTouchableHandle());
+  clone->SetNextTouchableHandle(track.GetNextTouchableHandle());
+#ifdef ADEPT_USE_ORIGINNAVSTATE
+  clone->SetOriginTouchableHandle(track.GetOriginTouchableHandle());
+#endif
+  clone->SetUserInformation(track.GetUserInformation());
+  clone->SetTrackStatus(track.GetTrackStatus());
+  return clone;
+}
 
 G4Track *AdePTGeant4Integration::ConstructSecondaryTrackInPlace(GPUHit const *secHit) const
 {
@@ -186,6 +292,10 @@ G4Track *AdePTGeant4Integration::ConstructSecondaryTrackInPlace(GPUHit const *se
 void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bool const callUserSteppingAction,
                                             bool const callUserTrackingAction)
 {
+  // FIXME: to be removed, as it is not needed with the direct VecGeom to G4 NavState.
+  // needed here only temporarily to match exactly the behavior of returning nuclear interaction steps as tracks
+  constexpr double tolerance = 10. * vecgeom::kTolerance;
+
   if (!fScoringObjects) {
     fScoringObjects.reset(new AdePTGeant4Integration_detail::ScoringObjects());
   }
@@ -251,6 +361,15 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
   // - for particles created on CPU, it was created in the AdePTTrackingManager when offloading to GPU,
   // - for particles createdon GPU, it was created in InitSecondaryHostTrackDataFromParent below
 
+  const bool isGammaNuclearStep = parentStep.fParticleType == ParticleType::Gamma && parentStep.fStepLimProcessId == 3;
+  const bool isLeptonNuclearStep =
+      (parentStep.fParticleType == ParticleType::Electron || parentStep.fParticleType == ParticleType::Positron) &&
+      parentStep.fStepLimProcessId == 3;
+  const bool isNuclearStep  = isGammaNuclearStep || isLeptonNuclearStep;
+  bool parentContinuesOnCPU = false;
+  G4Track *continuedParent  = nullptr;
+  G4TrackVector hadronicSecondaries;
+
   HostTrackData dummy; // default constructed dummy if no advanced information is available
 
   // if the userActions are used, advanced track information is available
@@ -294,8 +413,135 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
       FillG4Track(&secStep, secTrack, secTData, *fScoringObjects->fPreG4TouchableHistoryHandle,
                   *fScoringObjects->fPostG4TouchableHistoryHandle);
 
-      // 5. Attach secondaries to G4Step: the fSecondaryVector is the persistent storage for the G4Step->SecondaryVector
+      // 5. Attach secondaries to G4Step: the fSecondaryVector is the persistent
+      // storage for the G4Step->SecondaryVector.
       fScoringObjects->fSecondaryVector->push_back(secTrack);
+    }
+  }
+
+  // Handling of Steps that hit a nuclear reaction:
+  // before calling the SD code and the user actions, the nuclear reactions must be invoked, as those
+  // create new secondaries
+  if (isNuclearStep) {
+    // Two different objects are needed here:
+    // - the visible G4 step, which must keep the transported GPU step data
+    // - a temporary G4 track/step, used only to call the Geant4 nuclear process
+    // After the nuclear call, only the produced secondaries and the updated
+    // parent final state are copied back.
+    if (fHepEmTrackingManager == nullptr) {
+      throw std::runtime_error("Specialized HepEmTrackingManager no longer valid in integration!");
+    }
+
+    HostTrackData &parentTDataAfterSecondaries = actions ? fHostTrackDataMapper->get(parentStep.fTrackID) : dummy;
+
+    G4VProcess *nuclearProcess = nullptr;
+    int particleID             = 2;
+    if (isGammaNuclearStep) {
+      nuclearProcess = fHepEmTrackingManager->GetGammaNuclearProcess();
+      particleID     = 2;
+    } else {
+      particleID     = parentStep.fParticleType == ParticleType::Electron ? 0 : 1;
+      nuclearProcess = particleID == 0 ? fHepEmTrackingManager->GetElectronNuclearProcess()
+                                       : fHepEmTrackingManager->GetPositronNuclearProcess();
+    }
+
+    if (nuclearProcess != nullptr) {
+      parentContinuesOnCPU = isLeptonNuclearStep;
+
+      const G4ThreeVector direction(parentStep.fPostStepPoint.fMomentumDirection.x(),
+                                    parentStep.fPostStepPoint.fMomentumDirection.y(),
+                                    parentStep.fPostStepPoint.fMomentumDirection.z());
+      G4ThreeVector position(parentStep.fPostStepPoint.fPosition.x(), parentStep.fPostStepPoint.fPosition.y(),
+                             parentStep.fPostStepPoint.fPosition.z());
+      position += tolerance * direction;
+
+      auto *dynamic = new G4DynamicParticle(fScoringObjects->fG4Step->GetTrack()->GetParticleDefinition(), direction,
+                                            parentStep.fPostStepPoint.fEKin);
+
+      auto *nuclearReactionTrack = new G4Track(dynamic, parentStep.fGlobalTime, position);
+      nuclearReactionTrack->IncrementCurrentStepNumber();
+      nuclearReactionTrack->SetLocalTime(parentStep.fLocalTime);
+      nuclearReactionTrack->SetWeight(parentStep.fTrackWeight);
+      G4TouchableHandle postTouchable;
+      if (actions) {
+        nuclearReactionTrack->SetTrackID(parentTDataAfterSecondaries.g4id);
+        nuclearReactionTrack->SetParentID(parentTDataAfterSecondaries.g4parentid);
+        nuclearReactionTrack->SetCreatorProcess(parentTDataAfterSecondaries.creatorProcess);
+        nuclearReactionTrack->SetUserInformation(parentTDataAfterSecondaries.userTrackInfo);
+        nuclearReactionTrack->SetVertexPosition(parentTDataAfterSecondaries.vertexPosition);
+        nuclearReactionTrack->SetVertexMomentumDirection(parentTDataAfterSecondaries.vertexMomentumDirection);
+        nuclearReactionTrack->SetVertexKineticEnergy(parentTDataAfterSecondaries.vertexKineticEnergy);
+        nuclearReactionTrack->SetLogicalVolumeAtVertex(parentTDataAfterSecondaries.logicalVolumeAtVertex);
+        const_cast<G4DynamicParticle *>(nuclearReactionTrack->GetDynamicParticle())
+            ->SetPrimaryParticle(parentTDataAfterSecondaries.primary);
+      }
+      if (const auto postVolume = (*fScoringObjects->fPostG4TouchableHistoryHandle)->GetVolume();
+          postVolume != nullptr) {
+        postTouchable = MakeTouchableFromNavState(parentStep.fPostStepPoint.fNavigationState);
+        nuclearReactionTrack->SetTouchableHandle(postTouchable);
+        nuclearReactionTrack->SetNextTouchableHandle(postTouchable);
+      }
+
+      auto *nuclearStep = new G4Step();
+      nuclearStep->NewSecondaryVector();
+      nuclearStep->InitializeStep(nuclearReactionTrack);
+      nuclearStep->SetTrack(nuclearReactionTrack);
+      nuclearReactionTrack->SetStep(nuclearStep);
+
+      // ApplyCuts must be false, as we are not in a Geant4 tracking loop here and
+      // cannot deposit any cut secondaries locally.
+      fHepEmTrackingManager->PerformNuclear(nuclearReactionTrack, nuclearStep, particleID, /*isApplyCuts=*/false);
+
+      if (auto *newSecondaries = nuclearStep->GetfSecondary(); newSecondaries != nullptr) {
+        hadronicSecondaries.reserve(newSecondaries->size());
+        for (auto *secondary : *newSecondaries) {
+          hadronicSecondaries.push_back(secondary);
+          fScoringObjects->fSecondaryVector->push_back(secondary);
+        }
+      }
+
+      // The visible step remains the transported GPU step. Only the nuclear
+      // final state is merged back from the scratch replay object.
+      MergeNuclearReplayIntoVisibleStep(*nuclearReactionTrack, *nuclearStep, *fScoringObjects->fG4Step,
+                                        isLeptonNuclearStep);
+
+      if (isLeptonNuclearStep) {
+        continuedParent = nuclearReactionTrack;
+        if (actions) {
+          continuedParent->SetTrackID(parentTDataAfterSecondaries.g4id);
+          continuedParent->SetParentID(parentTDataAfterSecondaries.g4parentid);
+          continuedParent->SetCreatorProcess(parentTDataAfterSecondaries.creatorProcess);
+          continuedParent->SetUserInformation(parentTDataAfterSecondaries.userTrackInfo);
+          continuedParent->SetVertexPosition(parentTDataAfterSecondaries.vertexPosition);
+          continuedParent->SetVertexMomentumDirection(parentTDataAfterSecondaries.vertexMomentumDirection);
+          continuedParent->SetVertexKineticEnergy(parentTDataAfterSecondaries.vertexKineticEnergy);
+          continuedParent->SetLogicalVolumeAtVertex(parentTDataAfterSecondaries.logicalVolumeAtVertex);
+          const_cast<G4DynamicParticle *>(continuedParent->GetDynamicParticle())
+              ->SetPrimaryParticle(parentTDataAfterSecondaries.primary);
+        }
+        if (postTouchable) {
+          continuedParent->SetTouchableHandle(postTouchable);
+          continuedParent->SetNextTouchableHandle(postTouchable);
+        }
+#ifdef ADEPT_USE_ORIGINNAVSTATE
+        if (actions) {
+          continuedParent->SetOriginTouchableHandle(
+              MakeTouchableFromNavState(parentTDataAfterSecondaries.originNavState));
+        }
+#endif
+      }
+
+      if (!isLeptonNuclearStep) {
+        nuclearReactionTrack->SetUserInformation(nullptr);
+        delete nuclearStep;
+        delete nuclearReactionTrack;
+      }
+    } else {
+      // Fallback only for the case without an attached Geant4 nuclear process:
+      // there is then no temporary nuclear-replay track that can be continued
+      // on the CPU, so we create a separate heap-owned track for the stack.
+      continuedParent      = MakeTrackForCPUStacking(*fScoringObjects->fG4Step->GetTrack());
+      parentContinuesOnCPU = true;
     }
   }
 
@@ -319,14 +565,16 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
   }
 
   // call UserTrackingAction if required
-  if (parentStep.fLastStepOfTrack && (callUserTrackingAction)) {
+  if (parentStep.fLastStepOfTrack && !parentContinuesOnCPU && (callUserTrackingAction)) {
     auto *evtMgr             = G4EventManager::GetEventManager();
     auto *userTrackingAction = evtMgr->GetUserTrackingAction();
     if (userTrackingAction) userTrackingAction->PostUserTrackingAction(fScoringObjects->fG4Step->GetTrack());
   }
 
-  // Secondaries only get the PreUserTracking callback after the parent step has been
-  // fully processed. Now the secondaries are ready to process their next step that could arrive
+  // GPU-born secondaries only get the PreUserTracking callback after the parent
+  // step has been fully processed. Hadronic secondaries created by the host-side
+  // nuclear process stay on the CPU and will receive their normal Geant4
+  // tracking callbacks later.
   if (callUserTrackingAction || callUserSteppingAction) {
     auto *evtMgr             = G4EventManager::GetEventManager();
     auto *userTrackingAction = evtMgr->GetUserTrackingAction();
@@ -337,7 +585,6 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
         if (secondary == nullptr) continue;
 
         userTrackingAction->PreUserTrackingAction(secondary);
-
         auto &secTData = fHostTrackDataMapper->get(secondaries[i].fTrackID);
         if (secTData.userTrackInfo == nullptr && secondary->GetUserInformation() != nullptr) {
           secTData.userTrackInfo = secondary->GetUserInformation();
@@ -346,14 +593,24 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
     }
   }
 
+  if (isNuclearStep) {
+    if (!hadronicSecondaries.empty()) {
+      G4EventManager::GetEventManager()->StackTracks(&hadronicSecondaries);
+    }
+
+    if (parentContinuesOnCPU) {
+      G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(continuedParent);
+    }
+  }
+
   // If this was the last step of a track, the hostTrackData of that track can be safely deleted.
   // Note: This deletes the AdePT-owned UserTrackInfo data
-  // Exception: gamma-nuclear steps (fParticleType == 2 and fStepLimProcessId == 3):
-  // Steps are processed before the leaked tracks, and the hostTrackData is still used for invoking
-  // gamma-nuclear when the track is returned to the host (although it will die then). Thus, the hostTrackData must be
-  // kept alive until the invokation of the gamma-nuclear reaction
-  if (parentStep.fLastStepOfTrack &&
-      !(parentStep.fParticleType == ParticleType::Gamma && parentStep.fStepLimProcessId == 3)) {
+  if (isNuclearStep) {
+    auto *parentTrack = fScoringObjects->fG4Step->GetTrack();
+    parentTrack->SetUserInformation(nullptr);
+    fHostTrackDataMapper->FinalizePendingNuclearReaction(parentStep.fTrackID, parentContinuesOnCPU);
+  } else if (parentStep.fLastStepOfTrack) {
+    fScoringObjects->fG4Step->GetTrack()->SetUserInformation(nullptr);
     fHostTrackDataMapper->removeTrack(parentStep.fTrackID);
   }
 }
@@ -526,14 +783,6 @@ void AdePTGeant4Integration::FillG4Track(GPUHit const *aGPUHit, G4Track *aTrack,
   // if it exists, add UserTrackInfo
   aTrack->SetUserInformation(hostTData.userTrackInfo); // Real data
   // aTrack->SetAuxiliaryTrackInformation(0, nullptr);                                        // Missing data
-
-  // adjust for gamma-nuclear steps:
-  // As the steps are processed before the leaked tracks, the step has not undergone the gamma-nuclear reaction yet.
-  // Therefore, the kinetic energy for the track and postStepPoint must be set by hand to 0
-  if (aGPUHit->fLastStepOfTrack && aGPUHit->fParticleType == ParticleType::Gamma && aGPUHit->fStepLimProcessId == 3) {
-    aTrack->SetKineticEnergy(0.);
-    // aTrack->SetVelocity(0.);              // Not set in other cases, so also not set here
-  }
 }
 
 void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step, const HostTrackData &hostTData,
@@ -639,14 +888,6 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step, 
   aPostStepPoint->SetCharge(aTrack->GetParticleDefinition()->GetPDGCharge()); // Real data
   // aPostStepPoint->SetMagneticMoment(0);                                                            // Missing data
   // aPostStepPoint->SetWeight(0);                                                                    // Missing data
-
-  // adjust for gamma-nuclear steps:
-  // As the steps are processed before the leaked tracks, the step has not undergone the gamma-nuclear reaction yet.
-  // Therefore, the kinetic energy for the track and postStepPoint must be set by hand to 0
-  if (aGPUHit->fLastStepOfTrack && aGPUHit->fParticleType == ParticleType::Gamma && aGPUHit->fStepLimProcessId == 3) {
-    aPostStepPoint->SetKineticEnergy(0.);
-    // aPostStepPoint->SetVelocity(0.);      // Not set in other cases, so also not set here
-  }
 }
 
 void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex, int debugLevel,
@@ -739,94 +980,9 @@ void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsig
   leakedTrack->SetTouchableHandle(TouchableHandle);
   leakedTrack->SetNextTouchableHandle(TouchableHandle);
 
-  // handle gamma- and lepton-nuclear directly in G4HepEm
   if (track.leakStatus == LeakStatus::GammaNuclear || track.leakStatus == LeakStatus::LeptonNuclear) {
-
-    // create a new step
-    G4Step *step = new G4Step();
-    step->NewSecondaryVector();
-
-    // initialize preStepPoint values
-    step->InitializeStep(leakedTrack);
-
-    // entangle our newly created step and the leaked track
-    step->SetTrack(leakedTrack);
-    leakedTrack->SetStep(step);
-
-    // get fresh secondary vector
-    G4TrackVector *secondariesPtr = step->GetfSecondary();
-    if (!secondariesPtr) throw std::runtime_error("Failed to allocate secondary vector");
-    G4TrackVector &secondaries = *secondariesPtr;
-
-    if (fHepEmTrackingManager) {
-
-      if (track.leakStatus == LeakStatus::GammaNuclear) {
-
-        auto GNucProcess = fHepEmTrackingManager->GetGammaNuclearProcess();
-        if (GNucProcess != nullptr) {
-
-          // need to call StartTracking to set the particle type in the hadronic process (see G4HadronicProcess.cc)
-          GNucProcess->StartTracking(leakedTrack);
-
-          // perform gamma nuclear from G4HepEmTrackingManager
-          // ApplyCuts must be false, as we are not in a tracking loop here and could not deposit the energy
-          fHepEmTrackingManager->PerformNuclear(leakedTrack, step, /*particleID=*/2, /*isApplyCuts=*/false);
-
-          // Give secondaries to G4
-          G4EventManager::GetEventManager()->StackTracks(&secondaries);
-
-          // As Gamma-nuclear kills the track, and the track is owned by AdePT, it has to be deleted. This includes:
-          // 1. deleting the HostTrackData, which also deletes the UserTrackInfo
-          // 2. Setting the UserInformation pointer in the track to nullptr (as the data was just deleted)
-          // 3. deleting the track
-          // Note that it is safe to remove the track and the hostTrackData here, as the hits are always handled
-          // before the leaks and hits with Gamma-nuclear are not marked as last step.
-          fHostTrackDataMapper->removeTrack(track.trackId);
-          // as the UserTrackInfo was just deleted by removeTrack, the pointer must be set to null to avoid double
-          // deletion
-          leakedTrack->SetUserInformation(nullptr);
-          // Now the track and step can be safely deleted
-          delete leakedTrack;
-          delete step;
-        } else {
-          // no gamma nuclear process attached, just give back the track to G4 to put it back on GPU
-          G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(leakedTrack);
-          delete step;
-          // Track is how handled by CPU
-          fHostTrackDataMapper->retireToCPU(track.trackId);
-        }
-      } else {
-        // case LeakStatus::LeptonNuclear
-        const double charge   = leakedTrack->GetParticleDefinition()->GetPDGCharge();
-        const bool isElectron = (charge < 0.0);
-        int particleID        = isElectron ? 0 : 1;
-
-        // Invoke the electron/positron-nuclear process start tracking interace (if any)
-        G4VProcess *theNucProcess = isElectron ? fHepEmTrackingManager->GetElectronNuclearProcess()
-                                               : fHepEmTrackingManager->GetPositronNuclearProcess();
-        if (theNucProcess != nullptr) {
-
-          // perform lepton nuclear from G4HepEmTrackingManager
-          // ApplyCuts must be false, as we are not in a tracking loop here and could not deposit the energy
-          fHepEmTrackingManager->PerformNuclear(leakedTrack, step, particleID, /*isApplyCuts=*/false);
-
-          // Give secondaries to G4 - they are already stored from G4HepEm in the G4Step, now we need to pass them to G4
-          // itself
-          G4EventManager::GetEventManager()->StackTracks(&secondaries);
-          // Give updated primary after lepton nuclear reacton to G4
-          G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(leakedTrack);
-        } else {
-          // no lepton nuclear process attached, just give back the track to G4 to put it back on GPU
-          G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(leakedTrack);
-          delete step;
-        }
-        // Track is how handled by CPU
-        fHostTrackDataMapper->retireToCPU(track.trackId);
-      }
-    } else {
-      throw std::runtime_error("Specialized HepEmTrackingManager not longer valid in integration!");
-    }
-
+    throw std::runtime_error(
+        "Gamma/lepton nuclear should be reinjected from deferred GPU-hit processing, not from leaked tracks.");
   } else {
 
     // LeakStatus::OutOfGPURegion: just give track back to G4

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -77,6 +77,7 @@ std::shared_ptr<AdePTTransport> GetSharedAdePTTransport()
   }
   return transport;
 }
+
 } // namespace
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -351,29 +352,51 @@ void AdePTTrackingManager::FlushEvent()
   // Once the device side is flushed, take the plain returned-track batch from
   // transport and hand it back to Geant4 on the host side.
   std::vector<AsyncAdePT::TrackDataWithIDs> tracks = fAdeptTransport->TakeReturnedTracks(threadId);
+  auto deferredNuclearSteps                        = fGeant4Integration.TakeDeferredNuclearSteps();
   fAdeptTransport->MarkLeakedTracksRetrieved(threadId);
-  PrepareReturnedTracksForGeant4(threadId, eventId, tracks);
-  fGeant4Integration.ReturnTracks(tracks.begin(), tracks.end(), fAdeptTransport->GetDebugLevel(),
-                                  fAdeptTransport->GetReturnFirstAndLastStep());
-}
 
-void AdePTTrackingManager::PrepareReturnedTracksForGeant4(int threadId, int eventId,
-                                                          std::vector<AsyncAdePT::TrackDataWithIDs> &tracks)
-{
-#ifndef NDEBUG
-  for (auto const &track : tracks) {
-    bool error = false;
-    if (track.threadId != threadId || track.eventId != static_cast<unsigned int>(eventId)) error = true;
-    if (!(track.pdg == -11 || track.pdg == 11 || track.pdg == 22)) error = true;
-    if (error)
-      std::cerr << "Error in returning track: threadId=" << track.threadId << " eventId=" << track.eventId
-                << " pdg=" << track.pdg << "\n";
-    assert(!error);
-  }
-#endif
-
-  // Sort the tracks coming from device by energy. This is necessary to ensure reproducibility.
   std::sort(tracks.begin(), tracks.end());
+  std::sort(
+      deferredNuclearSteps.begin(), deferredNuclearSteps.end(),
+      [](const AdePTGeant4Integration::DeferredNuclearStep &lhs,
+         const AdePTGeant4Integration::DeferredNuclearStep &rhs) { return lhs.returnedTrack < rhs.returnedTrack; });
+
+  // FIXME: here we sort both containers of the deferredNuclearSteps and the returnedTracks and
+  // then consume them together. In principle, this could be simplified to just do a loop over the
+  // first container and then the next. However, for now it is kept like this to ensure the
+  // exact physics reproducibility (apart from the fix of handling the nuclear reactions correctly)
+  // In the future, this should be simplified, in a separate step, to make sure the physics change
+  // is well understood.
+  unsigned int trackIndex    = 0;
+  auto trackIt               = tracks.begin();
+  auto deferredNuclearStepIt = deferredNuclearSteps.begin();
+
+  while (trackIt != tracks.end() && deferredNuclearStepIt != deferredNuclearSteps.end()) {
+    // Ordinary leaked tracks are already ready to return to Geant4. Deferred
+    // nuclear steps must rebuild their G4 step and run the host-side nuclear
+    // process in that same deterministic order.
+    if (static_cast<const adeptint::TrackData &>(*trackIt) < deferredNuclearStepIt->returnedTrack) {
+      fGeant4Integration.ReturnTrack(*trackIt, trackIndex++, fAdeptTransport->GetDebugLevel(),
+                                     fAdeptTransport->GetReturnFirstAndLastStep());
+      ++trackIt;
+    } else {
+      fGeant4Integration.ProcessGPUStep(
+          std::span<const GPUHit>(deferredNuclearStepIt->hits.data(), deferredNuclearStepIt->hits.size()),
+          fAdeptTransport->GetReturnAllSteps(), fAdeptTransport->GetReturnFirstAndLastStep());
+      ++deferredNuclearStepIt;
+    }
+  }
+
+  for (; trackIt != tracks.end(); ++trackIt) {
+    fGeant4Integration.ReturnTrack(*trackIt, trackIndex++, fAdeptTransport->GetDebugLevel(),
+                                   fAdeptTransport->GetReturnFirstAndLastStep());
+  }
+
+  for (; deferredNuclearStepIt != deferredNuclearSteps.end(); ++deferredNuclearStepIt) {
+    fGeant4Integration.ProcessGPUStep(
+        std::span<const GPUHit>(deferredNuclearStepIt->hits.data(), deferredNuclearStepIt->hits.size()),
+        fAdeptTransport->GetReturnAllSteps(), fAdeptTransport->GetReturnFirstAndLastStep());
+  }
 }
 
 void AdePTTrackingManager::ProcessReturnedGPUHits(int threadId, int eventId)
@@ -407,8 +430,20 @@ void AdePTTrackingManager::ProcessReturnedGPUHits(int threadId, int eventId)
                   << "\033[0m" << std::endl;
       }
       auto blockSize = 1 + it->fNumSecondaries;
-      fGeant4Integration.ProcessGPUStep(std::span<const GPUHit>(&*it, blockSize), fAdeptTransport->GetReturnAllSteps(),
-                                        fAdeptTransport->GetReturnFirstAndLastStep());
+      const bool isNuclearStep =
+          (it->fParticleType == ParticleType::Gamma || it->fParticleType == ParticleType::Electron ||
+           it->fParticleType == ParticleType::Positron) &&
+          it->fStepLimProcessId == 3;
+      if (isNuclearStep) {
+        // Nuclear returned steps are replayed later at the same sorted barrier
+        // as leaked tracks, because the host-side hadronic process consumes
+        // Geant4 RNG and therefore must not run in hit-buffer arrival order.
+        fGeant4Integration.QueueDeferredNuclearStep(std::span<const GPUHit>(&*it, blockSize));
+      } else {
+        fGeant4Integration.ProcessGPUStep(std::span<const GPUHit>(&*it, blockSize),
+                                          fAdeptTransport->GetReturnAllSteps(),
+                                          fAdeptTransport->GetReturnFirstAndLastStep());
+      }
       it += blockSize;
     }
   });
@@ -416,7 +451,6 @@ void AdePTTrackingManager::ProcessReturnedGPUHits(int threadId, int eventId)
 
 void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
 {
-
   G4EventManager *eventManager       = G4EventManager::GetEventManager();
   G4TrackingManager *trackManager    = eventManager->GetTrackingManager();
   G4SteppingManager *steppingManager = trackManager->GetSteppingManager();


### PR DESCRIPTION
This PR is based on #583 and should be reviewed only after that one is merged.
This PR fixes #533. 

Before, the tracks undergoing the nuclear reactions were sent back as a leaked track. However, additionally also a GPUHit was sent back (in most cases).

The GPUHit was used to call the UserActions and the SD code, which was executed first. The nuclear reaction was then done on the track, when the leaked tracks were handled. That means, that the SD code was called before the nuclear reaction was actually done, leading to missing secondaries or wrong direction / energy in the final state in case of lepton nuclear reactions.

This problem is fixed by instead only sending back a GPUHit and not a leaked track anymore for the nuclear reactions (the GPUHit contains all the necessary information). However, in order to have the same RNG and to be reproducible, the GPUHit must still be deferred and handled only at the very end. The deferred nuclear step also has a TrackData struct, such that the sorting can be done together with the returned tracks. This ensures the **exact** same RNG ordering as on the current master branch. Note that in principle it would not be needed, one could also just sort the deferred nuclear steps and the returned tracks individually and process them one by one. 
However, that would change the RNG, so it should not be done in this PR, because currently, the `edep_per_volume` in the drift tests is untouched, only the expected MC truth histograms change, which were previously missing the secondaries that were not linked to the parents correctly.

This PR gives a slight run time improvement in the validation tests, as less data needs to be transferred back.
The PR does change the physics results, as it fixes the incorrect handling of the MC truth, however it does not change the energy deposition


It was verified that this PR
- [x] Changes physics results
- [ ] Does not change physics results