### PR TITLE
[mini] fix TruthHistogrammer warning

### DIFF
--- a/test/regression/IntegrationTest/src/TruthHistogrammer.cc
+++ b/test/regression/IntegrationTest/src/TruthHistogrammer.cc
@@ -126,6 +126,7 @@ std::string ParticleName(const G4Track *track)
   return track && track->GetParticleDefinition() ? track->GetParticleDefinition()->GetParticleName() : "none";
 }
 
+#ifdef ADEPT_INTEGRATIONTEST_HAS_ROOT
 std::string ExactValueLabel(double value)
 {
   if (std::isnan(value)) return "nan";
@@ -145,7 +146,6 @@ bool ValueKeyLess(double lhs, double rhs)
   return false;
 }
 
-#ifdef ADEPT_INTEGRATIONTEST_HAS_ROOT
 void WriteLabelMetadata(TFile &file, const std::string &name, const std::vector<std::string> &labels)
 {
   std::ostringstream metadata;


### PR DESCRIPTION
When the integration benchmark was build without ROOT support, these warnings appeared

```
/home/ndiederi/software/AdePT/test/regression/IntegrationTest/src/TruthHistogrammer.cc:139:6: warning: ‘bool {anonymous}::ValueKeyLess(double, double)’ defined but not used [-Wunused-function]
  139 | bool ValueKeyLess(double lhs, double rhs)
      |      ^~~~~~~~~~~~
/home/ndiederi/software/AdePT/test/regression/IntegrationTest/src/TruthHistogrammer.cc:129:13: warning: ‘std::string {anonymous}::ExactValueLabel(double)’ defined but not used [-Wunused-function]
  129 | std::string ExactValueLabel(double value)
      |             ^~~~~~~~~~~~~~~
```

because the guarding of the ROOT support was not scoping all it should have.

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results