### PR TITLE
Remove leaking of tracks and replace it by construction from steps

### DIFF
--- a/include/AdePT/core/AdePTConfiguration.hh
+++ b/include/AdePT/core/AdePTConfiguration.hh
@@ -25,7 +25,6 @@ public:
   void AddWDTRegionName(std::string name) { fWDTRegionNames.push_back(name); }
   void SetVerbosity(int verbosity) { fVerbosity = verbosity; };
   void SetMillionsOfTrackSlots(double millionSlots) { fMillionsOfTrackSlots = millionSlots; }
-  void SetMillionsOfLeakSlots(double millionSlots) { fMillionsOfLeakSlots = millionSlots; }
   void SetMillionsOfHitSlots(double millionSlots) { fMillionsOfHitSlots = millionSlots; }
   void SetHitBufferFlushThreshold(float threshold) { fHitBufferFlushThreshold = threshold; }
   void SetCPUCapacityFactor(float CPUCapacityFactor) { fCPUCapacityFactor = CPUCapacityFactor; }
@@ -69,7 +68,6 @@ public:
   float GetCPUCapacityFactor() { return fCPUCapacityFactor; }
   double GetHitBufferSafetyFactor() { return fHitBufferSafetyFactor; }
   double GetMillionsOfTrackSlots() { return fMillionsOfTrackSlots; }
-  double GetMillionsOfLeakSlots() { return fMillionsOfLeakSlots; }
   double GetMillionsOfHitSlots() { return fMillionsOfHitSlots; }
   std::vector<std::string> *GetGPURegionNames() { return &fGPURegionNames; }
   std::vector<std::string> *GetCPURegionNames() { return &fCPURegionNames; }
@@ -95,7 +93,6 @@ private:
   float fCPUCapacityFactor{2.5};
   double fHitBufferSafetyFactor{1.5};
   double fMillionsOfTrackSlots{1};
-  double fMillionsOfLeakSlots{1};
   double fMillionsOfHitSlots{1};
   unsigned short fLastNParticlesOnCPU{0};
   unsigned short fMaxWDTIter{5};

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -916,7 +916,6 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
 {
 
   using InjectState                             = GPUstate::InjectState;
-  using ExtractState                            = GPUstate::ExtractState;
   auto &cudaManager                             = vecgeom::cxx::CudaManager::Instance();
   const vecgeom::cuda::VPlacedVolume *world_dev = cudaManager.world_gpu();
 
@@ -925,22 +924,17 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
   SpeciesState &gammas           = gpuState.particles[GPUQueueIndex::Gamma];
   ParticleQueues &woodcockQueues = gpuState.woodcockQueues;
 
-  // Auxiliary struct used to keep track of the queues that need flushing
-  AllLeaked allLeaked{nullptr, nullptr, nullptr};
-
   ADEPT_DEVICE_API_SYMBOL(Event_t) cudaEvent, cudaStatsEvent;
-  ADEPT_DEVICE_API_SYMBOL(Stream_t) hitTransferStream, injectStream, extractStream, statsStream;
+  ADEPT_DEVICE_API_SYMBOL(Stream_t) hitTransferStream, injectStream, statsStream;
   ADEPT_DEVICE_API_CALL(EventCreateWithFlags(&cudaEvent, ADEPT_DEVICE_API_SYMBOL(EventDisableTiming)));
   ADEPT_DEVICE_API_CALL(EventCreateWithFlags(&cudaStatsEvent, ADEPT_DEVICE_API_SYMBOL(EventDisableTiming)));
   unique_ptr_cuda<ADEPT_DEVICE_API_SYMBOL(Event_t)> cudaEventCleanup{&cudaEvent};
   unique_ptr_cuda<ADEPT_DEVICE_API_SYMBOL(Event_t)> cudaStatsEventCleanup{&cudaStatsEvent};
   ADEPT_DEVICE_API_CALL(StreamCreate(&hitTransferStream));
   ADEPT_DEVICE_API_CALL(StreamCreate(&injectStream));
-  ADEPT_DEVICE_API_CALL(StreamCreate(&extractStream));
   ADEPT_DEVICE_API_CALL(StreamCreate(&statsStream));
   unique_ptr_cuda<ADEPT_DEVICE_API_SYMBOL(Stream_t)> cudaStreamCleanup{&hitTransferStream};
   unique_ptr_cuda<ADEPT_DEVICE_API_SYMBOL(Stream_t)> cudaInjectStreamCleanup{&injectStream};
-  unique_ptr_cuda<ADEPT_DEVICE_API_SYMBOL(Stream_t)> cudaExtractStreamCleanup{&extractStream};
   unique_ptr_cuda<ADEPT_DEVICE_API_SYMBOL(Stream_t)> cudaStatsStreamCleanup{&statsStream};
   auto waitForOtherStream = [&cudaEvent](ADEPT_DEVICE_API_SYMBOL(Stream_t) waitingStream,
                                          ADEPT_DEVICE_API_SYMBOL(Stream_t) streamToWaitFor) {
@@ -979,19 +973,16 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
     }
   }
 
-  TransportLoopCounters counters;
-
   while (gpuState.runTransport) {
     InitSlotManagers<<<80, 256, 0, gpuState.stream>>>(gpuState.slotManager_dev, gpuState.nSlotManager_dev);
     InitSlotManagers<<<80, 256, 0, gpuState.stream>>>(gpuState.slotManagerLeaks_dev, gpuState.nSlotManager_dev);
     ADEPT_DEVICE_API_CALL(MemsetAsync(gpuState.stats_dev, 0, sizeof(Stats), gpuState.stream));
 
     int inFlight                                              = 0;
-    unsigned int numLeaked                                    = 0;
     unsigned int particlesInFlight[GPUQueueIndex::NumSpecies] = {1, 1, 1};
 
     auto needTransport = [](std::atomic<EventState> const &state) {
-      return state.load(std::memory_order_acquire) < EventState::LeakedTracksRetrieved;
+      return state.load(std::memory_order_acquire) < EventState::HitsFlushed;
     };
     // Wait for work from G4 workers:
     while (gpuState.runTransport && std::none_of(eventStates.begin(), eventStates.end(), needTransport)) {
@@ -999,7 +990,7 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
       std::this_thread::sleep_for(10ms);
     }
     // Shutdown can wake the dedicated GPU steering thread out of the idle wait
-    // even when all event states are already LeakedTracksRetrieved. In that
+    // even when all event states are already DeviceFlushed. In that
     // case, one Geant4 worker has entered FreeGPU() and flipped runTransport.
     // The outer while-condition is only re-checked at the next iteration
     // boundary, so we must exit explicitly before this current iteration
@@ -1012,9 +1003,8 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
 
     ADEPT_DEVICE_API_CALL(StreamSynchronize(gpuState.stream));
 
-    for (unsigned int iteration = 0;
-         inFlight > 0 || gpuState.injectState != InjectState::Idle || gpuState.extractState != ExtractState::Idle ||
-         std::any_of(eventStates.begin(), eventStates.end(), needTransport);
+    for (unsigned int iteration = 0; inFlight > 0 || gpuState.injectState != InjectState::Idle ||
+                                     std::any_of(eventStates.begin(), eventStates.end(), needTransport);
          ++iteration) {
 
       // Swap the queues for the next iteration.
@@ -1022,7 +1012,6 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
       positrons.queues.SwapActive();
       gammas.queues.SwapActive();
       woodcockQueues.SwapActive();
-      ++counters.totalIterations;
 
       const ParticleManager particleManager = {
           .electrons = {electrons.tracks, electrons.leaks, electrons.slotManager, electrons.slotManagerLeaks,
@@ -1297,9 +1286,6 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
         ZeroEventCounters<<<1, 256, 0, statsStream>>>(gpuState.stats_dev);
         CountCurrentPopulation<<<GPUQueueIndex::NumParticleQueues, 128, 0, statsStream>>>(
             allParticleQueues, gpuState.stats_dev, tracksAndSlots);
-        // Count leaked tracks. Note that new tracks might be added while/after we count:
-        CountLeakedTracks<<<2 * GPUQueueIndex::NumSpecies, 128, 0, statsStream>>>(allParticleQueues, gpuState.stats_dev,
-                                                                                  tracksAndSlots);
 
         waitForOtherStream(gpuState.stream, statsStream);
 
@@ -1313,225 +1299,6 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
                                           ADEPT_DEVICE_API_SYMBOL(MemcpyDeviceToHost), statsStream));
         ADEPT_DEVICE_API_CALL(EventRecord(cudaStatsEvent, statsStream));
       }
-
-      // -------------------------
-      // *** Collect particles ***
-      // -------------------------
-
-      // There are two reasons to transfers leaks back to the host:
-      // - An event requested a flush
-      // - The leak queue usage is too high
-      //
-      // If the queue usage is too high, but we are already extracting leaks, the GPU transport
-      // thread needs to wait. It stops launching kernels and instead steers the leak extraction
-      // loop until all have been transferred
-      // This issue is very similar to the bottleneck encountered when extracting all steps
-      // done in simple geometries. It doesn't appear to be a problem in complex geometries
-      //
-      // If an event has requested a flush, but we are already extracting leaks, we don't necessarily
-      // need to wait. The GPU transport can continue as long as the current leak queue remains below
-      // the usage threshold
-
-      // Is any of the current leak queues over the usage threshold?
-      bool leakQueueNeedsTransfer = false;
-      for (int particleType = 0; particleType < GPUQueueIndex::NumSpecies; ++particleType) {
-        // NOTE: This chek is done without synchronization with the stats counting and transfer, which
-        // means that we might be seeing the usage during the previous iteration. We expect that this
-        // will not be an issue in most situations, while allowing us to parallelize this work with
-        // the stats counting
-        if (gpuState.stats->nLeakedCurrent[particleType] > 0.5 * leakCapacity) {
-          leakQueueNeedsTransfer = true;
-          break;
-        }
-      }
-      if (leakQueueNeedsTransfer) ++counters.leakExtractionByQueuePressure;
-
-      // Did an event request a flush?
-      bool leakExtractionRequested = std::any_of(eventStates.begin(), eventStates.end(), [](const auto &eventState) {
-        return eventState.load(std::memory_order_acquire) == EventState::HitsFlushed;
-      });
-      if (leakExtractionRequested) ++counters.leakExtractionByEventFlush;
-
-      bool leakExtractionNeeded = leakQueueNeedsTransfer || leakExtractionRequested;
-
-      // Leak Extraction
-      // We always do one pass of this loop. If the leak queues are over the usage threshold but
-      // an extraction is already in progress, the transport thread will stay in this loop until
-      // it finishes and the queues can be swapped
-      do {
-        if (gpuState.extractState.load(std::memory_order_acquire) != ExtractState::Idle) {
-          // If:
-          // - A previous extraction is in progress
-          // - The current leak queue usage is under the threshold
-          if (!leakQueueNeedsTransfer) {
-            // An event requested a flush, but the current leak queue usage is under the threshold,
-            // transport can continue
-            leakExtractionNeeded = false;
-          } else {
-            // Otherwise, the current leak queue usage is above the threshold. Transport needs to stop until the
-            // transfer of these leaks can start
-            printf("WARNING: Leak extraction blocked. Transport will stop until current extraction ends\n");
-            ++counters.leakExtractionBlocked;
-          }
-        }
-
-        // If not extracting tracks from a previous event, freeze the current leak queues and swap the next ones in
-        if (gpuState.extractState.load(std::memory_order_acquire) == ExtractState::Idle && leakExtractionNeeded) {
-
-          // Transport can continue
-          leakExtractionNeeded = false;
-
-          AdvanceEventStates(EventState::HitsFlushed, EventState::FlushingTracks, eventStates);
-          // Advance the extractState. This ensures that this code will not run again until this flush has been
-          // completed, this is important to ensure that no events can enter the `FlushingTracks` state while an
-          // extraction is already in progress
-          AdvanceExtractState(ExtractState::Idle, ExtractState::ExtractionRequested, gpuState.extractState);
-
-          if (debugLevel > 5) {
-            for (unsigned short threadId = 0; threadId < eventStates.size(); ++threadId) {
-              if (eventStates[threadId].load(std::memory_order_acquire) == EventState::FlushingTracks) {
-                printf("\033[48;5;25mFlushing leaks for event %d\033[0m\n", threadId);
-              }
-            }
-          }
-
-          // We need to keep track of how many tracks have already been transferred to the host
-          trackBuffer.fNumLeaksTransferred = 0;
-
-          // This struct will hold the queues that need to be flushed
-          allLeaked = {
-              .leakedElectrons = {electrons.leaks, electrons.queues.leakedTracksCurrent, electrons.slotManagerLeaks},
-              .leakedPositrons = {positrons.leaks, positrons.queues.leakedTracksCurrent, positrons.slotManagerLeaks},
-              .leakedGammas    = {gammas.leaks, gammas.queues.leakedTracksCurrent, gammas.slotManagerLeaks}};
-
-          // Ensure that transport that's writing to the old queues finishes before collecting leaked tracks
-          for (auto const &event : {electrons.event, positrons.event, gammas.event}) {
-            ADEPT_DEVICE_API_CALL(StreamWaitEvent(extractStream, event));
-          }
-
-          // Once transport has finished, we can start extracting the leaks
-          ADEPT_DEVICE_API_CALL(LaunchHostFunc(
-              extractStream,
-              [](void *arg) {
-                AdvanceExtractState(ExtractState::ExtractionRequested, ExtractState::TracksNeedTransfer,
-                                    *static_cast<decltype(GPUstate::extractState) *>(arg));
-              },
-              &gpuState.extractState));
-
-          // Swap host pointer to the leak queues. This freezes the current queues and starts filling the next
-          electrons.queues.SwapLeakedQueue();
-          positrons.queues.SwapLeakedQueue();
-          gammas.queues.SwapLeakedQueue();
-        }
-
-        // When the leak queues are frozen, we can start copying the leaks to the host
-        if (gpuState.extractState.load(std::memory_order_acquire) == ExtractState::TracksNeedTransfer) {
-
-          // Update the state so that the staging buffer will not be modified again until tracks have been copied
-          // gpuState.extractState = ExtractState::PreparingTracks;
-          AdvanceExtractState(ExtractState::TracksNeedTransfer, ExtractState::PreparingTracks, gpuState.extractState);
-
-          // // Populate the staging buffer and copy to host
-          constexpr unsigned int block_size = 128;
-          const unsigned int grid_size      = (trackBuffer.fNumFromDevice + block_size - 1) / block_size;
-          FillFromDeviceBuffer<<<grid_size, block_size, 0, extractStream>>>(
-              allLeaked, trackBuffer.fromDevice_dev.get(), trackBuffer.fNumFromDevice,
-              // printtotal, allLeaked, trackBuffer.fromDevice_dev.get(), trackBuffer.fNumFromDevice,
-              trackBuffer.fNumLeaksTransferred);
-
-          // Copy the number of leaked tracks to host
-          ADEPT_DEVICE_API_CALL(MemcpyFromSymbolAsync(trackBuffer.nFromDevice_host.get(), nFromDevice_dev,
-                                                      sizeof(unsigned int), 0,
-                                                      ADEPT_DEVICE_API_SYMBOL(MemcpyDeviceToHost), extractStream));
-          // Copy the number of tracks remaining on GPU to host
-          ADEPT_DEVICE_API_CALL(MemcpyFromSymbolAsync(trackBuffer.nRemainingLeaks_host.get(), nRemainingLeaks_dev,
-                                                      sizeof(unsigned int), 0,
-                                                      ADEPT_DEVICE_API_SYMBOL(MemcpyDeviceToHost), extractStream));
-
-          // Update the state after the copy
-          ADEPT_DEVICE_API_CALL(LaunchHostFunc(
-              extractStream,
-              [](void *arg) {
-                AdvanceExtractState(ExtractState::PreparingTracks, ExtractState::TracksReadyToCopy,
-                                    *static_cast<decltype(GPUstate::extractState) *>(arg));
-              },
-              &gpuState.extractState));
-        }
-
-        if (gpuState.extractState.load(std::memory_order_acquire) == ExtractState::TracksReadyToCopy) {
-          AdvanceExtractState(ExtractState::TracksReadyToCopy, ExtractState::CopyingTracks, gpuState.extractState);
-
-          // printf("COPYING: %d\n", *trackBuffer.nFromDevice_host);
-
-          // Copy leaked tracks to host
-          ADEPT_DEVICE_API_CALL(MemcpyAsync(trackBuffer.fromDevice_host.get(), trackBuffer.fromDevice_dev.get(),
-                                            (*trackBuffer.nFromDevice_host) * sizeof(TrackDataWithIDs),
-                                            ADEPT_DEVICE_API_SYMBOL(MemcpyDeviceToHost), extractStream));
-          // Update the state after the copy
-          ADEPT_DEVICE_API_CALL(LaunchHostFunc(
-              extractStream,
-              [](void *arg) {
-                AdvanceExtractState(ExtractState::CopyingTracks, ExtractState::TracksOnHost,
-                                    *static_cast<decltype(GPUstate::extractState) *>(arg));
-              },
-              &gpuState.extractState));
-        }
-
-        if (gpuState.extractState.load(std::memory_order_acquire) == ExtractState::TracksOnHost) {
-          AdvanceExtractState(ExtractState::TracksOnHost, ExtractState::SavingTracks, gpuState.extractState);
-          // Update the number of tracks already transferred
-          trackBuffer.fNumLeaksTransferred += *trackBuffer.nFromDevice_host;
-
-          // Auxiliary struct to pass the necessary data to the callback
-          struct CallbackData {
-            TrackBuffer *trackBuffer;
-            GPUstate *gpuState;
-            std::vector<std::atomic<EventState>> *eventStates;
-          };
-          // Needs to be dynamically allocated, since the callback may execute after
-          // the current scope has ended.
-          CallbackData *data = new CallbackData{&trackBuffer, &gpuState, &eventStates};
-
-          // Distribute the leaked tracks on host to the appropriate G4 workers
-          ADEPT_DEVICE_API_CALL(LaunchHostFunc(
-              extractStream,
-              [](void *userData) {
-                CallbackData *data = static_cast<CallbackData *>(userData);
-                ReturnTracksToG4(*data->trackBuffer, *data->gpuState, *data->eventStates);
-                AdvanceExtractState(ExtractState::SavingTracks, ExtractState::TracksSaved,
-                                    data->gpuState->extractState);
-                delete data;
-              },
-              data));
-        }
-
-        // Now we can re-use the host buffer for the next copy, if there are any remaining leaks on GPU
-        if (gpuState.extractState.load(std::memory_order_acquire) == ExtractState::TracksSaved) {
-          if (*trackBuffer.nRemainingLeaks_host == 0) {
-            // Extraction finished, clear the queues and set to idle
-            ClearQueues<<<1, 1, 0, extractStream>>>(allLeaked.leakedElectrons.fLeakedQueue,
-                                                    allLeaked.leakedPositrons.fLeakedQueue,
-                                                    allLeaked.leakedGammas.fLeakedQueue);
-            // ExtraxtState is set to Idle, a new extraction can be started
-            // The events that had requested a flush are guaranteed to have all their tracks available on host
-            AdvanceExtractState(ExtractState::TracksSaved, ExtractState::Idle, gpuState.extractState);
-
-            if (debugLevel > 5) {
-              for (unsigned short threadId = 0; threadId < eventStates.size(); ++threadId) {
-                if (eventStates[threadId].load(std::memory_order_acquire) == EventState::FlushingTracks) {
-                  printf("\033[48;5;208mEvent %d flushed\033[0m\n", threadId);
-                }
-              }
-            }
-
-            AdvanceEventStates(EventState::FlushingTracks, EventState::DeviceFlushed, eventStates);
-
-          } else {
-            // There are still tracks left on device
-            AdvanceExtractState(ExtractState::TracksSaved, ExtractState::TracksNeedTransfer, gpuState.extractState);
-          }
-        }
-      } while (leakExtractionNeeded);
 
       // -------------------------
       // *** Finish iteration ***
@@ -1552,14 +1319,12 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
             // with gpuState.stream
             waitForOtherStream(gpuState.stream, hitTransferStream);
             waitForOtherStream(gpuState.stream, injectStream);
-            waitForOtherStream(gpuState.stream, extractStream);
             static_assert(gpuState.nSlotManager_dev == GPUQueueIndex::NumSpecies,
                           "The below launches assume there is a slot manager per particle type.");
             FreeSlots1<<<10, 256, 0, gpuState.stream>>>(gpuState.slotManager_dev + i);
             FreeSlots2<<<1, 1, 0, gpuState.stream>>>(gpuState.slotManager_dev + i);
             waitForOtherStream(hitTransferStream, gpuState.stream);
             waitForOtherStream(injectStream, gpuState.stream);
-            waitForOtherStream(extractStream, gpuState.stream);
           }
           if (gpuState.stats->slotFillLevelLeaks[i] > 0.5) {
             // Freeing of slots has to run exclusively
@@ -1567,14 +1332,12 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
             // with gpuState.stream
             waitForOtherStream(gpuState.stream, hitTransferStream);
             waitForOtherStream(gpuState.stream, injectStream);
-            waitForOtherStream(gpuState.stream, extractStream);
             static_assert(gpuState.nSlotManager_dev == GPUQueueIndex::NumSpecies,
                           "The below launches assume there is a slot manager per particle type.");
             FreeSlots1<<<10, 256, 0, gpuState.stream>>>(gpuState.slotManagerLeaks_dev + i);
             FreeSlots2<<<1, 1, 0, gpuState.stream>>>(gpuState.slotManagerLeaks_dev + i);
             waitForOtherStream(hitTransferStream, gpuState.stream);
             waitForOtherStream(injectStream, gpuState.stream);
-            waitForOtherStream(extractStream, gpuState.stream);
           }
         }
       }
@@ -1591,8 +1354,7 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
 
       // *** Count particles in flight ***
       {
-        inFlight  = 0;
-        numLeaked = 0;
+        inFlight = 0;
         // Synchronize with stats count before taking decisions
         ADEPT_DEVICE_API_SYMBOL(Error_t) result;
         while ((result = ADEPT_DEVICE_API_SYMBOL(EventQuery(cudaStatsEvent))) ==
@@ -1605,7 +1367,6 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
 
         for (int i = 0; i < GPUQueueIndex::NumSpecies; i++) {
           inFlight += gpuState.stats->inFlight[i];
-          numLeaked += gpuState.stats->leakedTracks[i];
           particlesInFlight[i] = gpuState.stats->inFlight[i];
         }
 
@@ -1613,7 +1374,6 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
           const auto state = eventStates[threadId].load(std::memory_order_acquire);
           if (state == EventState::WaitingForTransportToFinish && gpuState.stats->perEventInFlight[threadId] == 0) {
             eventStates[threadId] = EventState::RequestHitFlush;
-            ++counters.eventDrainedToHitFlush;
           }
           if (state >= EventState::RequestHitFlush && gpuState.stats->perEventInFlight[threadId] != 0) {
             // FIXME: this case should not happen and is related to some late injection that shows up too late in the
@@ -1674,18 +1434,11 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
             }
           }
 
-          const bool swapByOccupancyHalf =
-              gpuState.stats->hitBufferOccupancy >= gpuState.fHitScoring->HitCapacity() / numThreads / 2;
-          const bool swapByOccupancy10k = gpuState.stats->hitBufferOccupancy >= 10000;
-          const bool swapByEventFlush   = std::any_of(eventStates.begin(), eventStates.end(), [](const auto &state) {
-            return state.load(std::memory_order_acquire) == EventState::RequestHitFlush;
-          });
-          if (swapByOccupancyHalf || swapByOccupancy10k || nextStepMightFail || swapByEventFlush) {
-            ++counters.hitBufferSwaps;
-            if (swapByOccupancyHalf) ++counters.hitBufferSwapByOccupancy;
-            if (swapByOccupancy10k) ++counters.hitBufferSwapByOccupancy10k;
-            if (nextStepMightFail) ++counters.hitBufferSwapByPressure;
-            if (swapByEventFlush) ++counters.hitBufferSwapByEventFlush;
+          if (gpuState.stats->hitBufferOccupancy >= gpuState.fHitScoring->HitCapacity() / numThreads / 2 ||
+              gpuState.stats->hitBufferOccupancy >= 10000 || nextStepMightFail ||
+              std::any_of(eventStates.begin(), eventStates.end(), [](const auto &state) {
+                return state.load(std::memory_order_acquire) == EventState::RequestHitFlush;
+              })) {
             // Reset hitBufferOccupancy to 0 when we swap, as the delay of updating it could cause another unwanted swap
             ADEPT_DEVICE_API_CALL(
                 MemsetAsync(&(gpuState.stats_dev->hitBufferOccupancy), 0, sizeof(unsigned int), gpuState.stream));
@@ -1694,11 +1447,18 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
             hitProcessing->cv.notify_one();
           }
         }
+
+        // A flush request can also arrive after all returned hit batches have
+        // already been drained on the host. In that case there is nothing left
+        // to swap, but the worker still needs a terminal host-visible state.
+        if (gpuState.stats->hitBufferOccupancy == 0 && gpuState.fHitScoring->ReadyToSwapBuffers()) {
+          AdvanceEventStates(EventState::RequestHitFlush, EventState::HitsFlushed, eventStates);
+        }
       }
 
       // *** Notify G4 workers if their events completed ***
       if (std::any_of(eventStates.begin(), eventStates.end(), [](const std::atomic<EventState> &state) {
-            return state.load(std::memory_order_acquire) == EventState::DeviceFlushed;
+            return state.load(std::memory_order_acquire) >= EventState::HitsFlushed;
           })) {
         // Notify HitProcessingThread to notify the workers. Do not notify workers directly, as this could bypass the
         // processing of hits
@@ -1717,10 +1477,8 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
                   << gpuState.stats->queueFillLevel[GPUQueueIndex::Gamma] << " "
                   << gpuState.stats->queueFillLevel[GPUQueueIndex::GammaWDT] << ")";
         std::cerr << "\t slots [e-, e+, gamma]: [" << gpuState.stats->slotFillLevel[0] << ", "
-                  << gpuState.stats->slotFillLevel[1] << ", " << gpuState.stats->slotFillLevel[2] << "], " << numLeaked
-                  << " leaked."
+                  << gpuState.stats->slotFillLevel[1] << ", " << gpuState.stats->slotFillLevel[2] << "]"
                   << "\tInjectState: " << static_cast<unsigned int>(gpuState.injectState.load())
-                  << "\tExtractState: " << static_cast<unsigned int>(gpuState.extractState.load())
                   << "\tHitBuffer: " << gpuState.stats->hitBufferOccupancy
                   << "\tHitBufferReadyToSwap: " << gpuState.fHitScoring->ReadyToSwapBuffers();
         gpuState.fHitScoring->PrintHostBufferState();
@@ -1737,8 +1495,7 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
 
 #ifndef NDEBUG
       // *** Check slots ***
-      if (false && iteration % 100 == 0 && gpuState.injectState != InjectState::CreatingSlots &&
-          gpuState.extractState != ExtractState::PreparingTracks) {
+      if (false && iteration % 100 == 0 && gpuState.injectState != InjectState::CreatingSlots) {
         AssertConsistencyOfSlotManagers<<<120, 256, 0, gpuState.stream>>>(gpuState.slotManager_dev,
                                                                           gpuState.nSlotManager_dev);
         ADEPT_DEVICE_API_CALL(StreamSynchronize(gpuState.stream));
@@ -1773,29 +1530,6 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
     ADEPT_DEVICE_API_CALL(StreamSynchronize(gpuState.stream));
 
     if (debugLevel > 2) std::cout << "End transport loop.\n";
-  }
-
-  if (debugLevel >= 1) {
-    std::cerr << "\n=== AdePT Transport Loop Summary ===\n"
-              << "  Total iterations:                     " << counters.totalIterations << "\n"
-              << "  Leak extractions by queue pressure:   " << counters.leakExtractionByQueuePressure << "\n"
-              << "  Leak extractions by event flush:      " << counters.leakExtractionByEventFlush << "\n"
-              << "  Transport stalls (extraction blocked): " << counters.leakExtractionBlocked << "\n"
-              << "  Events drained to hit flush:          " << counters.eventDrainedToHitFlush << "\n"
-              << "  Hit-buffer swaps total:               " << counters.hitBufferSwaps << "\n"
-              << "    of which by occupancy >= half cap:  " << counters.hitBufferSwapByOccupancy << "\n"
-              << "    of which by occupancy >= 10000:     " << counters.hitBufferSwapByOccupancy10k << "\n"
-              << "    of which by overflow pressure:      " << counters.hitBufferSwapByPressure << "\n"
-              << "    of which by event hit flush:        " << counters.hitBufferSwapByEventFlush << "\n";
-    if (counters.leakExtractionBlocked > 0)
-      std::cerr << "  ACTION: leakExtractionBlocked > 0 -> increase MillionsOfLeakSlots\n";
-    if (counters.hitBufferSwapByPressure > 0)
-      std::cerr << "  ACTION: hitBufferSwapByPressure > 0 -> increase MillionsOfHitSlots, increase CPUCapacityFactor,\n"
-                   "          or increase HitBufferThreshold (safe up to 1 - 1/CPUCapacityFactor)\n";
-    if (counters.hitBufferSwapByOccupancy > 0 && counters.hitBufferSwapByOccupancy > counters.hitBufferSwapByEventFlush)
-      std::cerr
-          << "  ACTION: frequent occupancy-driven swaps -> increase MillionsOfHitSlots or HitBufferFlushThreshold\n";
-    std::cerr << "=====================================\n";
   }
 
   hitProcessing->keepRunning = false;

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -116,7 +116,7 @@ bool InitializeTrackDebug()
 }
 
 // Kernel to initialize the set of queues per particle type.
-__global__ void InitParticleQueues(ParticleQueues queues, size_t CapacityTransport, size_t CapacityLeaked)
+__global__ void InitParticleQueues(ParticleQueues queues, size_t CapacityTransport)
 {
   adept::MParray::MakeInstanceAt(CapacityTransport, queues.initiallyActive);
   adept::MParray::MakeInstanceAt(CapacityTransport, queues.nextActive);
@@ -126,8 +126,6 @@ __global__ void InitParticleQueues(ParticleQueues queues, size_t CapacityTranspo
     adept::MParray::MakeInstanceAt(CapacityTransport, queues.interactionQueues[i]);
   }
 #endif
-  adept::MParray::MakeInstanceAt(CapacityLeaked, queues.leakedTracksCurrent);
-  adept::MParray::MakeInstanceAt(CapacityLeaked, queues.leakedTracksNext);
 }
 
 // Init a queue at the designated location
@@ -230,78 +228,6 @@ __global__ void EnqueueTracks(AllParticleQueues allQueues, adept::MParrayT<Queue
   }
 }
 
-__device__ unsigned int nFromDevice_dev;
-__device__ unsigned int nRemainingLeaks_dev;
-
-// Copy particles leaked from the GPU region into a compact buffer
-__global__ void FillFromDeviceBuffer(AllLeaked all, AsyncAdePT::TrackDataWithIDs *fromDevice,
-                                     unsigned int maxFromDeviceBuffer, unsigned int nAlreadyTransferred)
-{
-  const auto numElectrons = all.leakedElectrons.fLeakedQueue->size();
-  const auto numPositrons = all.leakedPositrons.fLeakedQueue->size();
-  const auto numGammas    = all.leakedGammas.fLeakedQueue->size();
-  const auto total        = numElectrons + numPositrons + numGammas - nAlreadyTransferred;
-  const auto nToCopy      = total < maxFromDeviceBuffer ? total : maxFromDeviceBuffer;
-
-  if (blockIdx.x == 0 && threadIdx.x == 0) {
-    // Update the number of particles that will be copied in this iteration
-    nFromDevice_dev     = nToCopy;
-    nRemainingLeaks_dev = total - nToCopy;
-  }
-
-  for (unsigned int i = threadIdx.x + blockIdx.x * blockDim.x + nAlreadyTransferred; i < nAlreadyTransferred + nToCopy;
-       i += blockDim.x * gridDim.x) {
-    LeakedTracks *leakedTracks = nullptr;
-    unsigned int queueSlot     = 0;
-    int pdg                    = 0;
-
-    if (i < numGammas) {
-      leakedTracks = &all.leakedGammas;
-      queueSlot    = i;
-      pdg          = 22;
-    } else if (i < numGammas + numElectrons) {
-      leakedTracks = &all.leakedElectrons;
-      queueSlot    = i - numGammas;
-      pdg          = 11;
-    } else {
-      leakedTracks = &all.leakedPositrons;
-      queueSlot    = i - numGammas - numElectrons;
-      pdg          = -11;
-    }
-
-    const auto trackSlot     = (*leakedTracks->fLeakedQueue)[queueSlot];
-    Track const *const track = leakedTracks->fTracks + trackSlot;
-
-    // Offset i by nAlreadyTransferred to get the index in the fromDevice buffer
-    auto idx = i - nAlreadyTransferred;
-
-    // NOTE: Sync transport copies data into trackData structs during transport.
-    // Async transport stores the slots and copies to trackdata structs for transfer to
-    // host here. These approaches should be unified.
-    fromDevice[idx].position[0]  = track->pos[0];
-    fromDevice[idx].position[1]  = track->pos[1];
-    fromDevice[idx].position[2]  = track->pos[2];
-    fromDevice[idx].direction[0] = track->dir[0];
-    fromDevice[idx].direction[1] = track->dir[1];
-    fromDevice[idx].direction[2] = track->dir[2];
-    fromDevice[idx].eKin         = track->eKin;
-    fromDevice[idx].globalTime   = track->globalTime;
-    fromDevice[idx].localTime    = track->localTime;
-    fromDevice[idx].properTime   = track->properTime;
-    fromDevice[idx].weight       = track->weight;
-    fromDevice[idx].pdg          = pdg;
-    fromDevice[idx].eventId      = track->eventId;
-    fromDevice[idx].threadId     = track->threadId;
-    fromDevice[idx].navState     = track->navState;
-    fromDevice[idx].leakStatus   = track->leakStatus;
-    fromDevice[idx].parentId     = track->parentId;
-    fromDevice[idx].trackId      = track->trackId;
-    fromDevice[idx].stepCounter  = track->stepCounter;
-
-    leakedTracks->fSlotManager->MarkSlotForFreeing(trackSlot);
-  }
-}
-
 template <typename... Ts>
 __global__ void FreeSlots1(Ts... slotManagers)
 {
@@ -328,7 +254,6 @@ __global__ void FinishIteration(AllParticleQueues all, Stats *stats, TracksAndSl
       }
 #endif
       stats->inFlight[i]       = all.queues[i].nextActive->size();
-      stats->leakedTracks[i]   = all.queues[i].leakedTracksCurrent->size() + all.queues[i].leakedTracksNext->size();
       stats->queueFillLevel[i] = float(all.queues[i].nextActive->size()) / all.queues[i].nextActive->max_size();
     }
     if (threadIdx.x == 0) {
@@ -346,8 +271,7 @@ __global__ void FinishIteration(AllParticleQueues all, Stats *stats, TracksAndSl
     for (int i = 0; i < GPUQueueIndex::NumSpecies; ++i) {
       particlesInFlight += all.queues[i].nextActive->size();
       occupiedSlots += tracksAndSlots.slotManagers[i]->OccupiedSlots();
-      stats->slotFillLevel[i]      = tracksAndSlots.slotManagers[i]->FillLevel();
-      stats->slotFillLevelLeaks[i] = tracksAndSlots.slotManagersLeaks[i]->FillLevel();
+      stats->slotFillLevel[i] = tracksAndSlots.slotManagers[i]->FillLevel();
     }
 
     // add gammas in Woodcock tracking. As the WDT gammas share the same slot manager as normal gammas, no other action
@@ -389,11 +313,6 @@ __global__ void ZeroEventCounters(Stats *stats)
   constexpr auto size = std::extent<decltype(stats->perEventInFlight)>::value;
   for (unsigned int i = threadIdx.x; i < size; i += blockDim.x) {
     stats->perEventInFlight[i] = 0;
-    stats->perEventLeaked[i]   = 0;
-  }
-  for (unsigned int i = threadIdx.x; i < GPUQueueIndex::NumSpecies; i += blockDim.x) {
-    stats->nLeakedCurrent[i] = 0;
-    stats->nLeakedNext[i]    = 0;
   }
 }
 
@@ -434,34 +353,6 @@ __global__ void CountCurrentPopulation(AllParticleQueues all, Stats *stats, Trac
   }
 }
 
