### PR TITLE
switch to use Jenkins user for trigger

### DIFF
--- a/.github/workflows/jenkins-trigger.yml
+++ b/.github/workflows/jenkins-trigger.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 CERN
+# SPDX-License-Identifier: Apache-2.0
+
 name: Trigger Jenkins
 
 on:

--- a/.github/workflows/jenkins-trigger.yml
+++ b/.github/workflows/jenkins-trigger.yml
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2026 CERN
-# SPDX-License-Identifier: Apache-2.0
-
 name: Trigger Jenkins
 
 on:
@@ -18,12 +15,16 @@ jobs:
     steps:
       - name: Trigger Jenkins
         env:
-          JENKINS_TRIGGER_TOKEN: ${{ secrets.JENKINS_TRIGGER_TOKEN }}
+          JENKINS_USER: ${{ secrets.JENKINS_USER }}
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}
         run: |
           PR=${{ github.event.workflow_run.pull_requests[0].number }}
           AUTHOR=${{ github.event.workflow_run.actor.login }}
 
-          curl -X POST \
-            "https://lcgapp-services.cern.ch/spi-jenkins/job/AdePT-PR-trigger/buildWithParameters?token=${JENKINS_TRIGGER_TOKEN}" \
+          echo "Triggering Jenkins for PR $PR by $AUTHOR"
+
+          curl --fail --show-error -u "$JENKINS_USER:$JENKINS_API_TOKEN" \
+            -X POST \
+            "https://lcgapp-services.cern.ch/spi-jenkins/job/AdePT-PR-trigger/buildWithParameters" \
             --data-urlencode "ghprbPullId=${PR}" \
             --data-urlencode "ghprbPullAuthorLogin=${AUTHOR}"


### PR DESCRIPTION
This is a follow up to #547.

Using the tokens as in #547 triggers the CERN SSO, so it does not run the job. 
This is (hopefully) fixed by providing the jenkins user and jenkins API token instead (both stored in github as a secret)


It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results