### PR TITLE
integrationBenchmark: use GetSecondaryInCurrentStep in MC truth linking

### DIFF
--- a/test/regression/IntegrationTest/src/SteppingAction.cc
+++ b/test/regression/IntegrationTest/src/SteppingAction.cc
@@ -37,7 +37,7 @@ void SteppingAction::UserSteppingAction(const G4Step *theStep)
     auto *parentInfo =
         parentTrack != nullptr ? dynamic_cast<TrackLineageInfo *>(parentTrack->GetUserInformation()) : nullptr;
 
-    const auto *secondaries = theStep->GetSecondary();
+    const auto *secondaries = theStep->GetSecondaryInCurrentStep();
     if (secondaries != nullptr && parentInfo != nullptr) {
       // This is the only callback where Geant4 exposes the stepped parent and
       // the newly created secondaries together. The drift test therefore

--- a/test/regression/IntegrationTest/src/TruthHistogrammer.cc
+++ b/test/regression/IntegrationTest/src/TruthHistogrammer.cc
@@ -364,7 +364,7 @@ void TruthHistogrammer::RecordFinalTrack(const G4Track *track)
   IncrementValue("final_step_length", step->GetStepLength());
   IncrementValue("final_total_edep", step->GetTotalEnergyDeposit());
 
-  const auto *secondaries = step->GetSecondary();
+  const auto *secondaries = step->GetSecondaryInCurrentStep();
   IncrementValue("final_num_secondaries", secondaries ? static_cast<double>(secondaries->size()) : 0.0);
 }
 


### PR DESCRIPTION
This PR fixes to use the `GetSecondaryInCurrentStep` instead of the `GetSecondary`. In principle, the `GetSecondary` gives all secondaries of the full track, not just of the current step. However, AdePT never provides those, it only provides the secondaries in the current step.

Thus, although equivalent here, the correct function should be used to avoid any confusion.


It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results. Note:
This does change the histogram of the `final_num_secondaries` for the tracks that are tracked by G4, which are the hadrons generated by nuclear reactions. This was confirmed by running this PR on top of #538, to confirm that only this expected histogram fails.