-/**
- * Count tracks both in the current and the future queue of leaked particles.
- */
-__global__ void CountLeakedTracks(AllParticleQueues all, Stats *stats, TracksAndSlots tracksAndSlots)
-{
-  constexpr auto nQueue = 2 * GPUQueueIndex::NumSpecies;
-  // One block processes each queue
-  for (unsigned int queueIndex = blockIdx.x; queueIndex < nQueue; queueIndex += gridDim.x) {
-    const auto particleType =
-        queueIndex < GPUQueueIndex::NumSpecies ? queueIndex : queueIndex - GPUQueueIndex::NumSpecies;
-    Track const *const leaks = tracksAndSlots.leaks[particleType];
-    auto const queue         = queueIndex < GPUQueueIndex::NumSpecies ? all.queues[particleType].leakedTracksCurrent
-                                                                      : all.queues[particleType].leakedTracksNext;
-    const auto size          = queue->size();
-    for (unsigned int i = threadIdx.x; i < size; i += blockDim.x) {
-      const auto slot     = (*queue)[i];
-      const auto threadId = leaks[slot].threadId;
-      atomicAdd(stats->perEventLeaked + threadId, 1u);
-    }
-
-    // Update the global usage
-    if (threadIdx.x == 0) {
-      queueIndex < GPUQueueIndex::NumSpecies ? stats->nLeakedCurrent[particleType] = size
-                                             : stats->nLeakedNext[particleType]    = size;
-    }
-  }
-}
-
 template <typename... Args>
 __global__ void ClearQueues(Args *...queue)
 {
@@ -481,8 +372,6 @@ __global__ void ClearAllQueues(AllParticleQueues all)
       all.queues[i].interactionQueues[j]->clear();
     }
 #endif
-    all.queues[i].leakedTracksCurrent->clear();
-    all.queues[i].leakedTracksNext->clear();
   }
 }
 
@@ -658,10 +547,9 @@ void FreeWDTOnDevice(adeptint::WDTDeviceBuffers &dev)
 /// If successful, this will initialise the member fGPUState.
 /// If memory allocation fails, an exception is thrown. In this case, the caller has to
 /// try again after some wait time or with less transport slots.
-std::unique_ptr<GPUstate, GPUstateDeleter> InitializeGPU(int trackCapacity, int leakCapacity, int scoringCapacity,
-                                                         int numThreads, TrackBuffer &trackBuffer,
-                                                         double CPUCapacityFactor, double CPUCopyFraction,
-                                                         std::string &generalBfieldFile,
+std::unique_ptr<GPUstate, GPUstateDeleter> InitializeGPU(int trackCapacity, int scoringCapacity, int numThreads,
+                                                         TrackBuffer &trackBuffer, double CPUCapacityFactor,
+                                                         double CPUCopyFraction, std::string &generalBfieldFile,
                                                          const std::vector<float> &uniformBfieldValues)
 {
   auto gpuState_ptr  = std::unique_ptr<GPUstate, GPUstateDeleter>(new GPUstate());
@@ -726,32 +614,21 @@ std::unique_ptr<GPUstate, GPUstateDeleter> InitializeGPU(int trackCapacity, int 
   // Allocate all slot managers on device
   gpuState.slotManager_dev = nullptr;
   gpuMalloc(gpuState.slotManager_dev, gpuState.nSlotManager_dev);
-  gpuState.slotManagerLeaks_dev = nullptr;
-  gpuMalloc(gpuState.slotManagerLeaks_dev, gpuState.nSlotManager_dev);
   for (int i = 0; i < GPUQueueIndex::NumSpecies; i++) {
     // Number of slots allocated computed based on the proportions set in SpeciesState::relativeQueueSize
     const size_t nSlot              = trackCapacity * SpeciesState::relativeQueueSize[i];
     const size_t sizeOfQueueStorage = adept::MParray::SizeOfInstance(nSlot);
-    const size_t nLeakSlots         = leakCapacity;
-    const size_t sizeOfLeakQueue    = adept::MParray::SizeOfInstance(nLeakSlots);
 
     // Initialize all host slot managers (This call allocates GPU memory)
     gpuState.allmgr_h.slotManagers[i] =
         SlotManager{static_cast<SlotManager::value_type>(nSlot), static_cast<SlotManager::value_type>(nSlot)};
-    gpuState.allmgr_h.slotManagersLeaks[i] =
-        SlotManager{static_cast<SlotManager::value_type>(nLeakSlots), static_cast<SlotManager::value_type>(nLeakSlots)};
     // Initialize dev slotmanagers by copying the host data
     ADEPT_DEVICE_API_CALL(Memcpy(&gpuState.slotManager_dev[i], &gpuState.allmgr_h.slotManagers[i], sizeof(SlotManager),
                                  ADEPT_DEVICE_API_SYMBOL(MemcpyDefault)));
-    ADEPT_DEVICE_API_CALL(Memcpy(&gpuState.slotManagerLeaks_dev[i], &gpuState.allmgr_h.slotManagersLeaks[i],
-                                 sizeof(SlotManager), ADEPT_DEVICE_API_SYMBOL(MemcpyDefault)));
 
-    // Allocate the queues where the active and leak indices are stored
-    // * Current and next active track indices
-    // * Current and next leaked track indices
-    SpeciesState &particleType    = gpuState.particles[i];
-    particleType.slotManager      = &gpuState.slotManager_dev[i];
-    particleType.slotManagerLeaks = &gpuState.slotManagerLeaks_dev[i];
+    // Allocate the queues where the active track indices are stored.
+    SpeciesState &particleType = gpuState.particles[i];
+    particleType.slotManager   = &gpuState.slotManager_dev[i];
 
     void *gpuPtr = nullptr;
     gpuMalloc(gpuPtr, sizeOfQueueStorage);
@@ -766,11 +643,7 @@ std::unique_ptr<GPUstate, GPUstateDeleter> InitializeGPU(int trackCapacity, int 
       particleType.queues.interactionQueues[j] = static_cast<adept::MParray *>(gpuPtr);
     }
 #endif
-    gpuMalloc(gpuPtr, sizeOfLeakQueue);
-    particleType.queues.leakedTracksCurrent = static_cast<adept::MParray *>(gpuPtr);
-    gpuMalloc(gpuPtr, sizeOfLeakQueue);
-    particleType.queues.leakedTracksNext = static_cast<adept::MParray *>(gpuPtr);
-    InitParticleQueues<<<1, 1>>>(particleType.queues, nSlot, nLeakSlots);
+    InitParticleQueues<<<1, 1>>>(particleType.queues, nSlot);
 
     ADEPT_DEVICE_API_CALL(StreamCreate(&particleType.stream));
     ADEPT_DEVICE_API_CALL(EventCreate(&particleType.event));
@@ -781,12 +654,6 @@ std::unique_ptr<GPUstate, GPUstateDeleter> InitializeGPU(int trackCapacity, int 
     gpuMalloc(trackStorage_dev, nSlot);
 
     gpuState.particles[i].tracks = trackStorage_dev;
-
-    // ALlocate space for the leaks
-    Track *leakStorage_dev = nullptr;
-    gpuMalloc(leakStorage_dev, nLeakSlots);
-
-    gpuState.particles[i].leaks = leakStorage_dev;
 
     printf("%lu track slots allocated for particle type %d on GPU (%.2lf%% of %d total slots allocated)\n", nSlot, i,
            SpeciesState::relativeQueueSize[i] * 100, trackCapacity);
@@ -848,44 +715,6 @@ void AdvanceEventStates(EventState oldState, EventState newState, std::vector<st
   }
 }
 
-// Atomically advances the Extract state
-void AdvanceExtractState(GPUstate::ExtractState oldState, GPUstate::ExtractState newState,
-                         std::atomic<GPUstate::ExtractState> &extractState)
-{
-  GPUstate::ExtractState expected = oldState;
-  auto success =
-      extractState.compare_exchange_strong(expected, newState, std::memory_order_release, std::memory_order_relaxed);
-#ifndef NDEBUG
-  if (!success)
-    std::cerr << "Error: Extract state is different than expected. Expected: " << (uint)expected
-              << " Found: " << (uint)extractState.load() << std::endl;
-  assert(success);
-#endif
-}
-
-__host__ void ReturnTracksToG4(TrackBuffer &trackBuffer, GPUstate &gpuState,
-                               std::vector<std::atomic<EventState>> &eventStates)
-{
-  std::scoped_lock lock{trackBuffer.fromDeviceMutex};
-  const auto &fromDevice                      = trackBuffer.fromDevice_host.get();
-  TrackDataWithIDs const *const fromDeviceEnd = fromDevice + *trackBuffer.nFromDevice_host;
-
-  for (TrackDataWithIDs *trackIt = fromDevice; trackIt < fromDeviceEnd; ++trackIt) {
-    // TODO: Pass numThreads here, only used in debug mode however
-    // assert(0 <= trackIt->threadId && trackIt->threadId <= numThreads);
-    trackBuffer.fromDeviceBuffers[trackIt->threadId].push_back(*trackIt);
-  }
-
-#ifndef NDEBUG
-  for (const auto &buffer : trackBuffer.fromDeviceBuffers) {
-    if (buffer.empty()) continue;
-    const auto eventId = buffer.front().eventId;
-    assert(std::all_of(buffer.begin(), buffer.end(),
-                       [eventId](const TrackDataWithIDs &track) { return eventId == track.eventId; }));
-  }
-#endif
-}
-
 void HitProcessingLoop(HitProcessingContext *const context, GPUstate &gpuState,
                        std::vector<std::atomic<EventState>> &eventStates, std::condition_variable &cvG4Workers,
                        int debugLevel)
@@ -908,11 +737,10 @@ void HitProcessingLoop(HitProcessingContext *const context, GPUstate &gpuState,
   }
 }
 
-void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int numThreads, TrackBuffer &trackBuffer,
-                   GPUstate &gpuState, std::vector<std::atomic<EventState>> &eventStates,
-                   std::condition_variable &cvG4Workers, int adeptSeed, int debugLevel, bool returnAllSteps,
-                   bool returnLastStep, unsigned short lastNParticlesOnCPU, const double hitBufferSafetyFactor,
-                   bool hasWDTRegions)
+void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, TrackBuffer &trackBuffer, GPUstate &gpuState,
+                   std::vector<std::atomic<EventState>> &eventStates, std::condition_variable &cvG4Workers,
+                   int adeptSeed, int debugLevel, bool returnAllSteps, bool returnLastStep,
+                   unsigned short lastNParticlesOnCPU, const double hitBufferSafetyFactor, bool hasWDTRegions)
 {
 
   using InjectState                             = GPUstate::InjectState;
@@ -975,7 +803,6 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
 
   while (gpuState.runTransport) {
     InitSlotManagers<<<80, 256, 0, gpuState.stream>>>(gpuState.slotManager_dev, gpuState.nSlotManager_dev);
-    InitSlotManagers<<<80, 256, 0, gpuState.stream>>>(gpuState.slotManagerLeaks_dev, gpuState.nSlotManager_dev);
     ADEPT_DEVICE_API_CALL(MemsetAsync(gpuState.stats_dev, 0, sizeof(Stats), gpuState.stream));
 
     int inFlight                                              = 0;
@@ -1014,17 +841,13 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
       woodcockQueues.SwapActive();
 
       const ParticleManager particleManager = {
-          .electrons = {electrons.tracks, electrons.leaks, electrons.slotManager, electrons.slotManagerLeaks,
-                        electrons.queues.initiallyActive, electrons.queues.nextActive,
-                        electrons.queues.leakedTracksCurrent},
-          .positrons = {positrons.tracks, positrons.leaks, positrons.slotManager, positrons.slotManagerLeaks,
-                        positrons.queues.initiallyActive, positrons.queues.nextActive,
-                        positrons.queues.leakedTracksCurrent},
-          .gammas    = {gammas.tracks, gammas.leaks, gammas.slotManager, gammas.slotManagerLeaks,
-                        gammas.queues.initiallyActive, gammas.queues.nextActive, gammas.queues.leakedTracksCurrent},
-          .gammasWDT = {gammas.tracks, gammas.leaks, gammas.slotManager, gammas.slotManagerLeaks,
-                        woodcockQueues.initiallyActive, woodcockQueues.nextActive, gammas.queues.leakedTracksCurrent}
-          // Note: the Woodcock tracking particleManager uses the same gamma tracks, leaks, and slotManager,
+          .electrons = {electrons.tracks, electrons.slotManager, electrons.queues.initiallyActive,
+                        electrons.queues.nextActive},
+          .positrons = {positrons.tracks, positrons.slotManager, positrons.queues.initiallyActive,
+                        positrons.queues.nextActive},
+          .gammas    = {gammas.tracks, gammas.slotManager, gammas.queues.initiallyActive, gammas.queues.nextActive},
+          .gammasWDT = {gammas.tracks, gammas.slotManager, woodcockQueues.initiallyActive, woodcockQueues.nextActive}
+          // Note: the Woodcock tracking particleManager uses the same gamma tracks and slot manager,
           // it only has its own initiallyActive and nextActive queues.
       };
       const AllParticleQueues allParticleQueues = {{electrons.queues, positrons.queues, gammas.queues, woodcockQueues}};
@@ -1040,11 +863,8 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
            positrons.queues.interactionQueues[2], positrons.queues.interactionQueues[3],
            positrons.queues.interactionQueues[4]}};
 #endif
-      const TracksAndSlots tracksAndSlots = {
-          {electrons.tracks, positrons.tracks, gammas.tracks},
-          {electrons.leaks, positrons.leaks, gammas.leaks},
-          {electrons.slotManager, positrons.slotManager, gammas.slotManager},
-          {electrons.slotManagerLeaks, positrons.slotManagerLeaks, gammas.slotManagerLeaks}};
+      const TracksAndSlots tracksAndSlots = {{electrons.tracks, positrons.tracks, gammas.tracks},
+                                             {electrons.slotManager, positrons.slotManager, gammas.slotManager}};
       // --------------------------
       // *** Particle injection ***
       // --------------------------
@@ -1326,19 +1146,6 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
             waitForOtherStream(hitTransferStream, gpuState.stream);
             waitForOtherStream(injectStream, gpuState.stream);
           }
-          if (gpuState.stats->slotFillLevelLeaks[i] > 0.5) {
-            // Freeing of slots has to run exclusively
-            // FIXME: Revise this code and make sure all three streams actually need to be synchronized
-            // with gpuState.stream
-            waitForOtherStream(gpuState.stream, hitTransferStream);
-            waitForOtherStream(gpuState.stream, injectStream);
-            static_assert(gpuState.nSlotManager_dev == GPUQueueIndex::NumSpecies,
-                          "The below launches assume there is a slot manager per particle type.");
-            FreeSlots1<<<10, 256, 0, gpuState.stream>>>(gpuState.slotManagerLeaks_dev + i);
-            FreeSlots2<<<1, 1, 0, gpuState.stream>>>(gpuState.slotManagerLeaks_dev + i);
-            waitForOtherStream(hitTransferStream, gpuState.stream);
-            waitForOtherStream(injectStream, gpuState.stream);
-          }
         }
       }
 
