### PR TITLE
update jenkins status trigger and poll result

### DIFF
--- a/.github/workflows/jenkins-trigger.yml
+++ b/.github/workflows/jenkins-trigger.yml
@@ -8,6 +8,10 @@ on:
     workflows: ["Prechecks"]
     types: [completed]
 
+concurrency:
+  group: trigger-jenkins-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 permissions:
   actions: read
   contents: read
@@ -20,6 +24,8 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
+    # Transitional bridge: GitHub triggers Jenkins and waits for its result so
+    # the PR gets a native status check until Jenkins reports status directly.
     timeout-minutes: 360
 
     steps:
@@ -39,6 +45,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -eo pipefail
 
@@ -78,6 +85,12 @@ jobs:
           echo "Resolved PR #${pr_number} by ${pr_author}"
           echo "PR SHA: ${pr_sha}"
           echo "PR URL: ${pr_url}"
+
+          if [ "${pr_sha}" != "${WORKFLOW_HEAD_SHA}" ]; then
+            echo "ERROR: Resolved PR SHA (${pr_sha}) does not match workflow_run.head_sha (${WORKFLOW_HEAD_SHA})." >&2
+            echo "A newer commit likely landed after the successful Prechecks run. Refusing to trigger Jenkins for a mismatched revision." >&2
+            exit 1
+          fi
 
           echo "number=${pr_number}" >> "${GITHUB_OUTPUT}"
           echo "author=${pr_author}" >> "${GITHUB_OUTPUT}"
@@ -122,6 +135,7 @@ jobs:
         id: trigger
         env:
           JENKINS_TRIGGER_TOKEN: ${{ secrets.JENKINS_TRIGGER_TOKEN }}
+          PR_COMMIT: ${{ steps.pr.outputs.sha }}
           PR_AUTHOR: ${{ steps.pr.outputs.author }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
@@ -140,6 +154,7 @@ jobs:
               "${jenkins_base_url}/buildByToken/buildWithParameters" \
               --data-urlencode "job=AdePT-PR-trigger" \
               --data-urlencode "token=${JENKINS_TRIGGER_TOKEN}" \
+              --data-urlencode "ghprbActualCommit=${PR_COMMIT}" \
               --data-urlencode "ghprbPullId=${PR_NUMBER}" \
               --data-urlencode "ghprbPullAuthorLogin=${PR_AUTHOR}"
           )

--- a/.github/workflows/jenkins-trigger.yml
+++ b/.github/workflows/jenkins-trigger.yml
@@ -8,53 +8,312 @@ on:
     workflows: ["Prechecks"]
     types: [completed]
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+  statuses: write
+
 jobs:
   trigger:
     if: >
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 360
 
     steps:
-      - name: Show workflow_run payload basics
+      - name: Show workflow_run basics
         run: |
-          echo "event=${{ github.event.workflow_run.event }}"
-          echo "conclusion=${{ github.event.workflow_run.conclusion }}"
-          echo "actor=${{ github.event.workflow_run.actor.login }}"
-          echo "pull_requests_json=${{ toJson(github.event.workflow_run.pull_requests) }}"
+          echo "workflow_run.id=${{ github.event.workflow_run.id }}"
+          echo "workflow_run.event=${{ github.event.workflow_run.event }}"
+          echo "workflow_run.conclusion=${{ github.event.workflow_run.conclusion }}"
+          echo "workflow_run.actor=${{ github.event.workflow_run.actor.login }}"
+          echo "workflow_run.head_branch=${{ github.event.workflow_run.head_branch }}"
+          echo "workflow_run.head_repository=${{ github.event.workflow_run.head_repository.full_name }}"
+          echo "workflow_run.pull_requests=${{ toJson(github.event.workflow_run.pull_requests) }}"
 
-      - name: Trigger Jenkins
+      - name: Resolve PR for this workflow_run
+        id: pr
         env:
-          JENKINS_USER: ${{ secrets.JENKINS_USER }}
-          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          set -u
+          set -eo pipefail
 
-          PR="${{ github.event.workflow_run.pull_requests[0].number }}"
-          AUTHOR="${{ github.event.workflow_run.actor.login }}"
-
-          echo "PR='${PR}'"
-          echo "AUTHOR='${AUTHOR}'"
-
-          if [ -z "${JENKINS_USER}" ]; then
-            echo "ERROR: JENKINS_USER is empty"
+          if [ -z "${HEAD_OWNER}" ] || [ -z "${HEAD_BRANCH}" ]; then
+            echo "ERROR: workflow_run head owner/branch is missing." >&2
             exit 1
           fi
 
