### PR TITLE
update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,17 @@
-It was verified that this PR
-- [] Changes physics results
-- [] Does not change physics results
+Describe briefly what this PR changes and why.
+
+
+
+Delete the guidance below before opening the PR.
+
+- Use `pre-commit` locally before pushing to catch formatting issues such as `clang-format`, as the same checks are enforced in CI.
+- Add SPDX headers or matching REUSE metadata for new files. License compliance is checked in CI.
+
+### PR approval workflow
+
+- The automatic prechecks must pass.
+- A repository member must trigger the physics checks.
+- For approval, either the physics results must remain unchanged, or the full validation must pass.
+- If the physics drift shows differences, explain them clearly in the PR description.
+
+---


### PR DESCRIPTION
This small PR updates the PR template.
One does not have to set the checks whether the PR changed the physics by hand anymore, as the CI test will clearly show whether the physics drifted and the validation was run or not.


It was verified that this PR
- [ ] Changes physics results
- [x] Does not change physics results