@@ -1555,15 +1362,14 @@ void CloseGPUBuffer(unsigned int threadId, GPUstate &gpuState, GPUHit *begin, co
 
 // TODO: Make it clear that this will initialize and return the GPUState or make a
 // separate init function that will compile here and be called from the .icc
-std::thread LaunchGPUWorker(int trackCapacity, int leakCapacity, int scoringCapacity, int numThreads,
-                            TrackBuffer &trackBuffer, GPUstate &gpuState,
-                            std::vector<std::atomic<EventState>> &eventStates, std::condition_variable &cvG4Workers,
-                            int adeptSeed, int debugLevel, bool returnAllSteps, bool returnLastStep,
-                            unsigned short lastNParticlesOnCPU, const double hitBufferSafetyFactor, bool hasWDTRegions)
+std::thread LaunchGPUWorker(int trackCapacity, int scoringCapacity, int numThreads, TrackBuffer &trackBuffer,
+                            GPUstate &gpuState, std::vector<std::atomic<EventState>> &eventStates,
+                            std::condition_variable &cvG4Workers, int adeptSeed, int debugLevel, bool returnAllSteps,
+                            bool returnLastStep, unsigned short lastNParticlesOnCPU, const double hitBufferSafetyFactor,
+                            bool hasWDTRegions)
 {
   return std::thread{&TransportLoop,
                      trackCapacity,
-                     leakCapacity,
                      scoringCapacity,
                      numThreads,
                      std::ref(trackBuffer),
@@ -1633,8 +1439,7 @@ void InitVolAuxArray(adeptint::VolAuxArray &array)
 }
 
 /// Initialise the track buffers used to communicate between host and device.
-TrackBuffer::TrackBuffer(unsigned int numToDevice, unsigned int numFromDevice, unsigned short nThread)
-    : fNumToDevice{numToDevice}, fNumFromDevice{numFromDevice}, fromDeviceBuffers(nThread)
+TrackBuffer::TrackBuffer(unsigned int numToDevice) : fNumToDevice{numToDevice}
 {
   TrackDataWithIDs *devPtr, *hostPtr;
   // Double buffer for lock-free host runs:
@@ -1643,19 +1448,6 @@ TrackBuffer::TrackBuffer(unsigned int numToDevice, unsigned int numFromDevice, u
 
   toDevice_host.reset(hostPtr);
   toDevice_dev.reset(devPtr);
-
-  ADEPT_DEVICE_API_CALL(MallocHost(&hostPtr, numFromDevice * sizeof(TrackDataWithIDs)));
-  ADEPT_DEVICE_API_CALL(Malloc(&devPtr, numFromDevice * sizeof(TrackDataWithIDs)));
-
-  fromDevice_host.reset(hostPtr);
-  fromDevice_dev.reset(devPtr);
-
-  unsigned int *nFromDevice = nullptr;
-  ADEPT_DEVICE_API_CALL(MallocHost(&nFromDevice, sizeof(unsigned int)));
-  nFromDevice_host.reset(nFromDevice);
-  unsigned int *nRemainingLeaks = nullptr;
-  ADEPT_DEVICE_API_CALL(MallocHost(&nRemainingLeaks, sizeof(unsigned int)));
-  nRemainingLeaks_host.reset(nRemainingLeaks);
 
   toDeviceBuffer[0].tracks    = toDevice_host.get();
   toDeviceBuffer[0].maxTracks = numToDevice;

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -108,12 +108,10 @@ public:
   void RequestFlush(int threadId);
   /// @brief Wait until the transport threads make further flush progress.
   void WaitForFlushProgress();
-  /// @brief Check whether the device side has completed flushing for the given worker.
-  bool IsDeviceFlushed(int threadId) const;
-  /// @brief Take the leaked-track batch returned by transport for the given worker.
-  std::vector<TrackDataWithIDs> TakeReturnedTracks(int threadId);
-  /// @brief Mark the returned-track batch for the given worker as consumed.
-  void MarkLeakedTracksRetrieved(int threadId);
+  /// @brief Check whether all returned GPU-hit batches have been made available on the host.
+  bool IsHitsFlushed(int threadId) const;
+  /// @brief Mark the worker event as fully handled on the host side after replaying the returned steps.
+  void MarkHostFlushed(int threadId);
 };
 
 } // namespace AsyncAdePT

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -13,7 +13,6 @@
 #include <AdePT/core/AdePTG4HepEmState.hh>
 #include <AdePT/core/AsyncAdePTTransportStruct.hh>
 #include <AdePT/core/GeometryAuxData.hh>
-#include <AdePT/core/ReturnedTrackData.hh>
 #include <AdePT/core/ScoringCommons.hh>
 
 #include <VecGeom/base/Config.h>
@@ -39,7 +38,6 @@ public:
 private:
   unsigned short fNThread{0};             ///< Number of G4 workers
   unsigned int fTrackCapacity{0};         ///< Number of track slots to allocate on device
-  unsigned int fLeakCapacity{0};          ///< Number of leak slots to allocate on device
   unsigned int fScoringCapacity{0};       ///< Number of hit slots to allocate on device
   int fDebugLevel{0};                     ///< Debug level
   int fCUDAStackLimit{0};                 ///< CUDA device stack limit

--- a/include/AdePT/core/AsyncAdePTTransportStruct.cuh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.cuh
@@ -28,29 +28,22 @@ namespace AsyncAdePT {
 // A bundle of pointers to generate particles of an implicit type.
 struct SpeciesParticleManager {
   Track *fTracks;
-  Track *fLeakedTracks;
   SlotManager *fSlotManager;
-  SlotManager *fSlotManagerLeaks;
   adept::MParray *fActiveQueue;
   adept::MParray *fNextActiveQueue;
-  adept::MParray *fActiveLeaksQueue;
 
 public:
-  __host__ __device__ SpeciesParticleManager(Track *tracks, Track *leakedTracks, SlotManager *slotManager,
-                                             SlotManager *slotManagerLeaks, adept::MParray *activeQueue,
-                                             adept::MParray *nextActiveQueue, adept::MParray *activeLeaksQueue)
-      : fTracks(tracks), fLeakedTracks(leakedTracks), fSlotManager(slotManager), fSlotManagerLeaks(slotManagerLeaks),
-        fActiveQueue(activeQueue), fNextActiveQueue(nextActiveQueue), fActiveLeaksQueue(activeLeaksQueue)
+  __host__ __device__ SpeciesParticleManager(Track *tracks, SlotManager *slotManager, adept::MParray *activeQueue,
+                                             adept::MParray *nextActiveQueue)
+      : fTracks(tracks), fSlotManager(slotManager), fActiveQueue(activeQueue), fNextActiveQueue(nextActiveQueue)
   {
   }
 
-  /// Obtain track and leaked track at given slot position
+  /// Obtain track at given slot position
   __device__ __forceinline__ Track &TrackAt(SlotManager::value_type slot) { return fTracks[slot]; }
-  __device__ __forceinline__ Track &LeakTrackAt(SlotManager::value_type slot) { return fLeakedTracks[slot]; }
 
   /// Obtain a slot for a track, but don't enqueue.
   __device__ auto NextSlot() { return fSlotManager->NextSlot(); }
-  __device__ auto NextLeakSlot() { return fSlotManagerLeaks->NextSlot(); }
 
   // enqueue into next-active queue
   __device__ __forceinline__ bool EnqueueNext(SlotManager::value_type slot)
@@ -81,37 +74,6 @@ public:
     auto &track = InitTrack(slot, std::forward<Ts>(args)...);
     return track;
   }
-
-  /// Obtains a leak slot, copies the track from the source slot to the leaks, and marks the slot in the active queue
-  /// for freeing
-  __device__ __forceinline__ void CopyTrackToLeaked(SlotManager::value_type srcSlot)
-  {
-    // get a leak slot
-    const auto leakSlot = NextLeakSlot();
-
-    // Create and construct track from other track
-    new (fLeakedTracks + leakSlot) Track{TrackAt(srcSlot)};
-
-    // enqueue into leak queue
-    const bool success = fActiveLeaksQueue->push_back(leakSlot);
-    if (!success) {
-      printf("ERROR: No space left in leaks queue.\n"
-             "\tThe threshold for flushing the leak buffer may be too high\n"
-             "\tThe space allocated to the leak buffer may be too small\n");
-      asm("trap;");
-    }
-
-    // free the source slot
-    fSlotManager->MarkSlotForFreeing(srcSlot);
-
-    return;
-  }
-};
-
-struct LeakedTracks {
-  Track *fTracks;
-  adept::MParray *fLeakedQueue;
-  SlotManager *fSlotManager;
 };
 
 // A bundle of generators for the three particle types.
@@ -120,13 +82,6 @@ struct ParticleManager {
   SpeciesParticleManager positrons;
   SpeciesParticleManager gammas;
   SpeciesParticleManager gammasWDT;
-};
-
-// Holds the leaked track structs for all three particle types
-struct AllLeaked {
-  LeakedTracks leakedElectrons;
-  LeakedTracks leakedPositrons;
-  LeakedTracks leakedGammas;
 };
 
 // A bundle of queues per particle type:
@@ -168,11 +123,8 @@ dynamic allocations
   adept::MParray *propagation;
   adept::MParray *interactionQueues[numInteractions];
 #endif
-  adept::MParray *leakedTracksCurrent;
-  adept::MParray *leakedTracksNext;
 
   void SwapActive() { std::swap(initiallyActive, nextActive); }
-  void SwapLeakedQueue() { std::swap(leakedTracksCurrent, leakedTracksNext); }
 };
 
 /// @brief Named array-index enum for the per-species GPU state arrays in @ref SpeciesState.
@@ -201,12 +153,10 @@ static_assert(GPUQueueIndex::Gamma == static_cast<int>(ParticleType::Gamma),
               "GPUQueueIndex and ParticleType gamma values must match");
 
 /// @brief Holds all GPU resources needed to manage in-flight tracks of one particle species:
-///        track buffer, leak buffer, slot managers, interaction queues, CUDA stream and event.
+///        track buffer, slot manager, interaction queues, CUDA stream and event.
 struct SpeciesState {
   Track *tracks;
-  Track *leaks;
   SlotManager *slotManager;
-  SlotManager *slotManagerLeaks;
   ParticleQueues queues;
   ADEPT_DEVICE_API_SYMBOL(Stream_t) stream;
   ADEPT_DEVICE_API_SYMBOL(Event_t) event;
@@ -230,9 +180,7 @@ struct AllInteractionQueues {
 // Pointers to track storage for each particle type
 struct TracksAndSlots {
   Track *const tracks[GPUQueueIndex::NumSpecies];
-  Track *const leaks[GPUQueueIndex::NumSpecies];
   SlotManager *const slotManagers[GPUQueueIndex::NumSpecies];
-  SlotManager *const slotManagersLeaks[GPUQueueIndex::NumSpecies];
 };
 
 // A bundle of queues for the three particle types.
@@ -243,21 +191,15 @@ struct AllParticleQueues {
 
 struct AllSlotManagers {
   SlotManager slotManagers[GPUQueueIndex::NumSpecies];
-  SlotManager slotManagersLeaks[GPUQueueIndex::NumSpecies];
 };
 
 // A data structure to transfer statistics after each iteration.
 struct Stats {
   int inFlight[GPUQueueIndex::NumSpecies];
-  int leakedTracks[GPUQueueIndex::NumSpecies];
   float queueFillLevel[GPUQueueIndex::NumParticleQueues];
   float slotFillLevel[GPUQueueIndex::NumSpecies];
-  float slotFillLevelLeaks[GPUQueueIndex::NumSpecies];
   unsigned int perEventInFlight[kMaxThreads];         // Updated asynchronously
   unsigned int perEventInFlightPrevious[kMaxThreads]; // Used in transport kernels
-  unsigned int perEventLeaked[kMaxThreads];
-  unsigned int nLeakedCurrent[GPUQueueIndex::NumSpecies];
-  unsigned int nLeakedNext[GPUQueueIndex::NumSpecies];
   unsigned int hitBufferOccupancy;
 };
 
@@ -297,8 +239,8 @@ struct GPUstate {
 
   SpeciesState particles[GPUQueueIndex::NumSpecies];
 
-  // particle queues for gammas doing woodcock tracking. Only the `initiallyActive` and `nextActive` queue are
-  // allocated, for the leaks the normal gamma queues inside particles[GPUQueueIndex::Gamma] are used.
+  // particle queues for gammas doing woodcock tracking. Only the `initiallyActive` and `nextActive` queues are
+  // allocated.
   ParticleQueues woodcockQueues;
 
   std::vector<void *> allCudaPointers;
@@ -307,9 +249,8 @@ struct GPUstate {
 
   static constexpr unsigned int nSlotManager_dev = 3;
 
-  AllSlotManagers allmgr_h;                   // All host slot managers, statically allocated
-  SlotManager *slotManager_dev{nullptr};      // All device slot managers
-  SlotManager *slotManagerLeaks_dev{nullptr}; // All device leak slot managers
+  AllSlotManagers allmgr_h;              // All host slot managers, statically allocated
+  SlotManager *slotManager_dev{nullptr}; // All device slot managers
 
 #ifdef ADEPT_USE_SPLIT_KERNELS
   HepEmBuffers hepEmBuffers_d; // All device buffers of hepem tracks
@@ -324,28 +265,6 @@ struct GPUstate {
 
   enum class InjectState { Idle, CreatingSlots, ReadyToEnqueue, Enqueueing };
   std::atomic<InjectState> injectState;
-  // ExtractState:
-  // Idle: No flush has been requested
-  // ExtractionRequested: An event requested a flush, waiting for transport to finish
-  // TracksNeedTransfer: An event requested a flush, leak buffer on device has tracks to transfer
-  // PreparingTracks: Tracks are being copied to the staging buffer
-  // TracksReadyToCopy: Staging buffer is ready to be copied to host
-  // CopyingTracks: Tracks are being copied to host
-  // TracksOnHost: Some or all the tracks have been transferred from device to host and are waiting in the copy buffer
-  // SavingTracks: Tracks are being copied to per-event queues
-  // TracksSaved: Tracks have been moved from the copy buffer to their respective per-event queues
-  enum class ExtractState {
-    Idle,
-    ExtractionRequested,
-    TracksNeedTransfer,
-    PreparingTracks,
-    TracksReadyToCopy,
-    CopyingTracks,
-    TracksOnHost,
-    SavingTracks,
-    TracksSaved
-  };
-  std::atomic<ExtractState> extractState;
   std::atomic_bool runTransport{true}; ///< Keep transport thread running
 
   ~GPUstate()

--- a/include/AdePT/core/AsyncAdePTTransportStruct.hh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.hh
@@ -26,9 +26,7 @@ enum class EventState : unsigned char {
   SwappingHitBuffers,
   FlushingHits,
   HitsFlushed,
-  FlushingTracks,
-  DeviceFlushed,
-  LeakedTracksRetrieved
+  DeviceFlushed
 };
 
 } // namespace AsyncAdePT

--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -690,7 +690,7 @@ __device__ void RecordHit(uint64_t aTrackID, uint64_t aParentID, short stepLimPr
                           vecgeom::Vector3D<double> const &aPreMomentumDirection, double aPreEKin,
                           vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<double> const &aPostPosition,
                           vecgeom::Vector3D<double> const &aPostMomentumDirection, double aPostEKin, double aGlobalTime,
-                          double aLocalTime, double aProperTime, double aPreGlobalTime, unsigned int eventID,
+                          float aLocalTime, float aProperTime, double aPreGlobalTime, unsigned int eventID,
                           short threadID, bool isLastStep, unsigned short stepCounter,
                           SecondaryInitData const *secondaryData, unsigned int nSecondaries)
 {
@@ -720,7 +720,7 @@ __device__ void RecordHit(uint64_t aTrackID, uint64_t aParentID, short stepLimPr
             secondaryData[i].particleType,
             /*steplength*/ 0., /*energydeposit*/ 0., aTrackWeight, aPostState, aPostPosition, secondaryData[i].dir,
             secondaryData[i].eKin, aPostState, aPostPosition, secondaryData[i].dir, secondaryData[i].eKin, aGlobalTime,
-            /*localTime*/ 0., /*properTime*/ 0., aGlobalTime, eventID, threadID, /*isLastStep*/ false,
+            /*localTime*/ 0.f, /*properTime*/ 0.f, aGlobalTime, eventID, threadID, /*isLastStep*/ false,
             /*stepCounter*/ 0, /*nSecondaries*/ 0);
   }
 }

--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -690,9 +690,9 @@ __device__ void RecordHit(uint64_t aTrackID, uint64_t aParentID, short stepLimPr
                           vecgeom::Vector3D<double> const &aPreMomentumDirection, double aPreEKin,
                           vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<double> const &aPostPosition,
                           vecgeom::Vector3D<double> const &aPostMomentumDirection, double aPostEKin, double aGlobalTime,
-                          double aLocalTime, double aPreGlobalTime, unsigned int eventID, short threadID,
-                          bool isLastStep, unsigned short stepCounter, SecondaryInitData const *secondaryData,
-                          unsigned int nSecondaries)
+                          double aLocalTime, double aProperTime, double aPreGlobalTime, unsigned int eventID,
+                          short threadID, bool isLastStep, unsigned short stepCounter,
+                          SecondaryInitData const *secondaryData, unsigned int nSecondaries)
 {
 
   // defensive check
@@ -709,8 +709,8 @@ __device__ void RecordHit(uint64_t aTrackID, uint64_t aParentID, short stepLimPr
   // Fill the required data for the parent step
   FillHit(parentStep, aTrackID, aParentID, stepLimProcessId, aParticleType, aStepLength, aTotalEnergyDeposit,
           aTrackWeight, aPreState, aPrePosition, aPreMomentumDirection, aPreEKin, aPostState, aPostPosition,
-          aPostMomentumDirection, aPostEKin, aGlobalTime, aLocalTime, aPreGlobalTime, eventID, threadID, isLastStep,
-          stepCounter, nSecondaries);
+          aPostMomentumDirection, aPostEKin, aGlobalTime, aLocalTime, aProperTime, aPreGlobalTime, eventID, threadID,
+          isLastStep, stepCounter, nSecondaries);
 
   // Fill the steps for the secondaries
   for (unsigned int i = 0; i < nSecondaries; ++i) {
@@ -720,8 +720,8 @@ __device__ void RecordHit(uint64_t aTrackID, uint64_t aParentID, short stepLimPr
             secondaryData[i].particleType,
             /*steplength*/ 0., /*energydeposit*/ 0., aTrackWeight, aPostState, aPostPosition, secondaryData[i].dir,
             secondaryData[i].eKin, aPostState, aPostPosition, secondaryData[i].dir, secondaryData[i].eKin, aGlobalTime,
-            /*localTime*/ 0., aGlobalTime, eventID, threadID, /*isLastStep*/ false, /*stepCounter*/ 0,
-            /*nSecondaries*/ 0);
+            /*localTime*/ 0., /*properTime*/ 0., aGlobalTime, eventID, threadID, /*isLastStep*/ false,
+            /*stepCounter*/ 0, /*nSecondaries*/ 0);
   }
 }
 

--- a/include/AdePT/core/ScoringCommons.hh
+++ b/include/AdePT/core/ScoringCommons.hh
@@ -41,6 +41,13 @@ struct GPUHit {
   unsigned char fNumSecondaries{0};
 };
 
+/// @brief AdePT-specific step-limiting process ids stored in GPUHit::fStepLimProcessId.
+constexpr short kAdePTTransportationProcess = 10;
+/// @brief Returned step for a track that leaves the GPU region and continues on the CPU.
+constexpr short kAdePTOutOfGPURegionProcess = 11;
+/// @brief Returned step for a track that is intentionally finished on the CPU.
+constexpr short kAdePTFinishOnCPUProcess = 12;
+
 /// @brief Minimal data struct that is needed along with the parent track to provide the initial track information that
 /// is sent back to the CPU
 struct SecondaryInitData {

--- a/include/AdePT/core/ScoringCommons.hh
+++ b/include/AdePT/core/ScoringCommons.hh
@@ -28,6 +28,7 @@ struct GPUHit {
   // double fNonIonizingEnergyDeposit{0};
   double fGlobalTime{0.};
   double fLocalTime{0.};
+  double fProperTime{0.};
   double fPreGlobalTime{0.};
   float fTrackWeight{1};
   uint64_t fTrackID{0};  // Track ID
@@ -114,8 +115,8 @@ __device__ __forceinline__ void FillHit(
     vecgeom::Vector3D<double> const &aPrePosition, vecgeom::Vector3D<double> const &aPreMomentumDirection,
     double aPreEKin, vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<double> const &aPostPosition,
     vecgeom::Vector3D<double> const &aPostMomentumDirection, double aPostEKin, double aGlobalTime, double aLocalTime,
-    double aPreGlobalTime, unsigned int eventID, short threadID, bool isLastStep, unsigned short stepCounter,
-    unsigned char aNumSecondaries)
+    double aProperTime, double aPreGlobalTime, unsigned int eventID, short threadID, bool isLastStep,
+    unsigned short stepCounter, unsigned char aNumSecondaries)
 {
   aGPUHit.fEventId = eventID;
   aGPUHit.threadId = threadID;
@@ -132,6 +133,7 @@ __device__ __forceinline__ void FillHit(
   aGPUHit.fTrackWeight        = aTrackWeight;
   aGPUHit.fGlobalTime         = aGlobalTime;
   aGPUHit.fLocalTime          = aLocalTime;
+  aGPUHit.fProperTime         = aProperTime;
   aGPUHit.fPreGlobalTime      = aPreGlobalTime;
   aGPUHit.fNumSecondaries     = aNumSecondaries;
   // Pre step point

--- a/include/AdePT/core/ScoringCommons.hh
+++ b/include/AdePT/core/ScoringCommons.hh
@@ -39,6 +39,46 @@ struct GPUHit {
   bool fLastStepOfTrack{false};
   ParticleType fParticleType{ParticleType::Electron};
   unsigned char fNumSecondaries{0};
+
+  bool operator<(GPUHit const &other) const
+  {
+    const auto pdgFromParticleType = [](ParticleType particleType) {
+      switch (particleType) {
+      case ParticleType::Electron:
+        return 11;
+      case ParticleType::Positron:
+        return -11;
+      case ParticleType::Gamma:
+        return 22;
+      }
+      return 0;
+    };
+
+    const int thisPDG  = pdgFromParticleType(fParticleType);
+    const int otherPDG = pdgFromParticleType(other.fParticleType);
+
+    if (thisPDG != otherPDG) return thisPDG < otherPDG;
+    if (fPostStepPoint.fEKin != other.fPostStepPoint.fEKin) return fPostStepPoint.fEKin < other.fPostStepPoint.fEKin;
+    if (fPostStepPoint.fPosition.x() != other.fPostStepPoint.fPosition.x()) {
+      return fPostStepPoint.fPosition.x() < other.fPostStepPoint.fPosition.x();
+    }
+    if (fPostStepPoint.fPosition.y() != other.fPostStepPoint.fPosition.y()) {
+      return fPostStepPoint.fPosition.y() < other.fPostStepPoint.fPosition.y();
+    }
+    if (fPostStepPoint.fPosition.z() != other.fPostStepPoint.fPosition.z()) {
+      return fPostStepPoint.fPosition.z() < other.fPostStepPoint.fPosition.z();
+    }
+    if (fPostStepPoint.fMomentumDirection.x() != other.fPostStepPoint.fMomentumDirection.x()) {
+      return fPostStepPoint.fMomentumDirection.x() < other.fPostStepPoint.fMomentumDirection.x();
+    }
+    if (fPostStepPoint.fMomentumDirection.y() != other.fPostStepPoint.fMomentumDirection.y()) {
+      return fPostStepPoint.fMomentumDirection.y() < other.fPostStepPoint.fMomentumDirection.y();
+    }
+    if (fPostStepPoint.fMomentumDirection.z() != other.fPostStepPoint.fMomentumDirection.z()) {
+      return fPostStepPoint.fMomentumDirection.z() < other.fPostStepPoint.fMomentumDirection.z();
+    }
+    return false;
+  }
 };
 
 /// @brief AdePT-specific step-limiting process ids stored in GPUHit::fStepLimProcessId.

--- a/include/AdePT/core/ScoringCommons.hh
+++ b/include/AdePT/core/ScoringCommons.hh
@@ -27,8 +27,8 @@ struct GPUHit {
   double fTotalEnergyDeposit{0};
   // double fNonIonizingEnergyDeposit{0};
   double fGlobalTime{0.};
-  double fLocalTime{0.};
-  double fProperTime{0.};
+  float fLocalTime{0.f};
+  float fProperTime{0.f};
   double fPreGlobalTime{0.};
   float fTrackWeight{1};
   uint64_t fTrackID{0};  // Track ID
@@ -114,8 +114,8 @@ __device__ __forceinline__ void FillHit(
     double aStepLength, double aTotalEnergyDeposit, float aTrackWeight, vecgeom::NavigationState const &aPreState,
     vecgeom::Vector3D<double> const &aPrePosition, vecgeom::Vector3D<double> const &aPreMomentumDirection,
     double aPreEKin, vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<double> const &aPostPosition,
-    vecgeom::Vector3D<double> const &aPostMomentumDirection, double aPostEKin, double aGlobalTime, double aLocalTime,
-    double aProperTime, double aPreGlobalTime, unsigned int eventID, short threadID, bool isLastStep,
+    vecgeom::Vector3D<double> const &aPostMomentumDirection, double aPostEKin, double aGlobalTime, float aLocalTime,
+    float aProperTime, double aPreGlobalTime, unsigned int eventID, short threadID, bool isLastStep,
     unsigned short stepCounter, unsigned char aNumSecondaries)
 {
   aGPUHit.fEventId = eventID;

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -72,8 +72,6 @@ struct Track {
   bool stopped{false};
 #endif
 
-  LeakStatus leakStatus{LeakStatus::NoLeak};
-
   __host__ __device__ Track(const Track &)            = default;
   __host__ __device__ Track &operator=(const Track &) = default;
 
@@ -87,9 +85,8 @@ struct Track {
         stepCounter{stepCounter}, looperCounter{0}, zeroStepCounter{0}
   {
     rngState.SetSeed(rngSeed);
-    pos        = {position[0], position[1], position[2]};
-    dir        = {direction[0], direction[1], direction[2]};
-    leakStatus = LeakStatus::NoLeak;
+    pos = {position[0], position[1], position[2]};
+    dir = {direction[0], direction[1], direction[2]};
   }
 
   /// Construct a secondary from a parent track.
@@ -109,7 +106,7 @@ struct Track {
       : rngState{rng_state}, eKin{eKin}, globalTime{globalTime}, pos{parentPos}, dir{newDirection},
         navState{newNavState}, trackId{rngState.IntRndm64()}, eventId{parentTrack.eventId},
         parentId{parentTrack.trackId}, threadId{parentTrack.threadId}, weight{childWeight}, stepCounter{0},
-        looperCounter{0}, zeroStepCounter{0}, leakStatus{LeakStatus::NoLeak}
+        looperCounter{0}, zeroStepCounter{0}
   {
   }
 

--- a/include/AdePT/core/TrackBuffer.hh
+++ b/include/AdePT/core/TrackBuffer.hh
@@ -14,12 +14,10 @@
 #include <mutex>
 #include <shared_mutex>
 #include <thread>
-#include <vector>
 
 namespace AsyncAdePT {
 
-/// @brief Buffer holding input tracks to be transported on GPU and output tracks to be
-/// re-injected in the Geant4 stack.
+/// @brief Buffer holding input tracks to be transported on GPU.
 struct TrackBuffer {
   struct alignas(64) ToDeviceBuffer {
     TrackDataWithIDs *tracks;
@@ -31,24 +29,12 @@ struct TrackBuffer {
   std::array<ToDeviceBuffer, 2> toDeviceBuffer;
   std::atomic_short toDeviceIndex{0};
 
-  unsigned int fNumToDevice{0};   ///< number of slots in the toDevice buffer
-  unsigned int fNumFromDevice{0}; ///< number of slots in the fromDevice buffer
-  unsigned int fNumLeaksTransferred{
-      0}; ///< Used to keep track of the number of tracks transferred from device during extraction
+  unsigned int fNumToDevice{0}; ///< number of slots in the toDevice buffer
   unique_ptr_cuda<TrackDataWithIDs, CudaHostDeleter<TrackDataWithIDs>>
       toDevice_host;                              ///< Tracks to be transported to the device
   unique_ptr_cuda<TrackDataWithIDs> toDevice_dev; ///< toDevice buffer of tracks
-  unique_ptr_cuda<TrackDataWithIDs, CudaHostDeleter<TrackDataWithIDs>> fromDevice_host; ///< Tracks from device
-  unique_ptr_cuda<TrackDataWithIDs> fromDevice_dev;                                     ///< fromDevice buffer of tracks
-  unique_ptr_cuda<unsigned int, CudaHostDeleter<unsigned int>>
-      nFromDevice_host; ///< Number of tracks collected on device
-  unique_ptr_cuda<unsigned int, CudaHostDeleter<unsigned int>>
-      nRemainingLeaks_host; ///< Number of tracks still left to transfer from device during extraction
 
-  std::vector<std::vector<TrackDataWithIDs>> fromDeviceBuffers;
-  std::mutex fromDeviceMutex;
-
-  TrackBuffer(unsigned int numToDevice, unsigned int numFromDevice, unsigned short nThread);
+  TrackBuffer(unsigned int numToDevice);
 
   ToDeviceBuffer &getActiveBuffer() { return toDeviceBuffer[toDeviceIndex.load()]; }
   void swapToDeviceBuffers() { toDeviceIndex.store((toDeviceIndex + 1) % 2); }
@@ -89,18 +75,6 @@ struct TrackBuffer {
       using namespace std::chrono_literals;
       std::this_thread::sleep_for(1ms);
     }
-  }
-
-  struct FromDeviceHandle {
-    std::vector<TrackDataWithIDs> &tracks;
-    std::scoped_lock<std::mutex> lock;
-  };
-
-  /// @brief Create a handle with lock for tracks that return from the device.
-  /// @return BufferHandle with lock and reference to track vector.
-  FromDeviceHandle getTracksFromDevice(int threadId)
-  {
-    return {fromDeviceBuffers[threadId], std::scoped_lock{fromDeviceMutex}};
   }
 };
 

--- a/include/AdePT/core/TrackData.h
+++ b/include/AdePT/core/TrackData.h
@@ -8,8 +8,6 @@
 
 #include "VecGeom/navigation/NavigationState.h"
 
-enum class LeakStatus : char { NoLeak, OutOfGPURegion, GammaNuclear, LeptonNuclear, FinishEventOnCPU };
-
 namespace adeptint {
 
 /// @brief Track data exchanged between Geant4 and AdePT
@@ -28,8 +26,6 @@ struct TrackData {
   uint64_t trackId{0};  ///< track id (non-consecutive, reproducible)
   uint64_t parentId{0}; // track id of the parent
   unsigned short stepCounter{0};
-
-  LeakStatus leakStatus{LeakStatus::NoLeak};
 
   TrackData() = default;
   TrackData(int pdg_id, uint64_t trackId, uint64_t parentId, double ene, double x, double y, double z, double dirx,

--- a/include/AdePT/integration/AdePTConfigurationMessenger.hh
+++ b/include/AdePT/integration/AdePTConfigurationMessenger.hh
@@ -52,7 +52,6 @@ private:
   std::unique_ptr<G4UIcmdWithAString> fAddWDTRegionCmd;
   std::unique_ptr<G4UIcmdWithAnInteger> fSetVerbosityCmd;
   std::unique_ptr<G4UIcmdWithADouble> fSetMillionsOfTrackSlotsCmd;
-  std::unique_ptr<G4UIcmdWithADouble> fSetMillionsOfLeakSlotsCmd;
   std::unique_ptr<G4UIcmdWithADouble> fSetMillionsOfHitSlotsCmd;
   std::unique_ptr<G4UIcmdWithADouble> fSetHitBufferFlushThresholdCmd;
   std::unique_ptr<G4UIcmdWithADouble> fSetCPUCapacityFactorCmd;

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -36,7 +36,14 @@ public:
   /// These steps are handled later in the same sorted CPU handoff order, so
   /// the Geant4 host work always runs in a fixed order.
   struct DeferredStep {
+    std::size_t firstHit{0};
+    std::size_t numHits{0};
+  };
+
+  /// @brief Owns the deferred returned-step data drained from the integration.
+  struct DeferredStepStore {
     std::vector<GPUHit> hits{};
+    std::vector<DeferredStep> steps{};
   };
 
   explicit AdePTGeant4Integration() : fHostTrackDataMapper(std::make_unique<HostTrackDataMapper>()) {}
@@ -67,9 +74,8 @@ public:
 
   /// @brief Transfer ownership of the currently queued deferred steps.
   /// @details
-  /// This drains the integration-local queue into a temporary vector without
-  /// copying the stored GPU-hit blocks.
-  std::vector<DeferredStep> TakeDeferredSteps();
+  /// This drains the integration-local deferred-hit storage without copying it.
+  DeferredStepStore TakeDeferredSteps();
 
   void SetHepEmTrackingManager(G4HepEmTrackingManagerSpecialized *hepEmTrackingManager)
   {
@@ -125,6 +131,7 @@ private:
   std::unique_ptr<AdePTGeant4Integration_detail::ScoringObjects, AdePTGeant4Integration_detail::Deleter>
       fScoringObjects{nullptr};
 
+  std::vector<GPUHit> fDeferredHits;
   std::vector<DeferredStep> fDeferredSteps;
 };
 

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -69,7 +69,7 @@ public:
   /// no secondaries, and zero deposited energy. In that case there is no GPU
   /// step to score on the host, so only the parent G4Track is rebuilt from the
   /// post-step state and pushed back to the Geant4 stack.
-  void ReturnDeferredTrack(std::span<const GPUHit> gpuSteps);
+  void ReturnDeferredTrack(std::span<const GPUHit> gpuSteps, bool const callUserActions = false);
 
   /// @brief Returns the Z value of the user-defined uniform magnetic field
   /// @details This function can only be called when the user-defined field is a G4UniformMagField

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -33,8 +33,8 @@ class AdePTGeant4Integration {
 public:
   /// @brief Stored work for a returned step that is replayed later on the host.
   /// @details
-  /// These steps are handled later in the same sorted return order as ordinary
-  /// leaked tracks, so the Geant4 host work always runs in a fixed order.
+  /// These steps are handled later in the same sorted CPU handoff order, so
+  /// the Geant4 host work always runs in a fixed order.
   struct DeferredStep {
     adeptint::TrackData returnedTrack{};
     std::vector<GPUHit> hits{};
@@ -110,7 +110,7 @@ private:
   /// storage.
   G4Track *MakeTrackForCPUStacking(const G4Track &track) const;
 
-  /// @brief Recreate the old leaked-track handoff from a returned parent step.
+  /// @brief Recreate a track to from a returned parent step to be continued on CPU.
   /// @details
   /// Out-of-GPU-region and finish-on-CPU steps used to hand Geant4 a returned
   /// track built from the post-step state. The visible reconstructed step keeps

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -31,11 +31,11 @@ struct Deleter {
 
 class AdePTGeant4Integration {
 public:
-  /// @brief Stored work for a returned gamma/lepton nuclear step.
+  /// @brief Stored work for a returned step that is replayed later on the host.
   /// @details
   /// These steps are handled later in the same sorted return order as ordinary
-  /// leaked tracks, so the Geant4 nuclear process always runs in a fixed order.
-  struct DeferredNuclearStep {
+  /// leaked tracks, so the Geant4 host work always runs in a fixed order.
+  struct DeferredStep {
     adeptint::TrackData returnedTrack{};
     std::vector<GPUHit> hits{};
   };
@@ -53,18 +53,6 @@ public:
   void ProcessGPUStep(std::span<const GPUHit> gpuSteps, bool const callUserSteppingAction = false,
                       bool const callUserTrackingaction = false);
 
-  /// @brief Takes a range of tracks coming from the device and gives them back to Geant4
-  template <typename Iterator>
-  void ReturnTracks(Iterator begin, Iterator end, int debugLevel, bool callUserActions = false) const
-  {
-    if (debugLevel > 1) {
-      G4cout << "Returning " << end - begin << " tracks from device" << G4endl;
-    }
-    for (Iterator it = begin; it != end; ++it) {
-      ReturnTrack(*it, it - begin, debugLevel, callUserActions);
-    }
-  }
-
   /// @brief Returns the Z value of the user-defined uniform magnetic field
   /// @details This function can only be called when the user-defined field is a G4UniformMagField
   std::vector<float> GetUniformField() const;
@@ -75,17 +63,14 @@ public:
 
   HostTrackDataMapper &GetHostTrackDataMapper() { return *fHostTrackDataMapper; }
 
-  /// @brief Defer a returned nuclear step for later sorted replay on the host.
-  void QueueDeferredNuclearStep(std::span<const GPUHit> gpuSteps);
+  /// @brief Defer a returned step for later sorted replay on the host.
+  void QueueDeferredStep(std::span<const GPUHit> gpuSteps);
 
-  /// @brief Transfer ownership of the currently queued deferred nuclear steps.
+  /// @brief Transfer ownership of the currently queued deferred steps.
   /// @details
   /// This drains the integration-local queue into a temporary vector without
   /// copying the stored GPU-hit blocks.
-  std::vector<DeferredNuclearStep> TakeDeferredNuclearSteps();
-
-  void ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex, int debugLevel,
-                   bool callUserActions = false) const;
+  std::vector<DeferredStep> TakeDeferredSteps();
 
   void SetHepEmTrackingManager(G4HepEmTrackingManagerSpecialized *hepEmTrackingManager)
   {
@@ -125,6 +110,15 @@ private:
   /// storage.
   G4Track *MakeTrackForCPUStacking(const G4Track &track) const;
 
+  /// @brief Recreate the old leaked-track handoff from a returned parent step.
+  /// @details
+  /// Out-of-GPU-region and finish-on-CPU steps used to hand Geant4 a returned
+  /// track built from the post-step state. The visible reconstructed step keeps
+  /// the transported GPU-step data, but the continued CPU track must still
+  /// match that old current-state handoff.
+  G4Track *MakeReturnedTrackFromStep(GPUHit const &parentStep, const HostTrackData &hostTData,
+                                     bool setStopButAlive) const;
+
   // pointer to specialized G4HepEmTrackingManager. Owned by AdePTTrackingManager,
   // this is just a reference to handle gamma-/lepton-nuclear reactions
   G4HepEmTrackingManagerSpecialized *fHepEmTrackingManager{nullptr};
@@ -135,7 +129,7 @@ private:
   std::unique_ptr<AdePTGeant4Integration_detail::ScoringObjects, AdePTGeant4Integration_detail::Deleter>
       fScoringObjects{nullptr};
 
-  std::vector<DeferredNuclearStep> fDeferredNuclearSteps;
+  std::vector<DeferredStep> fDeferredSteps;
 };
 
 #endif

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -36,7 +36,6 @@ public:
   /// These steps are handled later in the same sorted CPU handoff order, so
   /// the Geant4 host work always runs in a fixed order.
   struct DeferredStep {
-    adeptint::TrackData returnedTrack{};
     std::vector<GPUHit> hits{};
   };
 
@@ -97,9 +96,6 @@ private:
                   G4TouchableHandle &aPreG4TouchableHandle, G4TouchableHandle &aPostG4TouchableHandle,
                   G4StepStatus aPreStepStatus, G4StepStatus aPostStepStatus, bool callUserTrackingAction,
                   bool callUserSteppingAction) const;
-
-  /// @brief Build the ordering key for a deferred nuclear step.
-  adeptint::TrackData MakeReturnedTrackFromGPUHit(GPUHit const &gpuHit) const;
 
   /// @brief Create a heap-owned track that can be pushed onto the Geant4 stack.
   /// @details

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -12,12 +12,15 @@
 #include <AdePT/core/ScoringCommons.hh>
 #include <AdePT/core/TrackData.h>
 #include <AdePT/integration/G4HepEmTrackingManagerSpecialized.hh>
+#include <AdePT/core/ReturnedTrackData.hh>
 #include <AdePT/integration/HostTrackDataMapper.hh>
 
 #include <G4EventManager.hh>
 #include <G4Event.hh>
+#include <G4Track.hh>
 
 #include <span>
+#include <vector>
 
 namespace AdePTGeant4Integration_detail {
 struct ScoringObjects;
@@ -28,6 +31,15 @@ struct Deleter {
 
 class AdePTGeant4Integration {
 public:
+  /// @brief Stored work for a returned gamma/lepton nuclear step.
+  /// @details
+  /// These steps are handled later in the same sorted return order as ordinary
+  /// leaked tracks, so the Geant4 nuclear process always runs in a fixed order.
+  struct DeferredNuclearStep {
+    adeptint::TrackData returnedTrack{};
+    std::vector<GPUHit> hits{};
+  };
+
   explicit AdePTGeant4Integration() : fHostTrackDataMapper(std::make_unique<HostTrackDataMapper>()) {}
   ~AdePTGeant4Integration();
 
@@ -63,6 +75,18 @@ public:
 
   HostTrackDataMapper &GetHostTrackDataMapper() { return *fHostTrackDataMapper; }
 
+  /// @brief Defer a returned nuclear step for later sorted replay on the host.
+  void QueueDeferredNuclearStep(std::span<const GPUHit> gpuSteps);
+
+  /// @brief Transfer ownership of the currently queued deferred nuclear steps.
+  /// @details
+  /// This drains the integration-local queue into a temporary vector without
+  /// copying the stored GPU-hit blocks.
+  std::vector<DeferredNuclearStep> TakeDeferredNuclearSteps();
+
+  void ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex, int debugLevel,
+                   bool callUserActions = false) const;
+
   void SetHepEmTrackingManager(G4HepEmTrackingManagerSpecialized *hepEmTrackingManager)
   {
     fHepEmTrackingManager = hepEmTrackingManager;
@@ -89,8 +113,17 @@ private:
                   G4StepStatus aPreStepStatus, G4StepStatus aPostStepStatus, bool callUserTrackingAction,
                   bool callUserSteppingAction) const;
 
-  void ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex, int debugLevel,
-                   bool callUserActions = false) const;
+  /// @brief Build the ordering key for a deferred nuclear step.
+  adeptint::TrackData MakeReturnedTrackFromGPUHit(GPUHit const &gpuHit) const;
+
+  /// @brief Create a heap-owned track that can be pushed onto the Geant4 stack.
+  /// @details
+  /// This is only used as a fallback for gamma/lepton nuclear when no Geant4
+  /// nuclear process is attached. In that case there is no temporary nuclear
+  /// replay track to continue on the CPU, and the visible reconstructed track
+  /// cannot be handed to the stack manager because it is reused integration
+  /// storage.
+  G4Track *MakeTrackForCPUStacking(const G4Track &track) const;
 
   // pointer to specialized G4HepEmTrackingManager. Owned by AdePTTrackingManager,
   // this is just a reference to handle gamma-/lepton-nuclear reactions
@@ -101,6 +134,8 @@ private:
 
   std::unique_ptr<AdePTGeant4Integration_detail::ScoringObjects, AdePTGeant4Integration_detail::Deleter>
       fScoringObjects{nullptr};
+
+  std::vector<DeferredNuclearStep> fDeferredNuclearSteps;
 };
 
 #endif

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -31,13 +31,17 @@ struct Deleter {
 
 class AdePTGeant4Integration {
 public:
+  enum class DeferredStepType : unsigned char { ReplayStep, ReturnTrack };
+
   /// @brief Stored work for a returned step that is replayed later on the host.
   /// @details
-  /// These steps are handled later in the same sorted CPU handoff order, so
-  /// the Geant4 host work always runs in a fixed order.
+  /// The host collects returned GPU-hit blocks during transport and replays
+  /// them later in one fixed order, so the Geant4-side work stays
+  /// reproducible from run to run.
   struct DeferredStep {
     std::size_t firstHit{0};
     std::size_t numHits{0};
+    DeferredStepType type{DeferredStepType::ReplayStep};
   };
 
   /// @brief Owns the deferred returned-step data drained from the integration.
@@ -59,6 +63,14 @@ public:
   void ProcessGPUStep(std::span<const GPUHit> gpuSteps, bool const callUserSteppingAction = false,
                       bool const callUserTrackingaction = false);
 
+  /// @brief Return a deferred parent track to Geant4 without rebuilding the visible G4 step.
+  /// @details
+  /// This is only used for returned gamma handoff steps with one parent hit,
+  /// no secondaries, and zero deposited energy. In that case there is no GPU
+  /// step to score on the host, so only the parent G4Track is rebuilt from the
+  /// post-step state and pushed back to the Geant4 stack.
+  void ReturnDeferredTrack(std::span<const GPUHit> gpuSteps);
+
   /// @brief Returns the Z value of the user-defined uniform magnetic field
   /// @details This function can only be called when the user-defined field is a G4UniformMagField
   std::vector<float> GetUniformField() const;
@@ -70,7 +82,7 @@ public:
   HostTrackDataMapper &GetHostTrackDataMapper() { return *fHostTrackDataMapper; }
 
   /// @brief Defer a returned step for later sorted replay on the host.
-  void QueueDeferredStep(std::span<const GPUHit> gpuSteps);
+  void QueueDeferredStep(std::span<const GPUHit> gpuSteps, DeferredStepType type = DeferredStepType::ReplayStep);
 
   /// @brief Transfer ownership of the currently queued deferred steps.
   /// @details

--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -83,9 +83,6 @@ private:
   /// each batch.
   void ProcessReturnedGPUHits(int threadId, int eventId);
 
-  /// @brief Validate and sort returned tracks before reinjecting them into Geant4.
-  void PrepareReturnedTracksForGeant4(int threadId, int eventId, std::vector<AsyncAdePT::TrackDataWithIDs> &tracks);
-
   std::unique_ptr<G4HepEmTrackingManagerSpecialized> fHepEmTrackingManager;
   AdePTGeant4Integration fGeant4Integration;
   static inline int fNumThreads{0};

--- a/include/AdePT/integration/G4HepEmTrackingManagerSpecialized.hh
+++ b/include/AdePT/integration/G4HepEmTrackingManagerSpecialized.hh
@@ -42,7 +42,7 @@ public:
 private:
   bool fTrackInAllRegions = false;          ///< Whether the whole geometry is a GPU region
   std::set<G4Region const *> fGPURegions{}; ///< List of GPU regions
-  std::vector<int> fFinishEventOnCPU;       ///< vector over number of threads to keep certain leaked tracks on GPU
+  std::vector<int> fFinishEventOnCPU;       ///< Vector over worker threads for events finished on CPU
 
   // G4Region const * fPreviousRegion = nullptr;
 };

--- a/include/AdePT/integration/HostTrackDataMapper.hh
+++ b/include/AdePT/integration/HostTrackDataMapper.hh
@@ -24,9 +24,9 @@ struct HostTrackData {
   int g4id       = 0; // the Geant4 track ID
   int g4parentid = 0; // the Geant4 parent ID
   uint64_t gpuId = 0; // the GPU’s 64-bit track ID
-  // Deferred nuclear replay still needs this metadata even after the GPU track
+  // Deferred returned-step replay still needs this metadata even after the GPU track
   // has finished, so removal/retirement must wait while this flag is set.
-  bool pendingNuclearReaction            = false;
+  bool pendingReturnedStep               = false;
   G4PrimaryParticle *primary             = nullptr;
   G4VProcess *creatorProcess             = nullptr;
   G4VUserTrackInformation *userTrackInfo = nullptr;
@@ -150,20 +150,20 @@ public:
     return d;
   }
 
-  /// @brief Mark whether a deferred nuclear reaction still needs this host-side metadata.
+  /// @brief Mark whether a deferred returned step still needs this host-side metadata.
   /// @param gpuId GPU track id of the entry to update.
-  /// @param pending Whether deferred nuclear replay is still outstanding for this track.
-  void SetPendingNuclearReaction(uint64_t gpuId, bool pending)
+  /// @param pending Whether deferred replay is still outstanding for this track.
+  void SetPendingReturnedStep(uint64_t gpuId, bool pending)
   {
     auto it = gpuToIndex.find(gpuId);
     if (it == gpuToIndex.end()) return;
-    hostDataVec[it->second].pendingNuclearReaction = pending;
+    hostDataVec[it->second].pendingReturnedStep = pending;
   }
 
-  /// @brief Finish a deferred nuclear reaction and perform the final ownership transition.
+  /// @brief Finish deferred returned-step replay and perform the final ownership transition.
   /// @param gpuId GPU track id of the entry to finalize.
   /// @param continueOnCPU If true, retire the metadata to CPU ownership; otherwise remove it completely.
-  void FinalizePendingNuclearReaction(uint64_t gpuId, bool continueOnCPU)
+  void FinalizePendingReturnedStep(uint64_t gpuId, bool continueOnCPU)
   {
     auto it = gpuToIndex.find(gpuId);
     if (it == gpuToIndex.end()) return;
@@ -192,7 +192,7 @@ public:
     if (it == gpuToIndex.end()) return; // already gone
     int idx = it->second;
 
-    if (hostDataVec[idx].pendingNuclearReaction) return;
+    if (hostDataVec[idx].pendingReturnedStep) return;
     eraseHostTrackData(it, /*keepReverseMap=*/false, /*deleteUserTrackInfo=*/true);
   }
 
@@ -206,7 +206,7 @@ public:
     if (it == gpuToIndex.end()) return;
     int idx = it->second;
 
-    if (hostDataVec[idx].pendingNuclearReaction) return;
+    if (hostDataVec[idx].pendingReturnedStep) return;
     eraseHostTrackData(it, /*keepReverseMap=*/true, /*deleteUserTrackInfo=*/false);
   }
 

--- a/include/AdePT/integration/HostTrackDataMapper.hh
+++ b/include/AdePT/integration/HostTrackDataMapper.hh
@@ -21,9 +21,12 @@ class G4PrimaryParticle;
 
 /// @brief A helper struct to store the data that is stored exclusively on the CPU
 struct HostTrackData {
-  int g4id                               = 0; // the Geant4 track ID
-  int g4parentid                         = 0; // the Geant4 parent ID
-  uint64_t gpuId                         = 0; // the GPU’s 64-bit track ID
+  int g4id       = 0; // the Geant4 track ID
+  int g4parentid = 0; // the Geant4 parent ID
+  uint64_t gpuId = 0; // the GPU’s 64-bit track ID
+  // Deferred nuclear replay still needs this metadata even after the GPU track
+  // has finished, so removal/retirement must wait while this flag is set.
+  bool pendingNuclearReaction            = false;
   G4PrimaryParticle *primary             = nullptr;
   G4VProcess *creatorProcess             = nullptr;
   G4VUserTrackInformation *userTrackInfo = nullptr;
@@ -147,6 +150,26 @@ public:
     return d;
   }
 
+  /// @brief Mark whether a deferred nuclear reaction still needs this host-side metadata.
+  /// @param gpuId GPU track id of the entry to update.
+  /// @param pending Whether deferred nuclear replay is still outstanding for this track.
+  void SetPendingNuclearReaction(uint64_t gpuId, bool pending)
+  {
+    auto it = gpuToIndex.find(gpuId);
+    if (it == gpuToIndex.end()) return;
+    hostDataVec[it->second].pendingNuclearReaction = pending;
+  }
+
+  /// @brief Finish a deferred nuclear reaction and perform the final ownership transition.
+  /// @param gpuId GPU track id of the entry to finalize.
+  /// @param continueOnCPU If true, retire the metadata to CPU ownership; otherwise remove it completely.
+  void FinalizePendingNuclearReaction(uint64_t gpuId, bool continueOnCPU)
+  {
+    auto it = gpuToIndex.find(gpuId);
+    if (it == gpuToIndex.end()) return;
+    eraseHostTrackData(it, /*keepReverseMap=*/continueOnCPU, /*deleteUserTrackInfo=*/!continueOnCPU);
+  }
+
   /// @brief Sets the gpuid by reference and returns whether the entry already existed
   /// @param g4id int G4 id that is checked
   /// @param gpuid uint64 gpu id that is returned
@@ -169,26 +192,8 @@ public:
     if (it == gpuToIndex.end()) return; // already gone
     int idx = it->second;
 
-    // As the data of the userTrackInfo is owned by AdePT, it has to be deleted here
-    if (hostDataVec[idx].userTrackInfo) {
-      delete hostDataVec[idx].userTrackInfo;
-      hostDataVec[idx].userTrackInfo = nullptr;
-    }
-
-    int last = int(hostDataVec.size()) - 1;
-
-    // unused g4 id
-    const int g4idToErase = hostDataVec[idx].g4id;
-    if (idx != last) {
-      // move last element into idx
-      std::swap(hostDataVec[idx], hostDataVec[last]);
-      // update its map entry
-      gpuToIndex[hostDataVec[idx].gpuId] = idx;
-    }
-    hostDataVec.pop_back();
-    gpuToIndex.erase(it);
-    // second part of deletion of g4 ids
-    g4idToGpuId.erase(g4idToErase);
+    if (hostDataVec[idx].pendingNuclearReaction) return;
+    eraseHostTrackData(it, /*keepReverseMap=*/false, /*deleteUserTrackInfo=*/true);
   }
 
   // Free the big struct + index, keep g4id->gpuId for possible future reuse
@@ -199,16 +204,10 @@ public:
   {
     auto it = gpuToIndex.find(gpuId);
     if (it == gpuToIndex.end()) return;
-    int idx  = it->second;
-    int last = int(hostDataVec.size()) - 1;
+    int idx = it->second;
 
-    if (idx != last) {
-      std::swap(hostDataVec[idx], hostDataVec[last]);
-      gpuToIndex[hostDataVec[idx].gpuId] = idx;
-    }
-    hostDataVec.pop_back();
-    gpuToIndex.erase(it);
-    // NOTE: intentionally *do not* erase g4idToGpuId here
+    if (hostDataVec[idx].pendingNuclearReaction) return;
+    eraseHostTrackData(it, /*keepReverseMap=*/true, /*deleteUserTrackInfo=*/false);
   }
 
   /// @brief Whether an entry exists in the GPU to Index map for the given GPU id
@@ -217,6 +216,28 @@ public:
   bool contains(uint64_t gpuId) const { return gpuToIndex.find(gpuId) != gpuToIndex.end(); }
 
 private:
+  using GpuToIndexMap = std::unordered_map<uint64_t, int>;
+
+  void eraseHostTrackData(GpuToIndexMap::iterator it, bool keepReverseMap, bool deleteUserTrackInfo)
+  {
+    int idx = it->second;
+
+    if (deleteUserTrackInfo && hostDataVec[idx].userTrackInfo) {
+      delete hostDataVec[idx].userTrackInfo;
+      hostDataVec[idx].userTrackInfo = nullptr;
+    }
+
+    const int g4idToErase = hostDataVec[idx].g4id;
+    const int last        = int(hostDataVec.size()) - 1;
+    if (idx != last) {
+      std::swap(hostDataVec[idx], hostDataVec[last]);
+      gpuToIndex[hostDataVec[idx].gpuId] = idx;
+    }
+    hostDataVec.pop_back();
+    gpuToIndex.erase(it);
+    if (!keepReverseMap) g4idToGpuId.erase(g4idToErase);
+  }
+
   std::unordered_map<uint64_t, int> gpuToIndex;  // key→slot in hostDataVec
   std::unordered_map<int, uint64_t> g4idToGpuId; // geant4 id to GPU id, needed for reverse lookup
   std::vector<HostTrackData> hostDataVec;        // contiguous array of all data

--- a/include/AdePT/integration/HostTrackDataMapper.hh
+++ b/include/AdePT/integration/HostTrackDataMapper.hh
@@ -162,12 +162,13 @@ public:
 
   /// @brief Finish deferred returned-step replay and perform the final ownership transition.
   /// @param gpuId GPU track id of the entry to finalize.
-  /// @param continueOnCPU If true, retire the metadata to CPU ownership; otherwise remove it completely.
-  void FinalizePendingReturnedStep(uint64_t gpuId, bool continueOnCPU)
+  /// @param returnTrackToG4 If true, retire the metadata to CPU ownership because the track is returned to Geant4;
+  /// otherwise remove it completely.
+  void FinalizePendingReturnedStep(uint64_t gpuId, bool returnTrackToG4)
   {
     auto it = gpuToIndex.find(gpuId);
     if (it == gpuToIndex.end()) return;
-    eraseHostTrackData(it, /*keepReverseMap=*/continueOnCPU, /*deleteUserTrackInfo=*/!continueOnCPU);
+    eraseHostTrackData(it, /*keepReverseMap=*/returnTrackToG4, /*deleteUserTrackInfo=*/!returnTrackToG4);
   }
 
   /// @brief Sets the gpuid by reference and returns whether the entry already existed

--- a/include/AdePT/integration/HostTrackDataMapper.hh
+++ b/include/AdePT/integration/HostTrackDataMapper.hh
@@ -21,12 +21,9 @@ class G4PrimaryParticle;
 
 /// @brief A helper struct to store the data that is stored exclusively on the CPU
 struct HostTrackData {
-  int g4id       = 0; // the Geant4 track ID
-  int g4parentid = 0; // the Geant4 parent ID
-  uint64_t gpuId = 0; // the GPU’s 64-bit track ID
-  // Deferred returned-step replay still needs this metadata even after the GPU track
-  // has finished, so removal/retirement must wait while this flag is set.
-  bool pendingReturnedStep               = false;
+  int g4id                               = 0; // the Geant4 track ID
+  int g4parentid                         = 0; // the Geant4 parent ID
+  uint64_t gpuId                         = 0; // the GPU’s 64-bit track ID
   G4PrimaryParticle *primary             = nullptr;
   G4VProcess *creatorProcess             = nullptr;
   G4VUserTrackInformation *userTrackInfo = nullptr;
@@ -150,27 +147,6 @@ public:
     return d;
   }
 
-  /// @brief Mark whether a deferred returned step still needs this host-side metadata.
-  /// @param gpuId GPU track id of the entry to update.
-  /// @param pending Whether deferred replay is still outstanding for this track.
-  void SetPendingReturnedStep(uint64_t gpuId, bool pending)
-  {
-    auto it = gpuToIndex.find(gpuId);
-    if (it == gpuToIndex.end()) return;
-    hostDataVec[it->second].pendingReturnedStep = pending;
-  }
-
-  /// @brief Finish deferred returned-step replay and perform the final ownership transition.
-  /// @param gpuId GPU track id of the entry to finalize.
-  /// @param returnTrackToG4 If true, retire the metadata to CPU ownership because the track is returned to Geant4;
-  /// otherwise remove it completely.
-  void FinalizePendingReturnedStep(uint64_t gpuId, bool returnTrackToG4)
-  {
-    auto it = gpuToIndex.find(gpuId);
-    if (it == gpuToIndex.end()) return;
-    eraseHostTrackData(it, /*keepReverseMap=*/returnTrackToG4, /*deleteUserTrackInfo=*/!returnTrackToG4);
-  }
-
   /// @brief Sets the gpuid by reference and returns whether the entry already existed
   /// @param g4id int G4 id that is checked
   /// @param gpuid uint64 gpu id that is returned
@@ -191,9 +167,6 @@ public:
   {
     auto it = gpuToIndex.find(gpuId);
     if (it == gpuToIndex.end()) return; // already gone
-    int idx = it->second;
-
-    if (hostDataVec[idx].pendingReturnedStep) return;
     eraseHostTrackData(it, /*keepReverseMap=*/false, /*deleteUserTrackInfo=*/true);
   }
 
@@ -205,9 +178,6 @@ public:
   {
     auto it = gpuToIndex.find(gpuId);
     if (it == gpuToIndex.end()) return;
-    int idx = it->second;
-
-    if (hostDataVec[idx].pendingReturnedStep) return;
     eraseHostTrackData(it, /*keepReverseMap=*/true, /*deleteUserTrackInfo=*/false);
   }
 

--- a/include/AdePT/kernels/AdePTSteppingAction.cuh
+++ b/include/AdePT/kernels/AdePTSteppingAction.cuh
@@ -77,13 +77,8 @@ struct CMSAction {
   {
     // dead-region cut:
     // Missing: mark dead material regions in CMS
-    // Before, it was done via the LeakStatus, but it is not clear whether the parametrized shower will ever be used on
-    // the GPU, so the LeakStatus::OutOfGPURegion is a bad marker. Just left here for documenting purposes. Instead, the
-    // dead regions must be implemented for CMS, to check with the NavigationState if (leak ==
-    // LeakStatus::OutOfGPURegion) {
-    //   KillTrack(alive, eKin, edep, leak);
-    //   return;
-    // }
+    // Dead regions must be implemented explicitly for CMS and checked from the
+    // navigation state here if needed.
 
     // Out-of-time and out-of-z cut
     if (globalTime > params.tmax && fabs(pos.z()) >= params.zmax) {

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -824,6 +824,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
                                eKin,                                        // Post-step point kinetic energy
                                globalTime,                                  // global time
                                localTime,                                   // local time
+                               properTime,                                  // proper time
                                preStepGlobalTime,                           // global time at preStepPoint
                                currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                !trackSurvives && !continuesOnCPU,           // whether this was the last step

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -100,6 +100,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     double localTime         = currentTrack.localTime;
     double properTime        = currentTrack.properTime;
     vecgeom::NavigationState nextState;
+    bool continuesOnCPU = false;
 
     currentTrack.stepCounter++;
     bool printErrors = true;
@@ -692,9 +693,10 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
           break;
         }
         case 3: {
-          // Lepton nuclear needs to be handled by Geant4 directly, passing track back to CPU
-          trackSurvives = true;
-          leakReason    = LeakStatus::LeptonNuclear;
+          // Lepton nuclear is handled on the host from the returned step only.
+          // The GPU-side track dies here, but the parent continues on CPU later.
+          trackSurvives  = false;
+          continuesOnCPU = true;
           break;
         }
         }
@@ -803,7 +805,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     assert(nSecondaries <= 3);
 
     // Record the step. Edep includes the continuous energy loss and edep from secondaries which were cut
-    if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps ||
+    if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU ||
         (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
       adept_scoring::RecordHit(currentTrack.trackId, currentTrack.parentId, short(winnerProcessIndex),
                                IsElectron ? ParticleType::Electron : ParticleType::Positron,
@@ -822,7 +824,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
                                localTime,                                   // local time
                                preStepGlobalTime,                           // global time at preStepPoint
                                currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                               !trackSurvives,                              // whether this was the last step
+                               !trackSurvives && !continuesOnCPU,           // whether this was the last step
                                currentTrack.stepCounter,                    // stepcounter
                                secondaryData,                               // pointer to secondary init data
                                nSecondaries);                               // number of secondaries

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -125,7 +125,6 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
       currentTrack.localTime  = localTime;
       currentTrack.properTime = properTime;
       currentTrack.navState   = nextState;
-      currentTrack.leakStatus = LeakStatus::NoLeak;
       electronsOrPositrons.EnqueueNext(slot);
     };
 
@@ -439,7 +438,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
             pos += kPushDistance * dir;
 
 #if ADEPT_DEBUG_TRACK > 0
-            if (verbose) printf("\n| track leaked to Geant4\n");
+            if (verbose) printf("\n| track returned to Geant4\n");
 #endif
             trackSurvives     = false;
             continuesOnCPU    = true;

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -85,7 +85,6 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     VolAuxData const &auxData = gVolAuxData[lvolID];
 
     bool trackSurvives                       = false;
-    LeakStatus leakReason                    = LeakStatus::NoLeak;
     constexpr double kPushStuck              = 100 * vecgeom::kTolerance;
     constexpr unsigned short kStepsStuckPush = 5;
     constexpr unsigned short kStepsStuckKill = 25;
@@ -100,7 +99,8 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     double localTime         = currentTrack.localTime;
     double properTime        = currentTrack.properTime;
     vecgeom::NavigationState nextState;
-    bool continuesOnCPU = false;
+    bool continuesOnCPU     = false;
+    short returnedProcessId = 0;
 
     currentTrack.stepCounter++;
     bool printErrors = true;
@@ -125,13 +125,8 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
       currentTrack.localTime  = localTime;
       currentTrack.properTime = properTime;
       currentTrack.navState   = nextState;
-      currentTrack.leakStatus = leakReason;
-      if (leakReason != LeakStatus::NoLeak) {
-        // Copy track at slot to the leaked tracks
-        electronsOrPositrons.CopyTrackToLeaked(slot);
-      } else {
-        electronsOrPositrons.EnqueueNext(slot);
-      }
+      currentTrack.leakStatus = LeakStatus::NoLeak;
+      electronsOrPositrons.EnqueueNext(slot);
     };
 
     // Init a track with the needed data to call into G4HepEm.
@@ -249,6 +244,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     // care, but we need to make this available when splitting the operations.
     // double physicalStepLength = elTrack.GetPStepLength();
     int winnerProcessIndex = theTrack->GetWinnerProcessIndex();
+    returnedProcessId      = short(winnerProcessIndex);
 
 #if ADEPT_DEBUG_TRACK > 0
     if (verbose) printf("| winnerProc %d\n", winnerProcessIndex);
@@ -445,20 +441,25 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
 #if ADEPT_DEBUG_TRACK > 0
             if (verbose) printf("\n| track leaked to Geant4\n");
 #endif
-            leakReason = LeakStatus::OutOfGPURegion;
+            trackSurvives     = false;
+            continuesOnCPU    = true;
+            returnedProcessId = kAdePTOutOfGPURegionProcess;
           }
-
-          // the track survives, do not force return of step
-          trackSurvives = true;
-        } // else particle has left the world
-
-        winnerProcessIndex = 10; // mark winner process to be transport
+        }
+        if (!continuesOnCPU) {
+          winnerProcessIndex = kAdePTTransportationProcess; // mark winner process to be transport
+          returnedProcessId  = kAdePTTransportationProcess;
+          // A transportation step survives only if the track stayed inside the
+          // world and remains in a GPU region.
+          if (!nextState.IsOutside()) trackSurvives = true;
+        }
       } else if (!propagated || restrictedPhysicalStepLength) {
         // Did not yet reach the interaction point due to error in the magnetic
         // field propagation. Try again next time.
 
         // mark winner process to be transport, although this is not strictly true
-        winnerProcessIndex = 10;
+        winnerProcessIndex = kAdePTTransportationProcess;
+        returnedProcessId  = kAdePTTransportationProcess;
 
         trackSurvives       = true;
         reached_interaction = false;
@@ -789,7 +790,9 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
           printf("Thread %d Finishing e-/e+ of the %d last particles of event %d on CPU E=%f lvol=%d after %d steps.\n",
                  currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
                  currentTrack.eventId, eKin, lvolID, currentTrack.stepCounter);
-        leakReason = LeakStatus::FinishEventOnCPU;
+        trackSurvives     = false;
+        continuesOnCPU    = true;
+        returnedProcessId = kAdePTFinishOnCPUProcess;
       }
     }
 
@@ -807,7 +810,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     // Record the step. Edep includes the continuous energy loss and edep from secondaries which were cut
     if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU ||
         (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
-      adept_scoring::RecordHit(currentTrack.trackId, currentTrack.parentId, short(winnerProcessIndex),
+      adept_scoring::RecordHit(currentTrack.trackId, currentTrack.parentId, returnedProcessId,
                                IsElectron ? ParticleType::Electron : ParticleType::Positron,
                                elTrack.GetPStepLength(),                    // Step length
                                energyDeposit,                               // Total Edep

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -505,8 +505,9 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
       }
     }
 
-    // Now push the particles that reached their interaction into the per-interaction queues,
-    // except for lepton nuclear (winnerProcessIndex == 3), which is sent back to the CPU
+    // Now push the particles that reached their interaction into the
+    // per-interaction queues. Lepton nuclear (winnerProcessIndex == 3) is
+    // handled on the host from the returned step only.
     if (reached_interaction && winnerProcessIndex != 3) {
       // reset Looper counter if limited by discrete interaction or MSC
       currentTrack.looperCounter = 0;
@@ -524,27 +525,29 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
 
     } else {
 
+      const bool continuesOnCPU = reached_interaction && winnerProcessIndex == 3;
+
+      if (continuesOnCPU) {
+        // The returned hit is sufficient to reconstruct the step and later
+        // continue the parent on the CPU in sorted order.
+        trackSurvives = false;
+        slotManager.MarkSlotForFreeing(slot);
+      }
+
       // if not already dead, check for SteppingAction and survive
       if (trackSurvives) {
 
         // possible hook to SteppingAction here
 
-        // Lepton nuclear needs to be handled by Geant4 directly, passing track back to CPU
-        auto leakReason = winnerProcessIndex == 3 ? LeakStatus::LeptonNuclear : LeakStatus::NoLeak;
-
         // --- Survive --- //
-        currentTrack.leakStatus = leakReason;
-        if (leakReason == LeakStatus::LeptonNuclear) {
-          // Copy track at slot to the leaked tracks
-          electronsOrPositrons.CopyTrackToLeaked(slot);
-        } else {
-          electronsOrPositrons.EnqueueNext(slot);
-        }
+        currentTrack.leakStatus = LeakStatus::NoLeak;
+        electronsOrPositrons.EnqueueNext(slot);
       }
 
       // Only non-interacting, non-relocating tracks score here
       // Score the edep for particles that didn't reach the interaction
-      if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || (returnLastStep && !trackSurvives)) {
+      if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU ||
+          (returnLastStep && (!trackSurvives || continuesOnCPU))) {
         adept_scoring::RecordHit(currentTrack.trackId,                                         // Track ID
                                  currentTrack.parentId,                                        // parent Track ID
                                  static_cast<short>(winnerProcessIndex),                       // step defining process
@@ -564,7 +567,7 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
                                  currentTrack.localTime,                      // local time
                                  currentTrack.preStepGlobalTime,              // preStep global time
                                  currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                                 !trackSurvives,                              // whether this was the last step
+                                 !trackSurvives && !continuesOnCPU,           // whether this was the last step
                                  currentTrack.stepCounter,                    // stepcounter
                                  nullptr,                                     // pointer to secondary init data
                                  0);                                          // number of secondaries

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -616,86 +616,47 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID];
 
     auto survive = [&]() { electronsOrPositrons.EnqueueNext(slot); };
-  };
 
-  bool trackSurvives = true;
+    bool trackSurvives = true;
 
-  // Retrieve HepEM track
-  G4HepEmElectronTrack &elTrack = hepEMTracks[slot];
-  G4HepEmTrack *theTrack        = elTrack.GetTrack();
+    // Retrieve HepEM track
+    G4HepEmElectronTrack &elTrack = hepEMTracks[slot];
+    G4HepEmTrack *theTrack        = elTrack.GetTrack();
 
-  double energyDeposit = theTrack->GetEnergyDeposit();
+    double energyDeposit = theTrack->GetEnergyDeposit();
 
-  bool cross_boundary = false;
+    bool cross_boundary = false;
 
-  // Relocate to have the correct next state before RecordHit is called
+    // Relocate to have the correct next state before RecordHit is called
 
-  // - Kill loopers stuck at a boundary
-  // - Set cross boundary flag in order to set the correct navstate after scoring
-  // - Kill particles that left the world
+    // - Kill loopers stuck at a boundary
+    // - Set cross boundary flag in order to set the correct navstate after scoring
+    // - Kill particles that left the world
 
-  ++currentTrack.looperCounter;
+    ++currentTrack.looperCounter;
 
-  if (!currentTrack.nextState.IsOutside()) {
-    // Mark the particle. We need to change its navigation state to the next volume before enqueuing it
-    // This will happen after recording the step
-    // Relocate
-    cross_boundary = true;
+    if (!currentTrack.nextState.IsOutside()) {
+      // Mark the particle. We need to change its navigation state to the next volume before enqueuing it
+      // This will happen after recording the step
+      // Relocate
+      cross_boundary = true;
 #ifdef ADEPT_USE_SURF
-    AdePTNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, currentTrack.hitsurfID,
-                                         currentTrack.nextState);
+      AdePTNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, currentTrack.hitsurfID,
+                                           currentTrack.nextState);
 #else
-    AdePTNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, currentTrack.nextState);
+      AdePTNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, currentTrack.nextState);
 #endif
-  } else {
-    // Particle left the world, don't enqueue it and release the slot
-    slotManager.MarkSlotForFreeing(slot);
-    trackSurvives = false;
-  }
-
-  // Score
-  if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || (!trackSurvives && returnLastStep))
-    adept_scoring::RecordHit(currentTrack.trackId,                                         // Track ID
-                             currentTrack.parentId,                                        // parent Track ID
-                             kAdePTTransportationProcess,                                  // step limiting process ID
-                             IsElectron ? ParticleType::Electron : ParticleType::Positron, // Particle type
-                             elTrack.GetPStepLength(),                                     // Step length
-                             energyDeposit,                                                // Total Edep
-                             currentTrack.weight,                                          // Track weight
-                             currentTrack.navState,                                        // Pre-step point navstate
-                             currentTrack.preStepPos,                                      // Pre-step point position
-                             currentTrack.preStepDir,                     // Pre-step point momentum direction
-                             currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                             currentTrack.nextState,                      // Post-step point navstate
-                             currentTrack.pos,                            // Post-step point position
-                             currentTrack.dir,                            // Post-step point momentum direction
-                             currentTrack.eKin,                           // Post-step point kinetic energy
-                             currentTrack.globalTime,                     // global time
-                             currentTrack.localTime,                      // local time
-                             currentTrack.preStepGlobalTime,              // preStep global time
-                             currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                             !trackSurvives,                              // whether this was the last step
-                             currentTrack.stepCounter,                    // stepcounter
-                             nullptr,                                     // pointer to secondary init data
-                             0);                                          // number of secondaries
-
-  if (cross_boundary) {
-    // Move to the next boundary now that the Step is recorded
-    currentTrack.navState = currentTrack.nextState;
-    // Check if the next volume belongs to the GPU region and push it to the appropriate queue
-    const int nextlvolID          = currentTrack.nextState.GetLogicalId();
-    VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];
-    if (nextauxData.fGPUregionId >= 0) {
-      theTrack->SetMCIndex(nextauxData.fMCIndex);
-      survive();
     } else {
-      // To be safe, just push a bit the track exiting the GPU region to make sure
-      // Geant4 does not relocate it again inside the same region
-      currentTrack.pos += kPushDistance * currentTrack.dir;
+      // Particle left the world, don't enqueue it and release the slot
       slotManager.MarkSlotForFreeing(slot);
+      trackSurvives = false;
+    }
+
+    // Score
+    if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || (!trackSurvives && returnLastStep))
       adept_scoring::RecordHit(currentTrack.trackId,                                         // Track ID
                                currentTrack.parentId,                                        // parent Track ID
-                               kAdePTOutOfGPURegionProcess,                                  // step limiting process ID
+                               kAdePTTransportationProcess,                                  // step limiting process ID
                                IsElectron ? ParticleType::Electron : ParticleType::Positron, // Particle type
                                elTrack.GetPStepLength(),                                     // Step length
                                energyDeposit,                                                // Total Edep
@@ -712,13 +673,51 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
                                currentTrack.localTime,                      // local time
                                currentTrack.preStepGlobalTime,              // preStep global time
                                currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                               false,                                       // parent continues on CPU
+                               !trackSurvives,                              // whether this was the last step
                                currentTrack.stepCounter,                    // stepcounter
                                nullptr,                                     // pointer to secondary init data
                                0);                                          // number of secondaries
+
+    if (cross_boundary) {
+      // Move to the next boundary now that the Step is recorded
+      currentTrack.navState = currentTrack.nextState;
+      // Check if the next volume belongs to the GPU region and push it to the appropriate queue
+      const int nextlvolID          = currentTrack.nextState.GetLogicalId();
+      VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];
+      if (nextauxData.fGPUregionId >= 0) {
+        theTrack->SetMCIndex(nextauxData.fMCIndex);
+        survive();
+      } else {
+        // To be safe, just push a bit the track exiting the GPU region to make sure
+        // Geant4 does not relocate it again inside the same region
+        currentTrack.pos += kPushDistance * currentTrack.dir;
+        slotManager.MarkSlotForFreeing(slot);
+        adept_scoring::RecordHit(currentTrack.trackId,        // Track ID
+                                 currentTrack.parentId,       // parent Track ID
+                                 kAdePTOutOfGPURegionProcess, // step limiting process ID
+                                 IsElectron ? ParticleType::Electron : ParticleType::Positron, // Particle type
+                                 elTrack.GetPStepLength(),                                     // Step length
+                                 energyDeposit,                                                // Total Edep
+                                 currentTrack.weight,                                          // Track weight
+                                 currentTrack.navState,                       // Pre-step point navstate
+                                 currentTrack.preStepPos,                     // Pre-step point position
+                                 currentTrack.preStepDir,                     // Pre-step point momentum direction
+                                 currentTrack.preStepEKin,                    // Pre-step point kinetic energy
+                                 currentTrack.nextState,                      // Post-step point navstate
+                                 currentTrack.pos,                            // Post-step point position
+                                 currentTrack.dir,                            // Post-step point momentum direction
+                                 currentTrack.eKin,                           // Post-step point kinetic energy
+                                 currentTrack.globalTime,                     // global time
+                                 currentTrack.localTime,                      // local time
+                                 currentTrack.preStepGlobalTime,              // preStep global time
+                                 currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                 false,                                       // parent continues on CPU
+                                 currentTrack.stepCounter,                    // stepcounter
+                                 nullptr,                                     // pointer to secondary init data
+                                 0);                                          // number of secondaries
+      }
     }
   }
-}
 }
 
 __device__ __forceinline__ void PerformStoppedAnnihilation(const int slot, Track &currentTrack,

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -626,6 +626,7 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
     double energyDeposit = theTrack->GetEnergyDeposit();
 
     bool cross_boundary = false;
+    bool returnsToCPU   = false;
 
     // Relocate to have the correct next state before RecordHit is called
 
@@ -652,8 +653,16 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
       trackSurvives = false;
     }
 
-    // Score
-    if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || (!trackSurvives && returnLastStep))
+    if (cross_boundary) {
+      const int nextlvolID          = currentTrack.nextState.GetLogicalId();
+      VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];
+      returnsToCPU                  = nextauxData.fGPUregionId < 0;
+    }
+
+    // Score. A step leaving the GPU region is returned only once, with the
+    // out-of-GPU handoff process below.
+    if (!returnsToCPU &&
+        ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || (!trackSurvives && returnLastStep)))
       adept_scoring::RecordHit(currentTrack.trackId,                                         // Track ID
                                currentTrack.parentId,                                        // parent Track ID
                                kAdePTTransportationProcess,                                  // step limiting process ID
@@ -679,12 +688,12 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
                                0);                                          // number of secondaries
 
     if (cross_boundary) {
-      // Move to the next boundary now that the Step is recorded
-      currentTrack.navState = currentTrack.nextState;
       // Check if the next volume belongs to the GPU region and push it to the appropriate queue
       const int nextlvolID          = currentTrack.nextState.GetLogicalId();
       VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];
-      if (nextauxData.fGPUregionId >= 0) {
+      if (!returnsToCPU) {
+        // Move to the next boundary now that the step is recorded.
+        currentTrack.navState = currentTrack.nextState;
         theTrack->SetMCIndex(nextauxData.fMCIndex);
         survive();
       } else {

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -278,7 +278,7 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
 
     G4HepEmElectronManager::HowFarToMSC(&g4HepEmData, &g4HepEmPars, &elTrack, &rnge);
 
-    // Particles that were not cut or leaked are added to the queue used by the next kernels
+    // Particles that were not cut are added to the queue used by the next kernels
     propagationQueue->push_back(slot);
   }
 }

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -156,9 +156,31 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
                 currentTrack.eventId, currentTrack.eKin, lvolID, currentTrack.stepCounter);
           }
 
