### PR TITLE
Move PreuserTrackingAction into UseUserAction guard

### DIFF
--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -496,20 +496,20 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
         } else if (pdg == 22) {
           hostTrackData.particleType = ParticleType::Gamma;
         }
-      }
 
-      // if there has been no step, call PreUserTrackingAction and try to attach UserInformation
-      if (aTrack->GetCurrentStepNumber() == 0) {
-        auto *userTrackingAction = eventManager->GetUserTrackingAction();
-        if (userTrackingAction) {
+        // if there has been no step, call PreUserTrackingAction and try to attach UserInformation
+        if (aTrack->GetCurrentStepNumber() == 0) {
+          auto *userTrackingAction = eventManager->GetUserTrackingAction();
+          if (userTrackingAction) {
 
-          // this assumes that the UserTrackInformation is attached to the track in the PreUserTrackingAction
-          userTrackingAction->PreUserTrackingAction(aTrack);
+            // this assumes that the UserTrackInformation is attached to the track in the PreUserTrackingAction
+            userTrackingAction->PreUserTrackingAction(aTrack);
+            hostTrackData.userTrackInfo = aTrack->GetUserInformation();
+          }
+        } else {
+          // not the initializing step, just attach user information in case it is there
           hostTrackData.userTrackInfo = aTrack->GetUserInformation();
         }
-      } else {
-        // not the initializing step, just attach user information in case it is there
-        hostTrackData.userTrackInfo = aTrack->GetUserInformation();
       }
 
       uint64_t gpuParentID;


### PR DESCRIPTION
Previously, the PreUserTrackingAction was always called and potential custom UserTrackInfo was attached. However, if the CallUserTrackingAction in AdePT was off, it would have been attached to a dummy HostData, leading to a memory leak.

This is fixed by simply moving the block into the part that is guarded by CallUserTrackingAction

Reported by @dkonst13

It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results