### PR TITLE
mark AdePT safe for git

### DIFF
--- a/.github/workflows/self-hosted-pr-ci.yml
+++ b/.github/workflows/self-hosted-pr-ci.yml
@@ -128,6 +128,11 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
+      - name: Mark workspace as safe for git
+        run: |
+          set -eo pipefail
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+
       - name: Fetch upstream master reference
         run: |
           set -eo pipefail


### PR DESCRIPTION
Now when using docker, we need to mark the AdePT folder safe for git:

- the docker is run as `root`
- the repository /AdePT/ is owned by the user `adeptci`
This mismatch causes git to fail like this:
https://github.com/apt-sim/AdePT/actions/runs/24457470343/job/71462023923


It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results