-          if [ -z "${JENKINS_API_TOKEN}" ]; then
-            echo "ERROR: JENKINS_API_TOKEN is empty"
+          pr_json=$(
+            curl --fail --silent --show-error \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              --get "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls" \
+              --data-urlencode "state=open" \
+              --data-urlencode "head=${HEAD_OWNER}:${HEAD_BRANCH}"
+          )
+
+          echo "Matching PRs:"
+          echo "${pr_json}" | jq '[.[] | {number, state, head: .head.label, sha: .head.sha, url: .html_url}]'
+
+          pr_count=$(echo "${pr_json}" | jq 'length')
+          if [ "${pr_count}" -ne 1 ]; then
+            echo "ERROR: Expected exactly one open PR for ${HEAD_OWNER}:${HEAD_BRANCH}, found ${pr_count}." >&2
             exit 1
           fi
 
-          if [ -z "${PR}" ]; then
-            echo "ERROR: PR number is empty"
+          pr_number=$(echo "${pr_json}" | jq -r '.[0].number')
+          pr_author=$(echo "${pr_json}" | jq -r '.[0].user.login')
+          pr_sha=$(echo "${pr_json}" | jq -r '.[0].head.sha')
+          pr_url=$(echo "${pr_json}" | jq -r '.[0].html_url')
+
+          if [ -z "${pr_number}" ] || [ -z "${pr_author}" ] || [ -z "${pr_sha}" ] || [ -z "${pr_url}" ]; then
+            echo "ERROR: Failed to resolve complete PR metadata." >&2
             exit 1
           fi
 