-          // Set LeakStatus and copy to leaked queue
-          currentTrack.leakStatus = LeakStatus::FinishEventOnCPU;
-          electronsOrPositrons.CopyTrackToLeaked(slot);
+          slotManager.MarkSlotForFreeing(slot);
+
+          adept_scoring::RecordHit(currentTrack.trackId,     // Track ID
+                                   currentTrack.parentId,    // parent Track ID
+                                   kAdePTFinishOnCPUProcess, // step limiting process
+                                   IsElectron ? ParticleType::Electron : ParticleType::Positron, // Particle type
+                                   0.,                                                           // Step length
+                                   0.,                                                           // Total Edep
+                                   currentTrack.weight,                                          // Track weight
+                                   currentTrack.navState,                       // Pre-step point navstate
+                                   currentTrack.preStepPos,                     // Pre-step point position
+                                   currentTrack.preStepDir,                     // Pre-step point momentum direction
+                                   currentTrack.preStepEKin,                    // Pre-step point kinetic energy
+                                   currentTrack.navState,                       // Post-step point navstate
+                                   currentTrack.pos,                            // Post-step point position
+                                   currentTrack.dir,                            // Post-step point momentum direction
+                                   currentTrack.eKin,                           // Post-step point kinetic energy
+                                   currentTrack.globalTime,                     // global time
+                                   currentTrack.localTime,                      // local time
+                                   currentTrack.preStepGlobalTime,              // preStep global time
+                                   currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                   false,                                       // parent continues on CPU
+                                   currentTrack.stepCounter,                    // stepcounter
+                                   nullptr,                                     // pointer to secondary init data
+                                   0);                                          // number of secondaries
           continue;
         }
       } else {
@@ -540,7 +562,6 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
         // possible hook to SteppingAction here
 
         // --- Survive --- //
-        currentTrack.leakStatus = LeakStatus::NoLeak;
         electronsOrPositrons.EnqueueNext(slot);
       }
 
@@ -594,59 +615,87 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
 
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID];
 
-    auto survive = [&](LeakStatus leakReason = LeakStatus::NoLeak) {
-      // NOTE: When adapting the split kernels for async mode this won't
-      // work if we want to re-use slots on the fly. Directly copying to
-      // a trackdata struct would be better
-      currentTrack.leakStatus = leakReason;
-      if (leakReason != LeakStatus::NoLeak) {
-        // Copy track at slot to the leaked tracks
-        electronsOrPositrons.CopyTrackToLeaked(slot);
-      } else {
-        electronsOrPositrons.EnqueueNext(slot);
-      }
-    };
+    auto survive = [&]() { electronsOrPositrons.EnqueueNext(slot); };
+  };
 
-    bool trackSurvives = true;
+  bool trackSurvives = true;
 
-    // Retrieve HepEM track
-    G4HepEmElectronTrack &elTrack = hepEMTracks[slot];
-    G4HepEmTrack *theTrack        = elTrack.GetTrack();
+  // Retrieve HepEM track
+  G4HepEmElectronTrack &elTrack = hepEMTracks[slot];
+  G4HepEmTrack *theTrack        = elTrack.GetTrack();
 
-    double energyDeposit = theTrack->GetEnergyDeposit();
+  double energyDeposit = theTrack->GetEnergyDeposit();
 
-    bool cross_boundary = false;
+  bool cross_boundary = false;
 
-    // Relocate to have the correct next state before RecordHit is called
+  // Relocate to have the correct next state before RecordHit is called
 
-    // - Kill loopers stuck at a boundary
-    // - Set cross boundary flag in order to set the correct navstate after scoring
-    // - Kill particles that left the world
+  // - Kill loopers stuck at a boundary
+  // - Set cross boundary flag in order to set the correct navstate after scoring
+  // - Kill particles that left the world
 
-    ++currentTrack.looperCounter;
+  ++currentTrack.looperCounter;
 
-    if (!currentTrack.nextState.IsOutside()) {
-      // Mark the particle. We need to change its navigation state to the next volume before enqueuing it
-      // This will happen after recording the step
-      // Relocate
-      cross_boundary = true;
+  if (!currentTrack.nextState.IsOutside()) {
+    // Mark the particle. We need to change its navigation state to the next volume before enqueuing it
+    // This will happen after recording the step
+    // Relocate
+    cross_boundary = true;
 #ifdef ADEPT_USE_SURF
-      AdePTNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, currentTrack.hitsurfID,
-                                           currentTrack.nextState);
+    AdePTNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, currentTrack.hitsurfID,
+                                         currentTrack.nextState);
 #else
-      AdePTNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, currentTrack.nextState);
+    AdePTNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, currentTrack.nextState);
 #endif
-    } else {
-      // Particle left the world, don't enqueue it and release the slot
-      slotManager.MarkSlotForFreeing(slot);
-      trackSurvives = false;
-    }
+  } else {
+    // Particle left the world, don't enqueue it and release the slot
+    slotManager.MarkSlotForFreeing(slot);
+    trackSurvives = false;
+  }
 
-    // Score
-    if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || (!trackSurvives && returnLastStep))
+  // Score
+  if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || (!trackSurvives && returnLastStep))
+    adept_scoring::RecordHit(currentTrack.trackId,                                         // Track ID
+                             currentTrack.parentId,                                        // parent Track ID
+                             kAdePTTransportationProcess,                                  // step limiting process ID
+                             IsElectron ? ParticleType::Electron : ParticleType::Positron, // Particle type
+                             elTrack.GetPStepLength(),                                     // Step length
+                             energyDeposit,                                                // Total Edep
+                             currentTrack.weight,                                          // Track weight
+                             currentTrack.navState,                                        // Pre-step point navstate
+                             currentTrack.preStepPos,                                      // Pre-step point position
+                             currentTrack.preStepDir,                     // Pre-step point momentum direction
+                             currentTrack.preStepEKin,                    // Pre-step point kinetic energy
+                             currentTrack.nextState,                      // Post-step point navstate
+                             currentTrack.pos,                            // Post-step point position
+                             currentTrack.dir,                            // Post-step point momentum direction
+                             currentTrack.eKin,                           // Post-step point kinetic energy
+                             currentTrack.globalTime,                     // global time
+                             currentTrack.localTime,                      // local time
+                             currentTrack.preStepGlobalTime,              // preStep global time
+                             currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                             !trackSurvives,                              // whether this was the last step
+                             currentTrack.stepCounter,                    // stepcounter
+                             nullptr,                                     // pointer to secondary init data
+                             0);                                          // number of secondaries
+
+  if (cross_boundary) {
+    // Move to the next boundary now that the Step is recorded
+    currentTrack.navState = currentTrack.nextState;
+    // Check if the next volume belongs to the GPU region and push it to the appropriate queue
+    const int nextlvolID          = currentTrack.nextState.GetLogicalId();
+    VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];
+    if (nextauxData.fGPUregionId >= 0) {
+      theTrack->SetMCIndex(nextauxData.fMCIndex);
+      survive();
+    } else {
+      // To be safe, just push a bit the track exiting the GPU region to make sure
+      // Geant4 does not relocate it again inside the same region
+      currentTrack.pos += kPushDistance * currentTrack.dir;
+      slotManager.MarkSlotForFreeing(slot);
       adept_scoring::RecordHit(currentTrack.trackId,                                         // Track ID
                                currentTrack.parentId,                                        // parent Track ID
-                               static_cast<short>(/*transport*/ 10),                         // step limiting process ID
+                               kAdePTOutOfGPURegionProcess,                                  // step limiting process ID
                                IsElectron ? ParticleType::Electron : ParticleType::Positron, // Particle type
                                elTrack.GetPStepLength(),                                     // Step length
                                energyDeposit,                                                // Total Edep
@@ -663,28 +712,13 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
                                currentTrack.localTime,                      // local time
                                currentTrack.preStepGlobalTime,              // preStep global time
                                currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                               !trackSurvives,                              // whether this was the last step
+                               false,                                       // parent continues on CPU
                                currentTrack.stepCounter,                    // stepcounter
                                nullptr,                                     // pointer to secondary init data
                                0);                                          // number of secondaries
-
-    if (cross_boundary) {
-      // Move to the next boundary now that the Step is recorded
-      currentTrack.navState = currentTrack.nextState;
-      // Check if the next volume belongs to the GPU region and push it to the appropriate queue
-      const int nextlvolID          = currentTrack.nextState.GetLogicalId();
-      VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];
-      if (nextauxData.fGPUregionId >= 0) {
-        theTrack->SetMCIndex(nextauxData.fMCIndex);
-        survive();
-      } else {
-        // To be safe, just push a bit the track exiting the GPU region to make sure
-        // Geant4 does not relocate it again inside the same region
-        currentTrack.pos += kPushDistance * currentTrack.dir;
-        survive(LeakStatus::OutOfGPURegion);
-      }
     }
   }
+}
 }
 
 __device__ __forceinline__ void PerformStoppedAnnihilation(const int slot, Track &currentTrack,

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -175,6 +175,7 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
                                    currentTrack.eKin,                           // Post-step point kinetic energy
                                    currentTrack.globalTime,                     // global time
                                    currentTrack.localTime,                      // local time
+                                   currentTrack.properTime,                     // proper time
                                    currentTrack.preStepGlobalTime,              // preStep global time
                                    currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                    false,                                       // parent continues on CPU
@@ -206,6 +207,7 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
                                    currentTrack.eKin,        // Post-step point kinetic energy
                                    currentTrack.globalTime,  // global time
                                    currentTrack.localTime,   // local time
+                                   currentTrack.properTime,  // proper time
                                    currentTrack.preStepGlobalTime, // preStep global time
                                    currentTrack.eventId,           // eventID
                                    currentTrack.threadId,          // threadID
@@ -586,6 +588,7 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
                                  currentTrack.eKin,                           // Post-step point kinetic energy
                                  currentTrack.globalTime,                     // global time
                                  currentTrack.localTime,                      // local time
+                                 currentTrack.properTime,                     // proper time
                                  currentTrack.preStepGlobalTime,              // preStep global time
                                  currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                  !trackSurvives && !continuesOnCPU,           // whether this was the last step
@@ -687,6 +690,7 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
                                currentTrack.eKin,                           // Post-step point kinetic energy
                                currentTrack.globalTime,                     // global time
                                currentTrack.localTime,                      // local time
+                               currentTrack.properTime,                     // proper time
                                currentTrack.preStepGlobalTime,              // preStep global time
                                currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                isLastStep,                                  // whether this was the last step
@@ -874,6 +878,7 @@ __global__ void ElectronIonization(G4HepEmElectronTrack *hepEMTracks, ParticleMa
                                currentTrack.eKin,                           // Post-step point kinetic energy
                                currentTrack.globalTime,                     // global time
                                currentTrack.localTime,                      // local time
+                               currentTrack.properTime,                     // proper time
                                currentTrack.preStepGlobalTime,              // preStep global time
                                currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                !trackSurvives,                              // whether this was the last step
@@ -1014,6 +1019,7 @@ __global__ void ElectronBremsstrahlung(G4HepEmElectronTrack *hepEMTracks, Partic
                                currentTrack.eKin,                           // Post-step point kinetic energy
                                currentTrack.globalTime,                     // global time
                                currentTrack.localTime,                      // local time
+                               currentTrack.properTime,                     // proper time
                                currentTrack.preStepGlobalTime,              // preStep global time
                                currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                !trackSurvives,                              // whether this was the last step
@@ -1151,6 +1157,7 @@ __global__ void PositronAnnihilation(G4HepEmElectronTrack *hepEMTracks, Particle
                                currentTrack.eKin,                           // Post-step point kinetic energy
                                currentTrack.globalTime,                     // global time
                                currentTrack.localTime,                      // local time
+                               currentTrack.properTime,                     // proper time
                                currentTrack.preStepGlobalTime,              // preStep global time
                                currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                true, // whether this was the last step: always true for annihilating positrons
@@ -1222,6 +1229,7 @@ __global__ void PositronStoppedAnnihilation(G4HepEmElectronTrack *hepEMTracks, P
                                currentTrack.eKin,                           // Post-step point kinetic energy
                                currentTrack.globalTime,                     // global time
                                currentTrack.localTime,                      // local time
+                               currentTrack.properTime,                     // proper time
                                currentTrack.preStepGlobalTime,              // preStep global time
                                currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                true, // whether this was the last step: always true for annihilating positrons

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -653,19 +653,26 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
       trackSurvives = false;
     }
 
+    short stepProcessId = kAdePTTransportationProcess;
+    bool isLastStep     = !trackSurvives;
     if (cross_boundary) {
       const int nextlvolID          = currentTrack.nextState.GetLogicalId();
       VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];
       returnsToCPU                  = nextauxData.fGPUregionId < 0;
+      if (returnsToCPU) {
+        // Push the handoff point a little into the CPU region so Geant4 does
+        // not relocate the track back into the same GPU region.
+        currentTrack.pos += kPushDistance * currentTrack.dir;
+        stepProcessId = kAdePTOutOfGPURegionProcess;
+        isLastStep    = false;
+      }
     }
 
-    // Score. A step leaving the GPU region is returned only once, with the
-    // out-of-GPU handoff process below.
-    if (!returnsToCPU &&
-        ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || (!trackSurvives && returnLastStep)))
+    if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnsToCPU ||
+        (!trackSurvives && returnLastStep))
       adept_scoring::RecordHit(currentTrack.trackId,                                         // Track ID
                                currentTrack.parentId,                                        // parent Track ID
-                               kAdePTTransportationProcess,                                  // step limiting process ID
+                               stepProcessId,                                                // step limiting process ID
                                IsElectron ? ParticleType::Electron : ParticleType::Positron, // Particle type
                                elTrack.GetPStepLength(),                                     // Step length
                                energyDeposit,                                                // Total Edep
@@ -682,7 +689,7 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
                                currentTrack.localTime,                      // local time
                                currentTrack.preStepGlobalTime,              // preStep global time
                                currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                               !trackSurvives,                              // whether this was the last step
+                               isLastStep,                                  // whether this was the last step
                                currentTrack.stepCounter,                    // stepcounter
                                nullptr,                                     // pointer to secondary init data
                                0);                                          // number of secondaries
@@ -697,33 +704,7 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
         theTrack->SetMCIndex(nextauxData.fMCIndex);
         survive();
       } else {
-        // To be safe, just push a bit the track exiting the GPU region to make sure
-        // Geant4 does not relocate it again inside the same region
-        currentTrack.pos += kPushDistance * currentTrack.dir;
         slotManager.MarkSlotForFreeing(slot);
-        adept_scoring::RecordHit(currentTrack.trackId,        // Track ID
-                                 currentTrack.parentId,       // parent Track ID
-                                 kAdePTOutOfGPURegionProcess, // step limiting process ID
-                                 IsElectron ? ParticleType::Electron : ParticleType::Positron, // Particle type
-                                 elTrack.GetPStepLength(),                                     // Step length
-                                 energyDeposit,                                                // Total Edep
-                                 currentTrack.weight,                                          // Track weight
-                                 currentTrack.navState,                       // Pre-step point navstate
-                                 currentTrack.preStepPos,                     // Pre-step point position
-                                 currentTrack.preStepDir,                     // Pre-step point momentum direction
-                                 currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                                 currentTrack.nextState,                      // Post-step point navstate
-                                 currentTrack.pos,                            // Post-step point position
-                                 currentTrack.dir,                            // Post-step point momentum direction
-                                 currentTrack.eKin,                           // Post-step point kinetic energy
-                                 currentTrack.globalTime,                     // global time
-                                 currentTrack.localTime,                      // local time
-                                 currentTrack.preStepGlobalTime,              // preStep global time
-                                 currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                                 false,                                       // parent continues on CPU
-                                 currentTrack.stepCounter,                    // stepcounter
-                                 nullptr,                                     // pointer to secondary init data
-                                 0);                                          // number of secondaries
       }
     }
   }

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -401,8 +401,8 @@ __global__ void __launch_bounds__(256, 1)
 #if ADEPT_DEBUG_TRACK > 0
         if (verbose) printf("| GAMMA-NUCLEAR ");
 #endif
-        // Gamma nuclear needs to be handled by Geant4 directly, passing track back to CPU
-        leakReason = LeakStatus::GammaNuclear;
+        // Gamma nuclear is handled on the host from the returned step only.
+        trackSurvives = false;
       }
       } // end switch (winnerProcessIndex)
 
@@ -440,10 +440,10 @@ __global__ void __launch_bounds__(256, 1)
 
     __syncwarp();
 
