### PR TITLE
run self-hosted CI in el9 docker

### DIFF
--- a/.github/workflows/self-hosted-pr-ci.yml
+++ b/.github/workflows/self-hosted-pr-ci.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 CERN
 # SPDX-License-Identifier: Apache-2.0
 
-name: Self-Hosted PR CI
+name: Self-Hosted PR CI (EL9)
 
 on:
   issue_comment:
@@ -95,12 +95,12 @@ jobs:
                 "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${PR_SHA}" >/dev/null
           }
 
-          post_status pending "AdePT / Full CI" "Self-hosted CI queued"
-          post_status pending "AdePT / Drift + Unit" "Building PR/reference and running drift"
-          post_status pending "AdePT / Validation" "Waiting for drift result"
+          post_status pending "AdePT / Full CI (EL9)" "Self-hosted EL9 CI queued"
+          post_status pending "AdePT / Drift + Unit (EL9)" "Building PR/reference and running drift in EL9"
+          post_status pending "AdePT / Validation (EL9)" "Waiting for drift result in EL9"
 
   full-ci:
-    name: Full CI
+    name: Full CI (EL9)
     needs: prepare
     if: needs.prepare.outputs.should_run == 'true'
     runs-on:
@@ -110,6 +110,13 @@ jobs:
       - gpu
       - benchmark
       - adept
+    container:
+      image: gitlab-registry.cern.ch/sft/docker/alma9
+      volumes:
+        - /build:/build
+        - /ec/conf:/ec/conf
+        - /cvmfs:/cvmfs:ro
+      options: --user 0 --security-opt seccomp=unconfined --network host --gpus all
     timeout-minutes: 480
     steps:
       - name: Checkout PR head
@@ -131,6 +138,7 @@ jobs:
       - name: Show runner basics
         run: |
           set -eo pipefail
+          cat /etc/os-release | sed -n '1,6p'
           echo "PR #${{ needs.prepare.outputs.pr_number }}"
           echo "Repository: ${{ needs.prepare.outputs.pr_repo }}"
           echo "SHA: ${{ needs.prepare.outputs.pr_sha }}"
@@ -237,9 +245,9 @@ jobs:
                 "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${PR_SHA}" >/dev/null
           }
 
-          post_status "${drift_state}" "AdePT / Drift + Unit" "${drift_description}"
-          post_status "${validation_state}" "AdePT / Validation" "${validation_description}"
-          post_status "${full_state}" "AdePT / Full CI" "${full_description}"
+          post_status "${drift_state}" "AdePT / Drift + Unit (EL9)" "${drift_description}"
+          post_status "${validation_state}" "AdePT / Validation (EL9)" "${validation_description}"
+          post_status "${full_state}" "AdePT / Full CI (EL9)" "${full_description}"
 
       - name: Write summary
         if: always()

--- a/test/ci_common.sh
+++ b/test/ci_common.sh
@@ -15,16 +15,11 @@ select_devadept_lcg_setup() {
     return 0
   fi
 
-  if [[ -f /cvmfs/sft.cern.ch/lcg/views/devAdePT/latest/x86_64-el10-gcc13-opt/setup.sh ]]; then
-    printf '%s\n' /cvmfs/sft.cern.ch/lcg/views/devAdePT/latest/x86_64-el10-gcc13-opt/setup.sh
-    return 0
-  fi
-
   if [[ -f /cvmfs/sft.cern.ch/lcg/views/devAdePT/latest/x86_64-el9-gcc13-opt/setup.sh ]]; then
     printf '%s\n' /cvmfs/sft.cern.ch/lcg/views/devAdePT/latest/x86_64-el9-gcc13-opt/setup.sh
     return 0
   fi
 
-  printf '[ci-common] ERROR: No devAdePT gcc13 LCG view found for el10 or el9\n' >&2
+  printf '[ci-common] ERROR: No devAdePT gcc13 EL9 LCG view found\n' >&2
   return 1
 }

--- a/test/run_ci_matrix.sh
+++ b/test/run_ci_matrix.sh
@@ -57,7 +57,7 @@ Options:
   --build-type <type>        CMake build type (default: Release)
   --cuda-arch <arch|auto>    CUDA arch (default: auto)
   --jobs <N|auto>            Parallel build jobs (default: auto = nproc)
-  --lcg-setup <path>         Explicit LCG setup script (default: auto-discover el10, then el9)
+  --lcg-setup <path>         Explicit LCG setup script (default: devAdePT EL9 view)
   --build-root <path>        Build root directory (default: ${BUILD_ROOT})
   --master-ref <git-ref>     Master reference for drift comparisons (default: ${DEFAULT_MASTER_REF})
   --no-fetch-master          Do not fetch remote master refs before running drift


### PR DESCRIPTION
As the self-hosted CI machine is using el10 and there is so far only and el9 LCG view available, the CI must run in a el9 docker for now.

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results