### PR TITLE
fix number possible secondaries

### DIFF
--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -474,7 +474,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     __syncwarp(); // was found to be beneficial after divergent calls
 
     // data structure for possible secondaries that are generated
-    SecondaryInitData secondaryData[2];
+    SecondaryInitData secondaryData[3];
     unsigned int nSecondaries = 0;
 
     if (reached_interaction && !stopped) {


### PR DESCRIPTION
This fixes the number of returned secondaries in the monolithic kernels:
If a positron produces a secondary and falls below the tracking cut and annihilates to two gammas, three secondaries can be produced. While the assert is correct, the struct was too small (it is correct in the split kernels). This only happens with certain cut values and was not causing issues before.

It was verified that this PR
- [ ] Changes physics results
- [ ] Does not change physics results