-    // A track that survives must be enqueued to the leaks or the next queue.
-    // Note: gamma nuclear does not survive but must still be leaked to the CPU, which is done
-    // inside survive()
-    if (trackSurvives || leakReason == LeakStatus::GammaNuclear) {
+    // A surviving track must be enqueued to the leak buffer or the next queue.
+    // Gamma-nuclear is handled from the returned step only, so the GPU-side
+    // track simply dies after recording that step.
+    if (trackSurvives) {
       survive();
     } else {
       // particles that don't survive are killed by not enqueing them to the next queue and freeing the slot
@@ -453,7 +453,7 @@ __global__ void __launch_bounds__(256, 1)
     assert(nSecondaries <= 3);
 
     // If there is some edep from cutting particles, record the step
-    if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps ||
+    if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps || winnerProcessIndex == 3 ||
         (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
       adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
                                currentTrack.parentId,                       // parent Track ID

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -77,7 +77,6 @@ __global__ void __launch_bounds__(256, 1)
       currentTrack.localTime  = localTime;
       currentTrack.properTime = properTime;
       currentTrack.navState   = nextState;
-      currentTrack.leakStatus = LeakStatus::NoLeak;
       if (!enterWDTRegion) {
         particleManager.gammas.EnqueueNext(slot);
       } else {
@@ -211,7 +210,7 @@ __global__ void __launch_bounds__(256, 1)
           pos += kPushDistance * dir;
 
 #if ADEPT_DEBUG_TRACK > 0
-          if (verbose) printf("\n| track leaked to Geant4\n");
+          if (verbose) printf("\n| track returned to Geant4\n");
 #endif
 
           trackSurvives        = false;
@@ -422,7 +421,8 @@ __global__ void __launch_bounds__(256, 1)
       }
     }
 
-    // finishing on CPU must be last one only sets the LeakStatus but does not affect survival of the track
+    // Finishing on CPU must be checked last. It changes only the returned step
+    // type and does not affect whether the track survives this iteration.
     if (trackSurvives && !continuesOnCPU) {
       if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < allowFinishOffEvent[currentTrack.threadId] &&
           InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
@@ -438,7 +438,7 @@ __global__ void __launch_bounds__(256, 1)
 
     __syncwarp();
 
-    // A surviving track must be enqueued to the leak buffer or the next queue.
+    // A surviving track must be enqueued to the next queue.
     // Gamma-nuclear is handled from the returned step only, so the GPU-side
     // track simply dies after recording that step.
     if (trackSurvives) {

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -38,8 +38,8 @@ __global__ void __launch_bounds__(256, 1)
 
     bool trackSurvives                       = false;
     bool enterWDTRegion                      = false;
-    LeakStatus leakReason                    = LeakStatus::NoLeak;
     short stepDefinedProcessId               = 10; // default for transportation
+    bool continuesOnCPU                      = false;
     double edep                              = 0.;
     constexpr double kPushStuck              = 100 * vecgeom::kTolerance;
     constexpr unsigned short kStepsStuckPush = 5;
@@ -77,16 +77,11 @@ __global__ void __launch_bounds__(256, 1)
       currentTrack.localTime  = localTime;
       currentTrack.properTime = properTime;
       currentTrack.navState   = nextState;
-      currentTrack.leakStatus = leakReason;
-      if (leakReason != LeakStatus::NoLeak) {
-        // Copy track at slot to the leaked tracks
-        particleManager.gammas.CopyTrackToLeaked(slot);
+      currentTrack.leakStatus = LeakStatus::NoLeak;
+      if (!enterWDTRegion) {
+        particleManager.gammas.EnqueueNext(slot);
       } else {
-        if (!enterWDTRegion) {
-          particleManager.gammas.EnqueueNext(slot);
-        } else {
-          particleManager.gammasWDT.EnqueueNext(slot);
-        }
+        particleManager.gammasWDT.EnqueueNext(slot);
       }
     };
 
@@ -219,8 +214,9 @@ __global__ void __launch_bounds__(256, 1)
           if (verbose) printf("\n| track leaked to Geant4\n");
 #endif
 
-          trackSurvives = true;
-          leakReason    = LeakStatus::OutOfGPURegion;
+          trackSurvives        = false;
+          continuesOnCPU       = true;
+          stepDefinedProcessId = kAdePTOutOfGPURegionProcess;
         }
       } // else particle has left the world
 
@@ -427,14 +423,16 @@ __global__ void __launch_bounds__(256, 1)
     }
 
     // finishing on CPU must be last one only sets the LeakStatus but does not affect survival of the track
-    if (trackSurvives && leakReason == LeakStatus::NoLeak) {
+    if (trackSurvives && !continuesOnCPU) {
       if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < allowFinishOffEvent[currentTrack.threadId] &&
           InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
         printf("Thread %d Finishing gamma of the %d last particles of event %d on CPU E=%f lvol=%d after %d steps.\n",
                currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
                currentTrack.eventId, eKin, lvolID, currentTrack.stepCounter);
 
-        leakReason = LeakStatus::FinishEventOnCPU;
+        trackSurvives        = false;
+        continuesOnCPU       = true;
+        stepDefinedProcessId = kAdePTFinishOnCPUProcess;
       }
     }
 
@@ -453,7 +451,7 @@ __global__ void __launch_bounds__(256, 1)
     assert(nSecondaries <= 3);
 
     // If there is some edep from cutting particles, record the step
-    if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps || winnerProcessIndex == 3 ||
+    if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU || winnerProcessIndex == 3 ||
         (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
       adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
                                currentTrack.parentId,                       // parent Track ID
@@ -474,10 +472,10 @@ __global__ void __launch_bounds__(256, 1)
                                localTime,                                   // local time
                                preStepGlobalTime,                           // global time at preStepPoint
                                currentTrack.eventId, currentTrack.threadId, // event and thread ID
-                               !trackSurvives,           // whether this is the last step of the track
-                               currentTrack.stepCounter, // stepcounter
-                               secondaryData,            // pointer to secondary init data
-                               nSecondaries);            // number of secondaries
+                               !trackSurvives && !continuesOnCPU, // whether this is the last step of the track
+                               currentTrack.stepCounter,          // stepcounter
+                               secondaryData,                     // pointer to secondary init data
+                               nSecondaries);                     // number of secondaries
     }
   } // end for loop over tracks
 }

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -470,6 +470,7 @@ __global__ void __launch_bounds__(256, 1)
                                eKin,                                        // Post-step point kinetic energy
                                globalTime,                                  // global time
                                localTime,                                   // local time
+                               properTime,                                  // proper time
                                preStepGlobalTime,                           // global time at preStepPoint
                                currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                !trackSurvives && !continuesOnCPU, // whether this is the last step of the track

--- a/include/AdePT/kernels/gammasWDT.cuh
+++ b/include/AdePT/kernels/gammasWDT.cuh
@@ -65,8 +65,8 @@ __global__ void __launch_bounds__(256, 1)
 
     auto eKin = currentTrack.eKin;
 
-    LeakStatus leakReason = LeakStatus::NoLeak;
-    bool leftWDTRegion    = false;
+    bool leftWDTRegion  = false;
+    bool continuesOnCPU = false;
     // initialize nextState to current state
     vecgeom::NavigationState nextState = currentTrack.navState;
     double globalTime                  = currentTrack.globalTime;
@@ -83,16 +83,11 @@ __global__ void __launch_bounds__(256, 1)
       currentTrack.globalTime = globalTime;
       currentTrack.localTime  = localTime;
       currentTrack.navState   = nextState;
-      currentTrack.leakStatus = leakReason;
-      if (leakReason != LeakStatus::NoLeak) {
-        // Copy track at slot to the leaked tracks
-        particleManager.gammas.CopyTrackToLeaked(slot);
+      currentTrack.leakStatus = LeakStatus::NoLeak;
+      if (leftWDTRegion) {
+        particleManager.gammas.EnqueueNext(slot);
       } else {
-        if (leftWDTRegion) {
-          particleManager.gammas.EnqueueNext(slot);
-        } else {
-          particleManager.gammasWDT.EnqueueNext(slot);
-        }
+        particleManager.gammasWDT.EnqueueNext(slot);
       }
     };
 
@@ -415,8 +410,9 @@ __global__ void __launch_bounds__(256, 1)
           if (verbose) printf("\n| track leaked to Geant4\n");
 #endif
 
-          trackSurvives = true;
-          leakReason    = LeakStatus::OutOfGPURegion;
+          trackSurvives        = false;
+          continuesOnCPU       = true;
+          stepDefinedProcessId = kAdePTOutOfGPURegionProcess;
         }
       } // else particle has left the world
 
@@ -620,14 +616,16 @@ __global__ void __launch_bounds__(256, 1)
     }
 
     // finishing on CPU must be last one only sets the LeakStatus but does not affect survival of the track
-    if (trackSurvives && leakReason == LeakStatus::NoLeak) {
+    if (trackSurvives && !continuesOnCPU) {
       if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < allowFinishOffEvent[currentTrack.threadId] &&
           InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
         printf("Thread %d Finishing gamma of the %d last particles of event %d on CPU E=%f lvol=%d after %d steps.\n",
                currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
                currentTrack.eventId, eKin, lvolID, currentTrack.stepCounter);
 
-        leakReason = LeakStatus::FinishEventOnCPU;
+        trackSurvives        = false;
+        continuesOnCPU       = true;
+        stepDefinedProcessId = kAdePTFinishOnCPUProcess;
       }
     }
 
@@ -651,7 +649,7 @@ __global__ void __launch_bounds__(256, 1)
     assert(nSecondaries <= 3);
 
     // If there is some edep from cutting particles or if it is the last step, record the step
-    if ((edep > 0 && nextauxData.fSensIndex >= 0) || returnAllSteps || winnerProcessIndex == 3 ||
+    if ((edep > 0 && nextauxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU || winnerProcessIndex == 3 ||
         (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
       adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
                                currentTrack.parentId,                       // parent Track ID
@@ -672,10 +670,10 @@ __global__ void __launch_bounds__(256, 1)
                                localTime,                                   // local time
                                preStepGlobalTime,                           // global time at preStepPoint
                                currentTrack.eventId, currentTrack.threadId, // event and thread ID
-                               !trackSurvives,           // whether this is the last step of the track
-                               currentTrack.stepCounter, // stepcounter
-                               secondaryData,            // pointer to secondary init data
-                               nSecondaries);            // number of secondaries
+                               !trackSurvives && !continuesOnCPU, // whether this is the last step of the track
+                               currentTrack.stepCounter,          // stepcounter
+                               secondaryData,                     // pointer to secondary init data
+                               nSecondaries);                     // number of secondaries
     }
   } // end for loop over tracks
 }

--- a/include/AdePT/kernels/gammasWDT.cuh
+++ b/include/AdePT/kernels/gammasWDT.cuh
@@ -72,6 +72,7 @@ __global__ void __launch_bounds__(256, 1)
     double globalTime                  = currentTrack.globalTime;
     double preStepGlobalTime           = currentTrack.globalTime;
     double localTime                   = currentTrack.localTime;
+    double properTime                  = currentTrack.properTime;
 
     //
     // survive: decide whether to continue woodcock tracking or not:
@@ -82,6 +83,7 @@ __global__ void __launch_bounds__(256, 1)
       currentTrack.dir        = dir;
       currentTrack.globalTime = globalTime;
       currentTrack.localTime  = localTime;
+      currentTrack.properTime = properTime;
       currentTrack.navState   = nextState;
       if (leftWDTRegion) {
         particleManager.gammas.EnqueueNext(slot);
@@ -668,6 +670,7 @@ __global__ void __launch_bounds__(256, 1)
                                eKin,                                        // Post-step point kinetic energy
                                globalTime,                                  // global time
                                localTime,                                   // local time
+                               properTime,                                  // proper time
                                preStepGlobalTime,                           // global time at preStepPoint
                                currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                !trackSurvives && !continuesOnCPU, // whether this is the last step of the track

--- a/include/AdePT/kernels/gammasWDT.cuh
+++ b/include/AdePT/kernels/gammasWDT.cuh
@@ -83,7 +83,6 @@ __global__ void __launch_bounds__(256, 1)
       currentTrack.globalTime = globalTime;
       currentTrack.localTime  = localTime;
       currentTrack.navState   = nextState;
-      currentTrack.leakStatus = LeakStatus::NoLeak;
       if (leftWDTRegion) {
         particleManager.gammas.EnqueueNext(slot);
       } else {
@@ -407,7 +406,7 @@ __global__ void __launch_bounds__(256, 1)
           pos += kPushDistance * dir;
 
 #if ADEPT_DEBUG_TRACK > 0
-          if (verbose) printf("\n| track leaked to Geant4\n");
+          if (verbose) printf("\n| track returned to Geant4\n");
 #endif
 
           trackSurvives        = false;
@@ -615,7 +614,8 @@ __global__ void __launch_bounds__(256, 1)
       }
     }
 
-    // finishing on CPU must be last one only sets the LeakStatus but does not affect survival of the track
+    // Finishing on CPU must be checked last. It changes only the returned step
+    // type and does not affect whether the track survives this iteration.
     if (trackSurvives && !continuesOnCPU) {
       if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < allowFinishOffEvent[currentTrack.threadId] &&
           InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
@@ -636,7 +636,7 @@ __global__ void __launch_bounds__(256, 1)
       leftWDTRegion = true;
     }
 
-    // A surviving track must be enqueued to the leak buffer or the next queue.
+    // A surviving track must be enqueued to the next queue.
     // Gamma-nuclear is handled from the returned step only, so the GPU-side
     // track simply dies after recording that terminal step.
     if (trackSurvives) {

--- a/include/AdePT/kernels/gammasWDT.cuh
+++ b/include/AdePT/kernels/gammasWDT.cuh
@@ -597,8 +597,8 @@ __global__ void __launch_bounds__(256, 1)
 #if ADEPT_DEBUG_TRACK > 0
         if (verbose) printf("| GAMMA-NUCLEAR ");
 #endif
-        // Gamma nuclear needs to be handled by Geant4 directly, passing track back to CPU
-        leakReason = LeakStatus::GammaNuclear;
+        // Gamma nuclear is handled on the host from the returned step only.
+        trackSurvives = false;
       }
       } // end switch (winnerProcessIndex)
 
@@ -638,10 +638,10 @@ __global__ void __launch_bounds__(256, 1)
       leftWDTRegion = true;
     }
 
-    // A track that survives must be enqueued to the leaks or the next queue.
-    // Note: gamma nuclear does not survive but must still be leaked to the CPU, which is done
-    // inside survive()
-    if (trackSurvives || leakReason == LeakStatus::GammaNuclear) {
+    // A surviving track must be enqueued to the leak buffer or the next queue.
+    // Gamma-nuclear is handled from the returned step only, so the GPU-side
+    // track simply dies after recording that terminal step.
+    if (trackSurvives) {
       survive();
     } else {
       // particles that don't survive are killed by not enqueing them to the next queue and freeing the slot
@@ -651,7 +651,7 @@ __global__ void __launch_bounds__(256, 1)
     assert(nSecondaries <= 3);
 
     // If there is some edep from cutting particles or if it is the last step, record the step
-    if ((edep > 0 && nextauxData.fSensIndex >= 0) || returnAllSteps ||
+    if ((edep > 0 && nextauxData.fSensIndex >= 0) || returnAllSteps || winnerProcessIndex == 3 ||
         (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
       adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
                                currentTrack.parentId,                       // parent Track ID

--- a/include/AdePT/kernels/gammasWDT_split.cuh
+++ b/include/AdePT/kernels/gammasWDT_split.cuh
@@ -149,6 +149,7 @@ __global__ void __launch_bounds__(256, 1)
                                    currentTrack.eKin,                           // Post-step point kinetic energy
                                    currentTrack.globalTime,                     // global time
                                    currentTrack.localTime,                      // local time
+                                   currentTrack.properTime,                     // proper time
                                    currentTrack.preStepGlobalTime,              // preStep global time
                                    currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                    false,                                       // parent continues on CPU
@@ -180,6 +181,7 @@ __global__ void __launch_bounds__(256, 1)
                                    currentTrack.eKin,                           // Post-step point kinetic energy
                                    currentTrack.globalTime,                     // global time
                                    currentTrack.localTime,                      // local time
+                                   currentTrack.properTime,                     // proper time
                                    currentTrack.preStepGlobalTime,              // preStep global time
                                    currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                    true,                                        // whether this was the last step
@@ -516,6 +518,7 @@ __global__ void __launch_bounds__(256, 1)
                                    currentTrack.eKin,                           // Post-step point kinetic energy
                                    currentTrack.globalTime,                     // global time
                                    currentTrack.localTime,                      // local time
+                                   currentTrack.properTime,                     // proper time
                                    currentTrack.preStepGlobalTime,              // preStep global time
                                    currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                    false,                                       // parent continues on CPU

--- a/include/AdePT/kernels/gammasWDT_split.cuh
+++ b/include/AdePT/kernels/gammasWDT_split.cuh
@@ -495,7 +495,7 @@ __global__ void __launch_bounds__(256, 1)
           currentTrack.pos += kPushDistance * currentTrack.dir;
 
 #if ADEPT_DEBUG_TRACK > 0
-          if (verbose) printf("\n| track leaked to Geant4\n");
+          if (verbose) printf("\n| track returned to Geant4\n");
 #endif
 
           slotManager.MarkSlotForFreeing(slot);
@@ -537,7 +537,7 @@ __global__ void __launch_bounds__(256, 1)
       assert(!currentTrack.nextState.IsOnBoundary());
 
     } else {
-      // track survives and is given to either to the WDT gammas, the normal gammas, or leaked out of the GPU
+      // track survives and is given to either the WDT gammas or the normal gammas
       survive();
     }
 

--- a/include/AdePT/kernels/gammasWDT_split.cuh
+++ b/include/AdePT/kernels/gammasWDT_split.cuh
@@ -72,15 +72,10 @@ __global__ void __launch_bounds__(256, 1)
     // survive: decide whether to continue woodcock tracking or not:
     // Write local variables back into track and enqueue to correct queue
     auto survive = [&]() {
-      if (currentTrack.leakStatus != LeakStatus::NoLeak) {
-        // Copy track at slot to the leaked tracks
-        particleManager.gammas.CopyTrackToLeaked(slot);
+      if (leftWDTRegion) {
+        particleManager.gammas.EnqueueNext(slot);
       } else {
-        if (leftWDTRegion) {
-          particleManager.gammas.EnqueueNext(slot);
-        } else {
-          particleManager.gammasWDT.EnqueueNext(slot);
-        }
+        particleManager.gammasWDT.EnqueueNext(slot);
       }
     };
 
@@ -135,9 +130,31 @@ __global__ void __launch_bounds__(256, 1)
                 currentTrack.eventId, currentTrack.eKin, lvolID, currentTrack.stepCounter);
           }
 
-          // Set LeakStatus and copy to leaked queue
-          currentTrack.leakStatus = LeakStatus::FinishEventOnCPU;
-          particleManager.gammas.CopyTrackToLeaked(slot);
+          slotManager.MarkSlotForFreeing(slot);
+
+          adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
+                                   currentTrack.parentId,                       // parent Track ID
+                                   kAdePTFinishOnCPUProcess,                    // step limiting process ID
+                                   ParticleType::Gamma,                         // Particle type
+                                   0.,                                          // Step length
+                                   0.,                                          // Total Edep
+                                   currentTrack.weight,                         // Track weight
+                                   currentTrack.navState,                       // Pre-step point navstate
+                                   currentTrack.preStepPos,                     // Pre-step point position
+                                   currentTrack.preStepDir,                     // Pre-step point momentum direction
+                                   currentTrack.preStepEKin,                    // Pre-step point kinetic energy
+                                   currentTrack.navState,                       // Post-step point navstate
+                                   currentTrack.pos,                            // Post-step point position
+                                   currentTrack.dir,                            // Post-step point momentum direction
+                                   currentTrack.eKin,                           // Post-step point kinetic energy
+                                   currentTrack.globalTime,                     // global time
+                                   currentTrack.localTime,                      // local time
+                                   currentTrack.preStepGlobalTime,              // preStep global time
+                                   currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                   false,                                       // parent continues on CPU
+                                   currentTrack.stepCounter,                    // stepcounter
+                                   nullptr,                                     // pointer to secondary init data
+                                   0);                                          // number of secondaries
           continue;
         }
       } else {
@@ -481,7 +498,31 @@ __global__ void __launch_bounds__(256, 1)
           if (verbose) printf("\n| track leaked to Geant4\n");
 #endif
 
-          currentTrack.leakStatus = LeakStatus::OutOfGPURegion;
+          slotManager.MarkSlotForFreeing(slot);
+          adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
+                                   currentTrack.parentId,                       // parent Track ID
+                                   kAdePTOutOfGPURegionProcess,                 // step limiting process ID
+                                   ParticleType::Gamma,                         // Particle type
+                                   thePrimaryTrack->GetGStepLength(),           // Step length
+                                   0.,                                          // Total Edep
+                                   currentTrack.weight,                         // Track weight
+                                   currentTrack.navState,                       // Pre-step point navstate
+                                   currentTrack.preStepPos,                     // Pre-step point position
+                                   currentTrack.preStepDir,                     // Pre-step point momentum direction
+                                   currentTrack.preStepEKin,                    // Pre-step point kinetic energy
+                                   currentTrack.nextState,                      // Post-step point navstate
+                                   currentTrack.pos,                            // Post-step point position
+                                   currentTrack.dir,                            // Post-step point momentum direction
+                                   currentTrack.eKin,                           // Post-step point kinetic energy
+                                   currentTrack.globalTime,                     // global time
+                                   currentTrack.localTime,                      // local time
+                                   currentTrack.preStepGlobalTime,              // preStep global time
+                                   currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                   false,                                       // parent continues on CPU
+                                   currentTrack.stepCounter,                    // stepcounter
+                                   nullptr,                                     // pointer to secondary init data
+                                   0);                                          // number of secondaries
+          continue;
         }
       } // else particle has left the world
 

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -168,7 +168,7 @@ __global__ void GammaHowFar(G4HepEmGammaTrack *hepEMTracks, ParticleManager part
     // Call G4HepEm to compute the physics step limit.
     G4HepEmGammaManager::HowFar(&g4HepEmData, &g4HepEmPars, &gammaTrack);
 
-    // Particles that were not cut or leaked are added to the queue used by the next kernels
+    // Particles that were not cut are added to the queue used by the next kernels
     propagationQueue->push_back(slot);
   }
 }

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -210,23 +210,13 @@ __global__ void GammaSetupInteractions(G4HepEmGammaTrack *hepEMTracks, const ade
                                        ParticleManager particleManager, AllInteractionQueues interactionQueues,
                                        const bool returnAllSteps, const bool returnLastStep)
 {
-  int activeSize = propagationQueue->size();
+  auto &slotManager = *particleManager.gammas.fSlotManager;
+  int activeSize    = propagationQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot      = (*propagationQueue)[i];
     Track &currentTrack = particleManager.gammas.TrackAt(slot);
 
     int lvolID = currentTrack.navState.GetLogicalId();
-
-    // Write local variables back into track and enqueue
-    auto survive = [&](LeakStatus leakReason = LeakStatus::NoLeak) {
-      currentTrack.leakStatus = leakReason;
-      if (leakReason != LeakStatus::NoLeak) {
-        // Copy track at slot to the leaked tracks
-        particleManager.gammas.CopyTrackToLeaked(slot);
-      } else {
-        particleManager.gammas.EnqueueNext(slot);
-      }
-    };
 
     G4HepEmGammaTrack &gammaTrack = hepEMTracks[slot];
     G4HepEmTrack *theTrack        = gammaTrack.GetTrack();
@@ -247,36 +237,34 @@ __global__ void GammaSetupInteractions(G4HepEmGammaTrack *hepEMTracks, const ade
       if (theTrack->GetWinnerProcessIndex() < 3) {
         interactionQueues.queues[theTrack->GetWinnerProcessIndex()]->push_back(slot);
       } else {
-        // Gamma nuclear needs to be handled by Geant4 directly, passing track back to CPU
-        survive(LeakStatus::GammaNuclear);
+        // Gamma nuclear is handled on the host from the returned step only.
+        slotManager.MarkSlotForFreeing(slot);
 
-        // Record last step to enable UserPostTrackingAction to be called
-        if (returnAllSteps || returnLastStep) {
-          adept_scoring::RecordHit(
-              currentTrack.trackId,                        // Track ID
-              currentTrack.parentId,                       // parent Track ID
-              static_cast<short>(3),                       // step defining process ID
-              ParticleType::Gamma,                         // Particle type
-              theTrack->GetGStepLength(),                  // Step length
-              0,                                           // Total Edep
-              currentTrack.weight,                         // Track weight
-              currentTrack.navState,                       // Pre-step point navstate
-              currentTrack.preStepPos,                     // Pre-step point position
-              currentTrack.preStepDir,                     // Pre-step point momentum direction
-              currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-              currentTrack.nextState,                      // Post-step point navstate
-              currentTrack.pos,                            // Post-step point position
-              currentTrack.dir,                            // Post-step point momentum direction
-              0,                                           // Post-step point kinetic energy
-              currentTrack.globalTime,                     // global time
-              currentTrack.localTime,                      // local time
-              currentTrack.preStepGlobalTime,              // preStep global time
-              currentTrack.eventId, currentTrack.threadId, // event and thread ID
-              true, // whether this is the last step of the track: true as gamma nuclear kills the gamma
-              currentTrack.stepCounter, // stepcounter
-              nullptr,                  // pointer to secondary init data
-              0);                       // number of secondaries
-        }
+        // Gamma-nuclear must always return the step so the host can replay the
+        // interaction even when user callbacks are disabled.
+        adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
+                                 currentTrack.parentId,                       // parent Track ID
+                                 static_cast<short>(3),                       // step defining process ID
+                                 ParticleType::Gamma,                         // Particle type
+                                 theTrack->GetGStepLength(),                  // Step length
+                                 0,                                           // Total Edep
+                                 currentTrack.weight,                         // Track weight
+                                 currentTrack.navState,                       // Pre-step point navstate
+                                 currentTrack.preStepPos,                     // Pre-step point position
+                                 currentTrack.preStepDir,                     // Pre-step point momentum direction
+                                 currentTrack.preStepEKin,                    // Pre-step point kinetic energy
+                                 currentTrack.nextState,                      // Post-step point navstate
+                                 currentTrack.pos,                            // Post-step point position
+                                 currentTrack.dir,                            // Post-step point momentum direction
+                                 currentTrack.eKin,                           // Post-step point kinetic energy
+                                 currentTrack.globalTime,                     // global time
+                                 currentTrack.localTime,                      // local time
+                                 currentTrack.preStepGlobalTime,              // preStep global time
+                                 currentTrack.eventId, currentTrack.threadId, // event and thread ID
+                                 true,                                        // gamma nuclear kills the parent
+                                 currentTrack.stepCounter,                    // stepcounter
+                                 nullptr,                                     // pointer to secondary init data
+                                 0);                                          // number of secondaries
       }
     }
   }

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -102,9 +102,31 @@ __global__ void GammaHowFar(G4HepEmGammaTrack *hepEMTracks, ParticleManager part
                 currentTrack.eventId, currentTrack.eKin, lvolID, currentTrack.stepCounter);
           }
 
