### PR TITLE
feat: add transport kernel counters and summary

### DIFF
--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -1657,7 +1657,6 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
                       << (gpuState.fHitScoring->HitCapacity() / numThreads - gpuState.stats->hitBufferOccupancy)
                       << " Max particles in flight: " << maxInFlight
                       << "  | Waiting for HitBuffers to be freed by worker " << std::endl;
-            ++counters.hitBufferStalls;
 
             auto start = std::chrono::steady_clock::now();
             while (!gpuState.fHitScoring->ReadyToSwapBuffers()) {
@@ -1783,7 +1782,6 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
               << "  Leak extractions by event flush:      " << counters.leakExtractionByEventFlush << "\n"
               << "  Transport stalls (extraction blocked): " << counters.leakExtractionBlocked << "\n"
               << "  Events drained to hit flush:          " << counters.eventDrainedToHitFlush << "\n"
-              << "  Hit-buffer stalls (overflow risk):    " << counters.hitBufferStalls << "\n"
               << "  Hit-buffer swaps total:               " << counters.hitBufferSwaps << "\n"
               << "    of which by occupancy >= half cap:  " << counters.hitBufferSwapByOccupancy << "\n"
               << "    of which by occupancy >= 10000:     " << counters.hitBufferSwapByOccupancy10k << "\n"
@@ -1791,8 +1789,6 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
               << "    of which by event hit flush:        " << counters.hitBufferSwapByEventFlush << "\n";
     if (counters.leakExtractionBlocked > 0)
       std::cerr << "  ACTION: leakExtractionBlocked > 0 -> increase MillionsOfLeakSlots\n";
-    if (counters.hitBufferStalls > 0)
-      std::cerr << "  ACTION: hitBufferStalls > 0 -> increase MillionsOfHitSlots or lower HitBufferFlushThreshold\n";
     if (counters.hitBufferSwapByPressure > 0)
       std::cerr << "  ACTION: hitBufferSwapByPressure > 0 -> increase MillionsOfHitSlots\n";
     if (counters.hitBufferSwapByOccupancy > 0 && counters.hitBufferSwapByOccupancy > counters.hitBufferSwapByEventFlush)

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -1793,7 +1793,8 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
       std::cerr << "  ACTION: hitBufferSwapByPressure > 0 -> increase MillionsOfHitSlots, increase CPUCapacityFactor,\n"
                    "          or increase HitBufferThreshold (safe up to 1 - 1/CPUCapacityFactor)\n";
     if (counters.hitBufferSwapByOccupancy > 0 && counters.hitBufferSwapByOccupancy > counters.hitBufferSwapByEventFlush)
-      std::cerr << "  ACTION: frequent occupancy-driven swaps -> increase MillionsOfHitSlots or HitBufferFlushThreshold\n";
+      std::cerr
+          << "  ACTION: frequent occupancy-driven swaps -> increase MillionsOfHitSlots or HitBufferFlushThreshold\n";
     std::cerr << "=====================================\n";
   }
 

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -1790,7 +1790,8 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
     if (counters.leakExtractionBlocked > 0)
       std::cerr << "  ACTION: leakExtractionBlocked > 0 -> increase MillionsOfLeakSlots\n";
     if (counters.hitBufferSwapByPressure > 0)
-      std::cerr << "  ACTION: hitBufferSwapByPressure > 0 -> increase MillionsOfHitSlots\n";
+      std::cerr << "  ACTION: hitBufferSwapByPressure > 0 -> increase MillionsOfHitSlots, increase CPUCapacityFactor,\n"
+                   "          or increase HitBufferThreshold (safe up to 1 - 1/CPUCapacityFactor)\n";
     if (counters.hitBufferSwapByOccupancy > 0 && counters.hitBufferSwapByOccupancy > counters.hitBufferSwapByEventFlush)
       std::cerr << "  ACTION: frequent occupancy-driven swaps -> increase MillionsOfHitSlots or HitBufferFlushThreshold\n";
     std::cerr << "=====================================\n";

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -979,6 +979,8 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
     }
   }
 