-          curl --fail --show-error --silent \
-            --user "${JENKINS_USER}:${JENKINS_API_TOKEN}" \
-            --request POST \
-            --write-out "\nHTTP_STATUS=%{http_code}\n" \
-            "https://lcgapp-services.cern.ch/spi-jenkins/job/AdePT-PR-trigger/buildWithParameters" \
-            --data-urlencode "ghprbPullId=${PR}" \
-            --data-urlencode "ghprbPullAuthorLogin=${AUTHOR}"
+          echo "Resolved PR #${pr_number} by ${pr_author}"
+          echo "PR SHA: ${pr_sha}"
+          echo "PR URL: ${pr_url}"
+
+          echo "number=${pr_number}" >> "${GITHUB_OUTPUT}"
+          echo "author=${pr_author}" >> "${GITHUB_OUTPUT}"
+          echo "sha=${pr_sha}" >> "${GITHUB_OUTPUT}"
+          echo "url=${pr_url}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check Jenkins secrets are present
+        env:
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}
+          JENKINS_TRIGGER_TOKEN: ${{ secrets.JENKINS_TRIGGER_TOKEN }}
+          JENKINS_USER: ${{ secrets.JENKINS_USER }}
+        run: |
+          set -eo pipefail
+
+          [ -n "${JENKINS_USER}" ] || { echo "ERROR: JENKINS_USER is empty." >&2; exit 1; }
+          [ -n "${JENKINS_API_TOKEN}" ] || { echo "ERROR: JENKINS_API_TOKEN is empty." >&2; exit 1; }
+          [ -n "${JENKINS_TRIGGER_TOKEN}" ] || { echo "ERROR: JENKINS_TRIGGER_TOKEN is empty." >&2; exit 1; }
+
+      - name: Mark Jenkins as pending on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_SHA: ${{ steps.pr.outputs.sha }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+        run: |
+          set -eo pipefail
+
+          jq -n \
+            --arg state "pending" \
+            --arg context "Jenkins CI" \
+            --arg description "Queueing Jenkins validation" \
+            --arg target_url "${PR_URL}" \
+            '{state: $state, context: $context, description: $description, target_url: $target_url}' |
+            curl --fail --silent --show-error \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "Content-Type: application/json" \
+              -X POST \
+              -d @- \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${PR_SHA}" >/dev/null
+
+      - name: Trigger Jenkins job
+        id: trigger
+        env:
+          JENKINS_TRIGGER_TOKEN: ${{ secrets.JENKINS_TRIGGER_TOKEN }}
+          PR_AUTHOR: ${{ steps.pr.outputs.author }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          set -eo pipefail
+
+          jenkins_base_url="https://lcgapp-services.cern.ch/spi-jenkins"
+          trigger_headers=$(mktemp)
+          trigger_body=$(mktemp)
+
+          http_code=$(
+            curl --silent --show-error \
+              --output "${trigger_body}" \
+              --dump-header "${trigger_headers}" \
+              --write-out "%{http_code}" \
+              --request POST \
+              "${jenkins_base_url}/buildByToken/buildWithParameters" \
+              --data-urlencode "job=AdePT-PR-trigger" \
+              --data-urlencode "token=${JENKINS_TRIGGER_TOKEN}" \
+              --data-urlencode "ghprbPullId=${PR_NUMBER}" \
+              --data-urlencode "ghprbPullAuthorLogin=${PR_AUTHOR}"
+          )
+
+          echo "Jenkins trigger HTTP status: ${http_code}"
+          echo "Jenkins trigger response headers:"
+          sed -n '1,40p' "${trigger_headers}"
+
+          if [ "${http_code}" != "201" ] && [ "${http_code}" != "303" ]; then
+            echo "Jenkins trigger response body:" >&2
+            sed -n '1,120p' "${trigger_body}" >&2
+            exit 1
+          fi
+
+          queue_url=$(
+            awk 'BEGIN { IGNORECASE = 1 } /^Location:/ { print $2 }' "${trigger_headers}" |
+              tr -d '\r'
+          )
+          rm -f "${trigger_headers}" "${trigger_body}"
+
+          if [ -z "${queue_url}" ]; then
+            echo "ERROR: Jenkins did not return a queue URL." >&2
+            exit 1
+          fi
+
+          case "${queue_url}" in
+            http://*|https://*) ;;
+            /*) queue_url="${jenkins_base_url}${queue_url}" ;;
+            *) queue_url="${jenkins_base_url}/${queue_url}" ;;
+          esac
+
+          echo "Queued Jenkins item: ${queue_url}"
+          echo "queue_url=${queue_url}" >> "${GITHUB_OUTPUT}"
+
+      - name: Wait for Jenkins to start
+        id: started
+        env:
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}
+          JENKINS_USER: ${{ secrets.JENKINS_USER }}
+          QUEUE_URL: ${{ steps.trigger.outputs.queue_url }}
+        run: |
+          set -eo pipefail
+
+          build_url=""
+          for attempt in $(seq 1 60); do
+            echo "Polling Jenkins queue (${attempt}/60): ${QUEUE_URL}"
+            queue_json=$(
+              curl --fail --silent --show-error \
+                --user "${JENKINS_USER}:${JENKINS_API_TOKEN}" \
+                "${QUEUE_URL%/}/api/json"
+            )
+
+            echo "${queue_json}" | jq '{why, cancelled, executable}'
+
+            cancelled=$(echo "${queue_json}" | jq -r '.cancelled // false')
+            if [ "${cancelled}" = "true" ]; then
+              echo "ERROR: Jenkins queue item was cancelled." >&2
+              exit 1
+            fi
+
+            build_url=$(echo "${queue_json}" | jq -r '.executable.url // empty')
+            if [ -n "${build_url}" ]; then
+              break
+            fi
+
+            sleep 10
+          done
+
+          if [ -z "${build_url}" ]; then
+            echo "ERROR: Timed out waiting for Jenkins build to start." >&2
+            exit 1
+          fi
+
+          echo "Started Jenkins build: ${build_url}"
+          echo "build_url=${build_url}" >> "${GITHUB_OUTPUT}"
+
+      - name: Wait for Jenkins result
+        id: result
+        env:
+          JENKINS_API_TOKEN: ${{ secrets.JENKINS_API_TOKEN }}
+          JENKINS_USER: ${{ secrets.JENKINS_USER }}
+          BUILD_URL: ${{ steps.started.outputs.build_url }}
+        run: |
+          set -eo pipefail
+
+          build_result=""
+          for attempt in $(seq 1 360); do
+            echo "Polling Jenkins build (${attempt}/360): ${BUILD_URL}"
+            build_json=$(
+              curl --fail --silent --show-error \
+                --user "${JENKINS_USER}:${JENKINS_API_TOKEN}" \
+                "${BUILD_URL%/}/api/json"
+            )
+
+            echo "${build_json}" | jq '{building, result, url, fullDisplayName}'
+
+            building=$(echo "${build_json}" | jq -r '.building // false')
+            build_result=$(echo "${build_json}" | jq -r '.result // empty')
+
+            if [ "${building}" = "false" ] && [ -n "${build_result}" ]; then
+              break
+            fi
+
+            sleep 30
+          done
+
+          if [ -z "${build_result}" ]; then
+            echo "ERROR: Timed out waiting for Jenkins build to finish." >&2
+            exit 1
+          fi
+
+          echo "Jenkins final result: ${build_result}"
+          echo "result=${build_result}" >> "${GITHUB_OUTPUT}"
+
+      - name: Publish final Jenkins status to GitHub
+        if: always() && steps.pr.outputs.sha != ''
+        env:
+          BUILD_URL: ${{ steps.started.outputs.build_url || steps.trigger.outputs.queue_url || steps.pr.outputs.url }}
+          GH_TOKEN: ${{ github.token }}
+          PR_SHA: ${{ steps.pr.outputs.sha }}
+          RESULT: ${{ steps.result.outputs.result }}
+        run: |
+          set -eo pipefail
+
+          status_state="error"
+          status_description="Jenkins trigger failed"
+
+          case "${RESULT}" in
+            SUCCESS)
+              status_state="success"
+              status_description="Jenkins validation passed"
+              ;;
+            UNSTABLE)
+              status_state="failure"
+              status_description="Jenkins reported UNSTABLE"
+              ;;
+            FAILURE)
+              status_state="failure"
+              status_description="Jenkins validation failed"
+              ;;
+            ABORTED|NOT_BUILT)
+              status_state="error"
+              status_description="Jenkins finished with ${RESULT}"
+              ;;
+            "")
+              status_state="error"
+              status_description="Jenkins trigger failed"
+              ;;
+            *)
+              status_state="error"
+              status_description="Jenkins finished with ${RESULT}"
+              ;;
+          esac
+
+          echo "Publishing GitHub status: ${status_state} (${status_description})"
+
+          jq -n \
+            --arg state "${status_state}" \
+            --arg context "Jenkins CI" \
+            --arg description "${status_description}" \
+            --arg target_url "${BUILD_URL}" \
+            '{state: $state, context: $context, description: $description, target_url: $target_url}' |
+            curl --fail --silent --show-error \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "Content-Type: application/json" \
+              -X POST \
+              -d @- \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${PR_SHA}" >/dev/null
+
+      - name: Fail workflow if Jenkins was not successful
+        if: steps.result.outputs.result != 'SUCCESS'
+        env:
+          RESULT: ${{ steps.result.outputs.result }}
+        run: |
+          echo "Jenkins result was '${RESULT:-trigger_failed}', failing workflow."
+          exit 1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
     string(name: 'LABEL', defaultValue: 'TeslaT4', description: 'Jenkins label for physical nodes or container image for docker')
     string(name: 'ExtraCMakeOptions', defaultValue: '', description: 'CMake extra configuration options')
     string(name: 'DOCKER_LABEL', defaultValue: 'docker-host-noafs', description: 'Label for the the nodes able to launch docker images')
+    string(name: 'ghprbActualCommit', description: 'Immutable PR commit SHA validated by GitHub Actions')
     string(name: 'ghprbPullAuthorLogin', description: 'Author of the Pull Request (provided by GitHub)')
     string(name: 'ghprbPullId', description: 'Pull Request id (provided by GitHub)')
   }
@@ -233,6 +234,18 @@ def checkoutPrSource() {
   checkout scm
   dir('AdePT') {
     sh 'git submodule update --init'
+    if (params.ghprbActualCommit?.trim()) {
+      sh """
+        actual_commit=\$(git rev-parse HEAD)
+        expected_commit="${params.ghprbActualCommit}"
+        echo "Checked out PR commit: \${actual_commit}"
+        echo "Expected PR commit:   \${expected_commit}"
+        if [ "\${actual_commit}" != "\${expected_commit}" ]; then
+          echo "ERROR: Jenkins checked out a different PR commit than the one validated by GitHub Actions." >&2
+          exit 1
+        fi
+      """
+    }
   }
 }
 


### PR DESCRIPTION
This PR fixes the GitHub Actions to Jenkins trigger for pull requests, especially PRs from external forks.

### Problem

The previous workflow relied on `workflow_run.pull_requests[0].number`, which can be empty for fork PRs. In that case Jenkins was not triggered at all.

It also did not guarantee that Jenkins was run for the same commit SHA that had passed the GitHub `Prechecks` workflow.

### Changes

- resolve the PR via the GitHub API from the workflow run head repo + branch
- fail if the resolved PR head SHA does not match `workflow_run.head_sha`
- trigger Jenkins through the token endpoint
- post a `Jenkins CI` status back to the PR commit in GitHub
- mark `UNSTABLE` as failing in GitHub so it is visible on the PR
- add workflow concurrency to reduce overlapping trigger runs
- pass the validated PR SHA into Jenkins and verify after checkout that Jenkins is building the expected commit

### Result

For fork PRs, a successful `Prechecks` run now reliably triggers Jenkins and reports the Jenkins result directly on the PR.



It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results