-          // Set LeakStatus and copy to leaked queue
-          currentTrack.leakStatus = LeakStatus::FinishEventOnCPU;
-          particleManager.gammas.CopyTrackToLeaked(slot);
+          slotManager.MarkSlotForFreeing(slot);
+
+          adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
+                                   currentTrack.parentId,                       // parent Track ID
+                                   kAdePTFinishOnCPUProcess,                    // step limiting process ID
+                                   ParticleType::Gamma,                         // Particle type
+                                   0.,                                          // Step length
+                                   0.,                                          // Total Edep
+                                   currentTrack.weight,                         // Track weight
+                                   currentTrack.navState,                       // Pre-step point navstate
+                                   currentTrack.preStepPos,                     // Pre-step point position
+                                   currentTrack.preStepDir,                     // Pre-step point momentum direction
+                                   currentTrack.preStepEKin,                    // Pre-step point kinetic energy
+                                   currentTrack.navState,                       // Post-step point navstate
+                                   currentTrack.pos,                            // Post-step point position
+                                   currentTrack.dir,                            // Post-step point momentum direction
+                                   currentTrack.eKin,                           // Post-step point kinetic energy
+                                   currentTrack.globalTime,                     // global time
+                                   currentTrack.localTime,                      // local time
+                                   currentTrack.preStepGlobalTime,              // preStep global time
+                                   currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                   false,                                       // parent continues on CPU
+                                   currentTrack.stepCounter,                    // stepcounter
+                                   nullptr,                                     // pointer to secondary init data
+                                   0);                                          // number of secondaries
           continue;
         }
       } else {
@@ -284,17 +306,11 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
     bool enterWDTRegion = false;
 
     // Write local variables back into track and enqueue
-    auto survive = [&](LeakStatus leakReason = LeakStatus::NoLeak) {
-      currentTrack.leakStatus = leakReason;
-      if (leakReason != LeakStatus::NoLeak) {
-        // Copy track at slot to the leaked tracks
-        particleManager.gammas.CopyTrackToLeaked(slot);
+    auto survive = [&]() {
+      if (!enterWDTRegion) {
+        particleManager.gammas.EnqueueNext(slot);
       } else {
-        if (!enterWDTRegion) {
-          particleManager.gammas.EnqueueNext(slot);
-        } else {
-          particleManager.gammasWDT.EnqueueNext(slot);
-        }
+        particleManager.gammasWDT.EnqueueNext(slot);
       }
     };
 
@@ -321,7 +337,7 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
       if (returnAllSteps)
         adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
                                  currentTrack.parentId,                       // parent Track ID
-                                 static_cast<short>(10),                      // step defining process ID
+                                 kAdePTTransportationProcess,                 // step defining process ID
                                  ParticleType::Gamma,                         // Particle type
                                  theTrack->GetGStepLength(),                  // Step length
                                  0,                                           // Total Edep
@@ -368,7 +384,30 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
         // To be safe, just push a bit the track exiting the GPU region to make sure
         // Geant4 does not relocate it again inside the same region
         currentTrack.pos += kPushDistance * currentTrack.dir;
-        survive(LeakStatus::OutOfGPURegion);
+        slotManager.MarkSlotForFreeing(slot);
+        adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
+                                 currentTrack.parentId,                       // parent Track ID
+                                 kAdePTOutOfGPURegionProcess,                 // step defining process ID
+                                 ParticleType::Gamma,                         // Particle type
+                                 theTrack->GetGStepLength(),                  // Step length
+                                 0,                                           // Total Edep
+                                 currentTrack.weight,                         // Track weight
+                                 currentTrack.navState,                       // Pre-step point navstate
+                                 currentTrack.preStepPos,                     // Pre-step point position
+                                 currentTrack.preStepDir,                     // Pre-step point momentum direction
+                                 currentTrack.preStepEKin,                    // Pre-step point kinetic energy
+                                 currentTrack.nextState,                      // Post-step point navstate
+                                 currentTrack.pos,                            // Post-step point position
+                                 currentTrack.dir,                            // Post-step point momentum direction
+                                 currentTrack.eKin,                           // Post-step point kinetic energy
+                                 currentTrack.globalTime,                     // global time
+                                 currentTrack.localTime,                      // local time
+                                 currentTrack.preStepGlobalTime,              // preStep global time
+                                 currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                 false,                                       // parent continues on CPU
+                                 currentTrack.stepCounter,                    // stepcounter
+                                 nullptr,                                     // pointer to secondary init data
+                                 0);                                          // number of secondaries
       }
     } else {
       // release slot for particle that has left the world
@@ -379,7 +418,7 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
         adept_scoring::RecordHit(
             currentTrack.trackId,                        // Track ID
             currentTrack.parentId,                       // parent Track ID
-            static_cast<short>(10),                      // step defining process ID
+            kAdePTTransportationProcess,                 // step defining process ID
             ParticleType::Gamma,                         // Particle type
             theTrack->GetGStepLength(),                  // Step length
             0,                                           // Total Edep

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -121,6 +121,7 @@ __global__ void GammaHowFar(G4HepEmGammaTrack *hepEMTracks, ParticleManager part
                                    currentTrack.eKin,                           // Post-step point kinetic energy
                                    currentTrack.globalTime,                     // global time
                                    currentTrack.localTime,                      // local time
+                                   currentTrack.properTime,                     // proper time
                                    currentTrack.preStepGlobalTime,              // preStep global time
                                    currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                    false,                                       // parent continues on CPU
@@ -152,6 +153,7 @@ __global__ void GammaHowFar(G4HepEmGammaTrack *hepEMTracks, ParticleManager part
                                    currentTrack.eKin,                           // Post-step point kinetic energy
                                    currentTrack.globalTime,                     // global time
                                    currentTrack.localTime,                      // local time
+                                   currentTrack.properTime,                     // proper time
                                    currentTrack.preStepGlobalTime,              // preStep global time
                                    currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                    true,                                        // whether this was the last step
@@ -281,6 +283,7 @@ __global__ void GammaSetupInteractions(G4HepEmGammaTrack *hepEMTracks, const ade
                                  currentTrack.eKin,                           // Post-step point kinetic energy
                                  currentTrack.globalTime,                     // global time
                                  currentTrack.localTime,                      // local time
+                                 currentTrack.properTime,                     // proper time
                                  currentTrack.preStepGlobalTime,              // preStep global time
                                  currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                  true,                                        // gamma nuclear kills the parent
@@ -363,6 +366,7 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
                                  currentTrack.eKin,                           // Post-step point kinetic energy
                                  currentTrack.globalTime,                     // global time
                                  currentTrack.localTime,                      // local time
+                                 currentTrack.properTime,                     // proper time
                                  currentTrack.preStepGlobalTime,              // preStep global time
                                  currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                  false,                    // whether this is the last step of the track
@@ -415,6 +419,7 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
             currentTrack.eKin,                           // Post-step point kinetic energy
             currentTrack.globalTime,                     // global time
             currentTrack.localTime,                      // local time
+            currentTrack.properTime,                     // proper time
             currentTrack.preStepGlobalTime,              // preStep global time
             currentTrack.eventId, currentTrack.threadId, // event and thread ID
             true, // whether this is the last step of the track: true, as particle has left the world
@@ -545,6 +550,7 @@ __global__ void GammaConversion(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
           0.,                                          // Post-step point kinetic energy (0 after conversion)
           currentTrack.globalTime,                     // global time
           currentTrack.localTime,                      // local time
+          currentTrack.properTime,                     // proper time
           currentTrack.preStepGlobalTime,              // preStep global time
           currentTrack.eventId, currentTrack.threadId, // event and thread ID
           true, // whether this is the last step of the track: always true as gammas undergoing conversion are killed
@@ -672,6 +678,7 @@ __global__ void GammaCompton(G4HepEmGammaTrack *hepEMTracks, ParticleManager par
                                newEnergyGamma,                              // Post-step point kinetic energy
                                currentTrack.globalTime,                     // global time
                                currentTrack.localTime,                      // local time
+                               currentTrack.properTime,                     // proper time
                                currentTrack.preStepGlobalTime,              // preStep global time
                                currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                !trackSurvives,           // whether this is the last step of the track
@@ -773,6 +780,7 @@ __global__ void GammaPhotoelectric(G4HepEmGammaTrack *hepEMTracks, ParticleManag
                                0.,                             // Post-step point kinetic energy (0 after photoelectric)
                                currentTrack.globalTime,        // global time
                                currentTrack.localTime,         // local time
+                               currentTrack.properTime,        // proper time
                                currentTrack.preStepGlobalTime, // preStep global time
                                currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                true, // whether this is the last step of the track: always true as gammas undergoing the

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -304,6 +304,7 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
 
     int lvolID          = currentTrack.navState.GetLogicalId();
     bool enterWDTRegion = false;
+    bool returnsToCPU   = false;
 
     // Write local variables back into track and enqueue
     auto survive = [&]() {
@@ -332,9 +333,13 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
       AdePTNavigator::RelocateToNextVolume(currentTrack.pos, currentTrack.dir, currentTrack.nextState);
 #endif
 
-      // if all steps are returned, we need to record the hit here,
-      // as now the nextState is defined, but the navState is not yet replaced
-      if (returnAllSteps)
+      const int nextlvolID          = currentTrack.nextState.GetLogicalId();
+      VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];
+      returnsToCPU                  = nextauxData.fGPUregionId < 0;
+
+      // If all steps are returned, record the transported step here once. A
+      // step leaving the GPU region is returned below with the handoff process.
+      if (returnAllSteps && !returnsToCPU)
         adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
                                  currentTrack.parentId,                       // parent Track ID
                                  kAdePTTransportationProcess,                 // step defining process ID
@@ -359,13 +364,10 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
                                  nullptr,                  // pointer to secondary init data
                                  0);                       // number of secondaries
 
-      // Move to the next boundary.
-      currentTrack.navState = currentTrack.nextState;
-      // printf("  -> pvol=%d pos={%g, %g, %g} \n", navState.TopId(), pos[0], pos[1], pos[2]);
-      //  Check if the next volume belongs to the GPU region and push it to the appropriate queue
-      const int nextlvolID          = currentTrack.nextState.GetLogicalId();
-      VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];
-      if (nextauxData.fGPUregionId >= 0) {
+      // Check if the next volume belongs to the GPU region and push it to the appropriate queue.
+      if (!returnsToCPU) {
+        // Move to the next boundary after recording the transported step.
+        currentTrack.navState = currentTrack.nextState;
 
         // Check whether next region is a Woodcock tracking region
         const adeptint::WDTDeviceView &view = gWDTData;

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -337,12 +337,18 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
       VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];
       returnsToCPU                  = nextauxData.fGPUregionId < 0;
 
-      // If all steps are returned, record the transported step here once. A
-      // step leaving the GPU region is returned below with the handoff process.
-      if (returnAllSteps && !returnsToCPU)
+      short stepProcessId = kAdePTTransportationProcess;
+      if (returnsToCPU) {
+        // Push the handoff point a little into the CPU region so Geant4 does
+        // not relocate the track back into the same GPU region.
+        currentTrack.pos += kPushDistance * currentTrack.dir;
+        stepProcessId = kAdePTOutOfGPURegionProcess;
+      }
+
+      if (returnAllSteps || returnsToCPU)
         adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
                                  currentTrack.parentId,                       // parent Track ID
-                                 kAdePTTransportationProcess,                 // step defining process ID
+                                 stepProcessId,                               // step defining process ID
                                  ParticleType::Gamma,                         // Particle type
                                  theTrack->GetGStepLength(),                  // Step length
                                  0,                                           // Total Edep
@@ -383,33 +389,7 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
         theTrack->SetMCIndex(nextauxData.fMCIndex);
         survive();
       } else {
-        // To be safe, just push a bit the track exiting the GPU region to make sure
-        // Geant4 does not relocate it again inside the same region
-        currentTrack.pos += kPushDistance * currentTrack.dir;
         slotManager.MarkSlotForFreeing(slot);
-        adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
-                                 currentTrack.parentId,                       // parent Track ID
-                                 kAdePTOutOfGPURegionProcess,                 // step defining process ID
-                                 ParticleType::Gamma,                         // Particle type
-                                 theTrack->GetGStepLength(),                  // Step length
-                                 0,                                           // Total Edep
-                                 currentTrack.weight,                         // Track weight
-                                 currentTrack.navState,                       // Pre-step point navstate
-                                 currentTrack.preStepPos,                     // Pre-step point position
-                                 currentTrack.preStepDir,                     // Pre-step point momentum direction
-                                 currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                                 currentTrack.nextState,                      // Post-step point navstate
-                                 currentTrack.pos,                            // Post-step point position
-                                 currentTrack.dir,                            // Post-step point momentum direction
-                                 currentTrack.eKin,                           // Post-step point kinetic energy
-                                 currentTrack.globalTime,                     // global time
-                                 currentTrack.localTime,                      // local time
-                                 currentTrack.preStepGlobalTime,              // preStep global time
-                                 currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                                 false,                                       // parent continues on CPU
-                                 currentTrack.stepCounter,                    // stepcounter
-                                 nullptr,                                     // pointer to secondary init data
-                                 0);                                          // number of secondaries
       }
     } else {
       // release slot for particle that has left the world

--- a/src/AdePTConfigurationMessenger.cc
+++ b/src/AdePTConfigurationMessenger.cc
@@ -38,10 +38,6 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
   fSetMillionsOfTrackSlotsCmd->SetGuidance(
       "Set the total number of track slots that will be allocated on the GPU, in millions");
 
-  fSetMillionsOfLeakSlotsCmd = std::make_unique<G4UIcmdWithADouble>("/adept/setMillionsOfLeakSlots", this);
-  fSetMillionsOfLeakSlotsCmd->SetGuidance(
-      "Set the total number of leak slots that will be allocated on the GPU, in millions");
-
   fSetMillionsOfHitSlotsCmd = std::make_unique<G4UIcmdWithADouble>("/adept/setMillionsOfHitSlots", this);
   fSetMillionsOfHitSlotsCmd->SetGuidance(
       "Set the total number of hit slots that will be allocated on the GPU, in millions");
@@ -172,8 +168,6 @@ void AdePTConfigurationMessenger::SetNewValue(G4UIcommand *command, G4String new
     fAdePTConfiguration->SetVerbosity(fSetVerbosityCmd->GetNewIntValue(newValue));
   } else if (command == fSetMillionsOfTrackSlotsCmd.get()) {
     fAdePTConfiguration->SetMillionsOfTrackSlots(fSetMillionsOfTrackSlotsCmd->GetNewDoubleValue(newValue));
-  } else if (command == fSetMillionsOfLeakSlotsCmd.get()) {
-    fAdePTConfiguration->SetMillionsOfLeakSlots(fSetMillionsOfLeakSlotsCmd->GetNewDoubleValue(newValue));
   } else if (command == fSetMillionsOfHitSlotsCmd.get()) {
     fAdePTConfiguration->SetMillionsOfHitSlots(fSetMillionsOfHitSlotsCmd->GetNewDoubleValue(newValue));
   } else if (command == fSetHitBufferFlushThresholdCmd.get()) {

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -520,6 +520,10 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
         nuclearReactionTrack->SetLogicalVolumeAtVertex(parentTDataAfterSecondaries.logicalVolumeAtVertex);
         const_cast<G4DynamicParticle *>(nuclearReactionTrack->GetDynamicParticle())
             ->SetPrimaryParticle(parentTDataAfterSecondaries.primary);
+#ifdef ADEPT_USE_ORIGINNAVSTATE
+        nuclearReactionTrack->SetOriginTouchableHandle(
+            MakeTouchableFromNavState(parentTDataAfterSecondaries.originNavState));
+#endif
       }
       if (const auto postVolume = (*fScoringObjects->fPostG4TouchableHistoryHandle)->GetVolume();
           postVolume != nullptr) {
@@ -552,37 +556,16 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
                                         isLeptonNuclearStep);
 
       if (isLeptonNuclearStep) {
+        // lepton nuclear: track survives and must be handed back to G4
         returnedParentTrack = nuclearReactionTrack;
-        if (actions) {
-          returnedParentTrack->SetTrackID(parentTDataAfterSecondaries.g4id);
-          returnedParentTrack->SetParentID(parentTDataAfterSecondaries.g4parentid);
-          returnedParentTrack->SetCreatorProcess(parentTDataAfterSecondaries.creatorProcess);
-          returnedParentTrack->SetUserInformation(parentTDataAfterSecondaries.userTrackInfo);
-          returnedParentTrack->SetVertexPosition(parentTDataAfterSecondaries.vertexPosition);
-          returnedParentTrack->SetVertexMomentumDirection(parentTDataAfterSecondaries.vertexMomentumDirection);
-          returnedParentTrack->SetVertexKineticEnergy(parentTDataAfterSecondaries.vertexKineticEnergy);
-          returnedParentTrack->SetLogicalVolumeAtVertex(parentTDataAfterSecondaries.logicalVolumeAtVertex);
-          const_cast<G4DynamicParticle *>(returnedParentTrack->GetDynamicParticle())
-              ->SetPrimaryParticle(parentTDataAfterSecondaries.primary);
-        }
-        if (postTouchable) {
-          returnedParentTrack->SetTouchableHandle(postTouchable);
-          returnedParentTrack->SetNextTouchableHandle(postTouchable);
-        }
-#ifdef ADEPT_USE_ORIGINNAVSTATE
-        if (actions) {
-          returnedParentTrack->SetOriginTouchableHandle(
-              MakeTouchableFromNavState(parentTDataAfterSecondaries.originNavState));
-        }
-#endif
-      }
-
-      if (!isLeptonNuclearStep) {
+      } else {
+        // gamma nuclear: track stops with the interaction, thus delete UserTrackData and track
         nuclearReactionTrack->SetUserInformation(nullptr);
         delete nuclearStep;
         delete nuclearReactionTrack;
       }
     } else {
+      // No nuclear processes attached
       // Fallback only for the case without an attached Geant4 nuclear process:
       // there is then no temporary nuclear-replay track that can be continued
       // on the CPU, so we create a separate heap-owned track for the stack.

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -189,10 +189,7 @@ void AdePTGeant4Integration::QueueDeferredStep(std::span<const GPUHit> gpuSteps)
 
   fHostTrackDataMapper->SetPendingReturnedStep(gpuSteps.front().fTrackID, true);
 
-  // Keep the returned GPU-hit block together with the ordering key used when
-  // merging deferred returned steps with the other returned work on the host.
   DeferredStep deferred;
-  deferred.returnedTrack = MakeReturnedTrackFromGPUHit(gpuSteps.front());
   deferred.hits.assign(gpuSteps.begin(), gpuSteps.end());
   fDeferredSteps.push_back(std::move(deferred));
 }
@@ -204,35 +201,6 @@ std::vector<AdePTGeant4Integration::DeferredStep> AdePTGeant4Integration::TakeDe
   std::vector<DeferredStep> deferred;
   deferred.swap(fDeferredSteps);
   return deferred;
-}
-
-adeptint::TrackData AdePTGeant4Integration::MakeReturnedTrackFromGPUHit(GPUHit const &gpuHit) const
-{
-  adeptint::TrackData returnedTrack;
-
-  switch (gpuHit.fParticleType) {
-  case ParticleType::Electron:
-    returnedTrack.pdg = 11;
-    break;
-  case ParticleType::Positron:
-    returnedTrack.pdg = -11;
-    break;
-  case ParticleType::Gamma:
-    returnedTrack.pdg = 22;
-    break;
-  default:
-    throw std::runtime_error("Unknown particle type in MakeReturnedTrackFromGPUHit");
-  }
-
-  returnedTrack.eKin         = gpuHit.fPostStepPoint.fEKin;
-  returnedTrack.position[0]  = gpuHit.fPostStepPoint.fPosition.x();
-  returnedTrack.position[1]  = gpuHit.fPostStepPoint.fPosition.y();
-  returnedTrack.position[2]  = gpuHit.fPostStepPoint.fPosition.z();
-  returnedTrack.direction[0] = gpuHit.fPostStepPoint.fMomentumDirection.x();
-  returnedTrack.direction[1] = gpuHit.fPostStepPoint.fMomentumDirection.y();
-  returnedTrack.direction[2] = gpuHit.fPostStepPoint.fMomentumDirection.z();
-
-  return returnedTrack;
 }
 
 G4Track *AdePTGeant4Integration::MakeTrackForCPUStacking(const G4Track &track) const

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -286,13 +286,8 @@ G4Track *AdePTGeant4Integration::MakeReturnedTrackFromStep(GPUHit const &parentS
   track->IncrementCurrentStepNumber();
   track->SetTrackID(hostTData.g4id);
   track->SetParentID(hostTData.g4parentid);
-  // Match the historical leak-track handoff semantics for tracks that return
-  // to CPU transport: old ReturnTrack() copied times from the live device
-  // TrackData, which had already been quantized through the float-valued GPU
-  // Track state. The returned-step path otherwise preserves the higher
-  // precision GPUHit payload and shows tiny regions-only timing drift.
-  track->SetLocalTime(static_cast<float>(parentStep.fLocalTime));
-  track->SetProperTime(static_cast<float>(parentStep.fProperTime));
+  track->SetLocalTime(parentStep.fLocalTime);
+  track->SetProperTime(parentStep.fProperTime);
   track->SetWeight(parentStep.fTrackWeight);
   track->SetCreatorProcess(hostTData.creatorProcess);
   track->SetVertexPosition(hostTData.vertexPosition);
@@ -795,9 +790,7 @@ void AdePTGeant4Integration::FillG4Track(GPUHit const *aGPUHit, G4Track *aTrack,
   aTrack->SetPosition(aPostStepPointPosition); // Real data
   aTrack->SetGlobalTime(aGPUHit->fGlobalTime); // Real data
   aTrack->SetLocalTime(aGPUHit->fLocalTime);   // Real data
-  // Keep returned CPU-continuation tracks seeded with proper time, but match
-  // the old GPU-step replay semantics here: the transient G4Track used for
-  // callbacks did not carry proper time in fix_handling_of_nuclearreturns.
+  aTrack->SetProperTime(aGPUHit->fProperTime); // Real data
   if (const auto preVolume = aPreG4TouchableHandle->GetVolume();
       preVolume != nullptr) {                          // protect against nullptr if NavState is outside
     aTrack->SetTouchableHandle(aPreG4TouchableHandle); // Real data
@@ -914,6 +907,7 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step, 
   aPostStepPoint->SetPosition(aPostStepPointPosition);                   // Real data
   aPostStepPoint->SetLocalTime(aGPUHit->fLocalTime);                     // Real data
   aPostStepPoint->SetGlobalTime(aGPUHit->fGlobalTime);                   // Real data
+  aPostStepPoint->SetProperTime(aGPUHit->fProperTime);                   // Real data
   aPostStepPoint->SetMomentumDirection(aPostStepPointMomentumDirection); // Real data
   aPostStepPoint->SetKineticEnergy(aGPUHit->fPostStepPoint.fEKin);       // Real data
   // aPostStepPoint->SetVelocity(0);                                                                  // Missing data

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -183,26 +183,26 @@ void MergeNuclearReplayIntoVisibleStep(const G4Track &scratchTrack, const G4Step
 
 AdePTGeant4Integration::~AdePTGeant4Integration() {}
 
-void AdePTGeant4Integration::QueueDeferredNuclearStep(std::span<const GPUHit> gpuSteps)
+void AdePTGeant4Integration::QueueDeferredStep(std::span<const GPUHit> gpuSteps)
 {
   if (gpuSteps.empty()) return;
 
-  fHostTrackDataMapper->SetPendingNuclearReaction(gpuSteps.front().fTrackID, true);
+  fHostTrackDataMapper->SetPendingReturnedStep(gpuSteps.front().fTrackID, true);
 
   // Keep the returned GPU-hit block together with the ordering key that
   // places it in the same return order as an ordinary leaked track.
-  DeferredNuclearStep deferred;
+  DeferredStep deferred;
   deferred.returnedTrack = MakeReturnedTrackFromGPUHit(gpuSteps.front());
   deferred.hits.assign(gpuSteps.begin(), gpuSteps.end());
-  fDeferredNuclearSteps.push_back(std::move(deferred));
+  fDeferredSteps.push_back(std::move(deferred));
 }
 
-std::vector<AdePTGeant4Integration::DeferredNuclearStep> AdePTGeant4Integration::TakeDeferredNuclearSteps()
+std::vector<AdePTGeant4Integration::DeferredStep> AdePTGeant4Integration::TakeDeferredSteps()
 {
   // Swap with an empty vector so ownership of the queued work moves out
   // without copying the stored GPU-hit payloads.
-  std::vector<DeferredNuclearStep> deferred;
-  deferred.swap(fDeferredNuclearSteps);
+  std::vector<DeferredStep> deferred;
+  deferred.swap(fDeferredSteps);
   return deferred;
 }
 
@@ -265,6 +265,48 @@ G4Track *AdePTGeant4Integration::MakeTrackForCPUStacking(const G4Track &track) c
   return clone;
 }
 
+G4Track *AdePTGeant4Integration::MakeReturnedTrackFromStep(GPUHit const &parentStep, const HostTrackData &hostTData,
+                                                           bool setStopButAlive) const
+{
+  constexpr double tolerance = 10. * vecgeom::kTolerance;
+
+  G4ThreeVector direction(parentStep.fPostStepPoint.fMomentumDirection.x(),
+                          parentStep.fPostStepPoint.fMomentumDirection.y(),
+                          parentStep.fPostStepPoint.fMomentumDirection.z());
+  G4ThreeVector position(parentStep.fPostStepPoint.fPosition.x(), parentStep.fPostStepPoint.fPosition.y(),
+                         parentStep.fPostStepPoint.fPosition.z());
+  position += tolerance * direction;
+
+  auto *dynamic = new G4DynamicParticle(fScoringObjects->fG4Step->GetTrack()->GetParticleDefinition(), direction,
+                                        parentStep.fPostStepPoint.fEKin);
+  dynamic->SetPrimaryParticle(hostTData.primary);
+
+  auto *track = new G4Track(dynamic, parentStep.fGlobalTime, position);
+  track->IncrementCurrentStepNumber();
+  track->SetTrackID(hostTData.g4id);
+  track->SetParentID(hostTData.g4parentid);
+  track->SetLocalTime(parentStep.fLocalTime);
+  track->SetWeight(parentStep.fTrackWeight);
+  track->SetCreatorProcess(hostTData.creatorProcess);
+  track->SetVertexPosition(hostTData.vertexPosition);
+  track->SetVertexMomentumDirection(hostTData.vertexMomentumDirection);
+  track->SetVertexKineticEnergy(hostTData.vertexKineticEnergy);
+  track->SetLogicalVolumeAtVertex(hostTData.logicalVolumeAtVertex);
+  if (!parentStep.fPostStepPoint.fNavigationState.IsOutside()) {
+    auto touchable = MakeTouchableFromNavState(parentStep.fPostStepPoint.fNavigationState);
+    track->SetTouchableHandle(touchable);
+    track->SetNextTouchableHandle(touchable);
+  }
+#ifdef ADEPT_USE_ORIGINNAVSTATE
+  if (hostTData.g4id != 0) {
+    track->SetOriginTouchableHandle(MakeTouchableFromNavState(hostTData.originNavState));
+  }
+#endif
+  track->SetUserInformation(hostTData.userTrackInfo);
+  if (setStopButAlive) track->SetTrackStatus(fStopButAlive);
+  return track;
+}
+
 G4Track *AdePTGeant4Integration::ConstructSecondaryTrackInPlace(GPUHit const *secHit) const
 {
   auto &so = *fScoringObjects;
@@ -295,7 +337,6 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
   // FIXME: to be removed, as it is not needed with the direct VecGeom to G4 NavState.
   // needed here only temporarily to match exactly the behavior of returning nuclear interaction steps as tracks
   constexpr double tolerance = 10. * vecgeom::kTolerance;
-
   if (!fScoringObjects) {
     fScoringObjects.reset(new AdePTGeant4Integration_detail::ScoringObjects());
   }
@@ -365,9 +406,12 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
   const bool isLeptonNuclearStep =
       (parentStep.fParticleType == ParticleType::Electron || parentStep.fParticleType == ParticleType::Positron) &&
       parentStep.fStepLimProcessId == 3;
-  const bool isNuclearStep  = isGammaNuclearStep || isLeptonNuclearStep;
-  bool parentContinuesOnCPU = false;
-  G4Track *continuedParent  = nullptr;
+  const bool isOutOfGPURegionStep = parentStep.fStepLimProcessId == kAdePTOutOfGPURegionProcess;
+  const bool isFinishOnCPUStep    = parentStep.fStepLimProcessId == kAdePTFinishOnCPUProcess;
+  const bool isNuclearStep        = isGammaNuclearStep || isLeptonNuclearStep;
+  const bool isDeferredStep       = isNuclearStep || isOutOfGPURegionStep || isFinishOnCPUStep;
+  bool parentContinuesOnCPU       = false;
+  G4Track *continuedParent        = nullptr;
   G4TrackVector hadronicSecondaries;
 
   HostTrackData dummy; // default constructed dummy if no advanced information is available
@@ -543,6 +587,9 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
       continuedParent      = MakeTrackForCPUStacking(*fScoringObjects->fG4Step->GetTrack());
       parentContinuesOnCPU = true;
     }
+  } else if (isOutOfGPURegionStep || isFinishOnCPUStep) {
+    continuedParent      = MakeReturnedTrackFromStep(parentStep, parentTData, /*setStopButAlive=*/isFinishOnCPUStep);
+    parentContinuesOnCPU = true;
   }
 
   // Now, the G4Step is fully initialized and also contains the secondaries created in that step.
@@ -593,7 +640,7 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
     }
   }
 
-  if (isNuclearStep) {
+  if (isDeferredStep) {
     if (!hadronicSecondaries.empty()) {
       G4EventManager::GetEventManager()->StackTracks(&hadronicSecondaries);
     }
@@ -605,10 +652,10 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
 
   // If this was the last step of a track, the hostTrackData of that track can be safely deleted.
   // Note: This deletes the AdePT-owned UserTrackInfo data
-  if (isNuclearStep) {
+  if (isDeferredStep) {
     auto *parentTrack = fScoringObjects->fG4Step->GetTrack();
     parentTrack->SetUserInformation(nullptr);
-    fHostTrackDataMapper->FinalizePendingNuclearReaction(parentStep.fTrackID, parentContinuesOnCPU);
+    fHostTrackDataMapper->FinalizePendingReturnedStep(parentStep.fTrackID, parentContinuesOnCPU);
   } else if (parentStep.fLastStepOfTrack) {
     fScoringObjects->fG4Step->GetTrack()->SetUserInformation(nullptr);
     fHostTrackDataMapper->removeTrack(parentStep.fTrackID);
@@ -818,7 +865,8 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step, 
     const ParticleType ptype = hostTData.particleType;
 
     if (ptype == ParticleType::Electron || ptype == ParticleType::Positron) {
-      if (stepId == 10)
+      if (stepId == kAdePTTransportationProcess || stepId == kAdePTOutOfGPURegionProcess ||
+          stepId == kAdePTFinishOnCPUProcess)
         stepDefiningProcess = fHepEmTrackingManager->GetTransportNoProcess(); // set to transportation
       else if (stepId == -2)
         stepDefiningProcess = fHepEmTrackingManager->GetElectronNoProcessVector()[3]; // MSC
@@ -833,7 +881,8 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step, 
         stepDefiningProcess = fHepEmTrackingManager->GetElectronNoProcessVector()[stepId]; // discrete interactions
       }
     } else if (ptype == ParticleType::Gamma) {
-      stepDefiningProcess = (stepId == 10)
+      stepDefiningProcess = (stepId == kAdePTTransportationProcess || stepId == kAdePTOutOfGPURegionProcess ||
+                             stepId == kAdePTFinishOnCPUProcess)
                                 ? fHepEmTrackingManager->GetTransportNoProcess()            // transportation
                                 : fHepEmTrackingManager->GetGammaNoProcessVector()[stepId]; // discrete interactions
     }
@@ -888,112 +937,6 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step, 
   aPostStepPoint->SetCharge(aTrack->GetParticleDefinition()->GetPDGCharge()); // Real data
   // aPostStepPoint->SetMagneticMoment(0);                                                            // Missing data
   // aPostStepPoint->SetWeight(0);                                                                    // Missing data
-}
-
-void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex, int debugLevel,
-                                         bool callUserActions) const
-{
-  constexpr double tolerance = 10. * vecgeom::kTolerance;
-
-  // Build the secondaries and put them back on the Geant4 stack
-  if (debugLevel > 6) {
-    std::cout << "[" << GetThreadID() << "] fromDevice[ " << trackIndex << "]: pdg " << track.pdg << " parent id "
-              << track.parentId << " kinetic energy " << track.eKin << " position " << track.position[0] << " "
-              << track.position[1] << " " << track.position[2] << " direction " << track.direction[0] << " "
-              << track.direction[1] << " " << track.direction[2] << " global time, local time, proper time: "
-              << "(" << track.globalTime << ", " << track.localTime << ", " << track.properTime << ")" << " LeakStatus "
-              << static_cast<int>(track.leakStatus) << std::endl;
-  }
-  G4ParticleMomentum direction(track.direction[0], track.direction[1], track.direction[2]);
-
-  G4DynamicParticle *dynamic =
-      new G4DynamicParticle(G4ParticleTable::GetParticleTable()->FindParticle(track.pdg), direction, track.eKin);
-
-  G4ThreeVector posi(track.position[0], track.position[1], track.position[2]);
-  // The returned track will be located by Geant4. For now we need to
-  // push it to make sure it is not relocated again in the GPU region
-  posi += tolerance * direction;
-
-  if (track.stepCounter == 0) {
-    std::cerr << "\033[1;31mERROR: Leaked track with stepCounter == 0 detected, this should never be the case! "
-              << " (trackID = " << track.trackId << ", parentID = " << track.parentId << ") "
-              << " pdg " << track.pdg << " stepCounter " << track.stepCounter << "\033[0m" << std::endl;
-  }
-
-  HostTrackData dummy; // default constructed dummy if no advanced information is available
-
-  // Bind a reference *without* touching the mapper unless callUserActions==true
-  // When the userActions are enabled, the entry must exist
-  HostTrackData &hostTData = callUserActions ? fHostTrackDataMapper->get(track.trackId) : dummy;
-
-  dynamic->SetPrimaryParticle(hostTData.primary);
-
-  // Create track
-  G4Track *leakedTrack = new G4Track(dynamic, track.globalTime, posi);
-
-  // G4 does not allow to set the current step number directly, only to increment it.
-  // For now, it is sufficient to increment just once, to distinguish from the 0th step
-  leakedTrack->IncrementCurrentStepNumber();
-
-  leakedTrack->SetTrackID(hostTData.g4id);
-  leakedTrack->SetParentID(hostTData.g4parentid);
-
-  leakedTrack->SetUserInformation(hostTData.userTrackInfo);
-  leakedTrack->SetCreatorProcess(hostTData.creatorProcess);
-
-  // Set time information
-  leakedTrack->SetLocalTime(track.localTime);
-  leakedTrack->SetProperTime(track.properTime);
-
-  // Set weight
-  leakedTrack->SetWeight(track.weight);
-
-  // Set vertex information
-  leakedTrack->SetVertexPosition(hostTData.vertexPosition);
-  leakedTrack->SetVertexMomentumDirection(hostTData.vertexMomentumDirection);
-  leakedTrack->SetVertexKineticEnergy(hostTData.vertexKineticEnergy);
-  leakedTrack->SetLogicalVolumeAtVertex(hostTData.logicalVolumeAtVertex);
-#ifdef ADEPT_USE_ORIGINNAVSTATE
-  if (callUserActions) {
-    auto originTouchableHandle = MakeTouchableFromNavState(hostTData.originNavState);
-    leakedTrack->SetOriginTouchableHandle(originTouchableHandle);
-  }
-#endif
-
-  // ------ Handle leaked tracks according to their status, if not LeakStatus::OutOfGPURegion ---------
-
-  // sanity check
-  if (track.leakStatus == LeakStatus::NoLeak) throw std::runtime_error("Leaked track with status NoLeak detected!");
-
-  // We set the status of leaked tracks to fStopButAlive to be able to distinguish them to keep
-  // them on the CPU until they are done
-  if (track.leakStatus == LeakStatus::FinishEventOnCPU) {
-    // FIXME: previous approach was broken in sync AdePT, therefore it was removed
-    // to be fixed with a different approach e.g., negative track ID.
-    leakedTrack->SetTrackStatus(fStopButAlive);
-  }
-
-  // Set the Touchable and NextTouchable handle. This is always needed, as either
-  // gamma-/lepton-nuclear need it, or potentially any user stacking action, as this is called
-  // before the track is handed back to AdePT
-  auto TouchableHandle = MakeTouchableFromNavState(track.navState);
-  leakedTrack->SetTouchableHandle(TouchableHandle);
-  leakedTrack->SetNextTouchableHandle(TouchableHandle);
-
-  if (track.leakStatus == LeakStatus::GammaNuclear || track.leakStatus == LeakStatus::LeptonNuclear) {
-    throw std::runtime_error(
-        "Gamma/lepton nuclear should be reinjected from deferred GPU-hit processing, not from leaked tracks.");
-  } else {
-
-    // LeakStatus::OutOfGPURegion: just give track back to G4
-    G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(leakedTrack);
-
-    // The track is now handled on CPU. To reduce the map lookup time, the hostTrackData can be safely deleted because
-    // the leaks are guaranteed to be handled after the processing of steps. Only the g4idToGPUid mapping cannot be
-    // deleted as the GPU id needs to be the same for the reproducibility if the track returns to the GPU, as the
-    // trackID is used for seeding the rng
-    fHostTrackDataMapper->retireToCPU(track.trackId);
-  }
 }
 
 std::vector<float> AdePTGeant4Integration::GetUniformField() const

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -189,8 +189,8 @@ void AdePTGeant4Integration::QueueDeferredStep(std::span<const GPUHit> gpuSteps)
 
   fHostTrackDataMapper->SetPendingReturnedStep(gpuSteps.front().fTrackID, true);
 
-  // Keep the returned GPU-hit block together with the ordering key that
-  // places it in the same return order as an ordinary leaked track.
+  // Keep the returned GPU-hit block together with the ordering key used when
+  // merging deferred returned steps with the other returned work on the host.
   DeferredStep deferred;
   deferred.returnedTrack = MakeReturnedTrackFromGPUHit(gpuSteps.front());
   deferred.hits.assign(gpuSteps.begin(), gpuSteps.end());

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -190,16 +190,17 @@ void AdePTGeant4Integration::QueueDeferredStep(std::span<const GPUHit> gpuSteps)
   fHostTrackDataMapper->SetPendingReturnedStep(gpuSteps.front().fTrackID, true);
 
   DeferredStep deferred;
-  deferred.hits.assign(gpuSteps.begin(), gpuSteps.end());
-  fDeferredSteps.push_back(std::move(deferred));
+  deferred.firstHit = fDeferredHits.size();
+  deferred.numHits  = gpuSteps.size();
+  fDeferredHits.insert(fDeferredHits.end(), gpuSteps.begin(), gpuSteps.end());
+  fDeferredSteps.push_back(deferred);
 }
 
-std::vector<AdePTGeant4Integration::DeferredStep> AdePTGeant4Integration::TakeDeferredSteps()
+AdePTGeant4Integration::DeferredStepStore AdePTGeant4Integration::TakeDeferredSteps()
 {
-  // Swap with an empty vector so ownership of the queued work moves out
-  // without copying the stored GPU-hit payloads.
-  std::vector<DeferredStep> deferred;
-  deferred.swap(fDeferredSteps);
+  DeferredStepStore deferred;
+  deferred.hits.swap(fDeferredHits);
+  deferred.steps.swap(fDeferredSteps);
   return deferred;
 }
 
@@ -350,22 +351,6 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
     postStepStatus = G4StepStatus::fWorldBoundary;
   }
 
-  // Reconstruct G4Step
-  switch (parentStep.fParticleType) {
-  case ParticleType::Electron:
-    fScoringObjects->fG4Step->SetTrack(fScoringObjects->fElectronTrack);
-    break;
-  case ParticleType::Positron:
-    fScoringObjects->fG4Step->SetTrack(fScoringObjects->fPositronTrack);
-    break;
-  case ParticleType::Gamma:
-    fScoringObjects->fG4Step->SetTrack(fScoringObjects->fGammaTrack);
-    break;
-  default:
-    std::cerr << "Error: unknown particle type " << static_cast<int>(parentStep.fParticleType) << "\n";
-    std::abort();
-  }
-
   // For all steps, the HostTrackData Mapper must already exist:
   // - for particles created on CPU, it was created in the AdePTTrackingManager when offloading to GPU,
   // - for particles createdon GPU, it was created in InitSecondaryHostTrackDataFromParent below
@@ -391,6 +376,21 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
   HostTrackData &parentTData = actions ? fHostTrackDataMapper->get(parentStep.fTrackID) : dummy;
 
   // Fill the G4Step, fill the G4Track, and intertwine them
+  switch (parentStep.fParticleType) {
+  case ParticleType::Electron:
+    fScoringObjects->fG4Step->SetTrack(fScoringObjects->fElectronTrack);
+    break;
+  case ParticleType::Positron:
+    fScoringObjects->fG4Step->SetTrack(fScoringObjects->fPositronTrack);
+    break;
+  case ParticleType::Gamma:
+    fScoringObjects->fG4Step->SetTrack(fScoringObjects->fGammaTrack);
+    break;
+  default:
+    std::cerr << "Error: unknown particle type " << static_cast<int>(parentStep.fParticleType) << "\n";
+    std::abort();
+  }
+
   FillG4Step(&parentStep, fScoringObjects->fG4Step, parentTData, *fScoringObjects->fPreG4TouchableHistoryHandle,
              *fScoringObjects->fPostG4TouchableHistoryHandle, preStepStatus, postStepStatus, callUserTrackingAction,
              callUserSteppingAction);

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -202,8 +202,6 @@ void AdePTGeant4Integration::QueueDeferredStep(std::span<const GPUHit> gpuSteps,
 {
   if (gpuSteps.empty()) return;
 
-  fHostTrackDataMapper->SetPendingReturnedStep(gpuSteps.front().fTrackID, true);
-
   DeferredStep deferred;
   deferred.firstHit = fDeferredHits.size();
   deferred.numHits  = gpuSteps.size();
@@ -235,7 +233,7 @@ void AdePTGeant4Integration::ReturnDeferredTrack(std::span<const GPUHit> gpuStep
   auto *returnedParentTrack = MakeReturnedTrackFromStep(
       parentStep, parentTData, /*setStopButAlive=*/parentStep.fStepLimProcessId == kAdePTFinishOnCPUProcess);
   G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(returnedParentTrack);
-  fHostTrackDataMapper->FinalizePendingReturnedStep(parentStep.fTrackID, /*returnTrackToG4=*/true);
+  fHostTrackDataMapper->retireToCPU(parentStep.fTrackID);
 }
 
 G4Track *AdePTGeant4Integration::MakeTrackForCPUStacking(const G4Track &track) const
@@ -288,7 +286,13 @@ G4Track *AdePTGeant4Integration::MakeReturnedTrackFromStep(GPUHit const &parentS
   track->IncrementCurrentStepNumber();
   track->SetTrackID(hostTData.g4id);
   track->SetParentID(hostTData.g4parentid);
-  track->SetLocalTime(parentStep.fLocalTime);
+  // Match the historical leak-track handoff semantics for tracks that return
+  // to CPU transport: old ReturnTrack() copied times from the live device
+  // TrackData, which had already been quantized through the float-valued GPU
+  // Track state. The returned-step path otherwise preserves the higher
+  // precision GPUHit payload and shows tiny regions-only timing drift.
+  track->SetLocalTime(static_cast<float>(parentStep.fLocalTime));
+  track->SetProperTime(static_cast<float>(parentStep.fProperTime));
   track->SetWeight(parentStep.fTrackWeight);
   track->SetCreatorProcess(hostTData.creatorProcess);
   track->SetVertexPosition(hostTData.vertexPosition);
@@ -507,6 +511,7 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
       auto *nuclearReactionTrack = new G4Track(dynamic, parentStep.fGlobalTime, position);
       nuclearReactionTrack->IncrementCurrentStepNumber();
       nuclearReactionTrack->SetLocalTime(parentStep.fLocalTime);
+      nuclearReactionTrack->SetProperTime(parentStep.fProperTime);
       nuclearReactionTrack->SetWeight(parentStep.fTrackWeight);
       G4TouchableHandle postTouchable;
       if (actions) {
@@ -640,7 +645,11 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
   if (isDeferredStep) {
     auto *parentTrack = fScoringObjects->fG4Step->GetTrack();
     parentTrack->SetUserInformation(nullptr);
-    fHostTrackDataMapper->FinalizePendingReturnedStep(parentStep.fTrackID, returnParentTrackToG4);
+    if (returnParentTrackToG4) {
+      fHostTrackDataMapper->retireToCPU(parentStep.fTrackID);
+    } else {
+      fHostTrackDataMapper->removeTrack(parentStep.fTrackID);
+    }
   } else if (parentStep.fLastStepOfTrack) {
     fScoringObjects->fG4Step->GetTrack()->SetUserInformation(nullptr);
     fHostTrackDataMapper->removeTrack(parentStep.fTrackID);
@@ -786,7 +795,9 @@ void AdePTGeant4Integration::FillG4Track(GPUHit const *aGPUHit, G4Track *aTrack,
   aTrack->SetPosition(aPostStepPointPosition); // Real data
   aTrack->SetGlobalTime(aGPUHit->fGlobalTime); // Real data
   aTrack->SetLocalTime(aGPUHit->fLocalTime);   // Real data
-  // aTrack->SetProperTime(0);                                                                // Missing data
+  // Keep returned CPU-continuation tracks seeded with proper time, but match
+  // the old GPU-step replay semantics here: the transient G4Track used for
+  // callbacks did not carry proper time in fix_handling_of_nuclearreturns.
   if (const auto preVolume = aPreG4TouchableHandle->GetVolume();
       preVolume != nullptr) {                          // protect against nullptr if NavState is outside
     aTrack->SetTouchableHandle(aPreG4TouchableHandle); // Real data
@@ -900,10 +911,9 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step, 
 
   // Post-Step Point
   G4StepPoint *aPostStepPoint = aG4Step->GetPostStepPoint();
-  aPostStepPoint->SetPosition(aPostStepPointPosition); // Real data
-  aPostStepPoint->SetLocalTime(aGPUHit->fLocalTime);   // Real data
-  aPostStepPoint->SetGlobalTime(aGPUHit->fGlobalTime); // Real data
-  // aPostStepPoint->SetProperTime(0);                                                                // Missing data
+  aPostStepPoint->SetPosition(aPostStepPointPosition);                   // Real data
+  aPostStepPoint->SetLocalTime(aGPUHit->fLocalTime);                     // Real data
+  aPostStepPoint->SetGlobalTime(aGPUHit->fGlobalTime);                   // Real data
   aPostStepPoint->SetMomentumDirection(aPostStepPointMomentumDirection); // Real data
   aPostStepPoint->SetKineticEnergy(aGPUHit->fPostStepPoint.fEKin);       // Real data
   // aPostStepPoint->SetVelocity(0);                                                                  // Missing data

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -157,7 +157,113 @@ void Deleter::operator()(ScoringObjects *ptr)
 
 } // namespace AdePTGeant4Integration_detail
 
+namespace {
+
+void MergeNuclearReplayIntoVisibleStep(const G4Track &scratchTrack, const G4Step &scratchStep, G4Step &visibleStep,
+                                       bool isLeptonNuclearStep)
+{
+  G4Track *visibleTrack             = visibleStep.GetTrack();
+  G4StepPoint *visiblePostStepPoint = visibleStep.GetPostStepPoint();
+  const G4StepPoint *scratchPost    = scratchStep.GetPostStepPoint();
+
+  visibleTrack->SetTrackStatus(scratchTrack.GetTrackStatus());
+  visibleTrack->SetKineticEnergy(scratchTrack.GetKineticEnergy());
+  visiblePostStepPoint->SetKineticEnergy(scratchPost->GetKineticEnergy());
+  visiblePostStepPoint->SetVelocity(scratchPost->GetVelocity());
+  visiblePostStepPoint->SetStepStatus(scratchPost->GetStepStatus());
+
+  if (isLeptonNuclearStep) {
+    visibleTrack->SetMomentumDirection(scratchTrack.GetMomentumDirection());
+    visibleTrack->SetVelocity(scratchTrack.GetVelocity());
+    visiblePostStepPoint->SetMomentumDirection(scratchPost->GetMomentumDirection());
+  }
+}
+
+} // namespace
+
 AdePTGeant4Integration::~AdePTGeant4Integration() {}
+
+void AdePTGeant4Integration::QueueDeferredNuclearStep(std::span<const GPUHit> gpuSteps)
+{
+  if (gpuSteps.empty()) return;
+
+  fHostTrackDataMapper->SetPendingNuclearReaction(gpuSteps.front().fTrackID, true);
+
+  // Keep the returned GPU-hit block together with the ordering key that
+  // places it in the same return order as an ordinary leaked track.
+  DeferredNuclearStep deferred;
+  deferred.returnedTrack = MakeReturnedTrackFromGPUHit(gpuSteps.front());
+  deferred.hits.assign(gpuSteps.begin(), gpuSteps.end());
+  fDeferredNuclearSteps.push_back(std::move(deferred));
+}
+
+std::vector<AdePTGeant4Integration::DeferredNuclearStep> AdePTGeant4Integration::TakeDeferredNuclearSteps()
+{
+  // Swap with an empty vector so ownership of the queued work moves out
+  // without copying the stored GPU-hit payloads.
+  std::vector<DeferredNuclearStep> deferred;
+  deferred.swap(fDeferredNuclearSteps);
+  return deferred;
+}
+
+adeptint::TrackData AdePTGeant4Integration::MakeReturnedTrackFromGPUHit(GPUHit const &gpuHit) const
+{
+  adeptint::TrackData returnedTrack;
+
+  switch (gpuHit.fParticleType) {
+  case ParticleType::Electron:
+    returnedTrack.pdg = 11;
+    break;
+  case ParticleType::Positron:
+    returnedTrack.pdg = -11;
+    break;
+  case ParticleType::Gamma:
+    returnedTrack.pdg = 22;
+    break;
+  default:
+    throw std::runtime_error("Unknown particle type in MakeReturnedTrackFromGPUHit");
+  }
+
+  returnedTrack.eKin         = gpuHit.fPostStepPoint.fEKin;
+  returnedTrack.position[0]  = gpuHit.fPostStepPoint.fPosition.x();
+  returnedTrack.position[1]  = gpuHit.fPostStepPoint.fPosition.y();
+  returnedTrack.position[2]  = gpuHit.fPostStepPoint.fPosition.z();
+  returnedTrack.direction[0] = gpuHit.fPostStepPoint.fMomentumDirection.x();
+  returnedTrack.direction[1] = gpuHit.fPostStepPoint.fMomentumDirection.y();
+  returnedTrack.direction[2] = gpuHit.fPostStepPoint.fMomentumDirection.z();
+
+  return returnedTrack;
+}
+
+G4Track *AdePTGeant4Integration::MakeTrackForCPUStacking(const G4Track &track) const
+{
+  auto *dynamic =
+      new G4DynamicParticle(track.GetParticleDefinition(), track.GetMomentumDirection(), track.GetKineticEnergy());
+  dynamic->SetPrimaryParticle(track.GetDynamicParticle()->GetPrimaryParticle());
+
+  auto *clone = new G4Track(dynamic, track.GetGlobalTime(), track.GetPosition());
+  clone->IncrementCurrentStepNumber();
+  clone->SetTrackID(track.GetTrackID());
+  clone->SetParentID(track.GetParentID());
+  clone->SetLocalTime(track.GetLocalTime());
+  clone->SetProperTime(track.GetProperTime());
+  clone->SetWeight(track.GetWeight());
+  clone->SetCreatorProcess(track.GetCreatorProcess());
+  clone->SetStepLength(track.GetStepLength());
+  clone->SetMomentumDirection(track.GetMomentumDirection());
+  clone->SetVertexPosition(track.GetVertexPosition());
+  clone->SetVertexMomentumDirection(track.GetVertexMomentumDirection());
+  clone->SetVertexKineticEnergy(track.GetVertexKineticEnergy());
+  clone->SetLogicalVolumeAtVertex(const_cast<G4LogicalVolume *>(track.GetLogicalVolumeAtVertex()));
+  clone->SetTouchableHandle(track.GetTouchableHandle());
+  clone->SetNextTouchableHandle(track.GetNextTouchableHandle());
+#ifdef ADEPT_USE_ORIGINNAVSTATE
+  clone->SetOriginTouchableHandle(track.GetOriginTouchableHandle());
+#endif
+  clone->SetUserInformation(track.GetUserInformation());
+  clone->SetTrackStatus(track.GetTrackStatus());
+  return clone;
+}
 
 G4Track *AdePTGeant4Integration::ConstructSecondaryTrackInPlace(GPUHit const *secHit) const
 {
@@ -186,6 +292,10 @@ G4Track *AdePTGeant4Integration::ConstructSecondaryTrackInPlace(GPUHit const *se
 void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bool const callUserSteppingAction,
                                             bool const callUserTrackingAction)
 {
+  // FIXME: to be removed, as it is not needed with the direct VecGeom to G4 NavState.
+  // needed here only temporarily to match exactly the behavior of returning nuclear interaction steps as tracks
+  constexpr double tolerance = 10. * vecgeom::kTolerance;
+
   if (!fScoringObjects) {
     fScoringObjects.reset(new AdePTGeant4Integration_detail::ScoringObjects());
   }
@@ -251,6 +361,15 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
   // - for particles created on CPU, it was created in the AdePTTrackingManager when offloading to GPU,
   // - for particles createdon GPU, it was created in InitSecondaryHostTrackDataFromParent below
 
+  const bool isGammaNuclearStep = parentStep.fParticleType == ParticleType::Gamma && parentStep.fStepLimProcessId == 3;
+  const bool isLeptonNuclearStep =
+      (parentStep.fParticleType == ParticleType::Electron || parentStep.fParticleType == ParticleType::Positron) &&
+      parentStep.fStepLimProcessId == 3;
+  const bool isNuclearStep  = isGammaNuclearStep || isLeptonNuclearStep;
+  bool parentContinuesOnCPU = false;
+  G4Track *continuedParent  = nullptr;
+  G4TrackVector hadronicSecondaries;
+
   HostTrackData dummy; // default constructed dummy if no advanced information is available
 
   // if the userActions are used, advanced track information is available
@@ -294,8 +413,135 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
       FillG4Track(&secStep, secTrack, secTData, *fScoringObjects->fPreG4TouchableHistoryHandle,
                   *fScoringObjects->fPostG4TouchableHistoryHandle);
 
-      // 5. Attach secondaries to G4Step: the fSecondaryVector is the persistent storage for the G4Step->SecondaryVector
+      // 5. Attach secondaries to G4Step: the fSecondaryVector is the persistent
+      // storage for the G4Step->SecondaryVector.
       fScoringObjects->fSecondaryVector->push_back(secTrack);
+    }
+  }
+
+  // Handling of Steps that hit a nuclear reaction:
+  // before calling the SD code and the user actions, the nuclear reactions must be invoked, as those
+  // create new secondaries
+  if (isNuclearStep) {
+    // Two different objects are needed here:
+    // - the visible G4 step, which must keep the transported GPU step data
+    // - a temporary G4 track/step, used only to call the Geant4 nuclear process
+    // After the nuclear call, only the produced secondaries and the updated
+    // parent final state are copied back.
+    if (fHepEmTrackingManager == nullptr) {
+      throw std::runtime_error("Specialized HepEmTrackingManager no longer valid in integration!");
+    }
+
+    HostTrackData &parentTDataAfterSecondaries = actions ? fHostTrackDataMapper->get(parentStep.fTrackID) : dummy;
+
+    G4VProcess *nuclearProcess = nullptr;
+    int particleID             = 2;
+    if (isGammaNuclearStep) {
+      nuclearProcess = fHepEmTrackingManager->GetGammaNuclearProcess();
+      particleID     = 2;
+    } else {
+      particleID     = parentStep.fParticleType == ParticleType::Electron ? 0 : 1;
+      nuclearProcess = particleID == 0 ? fHepEmTrackingManager->GetElectronNuclearProcess()
+                                       : fHepEmTrackingManager->GetPositronNuclearProcess();
+    }
+
+    if (nuclearProcess != nullptr) {
+      parentContinuesOnCPU = isLeptonNuclearStep;
+
+      const G4ThreeVector direction(parentStep.fPostStepPoint.fMomentumDirection.x(),
+                                    parentStep.fPostStepPoint.fMomentumDirection.y(),
+                                    parentStep.fPostStepPoint.fMomentumDirection.z());
+      G4ThreeVector position(parentStep.fPostStepPoint.fPosition.x(), parentStep.fPostStepPoint.fPosition.y(),
+                             parentStep.fPostStepPoint.fPosition.z());
+      position += tolerance * direction;
+
+      auto *dynamic = new G4DynamicParticle(fScoringObjects->fG4Step->GetTrack()->GetParticleDefinition(), direction,
+                                            parentStep.fPostStepPoint.fEKin);
+
+      auto *nuclearReactionTrack = new G4Track(dynamic, parentStep.fGlobalTime, position);
+      nuclearReactionTrack->IncrementCurrentStepNumber();
+      nuclearReactionTrack->SetLocalTime(parentStep.fLocalTime);
+      nuclearReactionTrack->SetWeight(parentStep.fTrackWeight);
+      G4TouchableHandle postTouchable;
+      if (actions) {
+        nuclearReactionTrack->SetTrackID(parentTDataAfterSecondaries.g4id);
+        nuclearReactionTrack->SetParentID(parentTDataAfterSecondaries.g4parentid);
+        nuclearReactionTrack->SetCreatorProcess(parentTDataAfterSecondaries.creatorProcess);
+        nuclearReactionTrack->SetUserInformation(parentTDataAfterSecondaries.userTrackInfo);
+        nuclearReactionTrack->SetVertexPosition(parentTDataAfterSecondaries.vertexPosition);
+        nuclearReactionTrack->SetVertexMomentumDirection(parentTDataAfterSecondaries.vertexMomentumDirection);
+        nuclearReactionTrack->SetVertexKineticEnergy(parentTDataAfterSecondaries.vertexKineticEnergy);
+        nuclearReactionTrack->SetLogicalVolumeAtVertex(parentTDataAfterSecondaries.logicalVolumeAtVertex);
+        const_cast<G4DynamicParticle *>(nuclearReactionTrack->GetDynamicParticle())
+            ->SetPrimaryParticle(parentTDataAfterSecondaries.primary);
+      }
+      if (const auto postVolume = (*fScoringObjects->fPostG4TouchableHistoryHandle)->GetVolume();
+          postVolume != nullptr) {
+        postTouchable = MakeTouchableFromNavState(parentStep.fPostStepPoint.fNavigationState);
+        nuclearReactionTrack->SetTouchableHandle(postTouchable);
+        nuclearReactionTrack->SetNextTouchableHandle(postTouchable);
+      }
+
+      auto *nuclearStep = new G4Step();
+      nuclearStep->NewSecondaryVector();
+      nuclearStep->InitializeStep(nuclearReactionTrack);
+      nuclearStep->SetTrack(nuclearReactionTrack);
+      nuclearReactionTrack->SetStep(nuclearStep);
+
+      // ApplyCuts must be false, as we are not in a Geant4 tracking loop here and
+      // cannot deposit any cut secondaries locally.
+      fHepEmTrackingManager->PerformNuclear(nuclearReactionTrack, nuclearStep, particleID, /*isApplyCuts=*/false);
+
+      if (auto *newSecondaries = nuclearStep->GetfSecondary(); newSecondaries != nullptr) {
+        hadronicSecondaries.reserve(newSecondaries->size());
+        for (auto *secondary : *newSecondaries) {
+          hadronicSecondaries.push_back(secondary);
+          fScoringObjects->fSecondaryVector->push_back(secondary);
+        }
+      }
+
+      // The visible step remains the transported GPU step. Only the nuclear
+      // final state is merged back from the scratch replay object.
+      MergeNuclearReplayIntoVisibleStep(*nuclearReactionTrack, *nuclearStep, *fScoringObjects->fG4Step,
+                                        isLeptonNuclearStep);
+
+      if (isLeptonNuclearStep) {
+        continuedParent = nuclearReactionTrack;
+        if (actions) {
+          continuedParent->SetTrackID(parentTDataAfterSecondaries.g4id);
+          continuedParent->SetParentID(parentTDataAfterSecondaries.g4parentid);
+          continuedParent->SetCreatorProcess(parentTDataAfterSecondaries.creatorProcess);
+          continuedParent->SetUserInformation(parentTDataAfterSecondaries.userTrackInfo);
+          continuedParent->SetVertexPosition(parentTDataAfterSecondaries.vertexPosition);
+          continuedParent->SetVertexMomentumDirection(parentTDataAfterSecondaries.vertexMomentumDirection);
+          continuedParent->SetVertexKineticEnergy(parentTDataAfterSecondaries.vertexKineticEnergy);
+          continuedParent->SetLogicalVolumeAtVertex(parentTDataAfterSecondaries.logicalVolumeAtVertex);
+          const_cast<G4DynamicParticle *>(continuedParent->GetDynamicParticle())
+              ->SetPrimaryParticle(parentTDataAfterSecondaries.primary);
+        }
+        if (postTouchable) {
+          continuedParent->SetTouchableHandle(postTouchable);
+          continuedParent->SetNextTouchableHandle(postTouchable);
+        }
+#ifdef ADEPT_USE_ORIGINNAVSTATE
+        if (actions) {
+          continuedParent->SetOriginTouchableHandle(
+              MakeTouchableFromNavState(parentTDataAfterSecondaries.originNavState));
+        }
+#endif
+      }
+
+      if (!isLeptonNuclearStep) {
+        nuclearReactionTrack->SetUserInformation(nullptr);
+        delete nuclearStep;
+        delete nuclearReactionTrack;
+      }
+    } else {
+      // Fallback only for the case without an attached Geant4 nuclear process:
+      // there is then no temporary nuclear-replay track that can be continued
+      // on the CPU, so we create a separate heap-owned track for the stack.
+      continuedParent      = MakeTrackForCPUStacking(*fScoringObjects->fG4Step->GetTrack());
+      parentContinuesOnCPU = true;
     }
   }
 
@@ -319,14 +565,16 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
   }
 
   // call UserTrackingAction if required
-  if (parentStep.fLastStepOfTrack && (callUserTrackingAction)) {
+  if (parentStep.fLastStepOfTrack && !parentContinuesOnCPU && (callUserTrackingAction)) {
     auto *evtMgr             = G4EventManager::GetEventManager();
     auto *userTrackingAction = evtMgr->GetUserTrackingAction();
     if (userTrackingAction) userTrackingAction->PostUserTrackingAction(fScoringObjects->fG4Step->GetTrack());
   }
 
-  // Secondaries only get the PreUserTracking callback after the parent step has been
-  // fully processed. Now the secondaries are ready to process their next step that could arrive
+  // GPU-born secondaries only get the PreUserTracking callback after the parent
+  // step has been fully processed. Hadronic secondaries created by the host-side
+  // nuclear process stay on the CPU and will receive their normal Geant4
+  // tracking callbacks later.
   if (callUserTrackingAction || callUserSteppingAction) {
     auto *evtMgr             = G4EventManager::GetEventManager();
     auto *userTrackingAction = evtMgr->GetUserTrackingAction();
@@ -337,7 +585,6 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
         if (secondary == nullptr) continue;
 
         userTrackingAction->PreUserTrackingAction(secondary);
-
         auto &secTData = fHostTrackDataMapper->get(secondaries[i].fTrackID);
         if (secTData.userTrackInfo == nullptr && secondary->GetUserInformation() != nullptr) {
           secTData.userTrackInfo = secondary->GetUserInformation();
@@ -346,14 +593,24 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
     }
   }
 
+  if (isNuclearStep) {
+    if (!hadronicSecondaries.empty()) {
+      G4EventManager::GetEventManager()->StackTracks(&hadronicSecondaries);
+    }
+
+    if (parentContinuesOnCPU) {
+      G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(continuedParent);
+    }
+  }
+
   // If this was the last step of a track, the hostTrackData of that track can be safely deleted.
   // Note: This deletes the AdePT-owned UserTrackInfo data
-  // Exception: gamma-nuclear steps (fParticleType == 2 and fStepLimProcessId == 3):
-  // Steps are processed before the leaked tracks, and the hostTrackData is still used for invoking
-  // gamma-nuclear when the track is returned to the host (although it will die then). Thus, the hostTrackData must be
-  // kept alive until the invokation of the gamma-nuclear reaction
-  if (parentStep.fLastStepOfTrack &&
-      !(parentStep.fParticleType == ParticleType::Gamma && parentStep.fStepLimProcessId == 3)) {
+  if (isNuclearStep) {
+    auto *parentTrack = fScoringObjects->fG4Step->GetTrack();
+    parentTrack->SetUserInformation(nullptr);
+    fHostTrackDataMapper->FinalizePendingNuclearReaction(parentStep.fTrackID, parentContinuesOnCPU);
+  } else if (parentStep.fLastStepOfTrack) {
+    fScoringObjects->fG4Step->GetTrack()->SetUserInformation(nullptr);
     fHostTrackDataMapper->removeTrack(parentStep.fTrackID);
   }
 }
@@ -526,14 +783,6 @@ void AdePTGeant4Integration::FillG4Track(GPUHit const *aGPUHit, G4Track *aTrack,
   // if it exists, add UserTrackInfo
   aTrack->SetUserInformation(hostTData.userTrackInfo); // Real data
   // aTrack->SetAuxiliaryTrackInformation(0, nullptr);                                        // Missing data
-
-  // adjust for gamma-nuclear steps:
-  // As the steps are processed before the leaked tracks, the step has not undergone the gamma-nuclear reaction yet.
-  // Therefore, the kinetic energy for the track and postStepPoint must be set by hand to 0
-  if (aGPUHit->fLastStepOfTrack && aGPUHit->fParticleType == ParticleType::Gamma && aGPUHit->fStepLimProcessId == 3) {
-    aTrack->SetKineticEnergy(0.);
-    // aTrack->SetVelocity(0.);              // Not set in other cases, so also not set here
-  }
 }
 
 void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step, const HostTrackData &hostTData,
@@ -639,14 +888,6 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step, 
   aPostStepPoint->SetCharge(aTrack->GetParticleDefinition()->GetPDGCharge()); // Real data
   // aPostStepPoint->SetMagneticMoment(0);                                                            // Missing data
   // aPostStepPoint->SetWeight(0);                                                                    // Missing data
-
-  // adjust for gamma-nuclear steps:
-  // As the steps are processed before the leaked tracks, the step has not undergone the gamma-nuclear reaction yet.
-  // Therefore, the kinetic energy for the track and postStepPoint must be set by hand to 0
-  if (aGPUHit->fLastStepOfTrack && aGPUHit->fParticleType == ParticleType::Gamma && aGPUHit->fStepLimProcessId == 3) {
-    aPostStepPoint->SetKineticEnergy(0.);
-    // aPostStepPoint->SetVelocity(0.);      // Not set in other cases, so also not set here
-  }
 }
 
 void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsigned int trackIndex, int debugLevel,
@@ -739,94 +980,9 @@ void AdePTGeant4Integration::ReturnTrack(adeptint::TrackData const &track, unsig
   leakedTrack->SetTouchableHandle(TouchableHandle);
   leakedTrack->SetNextTouchableHandle(TouchableHandle);
 
-  // handle gamma- and lepton-nuclear directly in G4HepEm
   if (track.leakStatus == LeakStatus::GammaNuclear || track.leakStatus == LeakStatus::LeptonNuclear) {
-
-    // create a new step
-    G4Step *step = new G4Step();
-    step->NewSecondaryVector();
-
-    // initialize preStepPoint values
-    step->InitializeStep(leakedTrack);
-
-    // entangle our newly created step and the leaked track
-    step->SetTrack(leakedTrack);
-    leakedTrack->SetStep(step);
-
-    // get fresh secondary vector
-    G4TrackVector *secondariesPtr = step->GetfSecondary();
-    if (!secondariesPtr) throw std::runtime_error("Failed to allocate secondary vector");
-    G4TrackVector &secondaries = *secondariesPtr;
-
-    if (fHepEmTrackingManager) {
-
-      if (track.leakStatus == LeakStatus::GammaNuclear) {
-
-        auto GNucProcess = fHepEmTrackingManager->GetGammaNuclearProcess();
-        if (GNucProcess != nullptr) {
-
-          // need to call StartTracking to set the particle type in the hadronic process (see G4HadronicProcess.cc)
-          GNucProcess->StartTracking(leakedTrack);
-
-          // perform gamma nuclear from G4HepEmTrackingManager
-          // ApplyCuts must be false, as we are not in a tracking loop here and could not deposit the energy
-          fHepEmTrackingManager->PerformNuclear(leakedTrack, step, /*particleID=*/2, /*isApplyCuts=*/false);
-
-          // Give secondaries to G4
-          G4EventManager::GetEventManager()->StackTracks(&secondaries);
-
-          // As Gamma-nuclear kills the track, and the track is owned by AdePT, it has to be deleted. This includes:
-          // 1. deleting the HostTrackData, which also deletes the UserTrackInfo
-          // 2. Setting the UserInformation pointer in the track to nullptr (as the data was just deleted)
-          // 3. deleting the track
-          // Note that it is safe to remove the track and the hostTrackData here, as the hits are always handled
-          // before the leaks and hits with Gamma-nuclear are not marked as last step.
-          fHostTrackDataMapper->removeTrack(track.trackId);
-          // as the UserTrackInfo was just deleted by removeTrack, the pointer must be set to null to avoid double
-          // deletion
-          leakedTrack->SetUserInformation(nullptr);
-          // Now the track and step can be safely deleted
-          delete leakedTrack;
-          delete step;
-        } else {
-          // no gamma nuclear process attached, just give back the track to G4 to put it back on GPU
-          G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(leakedTrack);
-          delete step;
-          // Track is how handled by CPU
-          fHostTrackDataMapper->retireToCPU(track.trackId);
-        }
-      } else {
-        // case LeakStatus::LeptonNuclear
-        const double charge   = leakedTrack->GetParticleDefinition()->GetPDGCharge();
-        const bool isElectron = (charge < 0.0);
-        int particleID        = isElectron ? 0 : 1;
-
-        // Invoke the electron/positron-nuclear process start tracking interace (if any)
-        G4VProcess *theNucProcess = isElectron ? fHepEmTrackingManager->GetElectronNuclearProcess()
-                                               : fHepEmTrackingManager->GetPositronNuclearProcess();
-        if (theNucProcess != nullptr) {
-
-          // perform lepton nuclear from G4HepEmTrackingManager
-          // ApplyCuts must be false, as we are not in a tracking loop here and could not deposit the energy
-          fHepEmTrackingManager->PerformNuclear(leakedTrack, step, particleID, /*isApplyCuts=*/false);
-
-          // Give secondaries to G4 - they are already stored from G4HepEm in the G4Step, now we need to pass them to G4
-          // itself
-          G4EventManager::GetEventManager()->StackTracks(&secondaries);
-          // Give updated primary after lepton nuclear reacton to G4
-          G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(leakedTrack);
-        } else {
-          // no lepton nuclear process attached, just give back the track to G4 to put it back on GPU
-          G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(leakedTrack);
-          delete step;
-        }
-        // Track is how handled by CPU
-        fHostTrackDataMapper->retireToCPU(track.trackId);
-      }
-    } else {
-      throw std::runtime_error("Specialized HepEmTrackingManager not longer valid in integration!");
-    }
-
+    throw std::runtime_error(
+        "Gamma/lepton nuclear should be reinjected from deferred GPU-hit processing, not from leaked tracks.");
   } else {
 
     // LeakStatus::OutOfGPURegion: just give track back to G4

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -159,6 +159,21 @@ void Deleter::operator()(ScoringObjects *ptr)
 
 namespace {
 
+G4ParticleDefinition *GetParticleDefinition(ParticleType particleType)
+{
+  switch (particleType) {
+  case ParticleType::Electron:
+    return G4Electron::Definition();
+  case ParticleType::Positron:
+    return G4Positron::Definition();
+  case ParticleType::Gamma:
+    return G4Gamma::Definition();
+  default:
+    std::cerr << "Error: unknown particle type " << static_cast<int>(particleType) << "\n";
+    std::abort();
+  }
+}
+
 void MergeNuclearReplayIntoVisibleStep(const G4Track &scratchTrack, const G4Step &scratchStep, G4Step &visibleStep,
                                        bool isLeptonNuclearStep)
 {
@@ -183,7 +198,7 @@ void MergeNuclearReplayIntoVisibleStep(const G4Track &scratchTrack, const G4Step
 
 AdePTGeant4Integration::~AdePTGeant4Integration() {}
 
-void AdePTGeant4Integration::QueueDeferredStep(std::span<const GPUHit> gpuSteps)
+void AdePTGeant4Integration::QueueDeferredStep(std::span<const GPUHit> gpuSteps, DeferredStepType type)
 {
   if (gpuSteps.empty()) return;
 
@@ -192,6 +207,7 @@ void AdePTGeant4Integration::QueueDeferredStep(std::span<const GPUHit> gpuSteps)
   DeferredStep deferred;
   deferred.firstHit = fDeferredHits.size();
   deferred.numHits  = gpuSteps.size();
+  deferred.type     = type;
   fDeferredHits.insert(fDeferredHits.end(), gpuSteps.begin(), gpuSteps.end());
   fDeferredSteps.push_back(deferred);
 }
@@ -202,6 +218,24 @@ AdePTGeant4Integration::DeferredStepStore AdePTGeant4Integration::TakeDeferredSt
   deferred.hits.swap(fDeferredHits);
   deferred.steps.swap(fDeferredSteps);
   return deferred;
+}
+
+void AdePTGeant4Integration::ReturnDeferredTrack(std::span<const GPUHit> gpuSteps)
+{
+  assert(gpuSteps.size() == 1);
+
+  const GPUHit &parentStep = gpuSteps.front();
+  assert(parentStep.fParticleType == ParticleType::Gamma);
+  assert(parentStep.fStepLimProcessId == kAdePTOutOfGPURegionProcess ||
+         parentStep.fStepLimProcessId == kAdePTFinishOnCPUProcess);
+  assert(parentStep.fTotalEnergyDeposit == 0.);
+  HostTrackData dummy;
+
+  auto *returnedParentTrack = MakeReturnedTrackFromStep(
+      parentStep, dummy, /*setStopButAlive=*/parentStep.fStepLimProcessId == kAdePTFinishOnCPUProcess);
+  G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(returnedParentTrack);
+  returnedParentTrack->SetUserInformation(nullptr);
+  fHostTrackDataMapper->FinalizePendingReturnedStep(parentStep.fTrackID, /*returnTrackToG4=*/true);
 }
 
 G4Track *AdePTGeant4Integration::MakeTrackForCPUStacking(const G4Track &track) const
@@ -246,7 +280,7 @@ G4Track *AdePTGeant4Integration::MakeReturnedTrackFromStep(GPUHit const &parentS
                          parentStep.fPostStepPoint.fPosition.z());
   position += tolerance * direction;
 
-  auto *dynamic = new G4DynamicParticle(fScoringObjects->fG4Step->GetTrack()->GetParticleDefinition(), direction,
+  auto *dynamic = new G4DynamicParticle(GetParticleDefinition(parentStep.fParticleType), direction,
                                         parentStep.fPostStepPoint.fEKin);
   dynamic->SetPrimaryParticle(hostTData.primary);
 
@@ -363,8 +397,8 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
   const bool isFinishOnCPUStep    = parentStep.fStepLimProcessId == kAdePTFinishOnCPUProcess;
   const bool isNuclearStep        = isGammaNuclearStep || isLeptonNuclearStep;
   const bool isDeferredStep       = isNuclearStep || isOutOfGPURegionStep || isFinishOnCPUStep;
-  bool parentContinuesOnCPU       = false;
-  G4Track *continuedParent        = nullptr;
+  bool returnParentTrackToG4      = false;
+  G4Track *returnedParentTrack    = nullptr;
   G4TrackVector hadronicSecondaries;
 
   HostTrackData dummy; // default constructed dummy if no advanced information is available
@@ -458,7 +492,7 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
     }
 
     if (nuclearProcess != nullptr) {
-      parentContinuesOnCPU = isLeptonNuclearStep;
+      returnParentTrackToG4 = isLeptonNuclearStep;
 
       const G4ThreeVector direction(parentStep.fPostStepPoint.fMomentumDirection.x(),
                                     parentStep.fPostStepPoint.fMomentumDirection.y(),
@@ -518,26 +552,26 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
                                         isLeptonNuclearStep);
 
       if (isLeptonNuclearStep) {
-        continuedParent = nuclearReactionTrack;
+        returnedParentTrack = nuclearReactionTrack;
         if (actions) {
-          continuedParent->SetTrackID(parentTDataAfterSecondaries.g4id);
-          continuedParent->SetParentID(parentTDataAfterSecondaries.g4parentid);
-          continuedParent->SetCreatorProcess(parentTDataAfterSecondaries.creatorProcess);
-          continuedParent->SetUserInformation(parentTDataAfterSecondaries.userTrackInfo);
-          continuedParent->SetVertexPosition(parentTDataAfterSecondaries.vertexPosition);
-          continuedParent->SetVertexMomentumDirection(parentTDataAfterSecondaries.vertexMomentumDirection);
-          continuedParent->SetVertexKineticEnergy(parentTDataAfterSecondaries.vertexKineticEnergy);
-          continuedParent->SetLogicalVolumeAtVertex(parentTDataAfterSecondaries.logicalVolumeAtVertex);
-          const_cast<G4DynamicParticle *>(continuedParent->GetDynamicParticle())
+          returnedParentTrack->SetTrackID(parentTDataAfterSecondaries.g4id);
+          returnedParentTrack->SetParentID(parentTDataAfterSecondaries.g4parentid);
+          returnedParentTrack->SetCreatorProcess(parentTDataAfterSecondaries.creatorProcess);
+          returnedParentTrack->SetUserInformation(parentTDataAfterSecondaries.userTrackInfo);
+          returnedParentTrack->SetVertexPosition(parentTDataAfterSecondaries.vertexPosition);
+          returnedParentTrack->SetVertexMomentumDirection(parentTDataAfterSecondaries.vertexMomentumDirection);
+          returnedParentTrack->SetVertexKineticEnergy(parentTDataAfterSecondaries.vertexKineticEnergy);
+          returnedParentTrack->SetLogicalVolumeAtVertex(parentTDataAfterSecondaries.logicalVolumeAtVertex);
+          const_cast<G4DynamicParticle *>(returnedParentTrack->GetDynamicParticle())
               ->SetPrimaryParticle(parentTDataAfterSecondaries.primary);
         }
         if (postTouchable) {
-          continuedParent->SetTouchableHandle(postTouchable);
-          continuedParent->SetNextTouchableHandle(postTouchable);
+          returnedParentTrack->SetTouchableHandle(postTouchable);
+          returnedParentTrack->SetNextTouchableHandle(postTouchable);
         }
 #ifdef ADEPT_USE_ORIGINNAVSTATE
         if (actions) {
-          continuedParent->SetOriginTouchableHandle(
+          returnedParentTrack->SetOriginTouchableHandle(
               MakeTouchableFromNavState(parentTDataAfterSecondaries.originNavState));
         }
 #endif
@@ -552,12 +586,12 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
       // Fallback only for the case without an attached Geant4 nuclear process:
       // there is then no temporary nuclear-replay track that can be continued
       // on the CPU, so we create a separate heap-owned track for the stack.
-      continuedParent      = MakeTrackForCPUStacking(*fScoringObjects->fG4Step->GetTrack());
-      parentContinuesOnCPU = true;
+      returnedParentTrack   = MakeTrackForCPUStacking(*fScoringObjects->fG4Step->GetTrack());
+      returnParentTrackToG4 = true;
     }
   } else if (isOutOfGPURegionStep || isFinishOnCPUStep) {
-    continuedParent      = MakeReturnedTrackFromStep(parentStep, parentTData, /*setStopButAlive=*/isFinishOnCPUStep);
-    parentContinuesOnCPU = true;
+    returnedParentTrack   = MakeReturnedTrackFromStep(parentStep, parentTData, /*setStopButAlive=*/isFinishOnCPUStep);
+    returnParentTrackToG4 = true;
   }
 
   // Now, the G4Step is fully initialized and also contains the secondaries created in that step.
@@ -580,7 +614,7 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
   }
 
   // call UserTrackingAction if required
-  if (parentStep.fLastStepOfTrack && !parentContinuesOnCPU && (callUserTrackingAction)) {
+  if (parentStep.fLastStepOfTrack && !returnParentTrackToG4 && (callUserTrackingAction)) {
     auto *evtMgr             = G4EventManager::GetEventManager();
     auto *userTrackingAction = evtMgr->GetUserTrackingAction();
     if (userTrackingAction) userTrackingAction->PostUserTrackingAction(fScoringObjects->fG4Step->GetTrack());
@@ -613,8 +647,8 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
       G4EventManager::GetEventManager()->StackTracks(&hadronicSecondaries);
     }
 
-    if (parentContinuesOnCPU) {
-      G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(continuedParent);
+    if (returnParentTrackToG4) {
+      G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(returnedParentTrack);
     }
   }
 
@@ -623,7 +657,7 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
   if (isDeferredStep) {
     auto *parentTrack = fScoringObjects->fG4Step->GetTrack();
     parentTrack->SetUserInformation(nullptr);
-    fHostTrackDataMapper->FinalizePendingReturnedStep(parentStep.fTrackID, parentContinuesOnCPU);
+    fHostTrackDataMapper->FinalizePendingReturnedStep(parentStep.fTrackID, returnParentTrackToG4);
   } else if (parentStep.fLastStepOfTrack) {
     fScoringObjects->fG4Step->GetTrack()->SetUserInformation(nullptr);
     fHostTrackDataMapper->removeTrack(parentStep.fTrackID);

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -220,7 +220,7 @@ AdePTGeant4Integration::DeferredStepStore AdePTGeant4Integration::TakeDeferredSt
   return deferred;
 }
 
-void AdePTGeant4Integration::ReturnDeferredTrack(std::span<const GPUHit> gpuSteps)
+void AdePTGeant4Integration::ReturnDeferredTrack(std::span<const GPUHit> gpuSteps, bool const callUserActions)
 {
   assert(gpuSteps.size() == 1);
 
@@ -230,11 +230,11 @@ void AdePTGeant4Integration::ReturnDeferredTrack(std::span<const GPUHit> gpuStep
          parentStep.fStepLimProcessId == kAdePTFinishOnCPUProcess);
   assert(parentStep.fTotalEnergyDeposit == 0.);
   HostTrackData dummy;
+  HostTrackData &parentTData = callUserActions ? fHostTrackDataMapper->get(parentStep.fTrackID) : dummy;
 
   auto *returnedParentTrack = MakeReturnedTrackFromStep(
-      parentStep, dummy, /*setStopButAlive=*/parentStep.fStepLimProcessId == kAdePTFinishOnCPUProcess);
+      parentStep, parentTData, /*setStopButAlive=*/parentStep.fStepLimProcessId == kAdePTFinishOnCPUProcess);
   G4EventManager::GetEventManager()->GetStackManager()->PushOneTrack(returnedParentTrack);
-  returnedParentTrack->SetUserInformation(nullptr);
   fHostTrackDataMapper->FinalizePendingReturnedStep(parentStep.fTrackID, /*returnTrackToG4=*/true);
 }
 

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -405,9 +405,9 @@ void AdePTTrackingManager::ProcessReturnedGPUHits(int threadId, int eventId)
            it->fStepLimProcessId == 3) ||
           it->fStepLimProcessId == kAdePTOutOfGPURegionProcess || it->fStepLimProcessId == kAdePTFinishOnCPUProcess;
       if (isDeferredStep) {
-        // These returned steps are replayed later at the same sorted barrier
-        // as leaked tracks, because the host-side work may consume Geant4 RNG
-        // and therefore must not run in hit-buffer arrival order.
+        // These returned steps are replayed later in the same sorted order as
+        // the old CPU handoff path. The host-side work may consume Geant4 RNG,
+        // so it must not run in hit-buffer arrival order.
         fGeant4Integration.QueueDeferredStep(std::span<const GPUHit>(&*it, blockSize));
       } else {
         fGeant4Integration.ProcessGPUStep(std::span<const GPUHit>(&*it, blockSize),
@@ -442,7 +442,7 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
     fHepEmTrackingManager->SetFinishEventOnCPU(threadId, -1);
   }
 
-  // first leaked particle detected, let's finish this event on CPU
+  // first particle to be finished on CPU detected, let's finish the full event on CPU
   if (fHepEmTrackingManager->GetFinishEventOnCPU(threadId) < 0 && aTrack->GetTrackStatus() == fStopButAlive) {
     fHepEmTrackingManager->SetFinishEventOnCPU(threadId, eventID);
   }

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -357,7 +357,7 @@ void AdePTTrackingManager::FlushEvent()
 
   std::sort(deferredSteps.begin(), deferredSteps.end(),
             [](const AdePTGeant4Integration::DeferredStep &lhs, const AdePTGeant4Integration::DeferredStep &rhs) {
-              return lhs.returnedTrack < rhs.returnedTrack;
+              return lhs.hits.front() < rhs.hits.front();
             });
 
   for (auto deferredStepIt = deferredSteps.begin(); deferredStepIt != deferredSteps.end(); ++deferredStepIt) {

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -77,6 +77,7 @@ std::shared_ptr<AdePTTransport> GetSharedAdePTTransport()
   }
   return transport;
 }
+
 } // namespace
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -351,29 +352,51 @@ void AdePTTrackingManager::FlushEvent()
   // Once the device side is flushed, take the plain returned-track batch from
   // transport and hand it back to Geant4 on the host side.
   std::vector<AsyncAdePT::TrackDataWithIDs> tracks = fAdeptTransport->TakeReturnedTracks(threadId);
+  auto deferredNuclearSteps                        = fGeant4Integration.TakeDeferredNuclearSteps();
   fAdeptTransport->MarkLeakedTracksRetrieved(threadId);
-  PrepareReturnedTracksForGeant4(threadId, eventId, tracks);
-  fGeant4Integration.ReturnTracks(tracks.begin(), tracks.end(), fAdeptTransport->GetDebugLevel(),
-                                  fAdeptTransport->GetReturnFirstAndLastStep());
-}
 
-void AdePTTrackingManager::PrepareReturnedTracksForGeant4(int threadId, int eventId,
-                                                          std::vector<AsyncAdePT::TrackDataWithIDs> &tracks)
-{
-#ifndef NDEBUG
-  for (auto const &track : tracks) {
-    bool error = false;
-    if (track.threadId != threadId || track.eventId != static_cast<unsigned int>(eventId)) error = true;
-    if (!(track.pdg == -11 || track.pdg == 11 || track.pdg == 22)) error = true;
-    if (error)
-      std::cerr << "Error in returning track: threadId=" << track.threadId << " eventId=" << track.eventId
-                << " pdg=" << track.pdg << "\n";
-    assert(!error);
-  }
-#endif
-
-  // Sort the tracks coming from device by energy. This is necessary to ensure reproducibility.
   std::sort(tracks.begin(), tracks.end());
+  std::sort(
+      deferredNuclearSteps.begin(), deferredNuclearSteps.end(),
+      [](const AdePTGeant4Integration::DeferredNuclearStep &lhs,
+         const AdePTGeant4Integration::DeferredNuclearStep &rhs) { return lhs.returnedTrack < rhs.returnedTrack; });
+
+  // FIXME: here we sort both containers of the deferredNuclearSteps and the returnedTracks and
+  // then consume them together. In principle, this could be simplified to just do a loop over the
+  // first container and then the next. However, for now it is kept like this to ensure the
+  // exact physics reproducibility (apart from the fix of handling the nuclear reactions correctly)
+  // In the future, this should be simplified, in a separate step, to make sure the physics change
+  // is well understood.
+  unsigned int trackIndex    = 0;
+  auto trackIt               = tracks.begin();
+  auto deferredNuclearStepIt = deferredNuclearSteps.begin();
+
+  while (trackIt != tracks.end() && deferredNuclearStepIt != deferredNuclearSteps.end()) {
+    // Ordinary leaked tracks are already ready to return to Geant4. Deferred
+    // nuclear steps must rebuild their G4 step and run the host-side nuclear
+    // process in that same deterministic order.
+    if (static_cast<const adeptint::TrackData &>(*trackIt) < deferredNuclearStepIt->returnedTrack) {
+      fGeant4Integration.ReturnTrack(*trackIt, trackIndex++, fAdeptTransport->GetDebugLevel(),
+                                     fAdeptTransport->GetReturnFirstAndLastStep());
+      ++trackIt;
+    } else {
+      fGeant4Integration.ProcessGPUStep(
+          std::span<const GPUHit>(deferredNuclearStepIt->hits.data(), deferredNuclearStepIt->hits.size()),
+          fAdeptTransport->GetReturnAllSteps(), fAdeptTransport->GetReturnFirstAndLastStep());
+      ++deferredNuclearStepIt;
+    }
+  }
+
+  for (; trackIt != tracks.end(); ++trackIt) {
+    fGeant4Integration.ReturnTrack(*trackIt, trackIndex++, fAdeptTransport->GetDebugLevel(),
+                                   fAdeptTransport->GetReturnFirstAndLastStep());
+  }
+
+  for (; deferredNuclearStepIt != deferredNuclearSteps.end(); ++deferredNuclearStepIt) {
+    fGeant4Integration.ProcessGPUStep(
+        std::span<const GPUHit>(deferredNuclearStepIt->hits.data(), deferredNuclearStepIt->hits.size()),
+        fAdeptTransport->GetReturnAllSteps(), fAdeptTransport->GetReturnFirstAndLastStep());
+  }
 }
 
 void AdePTTrackingManager::ProcessReturnedGPUHits(int threadId, int eventId)
@@ -407,8 +430,20 @@ void AdePTTrackingManager::ProcessReturnedGPUHits(int threadId, int eventId)
                   << "\033[0m" << std::endl;
       }
       auto blockSize = 1 + it->fNumSecondaries;
-      fGeant4Integration.ProcessGPUStep(std::span<const GPUHit>(&*it, blockSize), fAdeptTransport->GetReturnAllSteps(),
-                                        fAdeptTransport->GetReturnFirstAndLastStep());
+      const bool isNuclearStep =
+          (it->fParticleType == ParticleType::Gamma || it->fParticleType == ParticleType::Electron ||
+           it->fParticleType == ParticleType::Positron) &&
+          it->fStepLimProcessId == 3;
+      if (isNuclearStep) {
+        // Nuclear returned steps are replayed later at the same sorted barrier
+        // as leaked tracks, because the host-side hadronic process consumes
+        // Geant4 RNG and therefore must not run in hit-buffer arrival order.
+        fGeant4Integration.QueueDeferredNuclearStep(std::span<const GPUHit>(&*it, blockSize));
+      } else {
+        fGeant4Integration.ProcessGPUStep(std::span<const GPUHit>(&*it, blockSize),
+                                          fAdeptTransport->GetReturnAllSteps(),
+                                          fAdeptTransport->GetReturnFirstAndLastStep());
+      }
       it += blockSize;
     }
   });
@@ -416,7 +451,6 @@ void AdePTTrackingManager::ProcessReturnedGPUHits(int threadId, int eventId)
 
 void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
 {
-
   G4EventManager *eventManager       = G4EventManager::GetEventManager();
   G4TrackingManager *trackManager    = eventManager->GetTrackingManager();
   G4SteppingManager *steppingManager = trackManager->GetSteppingManager();

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -355,15 +355,16 @@ void AdePTTrackingManager::FlushEvent()
 
   auto deferredSteps = fGeant4Integration.TakeDeferredSteps();
 
-  std::sort(deferredSteps.begin(), deferredSteps.end(),
-            [](const AdePTGeant4Integration::DeferredStep &lhs, const AdePTGeant4Integration::DeferredStep &rhs) {
-              return lhs.hits.front() < rhs.hits.front();
+  std::sort(deferredSteps.steps.begin(), deferredSteps.steps.end(),
+            [&deferredSteps](const AdePTGeant4Integration::DeferredStep &lhs,
+                             const AdePTGeant4Integration::DeferredStep &rhs) {
+              return deferredSteps.hits[lhs.firstHit] < deferredSteps.hits[rhs.firstHit];
             });
 
-  for (auto deferredStepIt = deferredSteps.begin(); deferredStepIt != deferredSteps.end(); ++deferredStepIt) {
-    fGeant4Integration.ProcessGPUStep(std::span<const GPUHit>(deferredStepIt->hits.data(), deferredStepIt->hits.size()),
-                                      fAdeptTransport->GetReturnAllSteps(),
-                                      fAdeptTransport->GetReturnFirstAndLastStep());
+  for (const auto &deferredStep : deferredSteps.steps) {
+    fGeant4Integration.ProcessGPUStep(
+        std::span<const GPUHit>(deferredSteps.hits.data() + deferredStep.firstHit, deferredStep.numHits),
+        fAdeptTransport->GetReturnAllSteps(), fAdeptTransport->GetReturnFirstAndLastStep());
   }
   fAdeptTransport->MarkHostFlushed(threadId);
 }

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -343,60 +343,29 @@ void AdePTTrackingManager::FlushEvent()
   // AdePTTrackingManager requests the flush while AdePTTransport still
   // owns the underlying state machine and buffer lifetime.
   fAdeptTransport->RequestFlush(threadId);
-
-  while (!fAdeptTransport->IsDeviceFlushed(threadId)) {
+  while (!fAdeptTransport->IsHitsFlushed(threadId)) {
     fAdeptTransport->WaitForFlushProgress();
     ProcessReturnedGPUHits(threadId, eventId);
   }
 
-  // Once the device side is flushed, take the plain returned-track batch from
-  // transport and hand it back to Geant4 on the host side.
-  std::vector<AsyncAdePT::TrackDataWithIDs> tracks = fAdeptTransport->TakeReturnedTracks(threadId);
-  auto deferredNuclearSteps                        = fGeant4Integration.TakeDeferredNuclearSteps();
-  fAdeptTransport->MarkLeakedTracksRetrieved(threadId);
+  // Transport stops at HitsFlushed once the last returned hit batches are
+  // available on the host. Drain once more here so the final batches are not
+  // skipped just because the worker observed that host-visible terminal state.
+  ProcessReturnedGPUHits(threadId, eventId);
 
-  std::sort(tracks.begin(), tracks.end());
-  std::sort(
-      deferredNuclearSteps.begin(), deferredNuclearSteps.end(),
-      [](const AdePTGeant4Integration::DeferredNuclearStep &lhs,
-         const AdePTGeant4Integration::DeferredNuclearStep &rhs) { return lhs.returnedTrack < rhs.returnedTrack; });
+  auto deferredSteps = fGeant4Integration.TakeDeferredSteps();
 
-  // FIXME: here we sort both containers of the deferredNuclearSteps and the returnedTracks and
-  // then consume them together. In principle, this could be simplified to just do a loop over the
-  // first container and then the next. However, for now it is kept like this to ensure the
-  // exact physics reproducibility (apart from the fix of handling the nuclear reactions correctly)
-  // In the future, this should be simplified, in a separate step, to make sure the physics change
-  // is well understood.
-  unsigned int trackIndex    = 0;
-  auto trackIt               = tracks.begin();
-  auto deferredNuclearStepIt = deferredNuclearSteps.begin();
+  std::sort(deferredSteps.begin(), deferredSteps.end(),
+            [](const AdePTGeant4Integration::DeferredStep &lhs, const AdePTGeant4Integration::DeferredStep &rhs) {
+              return lhs.returnedTrack < rhs.returnedTrack;
+            });
 
-  while (trackIt != tracks.end() && deferredNuclearStepIt != deferredNuclearSteps.end()) {
-    // Ordinary leaked tracks are already ready to return to Geant4. Deferred
-    // nuclear steps must rebuild their G4 step and run the host-side nuclear
-    // process in that same deterministic order.
-    if (static_cast<const adeptint::TrackData &>(*trackIt) < deferredNuclearStepIt->returnedTrack) {
-      fGeant4Integration.ReturnTrack(*trackIt, trackIndex++, fAdeptTransport->GetDebugLevel(),
-                                     fAdeptTransport->GetReturnFirstAndLastStep());
-      ++trackIt;
-    } else {
-      fGeant4Integration.ProcessGPUStep(
-          std::span<const GPUHit>(deferredNuclearStepIt->hits.data(), deferredNuclearStepIt->hits.size()),
-          fAdeptTransport->GetReturnAllSteps(), fAdeptTransport->GetReturnFirstAndLastStep());
-      ++deferredNuclearStepIt;
-    }
+  for (auto deferredStepIt = deferredSteps.begin(); deferredStepIt != deferredSteps.end(); ++deferredStepIt) {
+    fGeant4Integration.ProcessGPUStep(std::span<const GPUHit>(deferredStepIt->hits.data(), deferredStepIt->hits.size()),
+                                      fAdeptTransport->GetReturnAllSteps(),
+                                      fAdeptTransport->GetReturnFirstAndLastStep());
   }
-
-  for (; trackIt != tracks.end(); ++trackIt) {
-    fGeant4Integration.ReturnTrack(*trackIt, trackIndex++, fAdeptTransport->GetDebugLevel(),
-                                   fAdeptTransport->GetReturnFirstAndLastStep());
-  }
-
-  for (; deferredNuclearStepIt != deferredNuclearSteps.end(); ++deferredNuclearStepIt) {
-    fGeant4Integration.ProcessGPUStep(
-        std::span<const GPUHit>(deferredNuclearStepIt->hits.data(), deferredNuclearStepIt->hits.size()),
-        fAdeptTransport->GetReturnAllSteps(), fAdeptTransport->GetReturnFirstAndLastStep());
-  }
+  fAdeptTransport->MarkHostFlushed(threadId);
 }
 
 void AdePTTrackingManager::ProcessReturnedGPUHits(int threadId, int eventId)
@@ -430,15 +399,16 @@ void AdePTTrackingManager::ProcessReturnedGPUHits(int threadId, int eventId)
                   << "\033[0m" << std::endl;
       }
       auto blockSize = 1 + it->fNumSecondaries;
-      const bool isNuclearStep =
-          (it->fParticleType == ParticleType::Gamma || it->fParticleType == ParticleType::Electron ||
-           it->fParticleType == ParticleType::Positron) &&
-          it->fStepLimProcessId == 3;
-      if (isNuclearStep) {
-        // Nuclear returned steps are replayed later at the same sorted barrier
-        // as leaked tracks, because the host-side hadronic process consumes
-        // Geant4 RNG and therefore must not run in hit-buffer arrival order.
-        fGeant4Integration.QueueDeferredNuclearStep(std::span<const GPUHit>(&*it, blockSize));
+      const bool isDeferredStep =
+          ((it->fParticleType == ParticleType::Gamma || it->fParticleType == ParticleType::Electron ||
+            it->fParticleType == ParticleType::Positron) &&
+           it->fStepLimProcessId == 3) ||
+          it->fStepLimProcessId == kAdePTOutOfGPURegionProcess || it->fStepLimProcessId == kAdePTFinishOnCPUProcess;
+      if (isDeferredStep) {
+        // These returned steps are replayed later at the same sorted barrier
+        // as leaked tracks, because the host-side work may consume Geant4 RNG
+        // and therefore must not run in hit-buffer arrival order.
+        fGeant4Integration.QueueDeferredStep(std::span<const GPUHit>(&*it, blockSize));
       } else {
         fGeant4Integration.ProcessGPUStep(std::span<const GPUHit>(&*it, blockSize),
                                           fAdeptTransport->GetReturnAllSteps(),

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -376,7 +376,8 @@ void AdePTTrackingManager::FlushEvent()
   for (const auto &deferredStep : deferredSteps.steps) {
     std::span<const GPUHit> gpuSteps(deferredSteps.hits.data() + deferredStep.firstHit, deferredStep.numHits);
     if (deferredStep.type == AdePTGeant4Integration::DeferredStepType::ReturnTrack) {
-      fGeant4Integration.ReturnDeferredTrack(gpuSteps);
+      fGeant4Integration.ReturnDeferredTrack(gpuSteps, fAdeptTransport->GetReturnAllSteps() ||
+                                                           fAdeptTransport->GetReturnFirstAndLastStep());
     } else {
       fGeant4Integration.ProcessGPUStep(gpuSteps, fAdeptTransport->GetReturnAllSteps(),
                                         fAdeptTransport->GetReturnFirstAndLastStep());

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -78,6 +78,18 @@ std::shared_ptr<AdePTTransport> GetSharedAdePTTransport()
   return transport;
 }
 
+bool CanReturnTrackDirectly(const GPUHit &step, unsigned int blockSize, bool callUserSteppingAction)
+{
+  if (callUserSteppingAction) return false;
+  if (step.fParticleType != ParticleType::Gamma) return false;
+  if (step.fStepLimProcessId != kAdePTOutOfGPURegionProcess && step.fStepLimProcessId != kAdePTFinishOnCPUProcess) {
+    return false;
+  }
+  assert(blockSize == 1);
+  assert(step.fTotalEnergyDeposit == 0.);
+  return true;
+}
+
 } // namespace
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -362,9 +374,13 @@ void AdePTTrackingManager::FlushEvent()
             });
 
   for (const auto &deferredStep : deferredSteps.steps) {
-    fGeant4Integration.ProcessGPUStep(
-        std::span<const GPUHit>(deferredSteps.hits.data() + deferredStep.firstHit, deferredStep.numHits),
-        fAdeptTransport->GetReturnAllSteps(), fAdeptTransport->GetReturnFirstAndLastStep());
+    std::span<const GPUHit> gpuSteps(deferredSteps.hits.data() + deferredStep.firstHit, deferredStep.numHits);
+    if (deferredStep.type == AdePTGeant4Integration::DeferredStepType::ReturnTrack) {
+      fGeant4Integration.ReturnDeferredTrack(gpuSteps);
+    } else {
+      fGeant4Integration.ProcessGPUStep(gpuSteps, fAdeptTransport->GetReturnAllSteps(),
+                                        fAdeptTransport->GetReturnFirstAndLastStep());
+    }
   }
   fAdeptTransport->MarkHostFlushed(threadId);
 }
@@ -406,10 +422,11 @@ void AdePTTrackingManager::ProcessReturnedGPUHits(int threadId, int eventId)
            it->fStepLimProcessId == 3) ||
           it->fStepLimProcessId == kAdePTOutOfGPURegionProcess || it->fStepLimProcessId == kAdePTFinishOnCPUProcess;
       if (isDeferredStep) {
-        // These returned steps are replayed later in the same sorted order as
-        // the old CPU handoff path. The host-side work may consume Geant4 RNG,
-        // so it must not run in hit-buffer arrival order.
-        fGeant4Integration.QueueDeferredStep(std::span<const GPUHit>(&*it, blockSize));
+        const bool returnTrackDirectly = CanReturnTrackDirectly(*it, blockSize, fAdeptTransport->GetReturnAllSteps());
+        fGeant4Integration.QueueDeferredStep(std::span<const GPUHit>(&*it, blockSize),
+                                             returnTrackDirectly
+                                                 ? AdePTGeant4Integration::DeferredStepType::ReturnTrack
+                                                 : AdePTGeant4Integration::DeferredStepType::ReplayStep);
       } else {
         fGeant4Integration.ProcessGPUStep(std::span<const GPUHit>(&*it, blockSize),
                                           fAdeptTransport->GetReturnAllSteps(),

--- a/src/AsyncAdePTTransport.cc
+++ b/src/AsyncAdePTTransport.cc
@@ -23,11 +23,11 @@ void setDeviceLimits(int stackLimit = 0, int heapLimit = 0);
 void CopySurfaceModelToGPU();
 void InitWDTOnDevice(const adeptint::WDTHostPacked &, adeptint::WDTDeviceBuffers &, unsigned short);
 void UploadG4HepEmToGPU(G4HepEmData *hepEmData, G4HepEmParameters *hepEmParameters);
-std::thread LaunchGPUWorker(int, int, int, int, AsyncAdePT::TrackBuffer &, AsyncAdePT::GPUstate &,
+std::thread LaunchGPUWorker(int, int, int, AsyncAdePT::TrackBuffer &, AsyncAdePT::GPUstate &,
                             std::vector<std::atomic<AsyncAdePT::EventState>> &, std::condition_variable &, int, int,
                             bool, bool, unsigned short, const double, bool);
 std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> InitializeGPU(
-    int trackCapacity, int leakCapacity, int scoringCapacity, int numThreads, AsyncAdePT::TrackBuffer &trackBuffer,
+    int trackCapacity, int scoringCapacity, int numThreads, AsyncAdePT::TrackBuffer &trackBuffer,
     double CPUCapacityFactor, double CPUCopyFraction, std::string &generalBfieldFile,
     const std::vector<float> &uniformBfieldValues);
 void FreeGPU(std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> &, std::thread &,
@@ -42,7 +42,6 @@ AsyncAdePTTransport::AsyncAdePTTransport(AdePTConfiguration &configuration,
                                          const std::vector<float> &uniformFieldValues)
     : fAdePTSeed{configuration.GetAdePTSeed()}, fNThread{(ushort)configuration.GetNumThreads()},
       fTrackCapacity{(uint)(1024 * 1024 * configuration.GetMillionsOfTrackSlots())},
-      fLeakCapacity{(uint)(1024 * 1024 * configuration.GetMillionsOfLeakSlots())},
       fScoringCapacity{(uint)(1024 * 1024 * configuration.GetMillionsOfHitSlots())},
       fDebugLevel{configuration.GetVerbosity()}, fCUDAStackLimit{configuration.GetCUDAStackLimit()},
       fCUDAHeapLimit{configuration.GetCUDAHeapLimit()}, fLastNParticlesOnCPU{configuration.GetLastNParticlesOnCPU()},
@@ -168,17 +167,16 @@ void AsyncAdePTTransport::Initialize(adeptint::VolAuxData *auxData, const adepti
   fWDTDev = wdtDev;
 
   std::cout << "\nAllocating " << 4 * 8192 * fNThread << " To-device buffer slots\n";
-  std::cout << "\nAllocating " << 2048 * fNThread << " From-device buffer slots\n";
-  fBuffer = std::make_unique<TrackBuffer>(4 * 8192 * fNThread, 2048 * fNThread, fNThread);
+  fBuffer = std::make_unique<TrackBuffer>(4 * 8192 * fNThread);
 
   assert(fBuffer != nullptr);
 
-  fGPUstate  = async_adept_impl::InitializeGPU(fTrackCapacity, fLeakCapacity, fScoringCapacity, fNThread, *fBuffer,
-                                               fCPUCapacityFactor, fCPUCopyFraction, fBfieldFile, uniformFieldValues);
-  fGPUWorker = async_adept_impl::LaunchGPUWorker(fTrackCapacity, fLeakCapacity, fScoringCapacity, fNThread, *fBuffer,
-                                                 *fGPUstate, fEventStates, fCV_G4Workers, fAdePTSeed, fDebugLevel,
-                                                 fReturnAllSteps, fReturnFirstAndLastStep, fLastNParticlesOnCPU,
-                                                 fHitBufferSafetyFactor, fHasWDTRegions);
+  fGPUstate  = async_adept_impl::InitializeGPU(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, fCPUCapacityFactor,
+                                               fCPUCopyFraction, fBfieldFile, uniformFieldValues);
+  fGPUWorker = async_adept_impl::LaunchGPUWorker(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, *fGPUstate,
+                                                 fEventStates, fCV_G4Workers, fAdePTSeed, fDebugLevel, fReturnAllSteps,
+                                                 fReturnFirstAndLastStep, fLastNParticlesOnCPU, fHitBufferSafetyFactor,
+                                                 fHasWDTRegions);
 }
 
 void AsyncAdePTTransport::InitBVH()
@@ -189,7 +187,6 @@ void AsyncAdePTTransport::InitBVH()
 
 void AsyncAdePTTransport::RequestFlush(int threadId)
 {
-  assert(static_cast<unsigned int>(threadId) < fBuffer->fromDeviceBuffers.size());
   fEventStates[threadId].store(EventState::G4RequestsFlush, std::memory_order_release);
 }
 

--- a/src/AsyncAdePTTransport.cc
+++ b/src/AsyncAdePTTransport.cc
@@ -59,7 +59,7 @@ AsyncAdePTTransport::AsyncAdePTTransport(AdePTConfiguration &configuration,
     throw std::invalid_argument("AsyncAdePTTransport limited to " + std::to_string(kMaxThreads) + " threads");
 
   for (auto &eventState : fEventStates) {
-    std::atomic_init(&eventState, EventState::LeakedTracksRetrieved);
+    std::atomic_init(&eventState, EventState::DeviceFlushed);
   }
 
   Initialize(auxData, wdtPacked, uniformFieldValues);
@@ -196,25 +196,18 @@ void AsyncAdePTTransport::RequestFlush(int threadId)
 void AsyncAdePTTransport::WaitForFlushProgress()
 {
   std::unique_lock lock{fMutex_G4Workers};
-  fCV_G4Workers.wait(lock);
+  using namespace std::chrono_literals;
+  fCV_G4Workers.wait_for(lock, 1ms);
 }
 
-bool AsyncAdePTTransport::IsDeviceFlushed(int threadId) const
+bool AsyncAdePTTransport::IsHitsFlushed(int threadId) const
 {
-  return fEventStates[threadId].load(std::memory_order_acquire) >= EventState::DeviceFlushed;
+  return fEventStates[threadId].load(std::memory_order_acquire) >= EventState::HitsFlushed;
 }
 
-std::vector<TrackDataWithIDs> AsyncAdePTTransport::TakeReturnedTracks(int threadId)
+void AsyncAdePTTransport::MarkHostFlushed(int threadId)
 {
-  std::vector<TrackDataWithIDs> tracks;
-  auto handle = fBuffer->getTracksFromDevice(threadId);
-  tracks.swap(handle.tracks);
-  return tracks;
-}
-
-void AsyncAdePTTransport::MarkLeakedTracksRetrieved(int threadId)
-{
-  fEventStates[threadId].store(EventState::LeakedTracksRetrieved, std::memory_order_release);
+  fEventStates[threadId].store(EventState::DeviceFlushed, std::memory_order_release);
 }
 
 } // namespace AsyncAdePT

--- a/test/regression/scripts/example_template.mac
+++ b/test/regression/scripts/example_template.mac
@@ -19,7 +19,6 @@
 /adept/setSeed $adept_seed
 ## Total number of GPU track slots (not per thread)
 /adept/setMillionsOfTrackSlots $num_trackslots
-/adept/setMillionsOfLeakSlots $num_leakslots
 /adept/setMillionsOfHitSlots $num_hitslots
 /adept/setCUDAStackLimit 8192
 

--- a/test/regression/scripts/python_scripts/macro_generator.py
+++ b/test/regression/scripts/python_scripts/macro_generator.py
@@ -34,7 +34,6 @@ def generate_macro(template_path, output_path, args):
     macro_content = macro_content.replace("$num_threads", str(args.num_threads))
     macro_content = macro_content.replace("$num_events", str(args.num_events))
     macro_content = macro_content.replace("$num_trackslots", str(args.num_trackslots))
-    macro_content = macro_content.replace("$num_leakslots", str(args.num_leakslots))
     macro_content = macro_content.replace("$num_hitslots", str(args.num_hitslots))
     macro_content = macro_content.replace("$detector_field", str(args.detector_field))
     macro_content = macro_content.replace("$adept_seed", str(args.adept_seed))
@@ -97,8 +96,6 @@ def main():
     parser.add_argument("--num_events", type=int, help="Number of events to simulate.")
     parser.add_argument("--num_trackslots", type=int, default=3,
                         help="Number of trackslots in million. Should be chosen according to the GPU memory")
-    parser.add_argument("--num_leakslots", type=float, default=3,
-                        help="Number of leakslots in million. Should be chosen according to the GPU memory")
     parser.add_argument("--num_hitslots", type=int, default=12,
                         help="Number of hitslots in million. Should be chosen according to the GPU memory")
     parser.add_argument("--detector_field", type=str, default="0 0 0",

--- a/test/regression/scripts/reproducibility.sh
+++ b/test/regression/scripts/reproducibility.sh
@@ -40,7 +40,6 @@ $CI_TEST_DIR/python_scripts/macro_generator.py \
     --num_events 8 \
     --num_trackslots 5 \
     --num_hitslots 4 \
-    --num_leakslots 4 \
     --gun_type hepmc \
     --track_in_all_regions True\
     --event_file ${PROJECT_BINARY_DIR}/ppttbar.hepmc3

--- a/test/regression/scripts/reproducibility_WDT.sh
+++ b/test/regression/scripts/reproducibility_WDT.sh
@@ -39,13 +39,10 @@ $CI_TEST_DIR/python_scripts/macro_generator.py \
     --num_threads 4 \
     --num_events 50 \
     --num_trackslots 3 \
-    --num_leakslots 0.3 \
     --num_hitslots 15 \
     --track_in_all_regions True\
     --gun_type setDefault\
     --wdt_regions "WDT_Region_layers_10_40,Layer5,Layer44,Layer45"
-
-# Choose a small num_leakslots value in order to test the throttling mechanism
 
 # run test
 $ADEPT_EXECUTABLE --accumulated_events -m ${CI_TMP_DIR}/reproducibility_WDT.mac --output_dir ${CI_TMP_DIR} --output_file testem3_run1 --allsensitive

--- a/test/regression/scripts/reproducibility_regions.sh
+++ b/test/regression/scripts/reproducibility_regions.sh
@@ -39,7 +39,6 @@ $CI_TEST_DIR/python_scripts/macro_generator.py \
     --num_threads 4 \
     --num_events 50 \
     --num_trackslots 3 \
-    --num_leakslots 0.3 \
     --num_hitslots 15 \
     --track_in_all_regions False\
     --gun_type setDefault\
@@ -47,8 +46,6 @@ $CI_TEST_DIR/python_scripts/macro_generator.py \
             Layer11, Layer12, Layer13, Layer14, Layer15, Layer16, Layer17, Layer18, Layer19, Layer20,\
             Layer31, Layer32, Layer33, Layer34, Layer35, Layer36, Layer37, Layer38, Layer39, Layer40,\
             Layer41, Layer42, Layer43, Layer44, Layer45, Layer46, Layer47, Layer48, Layer49, Layer50"
-
-# Choose a small num_leakslots value in order to test the throttling mechanism
 
 # run test
 $ADEPT_EXECUTABLE --accumulated_events -m ${CI_TMP_DIR}/reproducibility_regions.mac --output_dir ${CI_TMP_DIR} --output_file testem3_run1 --allsensitive

--- a/test/regression/scripts/test_ui_commands_template.mac
+++ b/test/regression/scripts/test_ui_commands_template.mac
@@ -30,9 +30,6 @@
 /adept/setMillionsOfTrackSlots 1
 # Set the total number of track slots that will be allocated on the GPU, in millions
 
-/adept/setMillionsOfLeakSlots 1
-# Set the total number of leak slots that will be allocated on the GPU, in millions
-
 /adept/setMillionsOfHitSlots 1
 # Set the total number of hit slots that will be allocated on the GPU, in millions 
 

--- a/test/regression/scripts/validation_drift_test.sh
+++ b/test/regression/scripts/validation_drift_test.sh
@@ -34,7 +34,6 @@ NUM_THREADS=1
 NUM_EVENTS=1
 NUM_TRACKSLOTS=3
 NUM_HITSLOTS=12
-NUM_LEAKSLOTS=3
 GUN_NUMBER=20
 ADEPT_SEED=1234567
 # The ROOT truth path requires the user callbacks because the reconstructed
@@ -106,7 +105,6 @@ generate_validation_macro() {
       --num_events "${NUM_EVENTS}" \
       --num_trackslots "${NUM_TRACKSLOTS}" \
       --num_hitslots "${NUM_HITSLOTS}" \
-      --num_leakslots "${NUM_LEAKSLOTS}" \
       --track_in_all_regions "${track_in_all_regions}" \
       --gun_type setDefault \
       --gun_number "${GUN_NUMBER}" \

--- a/test/regression/scripts/validation_testem3.sh
+++ b/test/regression/scripts/validation_testem3.sh
@@ -40,7 +40,6 @@ $CI_TEST_DIR/python_scripts/macro_generator.py \
     --num_events 400 \
     --num_trackslots 3 \
     --num_hitslots 12 \
-    --num_leakslots 3 \
     --track_in_all_regions True\
     --gun_type setDefault 
 

--- a/test/regression/scripts/validation_testem3_WDT.sh
+++ b/test/regression/scripts/validation_testem3_WDT.sh
@@ -40,7 +40,6 @@ $CI_TEST_DIR/python_scripts/macro_generator.py \
     --num_events 400 \
     --num_trackslots 3 \
     --num_hitslots 12 \
-    --num_leakslots 3 \
     --track_in_all_regions True\
     --gun_type setDefault\
     --wdt_regions "WDT_Region_layers_10_40,Layer5,Layer44,Layer45"

--- a/test/regression/scripts/validation_testem3_regions.sh
+++ b/test/regression/scripts/validation_testem3_regions.sh
@@ -40,7 +40,6 @@ $CI_TEST_DIR/python_scripts/macro_generator.py \
     --num_events 400 \
     --num_trackslots 3 \
     --num_hitslots 12 \
-    --num_leakslots 3 \
     --track_in_all_regions False\
     --gun_type setDefault\
     --regions "caloregion, Layer1, Layer2, Layer3, Layer4, Layer5, Layer6, Layer7, Layer8, Layer9, Layer10,\


### PR DESCRIPTION
This PR is a follow up to #539 and should not be reviewed before that one is merged.

This PR extends the idea to use the GPUHits to create the tracks for nuclear reactions to use it for all leaked tracks.
This has the following consequences:

- all leaked tracks related machinery is removed, drastically simplifying the state machine, the asynchronous GPU transport loop, the interfaces
- the deferred nuclear steps and leaked tracks can now be treated as the same again and the sorting is simplified

Regarding performance:
- sending back leaked tracks is cheaper than steps. Therefore, this new implementation can be a) cheaper if a step + a track were sent back, b) more expensive before only a track was sent back, as the step is bigger. 
- simplifying the state machine and removing synchronizations should not really make a difference, as the leaks were usually not the problem.

### Performance results in Athena:
Run on the RTX4090

Note that there are quite the fluctuations between runs, larger than the std can show, as some results deviated quite a bit when run again on another day.
| Config | Mean Real [s] | Std [s] | Mean wall [min] |
|---|---:|---:|---:|
| `Mono_Master` | 860.3 | 11.6 | 14.338 |
| `Mono_PR` | 850.4 | 9.13 | 14.173 |
| `Split_Master` | 855.1 | 4.9 | 14.252 |
| `Split_PR` | 863.2 | 6.4 |14.386 |
| `G4HepEm` | 1149.9 | 2.2 | 19.165 |


### Changes in physics:
This PR does change the physics behavior: first, before #539 is merged, it contains the changes regarding the MC truth that are explained in that PR, which fixes previously incorrect behavior for gamma / lepton nuclear.

Then, this PR intentionally changes the local time and the proper time histograms. Now the `GPUHit` transfers both as `float` to the CPU, where they are changed to the G4double (note that the GPU track itself also stores them in float). This is different w.r.t. how the leaked tracks were handling both (they were returned in double). Furthermore, the proper time was not set in the G4Track when being returned. This is now also fixed. 

Note that commit `d2e170c34c53e9e71ca0d1106920c6cf4b61501e` intentionally recreates the exact behavior as before, so it passes the drift test cleanly, before in the final commit, the drift test behavior changes, but is correct.

As this PR superseded #539, it resolves #533