+  TransportLoopCounters counters;
+
   while (gpuState.runTransport) {
     InitSlotManagers<<<80, 256, 0, gpuState.stream>>>(gpuState.slotManager_dev, gpuState.nSlotManager_dev);
     InitSlotManagers<<<80, 256, 0, gpuState.stream>>>(gpuState.slotManagerLeaks_dev, gpuState.nSlotManager_dev);
@@ -1020,6 +1022,7 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
       positrons.queues.SwapActive();
       gammas.queues.SwapActive();
       woodcockQueues.SwapActive();
+      ++counters.totalIterations;
 
       const ParticleManager particleManager = {
           .electrons = {electrons.tracks, electrons.leaks, electrons.slotManager, electrons.slotManagerLeaks,
@@ -1341,11 +1344,13 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
           break;
         }
       }
+      if (leakQueueNeedsTransfer) ++counters.leakExtractionByQueuePressure;
 
       // Did an event request a flush?
       bool leakExtractionRequested = std::any_of(eventStates.begin(), eventStates.end(), [](const auto &eventState) {
         return eventState.load(std::memory_order_acquire) == EventState::HitsFlushed;
       });
+      if (leakExtractionRequested) ++counters.leakExtractionByEventFlush;
 
       bool leakExtractionNeeded = leakQueueNeedsTransfer || leakExtractionRequested;
 
@@ -1366,6 +1371,7 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
             // Otherwise, the current leak queue usage is above the threshold. Transport needs to stop until the
             // transfer of these leaks can start
             printf("WARNING: Leak extraction blocked. Transport will stop until current extraction ends\n");
+            ++counters.leakExtractionBlocked;
           }
         }
 
@@ -1607,6 +1613,7 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
           const auto state = eventStates[threadId].load(std::memory_order_acquire);
           if (state == EventState::WaitingForTransportToFinish && gpuState.stats->perEventInFlight[threadId] == 0) {
             eventStates[threadId] = EventState::RequestHitFlush;
+            ++counters.eventDrainedToHitFlush;
           }
           if (state >= EventState::RequestHitFlush && gpuState.stats->perEventInFlight[threadId] != 0) {
             // FIXME: this case should not happen and is related to some late injection that shows up too late in the
@@ -1650,6 +1657,7 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
                       << (gpuState.fHitScoring->HitCapacity() / numThreads - gpuState.stats->hitBufferOccupancy)
                       << " Max particles in flight: " << maxInFlight
                       << "  | Waiting for HitBuffers to be freed by worker " << std::endl;
+            ++counters.hitBufferStalls;
 
             auto start = std::chrono::steady_clock::now();
             while (!gpuState.fHitScoring->ReadyToSwapBuffers()) {
@@ -1667,11 +1675,18 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
             }
           }
 
