### PR TITLE
fix(cmake): check_cxx_source_compile into static library only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,13 +324,13 @@ foreach(_g4lib IN LISTS Geant4_LIBRARIES)
 endforeach()
 
 set(CMAKE_REQUIRED_INCLUDES ${Geant4_INCLUDE_DIRS})
-set(CMAKE_REQUIRED_LIBRARIES ${_adept_geant4_libraries})
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 # Check if Geant4 is supports G4VTrackingManager
 # Always available from v11.0, but experiments may backport it to earlier versions
 # so we do a compile check.
-check_cxx_source_compiles("
-  #include \"G4VTrackingManager.hh\"
-  #include \"G4Track.hh\"
+check_cxx_source_compiles([[
+  #include "G4VTrackingManager.hh"
+  #include "G4Track.hh"
 
   struct testtm_ : G4VTrackingManager {
     void HandOverOneTrack(G4Track*) override {}
@@ -339,7 +339,8 @@ check_cxx_source_compiles("
   int main() {
     testtm_ t;
     return 0;
-  }" AdePT_HAS_G4VTRACKINGMANAGER)
+  }
+  ]] AdePT_HAS_G4VTRACKINGMANAGER)
 
 # Find HepMC3, used by integration examples to load realistic events
 find_package(HepMC3 QUIET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,24 +323,26 @@ foreach(_g4lib IN LISTS Geant4_LIBRARIES)
   list(APPEND _adept_geant4_libraries "${_adept_g4lib}")
 endforeach()
 
-set(CMAKE_REQUIRED_INCLUDES ${Geant4_INCLUDE_DIRS})
-set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
-# Check if Geant4 is supports G4VTrackingManager
-# Always available from v11.0, but experiments may backport it to earlier versions
-# so we do a compile check.
-check_cxx_source_compiles([[
-  #include "G4VTrackingManager.hh"
-  #include "G4Track.hh"
-
-  struct testtm_ : G4VTrackingManager {
-    void HandOverOneTrack(G4Track*) override {}
-  };
-
-  int main() {
-    testtm_ t;
-    return 0;
-  }
-  ]] AdePT_HAS_G4VTRACKINGMANAGER)
+block()
+  set(CMAKE_REQUIRED_INCLUDES ${Geant4_INCLUDE_DIRS})
+  set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+  # Check if Geant4 is supports G4VTrackingManager
+  # Always available from v11.0, but experiments may backport it to earlier versions
+  # so we do a compile check.
+  check_cxx_source_compiles([[
+    #include "G4VTrackingManager.hh"
+    #include "G4Track.hh"
+  
+    struct testtm_ : G4VTrackingManager {
+      void HandOverOneTrack(G4Track*) override {}
+    };
+  
+    int main() {
+      testtm_ t;
+      return 0;
+    }
+    ]] AdePT_HAS_G4VTRACKINGMANAGER)
+endblock()
 
 # Find HepMC3, used by integration examples to load realistic events
 find_package(HepMC3 QUIET)


### PR DESCRIPTION
It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results

This is the same as https://github.com/mnovak42/g4hepem/pull/131, so comments there reproduced here.

In my CUDA-enabled dependency stack, `check_cxx_source_compiles` was messing up the vecgeom linking which geant4 pulls in (missing `__cudaRegisterLinkedBinary_` symbols). The point of this test is to see if the header is available, so linking is not necessary. This PR changes the scope to build the provided source snippet into a static library, which is sufficient to validate the presence of the header and avoids the linking issues. With this fix, my geant4 v11 installation is correctly setting `G4HepEm_HAS_G4VTRACKINGMANAGER`.

Also: moved to lua-style backet block quoting to avoid need for escaped quotes.