### PR TITLE
fix cancel procedure for selfhosted CI runs

### DIFF
--- a/.github/workflows/self-hosted-pr-ci.yml
+++ b/.github/workflows/self-hosted-pr-ci.yml
@@ -13,10 +13,6 @@ permissions:
   pull-requests: read
   statuses: write
 
-concurrency:
-  group: self-hosted-pr-ci-${{ github.event.issue.number || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   prepare:
     name: Prepare
@@ -103,6 +99,9 @@ jobs:
     name: Full CI (EL9)
     needs: prepare
     if: needs.prepare.outputs.should_run == 'true'
+    concurrency:
+      group: self-hosted-pr-ci-${{ needs.prepare.outputs.pr_number || github.event.issue.number }}
+      cancel-in-progress: true
     runs-on:
       - self-hosted
       - linux


### PR DESCRIPTION
This fixes a bug in the concurrency setup of the self-hosted CI:

The idea is to cancel a running job on the same PR, such that the latest job always overrides the first one and doesn't have to wait for it.
However, it cancelled the job on the trigger (which is just any comment), before checking whether the trigger (any comment) is a valid one to start the CI (`/run-test` by a member of AdePT). Now, the cancellation is moved to after it is validated that the initial trigger is valid


It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results