### PR TITLE
fix cvmfs access in docker

### DIFF
--- a/.github/workflows/self-hosted-pr-ci.yml
+++ b/.github/workflows/self-hosted-pr-ci.yml
@@ -115,7 +115,7 @@ jobs:
       volumes:
         - /build:/build
         - /ec/conf:/ec/conf
-        - /cvmfs:/cvmfs:ro
+        - /cvmfs:/cvmfs:ro,rslave
       options: --user 0 --security-opt seccomp=unconfined --gpus all
     timeout-minutes: 480
     steps:


### PR DESCRIPTION
This PR adds the propagation mode for mounting cvmfs in the docker such that sft.cern.ch is available. Tested locally, should work

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results