### PR TITLE
Add selfhosted nightly

### DIFF
--- a/.github/workflows/nightly-ci-el9.yml
+++ b/.github/workflows/nightly-ci-el9.yml
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: 2026 CERN
+# SPDX-License-Identifier: Apache-2.0
+
+name: Nightly CI (EL9)
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-ci-el9
+  cancel-in-progress: false
+
+jobs:
+  nightly:
+    name: Nightly CI (EL9)
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - gpu
+      - benchmark
+      - adept
+    timeout-minutes: 480
+    env:
+      RESULTS_FILE: ${{ github.workspace }}/nightly-ci-results.env
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v6
+        with:
+          ref: master
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Show runner basics
+        run: |
+          set -eo pipefail
+          cat /etc/os-release | sed -n '1,6p'
+          echo "event=${GITHUB_EVENT_NAME}"
+          echo "ref=${GITHUB_REF}"
+          echo "sha=${GITHUB_SHA}"
+          echo "hostname=$(hostname)"
+          echo "user=$(whoami)"
+          echo "pwd=$(pwd)"
+          id
+
+      - name: Pre-touch required CVMFS repos on host
+        run: |
+          set -eo pipefail
+          ls /cvmfs/sft.cern.ch/lcg/views/devAdePT/latest/x86_64-el9-gcc13-opt/setup.sh
+          ls /cvmfs/geant4.cern.ch/share/data/G4ENSDFSTATE3.0/ENSDFSTATE.dat
+
+      - name: Check GPU visibility
+        run: |
+          set -eo pipefail
+          nvidia-smi
+
+      - name: Check Docker basics
+        run: |
+          set -eo pipefail
+          docker --version
+
+      - name: Run nightly CI in Alma 9 container
+        continue-on-error: true
+        run: |
+          set -eo pipefail
+
+          rm -f "${RESULTS_FILE}"
+
+          docker_group_args=()
+          for group_name in video render; do
+            if getent group "${group_name}" >/dev/null 2>&1; then
+              docker_group_args+=(--group-add "$(getent group "${group_name}" | cut -d: -f3)")
+            fi
+          done
+
+          docker run --rm --pull always \
+            --gpus all \
+            --user "$(id -u):$(id -g)" \
+            "${docker_group_args[@]}" \
+            --security-opt seccomp=unconfined \
+            -v /build:/build \
+            -v /ec/conf:/ec/conf \
+            -v /cvmfs:/cvmfs:ro,rslave \
+            -v "${GITHUB_WORKSPACE}:/work/AdePT" \
+            -e HOME=/tmp/adeptci-home \
+            -w /work/AdePT \
+            gitlab-registry.cern.ch/sft/docker/alma9 \
+            bash -lc '
+              set -eo pipefail
+              mkdir -p "${HOME}"
+              git config --global --add safe.directory /work/AdePT
+              ./test/run_nightly_ci.sh \
+                --build-root /tmp/adept-nightly-ci \
+                --results-file /work/AdePT/nightly-ci-results.env \
+                --build-type Release \
+                --cuda-arch 89 \
+                --jobs auto \
+                --ctest-timeout-sec 180
+            '
+
+      - name: Write summary
+        if: always()
+        run: |
+          if [ -r "${RESULTS_FILE}" ]; then
+            # shellcheck disable=SC1091
+            source "${RESULTS_FILE}"
+          fi
+
+          {
+            echo "### Nightly CI (EL9)"
+            echo
+            echo "- Event: \`${GITHUB_EVENT_NAME}\`"
+            echo "- Ref: \`${GITHUB_REF}\`"
+            echo "- SHA: \`${GITHUB_SHA}\`"
+            echo "- Runner: \`$(hostname)\`"
+            echo "- User: \`$(whoami)\`"
+            echo "- LCG setup: \`${LCG_SETUP:-missing}\`"
+            echo "- Build type: \`${BUILD_TYPE:-missing}\`"
+            echo "- Build root: \`${BUILD_ROOT:-/tmp/adept-nightly-ci}\`"
+            echo "- Nightly status: \`${NIGHTLY_STATUS:-missing}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload nightly summary artifact
+        if: always() && hashFiles(env.RESULTS_FILE) != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-ci-results
+          path: ${{ env.RESULTS_FILE }}
+          if-no-files-found: error
+
+      - name: Fail workflow if nightly CI failed
+        if: always()
+        run: |
+          if [ -r "${RESULTS_FILE}" ]; then
+            # shellcheck disable=SC1091
+            source "${RESULTS_FILE}"
+          else
+            NIGHTLY_STATUS=1
+          fi
+
+          test "${NIGHTLY_STATUS}" -eq 0

--- a/.github/workflows/nightly-ci-el9.yml
+++ b/.github/workflows/nightly-ci-el9.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: nightly-ci-el9
@@ -132,6 +133,98 @@ jobs:
           name: nightly-ci-results
           path: ${{ env.RESULTS_FILE }}
           if-no-files-found: error
+
+      - name: Resolve nightly status
+        if: always()
+        id: resolve_status
+        run: |
+          if [ -r "${RESULTS_FILE}" ]; then
+            # shellcheck disable=SC1091
+            source "${RESULTS_FILE}"
+          else
+            NIGHTLY_STATUS=1
+          fi
+
+          echo "nightly_status=${NIGHTLY_STATUS}" >> "${GITHUB_OUTPUT}"
+
+      - name: Open or update nightly failure issue
+        if: always() && steps.resolve_status.outputs.nightly_status != '0'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const title = "Nightly CI (EL9) failure";
+            const label = "nightly-failure";
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              "The nightly CI failed.",
+              "",
+              `- Workflow: ${context.workflow}`,
+              `- Run: ${runUrl}`,
+              `- Commit: ${context.sha}`,
+              `- Ref: ${context.ref}`,
+            ].join("\n");
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: label,
+              per_page: 100,
+            });
+
+            const existing = issues.find(issue => issue.title === title);
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: [label],
+              });
+            }
+
+      - name: Close nightly failure issue on recovery
+        if: always() && steps.resolve_status.outputs.nightly_status == '0'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const title = "Nightly CI (EL9) failure";
+            const label = "nightly-failure";
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              labels: label,
+              per_page: 100,
+            });
+
+            for (const issue of issues) {
+              if (issue.title !== title) continue;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Nightly CI recovered: ${runUrl}`,
+              });
+
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: "closed",
+              });
+            }
 
       - name: Fail workflow if nightly CI failed
         if: always()

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ SPDX-License-Identifier: CC-BY-4.0
 # AdePT
 
 [![Documentation Status](https://readthedocs.org/projects/adept-project/badge/?version=latest)](https://adept-project.readthedocs.io/en/latest/?badge=latest)
+[![Nightly CI (EL9)](https://github.com/apt-sim/AdePT/actions/workflows/nightly-ci-el9.yml/badge.svg?branch=master)](https://github.com/apt-sim/AdePT/actions/workflows/nightly-ci-el9.yml)
 
 
 Accelerated demonstrator of electromagnetic Particle Transport

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # AdePT Documentation
 
+[![Nightly CI (EL9)](https://github.com/apt-sim/AdePT/actions/workflows/nightly-ci-el9.yml/badge.svg?branch=master)](https://github.com/apt-sim/AdePT/actions/workflows/nightly-ci-el9.yml)
+
 This site is the home for AdePT installation, user guide, and API reference.
 
 ## Introduction

--- a/test/run_nightly_ci.sh
+++ b/test/run_nightly_ci.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 CERN
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+MATRIX_RUNNER="${REPO_ROOT}/test/run_ci_matrix.sh"
+
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/ci_common.sh"
+
+DEFAULT_BUILD_ROOT="/tmp/adept-nightly-ci"
+DEFAULT_RESULTS_FILE=""
+
+BUILD_ROOT="${DEFAULT_BUILD_ROOT}"
+RESULTS_FILE="${DEFAULT_RESULTS_FILE}"
+LCG_SETUP=""
+BUILD_TYPE="Release"
+CUDA_ARCH="auto"
+CTEST_TIMEOUT_SEC=0
+JOBS="auto"
+declare -a CMAKE_EXTRA_ARGS=()
+
+log() {
+  printf '[nightly-ci] %s\n' "$*"
+}
+
+die() {
+  printf '[nightly-ci] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+Runs the nightly CI selection on the self-hosted runner:
+  1. build Release matrix for async/split/mixed
+  2. run unit tests on async
+  3. run validation tests on async and split
+
+Options:
+  --build-root <path>        Build root (default: ${DEFAULT_BUILD_ROOT})
+  --results-file <path>      Write KEY=VALUE results for workflow consumption
+  --lcg-setup <path>         Explicit LCG setup script
+  --build-type <type>        CMake build type (default: ${BUILD_TYPE})
+  --cuda-arch <arch|auto>    CUDA arch passed to the matrix runner (default: ${CUDA_ARCH})
+  --jobs <N|auto>            Parallel build jobs passed through to the matrix runner (default: ${JOBS})
+  --ctest-timeout-sec <sec>  Optional timeout for each ctest invocation
+  --cmake-extra <arg>        Additional CMake argument passed through to the matrix runner
+  -h, --help                 Show this help
+EOF
+}
+
+write_results() {
+  [[ -n "${RESULTS_FILE}" ]] || return
+
+  {
+    printf 'LCG_SETUP=%q\n' "${LCG_SETUP}"
+    printf 'BUILD_ROOT=%q\n' "${BUILD_ROOT}"
+    printf 'BUILD_TYPE=%q\n' "${BUILD_TYPE}"
+    printf 'NIGHTLY_STATUS=%s\n' "${NIGHTLY_STATUS}"
+  } > "${RESULTS_FILE}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --build-root)
+      [[ $# -ge 2 ]] || die "Missing value for --build-root"
+      BUILD_ROOT=$2
+      shift 2
+      ;;
+    --results-file)
+      [[ $# -ge 2 ]] || die "Missing value for --results-file"
+      RESULTS_FILE=$2
+      shift 2
+      ;;
+    --lcg-setup)
+      [[ $# -ge 2 ]] || die "Missing value for --lcg-setup"
+      LCG_SETUP=$2
+      shift 2
+      ;;
+    --build-type)
+      [[ $# -ge 2 ]] || die "Missing value for --build-type"
+      BUILD_TYPE=$2
+      shift 2
+      ;;
+    --cuda-arch)
+      [[ $# -ge 2 ]] || die "Missing value for --cuda-arch"
+      CUDA_ARCH=$2
+      shift 2
+      ;;
+    --jobs)
+      [[ $# -ge 2 ]] || die "Missing value for --jobs"
+      JOBS=$2
+      shift 2
+      ;;
+    --ctest-timeout-sec)
+      [[ $# -ge 2 ]] || die "Missing value for --ctest-timeout-sec"
+      CTEST_TIMEOUT_SEC=$2
+      shift 2
+      ;;
+    --cmake-extra)
+      [[ $# -ge 2 ]] || die "Missing value for --cmake-extra"
+      CMAKE_EXTRA_ARGS+=("$2")
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown option: $1"
+      ;;
+  esac
+done
+
+[[ -x "${MATRIX_RUNNER}" ]] || die "Matrix runner not found: ${MATRIX_RUNNER}"
+[[ "${CTEST_TIMEOUT_SEC}" =~ ^[0-9]+$ ]] || die "Invalid --ctest-timeout-sec '${CTEST_TIMEOUT_SEC}'"
+if [[ "${CTEST_TIMEOUT_SEC}" -gt 0 ]]; then
+  command -v timeout >/dev/null 2>&1 || die "'timeout' command not found but --ctest-timeout-sec was set"
+fi
+if [[ "${JOBS}" != "auto" && ! "${JOBS}" =~ ^[1-9][0-9]*$ ]]; then
+  die "Invalid --jobs '${JOBS}'. Expected 'auto' or a positive integer."
+fi
+
+LCG_SETUP=$(select_devadept_lcg_setup "${LCG_SETUP}") || die "Failed to resolve devAdePT LCG setup"
+
+# shellcheck disable=SC1090
+set +u
+source "${LCG_SETUP}"
+set -u
+normalize_lcg_cuda_env || die "Failed to normalize CUDA environment from LCG setup"
+
+mkdir -p "${BUILD_ROOT}"
+
+matrix_args=(
+  --suite ci
+  --configs async,split,mixed
+  --build-root "${BUILD_ROOT}"
+  --build-type "${BUILD_TYPE}"
+  --cuda-arch "${CUDA_ARCH}"
+  --jobs "${JOBS}"
+  --ctest-timeout-sec "${CTEST_TIMEOUT_SEC}"
+)
+
+for arg in "${CMAKE_EXTRA_ARGS[@]}"; do
+  matrix_args+=(--cmake-extra "${arg}")
+done
+
+log "Using LCG setup: ${LCG_SETUP}"
+log "Build type: ${BUILD_TYPE}"
+log "Build root: ${BUILD_ROOT}"
+log "CUDA arch: ${CUDA_ARCH}"
+log "Build jobs: ${JOBS}"
+log "Running Jenkins-like nightly CI selection"
+
+NIGHTLY_STATUS=1
+if "${MATRIX_RUNNER}" "${matrix_args[@]}"; then
+  NIGHTLY_STATUS=0
+fi
+
+write_results
+
+log "Nightly status: ${NIGHTLY_STATUS}"
+
+exit "${NIGHTLY_STATUS}"


### PR DESCRIPTION
This PR adds a nightly workflow on the self-hosted machine. It does the same as Jenkins is currently doing:

Running the unit tests on the monolithic build, and the validation on the monolithic and the split build. The drift tests are not run, as they only make sense in comparing two branches.

A badge is added to the readme to show the nightly status.
If a nightly fails, an issue is automatically created. Further failures will be added to the same issue. The issue is closed automatically when the nightlies pass.

When this PR is merged, AdePT does not require any use of Jenkins anymore.