### PR TITLE
fix self-hosted CI timeout

### DIFF
--- a/.github/workflows/nightly-ci-el9.yml
+++ b/.github/workflows/nightly-ci-el9.yml
@@ -101,7 +101,7 @@ jobs:
                 --build-type Release \
                 --cuda-arch 89 \
                 --jobs auto \
-                --ctest-timeout-sec 180
+                --ctest-timeout-sec 900
             '
 
       - name: Write summary

--- a/.github/workflows/self-hosted-pr-ci.yml
+++ b/.github/workflows/self-hosted-pr-ci.yml
@@ -198,7 +198,7 @@ jobs:
                 --no-fetch-master \
                 --cuda-arch 89 \
                 --jobs auto \
-                --ctest-timeout-sec 180
+                --ctest-timeout-sec 900
             '
 
       - name: Publish PR contexts

--- a/test/run_ci_matrix.sh
+++ b/test/run_ci_matrix.sh
@@ -67,7 +67,7 @@ Options:
   --refresh-master           Recreate the cached master worktree
   --g4vg-dir <path>          Path containing G4VGConfig.cmake (disables FetchContent G4VG)
   --cmake-extra <arg>        Additional CMake arg (repeatable)
-  --ctest-timeout-sec <sec>  Optional timeout per ctest invocation (default: 0 = disabled)
+  --ctest-timeout-sec <sec>  Optional per-test timeout passed to ctest --timeout (default: 0 = disabled)
   -h, --help                 Show help
 
 Suite behavior:
@@ -181,9 +181,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 [[ "${CTEST_TIMEOUT_SEC}" =~ ^[0-9]+$ ]] || die "Invalid --ctest-timeout-sec '${CTEST_TIMEOUT_SEC}'. Expected a non-negative integer."
-if [[ "${CTEST_TIMEOUT_SEC}" -gt 0 ]]; then
-  command -v timeout >/dev/null 2>&1 || die "'timeout' command not found but --ctest-timeout-sec was set"
-fi
 if [[ "${JOBS}" != "auto" && ! "${JOBS}" =~ ^[1-9][0-9]*$ ]]; then
   die "Invalid --jobs '${JOBS}'. Expected 'auto' or a positive integer."
 fi
@@ -374,7 +371,8 @@ prepare_master_worktree() {
 run_ctest() {
   local -a cmd=(ctest "$@")
   if [[ "${CTEST_TIMEOUT_SEC}" -gt 0 ]]; then
-    timeout --preserve-status "${CTEST_TIMEOUT_SEC}" "${cmd[@]}"
+    cmd+=(--timeout "${CTEST_TIMEOUT_SEC}")
+    "${cmd[@]}"
   else
     "${cmd[@]}"
   fi

--- a/test/run_nightly_ci.sh
+++ b/test/run_nightly_ci.sh
@@ -49,7 +49,7 @@ Options:
   --build-type <type>        CMake build type (default: ${BUILD_TYPE})
   --cuda-arch <arch|auto>    CUDA arch passed to the matrix runner (default: ${CUDA_ARCH})
   --jobs <N|auto>            Parallel build jobs passed through to the matrix runner (default: ${JOBS})
-  --ctest-timeout-sec <sec>  Optional timeout for each ctest invocation
+  --ctest-timeout-sec <sec>  Optional per-test timeout passed to ctest --timeout
   --cmake-extra <arg>        Additional CMake argument passed through to the matrix runner
   -h, --help                 Show this help
 EOF
@@ -120,9 +120,6 @@ done
 
 [[ -x "${MATRIX_RUNNER}" ]] || die "Matrix runner not found: ${MATRIX_RUNNER}"
 [[ "${CTEST_TIMEOUT_SEC}" =~ ^[0-9]+$ ]] || die "Invalid --ctest-timeout-sec '${CTEST_TIMEOUT_SEC}'"
-if [[ "${CTEST_TIMEOUT_SEC}" -gt 0 ]]; then
-  command -v timeout >/dev/null 2>&1 || die "'timeout' command not found but --ctest-timeout-sec was set"
-fi
 if [[ "${JOBS}" != "auto" && ! "${JOBS}" =~ ^[1-9][0-9]*$ ]]; then
   die "Invalid --jobs '${JOBS}'. Expected 'auto' or a positive integer."
 fi

--- a/test/run_pr_ci.sh
+++ b/test/run_pr_ci.sh
@@ -54,7 +54,7 @@ Options:
   --no-fetch-master          Do not let the matrix runner fetch the master ref
   --cuda-arch <arch|auto>    CUDA arch passed to the matrix runner (default: auto)
   --jobs <N|auto>            Parallel build jobs passed through to the matrix runner (default: auto)
-  --ctest-timeout-sec <sec>  Optional timeout for each ctest invocation
+  --ctest-timeout-sec <sec>  Optional per-test timeout passed to ctest --timeout
   --force-rebuild            Force clean rebuilds in the matrix runner
   --refresh-master           Refresh cached master worktree/builds
   -h, --help                 Show this help
@@ -68,7 +68,8 @@ select_lcg_setup() {
 run_ctest() {
   local -a cmd=(ctest "$@")
   if [[ "${CTEST_TIMEOUT_SEC}" -gt 0 ]]; then
-    timeout --preserve-status "${CTEST_TIMEOUT_SEC}" "${cmd[@]}"
+    cmd+=(--timeout "${CTEST_TIMEOUT_SEC}")
+    "${cmd[@]}"
   else
     "${cmd[@]}"
   fi
@@ -180,9 +181,6 @@ done
 
 [[ -x "${MATRIX_RUNNER}" ]] || die "Matrix runner not found: ${MATRIX_RUNNER}"
 [[ "${CTEST_TIMEOUT_SEC}" =~ ^[0-9]+$ ]] || die "Invalid --ctest-timeout-sec '${CTEST_TIMEOUT_SEC}'"
-if [[ "${CTEST_TIMEOUT_SEC}" -gt 0 ]]; then
-  command -v timeout >/dev/null 2>&1 || die "'timeout' command not found but --ctest-timeout-sec was set"
-fi
 if [[ "${JOBS}" != "auto" && ! "${JOBS}" =~ ^[1-9][0-9]*$ ]]; then
   die "Invalid --jobs '${JOBS}'. Expected 'auto' or a positive integer."
 fi


### PR DESCRIPTION
The CI time out time was global, not per test and 180s is not necessarily enough (before optimizing the setup for the much faster GPU now). This PR makes the timeout per test and sets it to 900. It should be much faster especially after optimizing it for the better GPU.