-          if (gpuState.stats->hitBufferOccupancy >= gpuState.fHitScoring->HitCapacity() / numThreads / 2 ||
-              gpuState.stats->hitBufferOccupancy >= 10000 || nextStepMightFail ||
-              std::any_of(eventStates.begin(), eventStates.end(), [](const auto &state) {
-                return state.load(std::memory_order_acquire) == EventState::RequestHitFlush;
-              })) {
+          const bool swapByOccupancyHalf =
+              gpuState.stats->hitBufferOccupancy >= gpuState.fHitScoring->HitCapacity() / numThreads / 2;
+          const bool swapByOccupancy10k = gpuState.stats->hitBufferOccupancy >= 10000;
+          const bool swapByEventFlush   = std::any_of(eventStates.begin(), eventStates.end(), [](const auto &state) {
+            return state.load(std::memory_order_acquire) == EventState::RequestHitFlush;
+          });
+          if (swapByOccupancyHalf || swapByOccupancy10k || nextStepMightFail || swapByEventFlush) {
+            ++counters.hitBufferSwaps;
+            if (swapByOccupancyHalf) ++counters.hitBufferSwapByOccupancy;
+            if (swapByOccupancy10k) ++counters.hitBufferSwapByOccupancy10k;
+            if (nextStepMightFail) ++counters.hitBufferSwapByPressure;
+            if (swapByEventFlush) ++counters.hitBufferSwapByEventFlush;
             // Reset hitBufferOccupancy to 0 when we swap, as the delay of updating it could cause another unwanted swap
             ADEPT_DEVICE_API_CALL(
                 MemsetAsync(&(gpuState.stats_dev->hitBufferOccupancy), 0, sizeof(unsigned int), gpuState.stream));
@@ -1759,6 +1774,30 @@ void TransportLoop(int trackCapacity, int leakCapacity, int scoringCapacity, int
     ADEPT_DEVICE_API_CALL(StreamSynchronize(gpuState.stream));
 
     if (debugLevel > 2) std::cout << "End transport loop.\n";
+  }
+
+  if (debugLevel >= 1) {
+    std::cerr << "\n=== AdePT Transport Loop Summary ===\n"
+              << "  Total iterations:                     " << counters.totalIterations << "\n"
+              << "  Leak extractions by queue pressure:   " << counters.leakExtractionByQueuePressure << "\n"
+              << "  Leak extractions by event flush:      " << counters.leakExtractionByEventFlush << "\n"
+              << "  Transport stalls (extraction blocked): " << counters.leakExtractionBlocked << "\n"
+              << "  Events drained to hit flush:          " << counters.eventDrainedToHitFlush << "\n"
+              << "  Hit-buffer stalls (overflow risk):    " << counters.hitBufferStalls << "\n"
+              << "  Hit-buffer swaps total:               " << counters.hitBufferSwaps << "\n"
+              << "    of which by occupancy >= half cap:  " << counters.hitBufferSwapByOccupancy << "\n"
+              << "    of which by occupancy >= 10000:     " << counters.hitBufferSwapByOccupancy10k << "\n"
+              << "    of which by overflow pressure:      " << counters.hitBufferSwapByPressure << "\n"
+              << "    of which by event hit flush:        " << counters.hitBufferSwapByEventFlush << "\n";
+    if (counters.leakExtractionBlocked > 0)
+      std::cerr << "  ACTION: leakExtractionBlocked > 0 -> increase MillionsOfLeakSlots\n";
+    if (counters.hitBufferStalls > 0)
+      std::cerr << "  ACTION: hitBufferStalls > 0 -> increase MillionsOfHitSlots or lower HitBufferFlushThreshold\n";
+    if (counters.hitBufferSwapByPressure > 0)
+      std::cerr << "  ACTION: hitBufferSwapByPressure > 0 -> increase MillionsOfHitSlots\n";
+    if (counters.hitBufferSwapByOccupancy > 0 && counters.hitBufferSwapByOccupancy > counters.hitBufferSwapByEventFlush)
+      std::cerr << "  ACTION: frequent occupancy-driven swaps -> increase MillionsOfHitSlots or HitBufferFlushThreshold\n";
+    std::cerr << "=====================================\n";
   }
 
   hitProcessing->keepRunning = false;

--- a/include/AdePT/core/AsyncAdePTTransportStruct.cuh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.cuh
@@ -261,6 +261,22 @@ struct Stats {
   unsigned int hitBufferOccupancy;
 };
 
+/// Host-only counters accumulating transport-loop stop/stall/flush action reasons across the full run.
+/// These are incremented on the host transport thread and printed at shutdown when verbosity >= 1.
+struct TransportLoopCounters {
+  unsigned long long totalIterations{0};             ///< Total transport iterations executed
+  unsigned long long leakExtractionByQueuePressure{0}; ///< Iterations where leak queue exceeded 50% threshold
+  unsigned long long leakExtractionByEventFlush{0};  ///< Iterations where an event flush requested leak extraction
+  unsigned long long leakExtractionBlocked{0};       ///< Times transport stalled waiting for in-progress extraction
+  unsigned long long eventDrainedToHitFlush{0};      ///< Events that transitioned to RequestHitFlush (queues drained)
+  unsigned long long hitBufferStalls{0};             ///< Times transport stalled waiting for hit buffer to free
+  unsigned long long hitBufferSwaps{0};              ///< Total hit-buffer swaps performed
+  unsigned long long hitBufferSwapByOccupancy{0};    ///< Swaps triggered by occupancy >= half capacity
+  unsigned long long hitBufferSwapByOccupancy10k{0}; ///< Swaps triggered by occupancy >= 10000
+  unsigned long long hitBufferSwapByPressure{0};     ///< Swaps triggered by nextStepMightFail (overflow risk)
+  unsigned long long hitBufferSwapByEventFlush{0};   ///< Swaps triggered by event RequestHitFlush
+};
+
 /// @brief Array of flags whether the event can be finished off
 struct AllowFinishOffEventArray {
   unsigned short flags[kMaxThreads];

--- a/include/AdePT/core/AsyncAdePTTransportStruct.cuh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.cuh
@@ -269,7 +269,6 @@ struct TransportLoopCounters {
   unsigned long long leakExtractionByEventFlush{0};  ///< Iterations where an event flush requested leak extraction
   unsigned long long leakExtractionBlocked{0};       ///< Times transport stalled waiting for in-progress extraction
   unsigned long long eventDrainedToHitFlush{0};      ///< Events that transitioned to RequestHitFlush (queues drained)
-  unsigned long long hitBufferStalls{0};             ///< Times transport stalled waiting for hit buffer to free
   unsigned long long hitBufferSwaps{0};              ///< Total hit-buffer swaps performed
   unsigned long long hitBufferSwapByOccupancy{0};    ///< Swaps triggered by occupancy >= half capacity
   unsigned long long hitBufferSwapByOccupancy10k{0}; ///< Swaps triggered by occupancy >= 10000

--- a/include/AdePT/core/AsyncAdePTTransportStruct.cuh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.cuh
@@ -264,16 +264,16 @@ struct Stats {
 /// Host-only counters accumulating transport-loop stop/stall/flush action reasons across the full run.
 /// These are incremented on the host transport thread and printed at shutdown when verbosity >= 1.
 struct TransportLoopCounters {
-  unsigned long long totalIterations{0};             ///< Total transport iterations executed
+  unsigned long long totalIterations{0};               ///< Total transport iterations executed
   unsigned long long leakExtractionByQueuePressure{0}; ///< Iterations where leak queue exceeded 50% threshold
-  unsigned long long leakExtractionByEventFlush{0};  ///< Iterations where an event flush requested leak extraction
-  unsigned long long leakExtractionBlocked{0};       ///< Times transport stalled waiting for in-progress extraction
-  unsigned long long eventDrainedToHitFlush{0};      ///< Events that transitioned to RequestHitFlush (queues drained)
-  unsigned long long hitBufferSwaps{0};              ///< Total hit-buffer swaps performed
-  unsigned long long hitBufferSwapByOccupancy{0};    ///< Swaps triggered by occupancy >= half capacity
-  unsigned long long hitBufferSwapByOccupancy10k{0}; ///< Swaps triggered by occupancy >= 10000
-  unsigned long long hitBufferSwapByPressure{0};     ///< Swaps triggered by nextStepMightFail (overflow risk)
-  unsigned long long hitBufferSwapByEventFlush{0};   ///< Swaps triggered by event RequestHitFlush
+  unsigned long long leakExtractionByEventFlush{0};    ///< Iterations where an event flush requested leak extraction
+  unsigned long long leakExtractionBlocked{0};         ///< Times transport stalled waiting for in-progress extraction
+  unsigned long long eventDrainedToHitFlush{0};        ///< Events that transitioned to RequestHitFlush (queues drained)
+  unsigned long long hitBufferSwaps{0};                ///< Total hit-buffer swaps performed
+  unsigned long long hitBufferSwapByOccupancy{0};      ///< Swaps triggered by occupancy >= half capacity
+  unsigned long long hitBufferSwapByOccupancy10k{0};   ///< Swaps triggered by occupancy >= 10000
+  unsigned long long hitBufferSwapByPressure{0};       ///< Swaps triggered by nextStepMightFail (overflow risk)
+  unsigned long long hitBufferSwapByEventFlush{0};     ///< Swaps triggered by event RequestHitFlush
 };
 
 /// @brief Array of flags whether the event can be finished off


### PR DESCRIPTION
As part of an effort to determine optimal running configs, I added some kernel exit state counters that are printed at the end. It's purely for debugging/tuning, but maybe it is useful. I was looking to make it return some heuristic suggestions.

It was NOT verified that this PR
- [] Changes physics results
- [] Does not change physics results

But this is unlikely to change anything.