### PR TITLE
add athena performance benchmark job

### DIFF
--- a/.github/workflows/athena-performance.yml
+++ b/.github/workflows/athena-performance.yml
@@ -1,0 +1,439 @@
+# SPDX-FileCopyrightText: 2026 CERN
+# SPDX-License-Identifier: Apache-2.0
+
+name: Athena Performance (EL9)
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Benchmark mode to run
+        required: true
+        type: choice
+        options:
+          - mono
+          - split
+      athena_gpu_repository:
+        description: Optional override for the Athena GPU merge repository
+        required: false
+        type: string
+      athena_gpu_ref:
+        description: Optional override for the Athena GPU merge ref
+        required: false
+        type: string
+      athena_base_ref:
+        description: Optional Athena base branch/ref override
+        required: false
+        type: string
+      atlasexternals_base_ref:
+        description: Optional AtlasExternals base branch/ref override
+        required: false
+        type: string
+      threads:
+        description: Optional ATHENA_CORE_NUMBER override
+        required: false
+        type: string
+      events:
+        description: Optional maxEvents override
+        required: false
+        type: string
+      repetitions:
+        description: Optional repetition count override
+        required: false
+        type: string
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: athena-performance-el9
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.prepare.outputs.should_run }}
+      mode: ${{ steps.prepare.outputs.mode }}
+      adept_repo: ${{ steps.prepare.outputs.adept_repo }}
+      adept_ref: ${{ steps.prepare.outputs.adept_ref }}
+      pr_number: ${{ steps.prepare.outputs.pr_number }}
+      comment_back: ${{ steps.prepare.outputs.comment_back }}
+      athena_repository: ${{ steps.prepare.outputs.athena_repository }}
+      athena_base_ref: ${{ steps.prepare.outputs.athena_base_ref }}
+      athena_gpu_repository: ${{ steps.prepare.outputs.athena_gpu_repository }}
+      athena_gpu_ref: ${{ steps.prepare.outputs.athena_gpu_ref }}
+      atlasexternals_repository: ${{ steps.prepare.outputs.atlasexternals_repository }}
+      atlasexternals_ref: ${{ steps.prepare.outputs.atlasexternals_ref }}
+      threads: ${{ steps.prepare.outputs.threads }}
+      events: ${{ steps.prepare.outputs.events }}
+      repetitions: ${{ steps.prepare.outputs.repetitions }}
+    steps:
+      - name: Resolve trigger inputs
+        id: prepare
+        uses: actions/github-script@v8
+        env:
+          DEFAULT_ATHENA_REPOSITORY: https://gitlab.cern.ch/atlas/athena.git
+          DEFAULT_ATHENA_BASE_REF: main
+          DEFAULT_ATHENA_GPU_REPOSITORY: https://gitlab.cern.ch/elmsheus/athena.git
+          DEFAULT_ATHENA_GPU_REF: atlassim-6635-main
+          DEFAULT_ATLAS_EXTERNALS_REPOSITORY: https://gitlab.cern.ch/atlas/atlasexternals.git
+          DEFAULT_ATLAS_EXTERNALS_BASE_REF: main
+          DEFAULT_THREADS: "96"
+          DEFAULT_EVENTS: "1000"
+          DEFAULT_REPETITIONS: "5"
+        with:
+          script: |
+            const defaults = {
+              athenaRepository: process.env.DEFAULT_ATHENA_REPOSITORY,
+              athenaBaseRef: process.env.DEFAULT_ATHENA_BASE_REF,
+              athenaGpuRepository: process.env.DEFAULT_ATHENA_GPU_REPOSITORY || "",
+              athenaGpuRef: process.env.DEFAULT_ATHENA_GPU_REF || "",
+              atlasexternalsRepository: process.env.DEFAULT_ATLAS_EXTERNALS_REPOSITORY,
+              atlasexternalsBaseRef: process.env.DEFAULT_ATLAS_EXTERNALS_BASE_REF,
+              threads: process.env.DEFAULT_THREADS,
+              events: process.env.DEFAULT_EVENTS,
+              repetitions: process.env.DEFAULT_REPETITIONS,
+            };
+
+            function output(name, value) {
+              core.setOutput(name, value ?? "");
+            }
+
+            output("should_run", "false");
+            output("comment_back", "false");
+            output("pr_number", "");
+            output("athena_repository", defaults.athenaRepository);
+            output("athena_base_ref", defaults.athenaBaseRef);
+            output("athena_gpu_repository", defaults.athenaGpuRepository);
+            output("athena_gpu_ref", defaults.athenaGpuRef);
+            output("atlasexternals_repository", defaults.atlasexternalsRepository);
+            output("atlasexternals_ref", defaults.atlasexternalsBaseRef);
+            output("threads", defaults.threads);
+            output("events", defaults.events);
+            output("repetitions", defaults.repetitions);
+
+            let resolvedMode = "";
+            let resolvedAdeptRepo = "";
+            let resolvedAdeptRef = "";
+            let resolvedAthenaRepository = defaults.athenaRepository;
+            let resolvedAthenaBaseRef = defaults.athenaBaseRef;
+            let resolvedAthenaGpuRepository = defaults.athenaGpuRepository;
+            let resolvedAthenaGpuRef = defaults.athenaGpuRef;
+            let resolvedAtlasExternalsRepository = defaults.atlasexternalsRepository;
+            let resolvedAtlasExternalsBaseRef = defaults.atlasexternalsBaseRef;
+            let resolvedThreads = defaults.threads;
+            let resolvedEvents = defaults.events;
+            let resolvedRepetitions = defaults.repetitions;
+
+            if (context.eventName === "workflow_dispatch") {
+              if (context.ref !== "refs/heads/master") {
+                core.setFailed("workflow_dispatch performance runs must be launched from master");
+                return;
+              }
+
+              const inputs = context.payload.inputs || {};
+              resolvedMode = inputs.mode || "";
+              resolvedAdeptRepo = `${context.repo.owner}/${context.repo.repo}`;
+              resolvedAdeptRef = context.sha;
+              resolvedAthenaBaseRef = inputs.athena_base_ref || defaults.athenaBaseRef;
+              resolvedAthenaGpuRepository = inputs.athena_gpu_repository || defaults.athenaGpuRepository;
+              resolvedAthenaGpuRef = inputs.athena_gpu_ref || defaults.athenaGpuRef;
+              resolvedAtlasExternalsBaseRef = inputs.atlasexternals_base_ref || defaults.atlasexternalsBaseRef;
+              resolvedThreads = inputs.threads || defaults.threads;
+              resolvedEvents = inputs.events || defaults.events;
+              resolvedRepetitions = inputs.repetitions || defaults.repetitions;
+            } else {
+              if (context.payload.issue?.pull_request == null) {
+                core.notice("Ignoring non-PR issue comment");
+                return;
+              }
+
+              const body = (context.payload.comment.body || "").trim();
+              const match = body.match(/^\/run-(?:benchmark|performance)\s+(mono|split)\s*$/);
+              if (!match) {
+                core.notice(`Ignoring comment '${body}'`);
+                return;
+              }
+
+              const assoc = context.payload.comment.author_association || "NONE";
+              const trusted = ["OWNER", "MEMBER"].includes(assoc);
+              if (!trusted) {
+                core.notice(`Ignoring benchmark trigger from untrusted role ${assoc}`);
+                return;
+              }
+
+              const prNumber = context.payload.issue.number;
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+
+              output("should_run", "true");
+              output("comment_back", "true");
+              resolvedMode = match[1];
+              output("pr_number", String(pr.number));
+              resolvedAdeptRepo = pr.head.repo.full_name;
+              resolvedAdeptRef = pr.head.sha;
+            }
+
+            if (!resolvedMode) {
+              core.setFailed("No benchmark mode was resolved");
+              return;
+            }
+            if (!resolvedAdeptRepo || !resolvedAdeptRef) {
+              core.setFailed("No AdePT repository/ref was resolved");
+              return;
+            }
+            if (!resolvedAthenaGpuRepository) {
+              core.setFailed("No Athena GPU repository configured; set repo variable ADEPT_ATHENA_GPU_REPOSITORY or pass an input");
+              return;
+            }
+            if (!resolvedAthenaGpuRef) {
+              core.setFailed("No Athena GPU ref configured; set repo variable ADEPT_ATHENA_GPU_REF or pass an input");
+              return;
+            }
+
+            output("should_run", "true");
+            output("mode", resolvedMode);
+            output("adept_repo", resolvedAdeptRepo);
+            output("adept_ref", resolvedAdeptRef);
+            output("athena_repository", resolvedAthenaRepository);
+            output("athena_base_ref", resolvedAthenaBaseRef);
+            output("athena_gpu_repository", resolvedAthenaGpuRepository);
+            output("athena_gpu_ref", resolvedAthenaGpuRef);
+            output("atlasexternals_repository", resolvedAtlasExternalsRepository);
+            output("atlasexternals_ref", resolvedAtlasExternalsBaseRef);
+            output("threads", resolvedThreads);
+            output("events", resolvedEvents);
+            output("repetitions", resolvedRepetitions);
+
+  benchmark:
+    name: Athena Performance
+    needs: prepare
+    if: needs.prepare.outputs.should_run == 'true'
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - gpu
+      - benchmark
+      - adept
+    timeout-minutes: 480
+    env:
+      RESULTS_FILE: ${{ github.workspace }}/athena-performance-results.env
+      ARTIFACTS_DIR: ${{ github.workspace }}/athena-performance-results/run-${{ github.run_id }}-${{ needs.prepare.outputs.mode }}
+    steps:
+      - name: Checkout AdePT under test
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ needs.prepare.outputs.adept_repo }}
+          ref: ${{ needs.prepare.outputs.adept_ref }}
+          persist-credentials: false
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Show runner basics
+        run: |
+          set -eo pipefail
+          cat /etc/os-release | sed -n '1,6p'
+          echo "event=${GITHUB_EVENT_NAME}"
+          echo "mode=${{ needs.prepare.outputs.mode }}"
+          echo "adept_repo=${{ needs.prepare.outputs.adept_repo }}"
+          echo "adept_ref=${{ needs.prepare.outputs.adept_ref }}"
+          echo "hostname=$(hostname)"
+          echo "user=$(whoami)"
+          echo "pwd=$(pwd)"
+          id
+
+      - name: Pre-touch required CVMFS repos on host
+        run: |
+          set -eo pipefail
+          ls /cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase/user/atlasLocalSetup.sh
+          ls /cvmfs/atlas-nightlies.cern.ch/repo/sw/main--simGPU_AthSimulation_x86_64-el9-gcc14-opt/Geant4 || true
+          ls /cvmfs/geant4.cern.ch/share/data/G4ENSDFSTATE3.0/ENSDFSTATE.dat
+          if [ -d /afs ]; then
+            ls /afs >/dev/null
+            echo "/afs is present on the host and will be mounted into the container"
+          else
+            echo "/afs is not present on the host"
+          fi
+
+      - name: Check GPU visibility
+        run: |
+          set -eo pipefail
+          nvidia-smi
+
+      - name: Check Docker basics
+        run: |
+          set -eo pipefail
+          docker --version
+
+      - name: Run Athena performance benchmark in Alma 9 container
+        id: run_perf
+        continue-on-error: true
+        env:
+          PERF_MODE: ${{ needs.prepare.outputs.mode }}
+          ADEPT_REPOSITORY: ${{ needs.prepare.outputs.adept_repo }}
+          ADEPT_REF: ${{ needs.prepare.outputs.adept_ref }}
+          ATHENA_REPOSITORY: ${{ needs.prepare.outputs.athena_repository }}
+          ATHENA_BASE_REF: ${{ needs.prepare.outputs.athena_base_ref }}
+          ATHENA_GPU_REPOSITORY: ${{ needs.prepare.outputs.athena_gpu_repository }}
+          ATHENA_GPU_REF: ${{ needs.prepare.outputs.athena_gpu_ref }}
+          ATLAS_EXTERNALS_REPOSITORY: ${{ needs.prepare.outputs.atlasexternals_repository }}
+          ATLAS_EXTERNALS_BASE_REF: ${{ needs.prepare.outputs.atlasexternals_ref }}
+          PERF_THREADS: ${{ needs.prepare.outputs.threads }}
+          PERF_EVENTS: ${{ needs.prepare.outputs.events }}
+          PERF_REPETITIONS: ${{ needs.prepare.outputs.repetitions }}
+        run: |
+          set -eo pipefail
+
+          rm -f "${RESULTS_FILE}"
+          rm -rf "${ARTIFACTS_DIR}"
+          mkdir -p "${ARTIFACTS_DIR}"
+
+          docker_group_args=()
+          for group_name in video render; do
+            if getent group "${group_name}" >/dev/null 2>&1; then
+              docker_group_args+=(--group-add "$(getent group "${group_name}" | cut -d: -f3)")
+            fi
+          done
+
+          docker_mount_args=(
+            -v /build:/build
+            -v /ec/conf:/ec/conf
+            -v /cvmfs:/cvmfs:ro,rslave
+            -v "${GITHUB_WORKSPACE}:/work/AdePT"
+          )
+          if [ -d /afs ]; then
+            docker_mount_args+=(-v /afs:/afs:ro,rslave)
+          fi
+
+          docker run --rm --pull always \
+            --gpus all \
+            --user "$(id -u):$(id -g)" \
+            "${docker_group_args[@]}" \
+            --security-opt seccomp=unconfined \
+            "${docker_mount_args[@]}" \
+            -e HOME=/tmp/adeptci-home \
+            -e PERF_MODE \
+            -e ADEPT_REPOSITORY \
+            -e ADEPT_REF \
+            -e ATHENA_REPOSITORY \
+            -e ATHENA_BASE_REF \
+            -e ATHENA_GPU_REPOSITORY \
+            -e ATHENA_GPU_REF \
+            -e ATLAS_EXTERNALS_REPOSITORY \
+            -e ATLAS_EXTERNALS_BASE_REF \
+            -e PERF_THREADS \
+            -e PERF_EVENTS \
+            -e PERF_REPETITIONS \
+            -w /work/AdePT \
+            gitlab-registry.cern.ch/sft/docker/alma9 \
+            bash -lc '
+              set -eo pipefail
+              mkdir -p "${HOME}"
+              git config --global --add safe.directory /work/AdePT
+              container_results_file="/work/AdePT/athena-performance-results.env"
+              container_artifacts_dir="/work/AdePT/athena-performance-results/run-${GITHUB_RUN_ID}-${PERF_MODE}"
+              ./test/athena-performance/run_athena_performance.sh \
+                --mode "${PERF_MODE}" \
+                --adept-repository "${ADEPT_REPOSITORY}" \
+                --adept-ref "${ADEPT_REF}" \
+                --athena-repository "${ATHENA_REPOSITORY}" \
+                --athena-base-ref "${ATHENA_BASE_REF}" \
+                --athena-gpu-repository "${ATHENA_GPU_REPOSITORY}" \
+                --athena-gpu-ref "${ATHENA_GPU_REF}" \
+                --atlasexternals-repository "${ATLAS_EXTERNALS_REPOSITORY}" \
+                --atlasexternals-base-ref "${ATLAS_EXTERNALS_BASE_REF}" \
+                --threads "${PERF_THREADS}" \
+                --events "${PERF_EVENTS}" \
+                --repetitions "${PERF_REPETITIONS}" \
+                --build-root "/tmp/adept-athena-performance/run-${GITHUB_RUN_ID}-${PERF_MODE}" \
+                --artifacts-dir "${container_artifacts_dir}" \
+                --results-file "${container_results_file}"
+            '
+
+      - name: Load benchmark results
+        if: always() && hashFiles(env.RESULTS_FILE) != ''
+        run: |
+          set -eo pipefail
+          # shellcheck disable=SC1091
+          source "${RESULTS_FILE}"
+
+          host_summary_markdown_file="${SUMMARY_MARKDOWN_FILE:-}"
+          case "${host_summary_markdown_file}" in
+            /work/AdePT/*)
+              host_summary_markdown_file="${GITHUB_WORKSPACE}/${host_summary_markdown_file#/work/AdePT/}"
+              ;;
+          esac
+
+          {
+            echo "PERF_STATUS=${PERF_STATUS:-1}"
+            echo "SUMMARY_MARKDOWN_FILE=${host_summary_markdown_file}"
+          } >> "${GITHUB_ENV}"
+
+      - name: Write summary
+        if: always()
+        run: |
+          if [ -n "${SUMMARY_MARKDOWN_FILE:-}" ] && [ -f "${SUMMARY_MARKDOWN_FILE}" ]; then
+            cat "${SUMMARY_MARKDOWN_FILE}" >> "${GITHUB_STEP_SUMMARY}"
+          else
+            {
+              echo "### Athena Performance Benchmark (${{ needs.prepare.outputs.mode }})"
+              echo
+              echo "The benchmark failed before producing a summary."
+            } >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload benchmark artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: athena-performance-${{ needs.prepare.outputs.mode }}-${{ github.run_id }}
+          path: ${{ env.ARTIFACTS_DIR }}
+          if-no-files-found: warn
+
+      - name: Comment on PR with results
+        if: always() && needs.prepare.outputs.comment_back == 'true'
+        uses: actions/github-script@v8
+        env:
+          SUMMARY_MARKDOWN_FILE: ${{ env.SUMMARY_MARKDOWN_FILE }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          script: |
+            const fs = require("fs");
+            let body = "";
+
+            if (process.env.SUMMARY_MARKDOWN_FILE && fs.existsSync(process.env.SUMMARY_MARKDOWN_FILE)) {
+              body = fs.readFileSync(process.env.SUMMARY_MARKDOWN_FILE, "utf8").trim();
+            } else {
+              body = `### Athena Performance Benchmark (${context.payload.comment?.body || "${{ needs.prepare.outputs.mode }}"})\n\nThe benchmark failed before producing a summary.`;
+            }
+
+            body += `\n\n- Actions run: ${process.env.RUN_URL}`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number("${{ needs.prepare.outputs.pr_number }}"),
+              body,
+            });
+
+      - name: Fail workflow if benchmark failed
+        if: always()
+        run: |
+          if [ -r "${RESULTS_FILE}" ]; then
+            # shellcheck disable=SC1091
+            source "${RESULTS_FILE}"
+          else
+            PERF_STATUS=1
+          fi
+
+          test "${PERF_STATUS}" -eq 0

--- a/.github/workflows/athena-performance.yml
+++ b/.github/workflows/athena-performance.yml
@@ -83,7 +83,7 @@ jobs:
           DEFAULT_ATHENA_GPU_REPOSITORY: https://gitlab.cern.ch/elmsheus/athena.git
           DEFAULT_ATHENA_GPU_REF: atlassim-6635-main
           DEFAULT_ATLAS_EXTERNALS_REPOSITORY: https://gitlab.cern.ch/atlas/atlasexternals.git
-          DEFAULT_ATLAS_EXTERNALS_BASE_REF: main
+          DEFAULT_ATLAS_EXTERNALS_BASE_REF: 21.1.X-simGPU
           DEFAULT_THREADS: "96"
           DEFAULT_EVENTS: "1000"
           DEFAULT_REPETITIONS: "5"
@@ -103,6 +103,22 @@ jobs:
 
             function output(name, value) {
               core.setOutput(name, value ?? "");
+            }
+
+            async function hasWriteLikeRepoAccess(username) {
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username,
+                });
+                return ["write", "maintain", "admin"].includes(data.permission);
+              } catch (error) {
+                if (error.status === 404) {
+                  return false;
+                }
+                throw error;
+              }
             }
 
             output("should_run", "false");
@@ -132,6 +148,11 @@ jobs:
             let resolvedRepetitions = defaults.repetitions;
 
             if (context.eventName === "workflow_dispatch") {
+              if (!(await hasWriteLikeRepoAccess(context.actor))) {
+                core.setFailed(`workflow_dispatch is restricted to users with write access on ${context.repo.owner}/${context.repo.repo}`);
+                return;
+              }
+
               if (context.ref !== "refs/heads/master") {
                 core.setFailed("workflow_dispatch performance runs must be launched from master");
                 return;

--- a/test/athena-performance/mono/run_adept.sh
+++ b/test/athena-performance/mono/run_adept.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NWORK=${1:-32}
+export ATHENA_CORE_NUMBER=${NWORK}
+MAX_EVENTS="${ADEPT_MAX_EVENTS:-1000}"
+OUTPUT_HITS_FILE="${ADEPT_OUTPUT_HITS_FILE:-test.CA.HITS.pool_AdePT_${MAX_EVENTS}.root}"
+
+echo "=== Running AdePT with ATHENA_CORE_NUMBER=${ATHENA_CORE_NUMBER}, MAX_EVENTS=${MAX_EVENTS} ==="
+
+PREEXEC_CMD=$(cat <<'EOF'
+flags.Sim.G4Commands+=[
+  "/adept/MaxWDTIterations 10",
+  "/adept/setSeed 2312452",
+  "/adept/CallUserTrackingAction true",
+  "/adept/CallUserSteppingAction false",
+  "/adept/setCovfieBfieldFile /cvmfs/atlas.cern.ch/repo/sw/database/GroupData/MagneticFieldMaps/bmagatlas_09_fullAsym20400_forGPU_v1.cvf",
+  "/adept/setVerbosity 0",
+  "/adept/addGPURegion EMB",
+  "/adept/addGPURegion EMEC",
+  "/adept/addGPURegion HEC",
+  "/adept/addGPURegion PreSampLAr",
+  "/adept/setTrackInAllRegions false",
+  "/adept/setMillionsOfTrackSlots 8",
+  "/adept/setMillionsOfHitSlots 20",
+  "/adept/setCUDAStackLimit 32192",
+  "/adept/setCUDAHeapLimit 84857600"
+];
+flags.GeoModel.EMECStandard=True
+EOF
+)
+
+AtlasG4_tf.py \
+  --multithreaded \
+  --randomSeed 1212353 \
+  --conditionsTag 'default:OFLCOND-MC21-SDR-RUN4-02' \
+  --geometryVersion 'default:ATLAS-P2-RUN4-04-00-00' \
+  --preInclude 'AtlasG4Tf:Campaigns.MC23aSimulationMultipleIoV' \
+  --postInclude 'PyJobTransforms.UseFrontier' \
+  --inputEVNTFile "/cvmfs/atlas-nightlies.cern.ch/repo/data/data-art/CampaignInputs/mc23/EVNT/mc23_13p6TeV.601229.PhPy8EG_A14_ttbar_hdamp258p75_SingleLep.evgen.EVNT.e8514/EVNT.32288062._002040.pool.root.1" \
+  --outputHITSFile "${OUTPUT_HITS_FILE}" \
+  --maxEvents "${MAX_EVENTS}" \
+  --jobNumber 1 \
+  --postExec 'with open("ConfigSimCA.pkl", "wb") as f: cfg.store(f)' \
+  --physicsList "FTFP_BERT_ATL_AdePT" \
+  --imf False \
+  --preExec "${PREEXEC_CMD}"

--- a/test/athena-performance/mono/run_adept.sh
+++ b/test/athena-performance/mono/run_adept.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2026 CERN
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 NWORK=${1:-32}

--- a/test/athena-performance/run_all_5.sh
+++ b/test/athena-performance/run_all_5.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NWORK=${1:-96}
+
+for I in 1 2 3 4 5; do
+  echo "=== Starting AdePT run ${I}, T=${NWORK} ==="
+  ./run_adept.sh "${NWORK}" > "adept_T${NWORK}_run${I}.log" 2>&1
+  if [ -f log.AtlasG4Tf ]; then
+    mv log.AtlasG4Tf "log.AtlasG4Tf_AdePT_T${NWORK}_run${I}"
+  else
+    echo "WARNING: log.AtlasG4Tf missing after AdePT run ${I}" >&2
+  fi
+done
+
+echo "All done."

--- a/test/athena-performance/run_all_5.sh
+++ b/test/athena-performance/run_all_5.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2026 CERN
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 NWORK=${1:-96}

--- a/test/athena-performance/run_all_5.sh
+++ b/test/athena-performance/run_all_5.sh
@@ -3,8 +3,14 @@
 set -euo pipefail
 
 NWORK=${1:-96}
+REPETITIONS=${2:-${ADEPT_REPETITIONS:-5}}
 
-for I in 1 2 3 4 5; do
+[[ "${REPETITIONS}" =~ ^[1-9][0-9]*$ ]] || {
+  echo "ERROR: invalid repetition count '${REPETITIONS}'" >&2
+  exit 1
+}
+
+for I in $(seq 1 "${REPETITIONS}"); do
   echo "=== Starting AdePT run ${I}, T=${NWORK} ==="
   ./run_adept.sh "${NWORK}" > "adept_T${NWORK}_run${I}.log" 2>&1
   if [ -f log.AtlasG4Tf ]; then
@@ -14,4 +20,4 @@ for I in 1 2 3 4 5; do
   fi
 done
 
-echo "All done."
+echo "All done after ${REPETITIONS} run(s)."

--- a/test/athena-performance/run_athena_performance.sh
+++ b/test/athena-performance/run_athena_performance.sh
@@ -25,7 +25,7 @@ ATHENA_GPU_REPOSITORY=""
 ATHENA_GPU_REF=""
 
 ATLAS_EXTERNALS_REPOSITORY="https://gitlab.cern.ch/atlas/atlasexternals.git"
-ATLAS_EXTERNALS_BASE_REF="main"
+ATLAS_EXTERNALS_BASE_REF="21.1.X-simGPU"
 
 THREADS="96"
 EVENTS="1000"
@@ -489,15 +489,16 @@ run_benchmark() {
     source "${GPU_BUILD_DIR}/setup_run.sh"
     cd "${RUN_DIR}"
     export ADEPT_MAX_EVENTS="${EVENTS}"
+    export ADEPT_REPETITIONS="${REPETITIONS}"
     export ADEPT_OUTPUT_HITS_FILE="test.CA.HITS.pool_AdePT_E${EVENTS}.root"
-    ./run_all_5.sh "${THREADS}"
+    ./run_all_5.sh "${THREADS}" "${REPETITIONS}"
   )
 }
 
 summarize_results() {
   local env_file="${ARTIFACTS_DIR}/summary.env"
 
-  python3 - "${RUN_DIR}" "${THREADS}" "${MODE}" "${ADEPT_REPOSITORY}" "${ADEPT_REF}" \
+  python3 - "${RUN_DIR}" "${THREADS}" "${REPETITIONS}" "${MODE}" "${ADEPT_REPOSITORY}" "${ADEPT_REF}" \
     "${ATHENA_REPOSITORY}" "${ATHENA_BASE_REF}" "${ATHENA_HEAD_SHA}" \
     "${ATHENA_GPU_REPOSITORY}" "${ATHENA_GPU_REF}" \
     "${ATLAS_EXTERNALS_REPOSITORY}" "${ATLAS_EXTERNALS_BASE_REF}" "${ATLAS_EXTERNALS_LOCAL_SHA}" \
@@ -511,6 +512,7 @@ import sys
 (
     run_dir,
     threads,
+    repetitions,
     mode,
     adept_repo,
     adept_ref,
@@ -553,7 +555,7 @@ overall_stddev = statistics.stdev(means) if len(means) > 1 else 0.0
 
 mode_label = "Mono_NoLeaks" if mode == "mono" else "Split_NoLeaks"
 build_cmd = f"./Projects/AthSimulation/build_gpu.sh -b ../gpu_build_{mode_label}_{adept_ref[:7]} > output_build.txt"
-run_cmd = f"bash -lc 'source {setup_run_path} && cd {run_dir} && ./run_all_5.sh {threads}'"
+run_cmd = f"bash -lc 'source {setup_run_path} && cd {run_dir} && ./run_all_5.sh {threads} {repetitions}'"
 
 lines = [
     f"### Athena Performance Benchmark ({mode})",
@@ -566,6 +568,7 @@ lines = [
     f"- AtlasExternals benchmark commit: `{atlasexternals_sha}`",
     f"- Build command: `{build_cmd}`",
     f"- Run command: `{run_cmd}`",
+    f"- Configured repetitions: `{repetitions}`",
     (
         "- Runtime extraction: per-run average of `Real=` measurements with the first "
         "measurement skipped, matching "

--- a/test/athena-performance/run_athena_performance.sh
+++ b/test/athena-performance/run_athena_performance.sh
@@ -1,0 +1,613 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 CERN
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+
+DEFAULT_BUILD_ROOT="/tmp/adept-athena-performance"
+DEFAULT_ARTIFACTS_DIR="${REPO_ROOT}/athena-performance-results"
+
+MODE=""
+BUILD_ROOT="${DEFAULT_BUILD_ROOT}"
+ARTIFACTS_DIR="${DEFAULT_ARTIFACTS_DIR}"
+RESULTS_FILE=""
+
+ADEPT_REPOSITORY=""
+ADEPT_REF=""
+
+ATHENA_REPOSITORY="https://gitlab.cern.ch/atlas/athena.git"
+ATHENA_BASE_REF="main"
+ATHENA_GPU_REPOSITORY=""
+ATHENA_GPU_REF=""
+
+ATLAS_EXTERNALS_REPOSITORY="https://gitlab.cern.ch/atlas/atlasexternals.git"
+ATLAS_EXTERNALS_BASE_REF="main"
+
+THREADS="96"
+EVENTS="1000"
+REPETITIONS="5"
+
+ADEPT_SHORT_SHA=""
+RUN_LABEL=""
+MODE_LABEL=""
+RUN_DIR_LABEL=""
+
+ATHENA_WORKTREE=""
+ATHENA_HEAD_SHA=""
+GPU_BUILD_DIR=""
+GPU_BUILD_RELATIVE=""
+BUILD_LOG=""
+RUN_DIR=""
+SUMMARY_MARKDOWN_FILE=""
+ATLAS_EXTERNALS_LOCAL_REPO=""
+ATLAS_EXTERNALS_LOCAL_REF=""
+ATLAS_EXTERNALS_LOCAL_SHA=""
+OVERALL_REAL_MEAN_SEC=""
+OVERALL_REAL_STDDEV_SEC=""
+PER_RUN_REAL_TIMES_CSV=""
+PER_RUN_MEASUREMENT_COUNTS_CSV=""
+
+PERF_STATUS=1
+
+log() {
+  printf '[athena-perf] %s\n' "$*"
+}
+
+die() {
+  printf '[athena-perf] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+retry_command() {
+  local attempts=${1:-3}
+  shift
+
+  local try
+  for try in $(seq 1 "${attempts}"); do
+    if "$@"; then
+      return 0
+    fi
+    if [[ "${try}" -lt "${attempts}" ]]; then
+      log "Command failed (attempt ${try}/${attempts}): $*"
+      sleep 10
+    fi
+  done
+
+  return 1
+}
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+Runs the Athena+AtlasExternals performance benchmark for the checked-out AdePT
+revision and writes a markdown summary suitable for GitHub Actions.
+
+Required options:
+  --mode <mono|split>            Benchmark mode to run
+  --adept-repository <owner/repo>
+                                  AdePT repository to build from
+  --adept-ref <git-ref>          AdePT ref/SHA to build from
+  --athena-gpu-repository <url>  Athena GPU branch repository/clone URL
+  --athena-gpu-ref <git-ref>     Athena GPU branch to merge on top of main
+
+Optional options:
+  --build-root <path>            Working root (default: ${DEFAULT_BUILD_ROOT})
+  --artifacts-dir <path>         Directory for logs and summary output
+  --results-file <path>          Write KEY=VALUE results for workflow consumption
+  --athena-repository <url>      Athena base repository
+  --athena-base-ref <ref>        Athena base branch/ref (default: ${ATHENA_BASE_REF})
+  --atlasexternals-repository <url>
+                                  AtlasExternals base repository
+  --atlasexternals-base-ref <ref>
+                                  AtlasExternals base branch/ref (default: ${ATLAS_EXTERNALS_BASE_REF})
+  --threads <N>                  ATHENA_CORE_NUMBER and T<N> log tag (default: ${THREADS})
+  --events <N>                   Number of events per run (default: ${EVENTS})
+  --repetitions <N>              Number of repeated runs (default: ${REPETITIONS})
+  -h, --help                     Show this help
+EOF
+}
+
+verify_remote_ref() {
+  local repo_url=$1
+  local ref=$2
+
+  retry_command 3 git ls-remote --exit-code "${repo_url}" \
+    "${ref}" "refs/heads/${ref}" "refs/tags/${ref}" >/dev/null 2>&1
+}
+
+preflight_checks() {
+  command -v git >/dev/null 2>&1 || die "git is required"
+  command -v python3 >/dev/null 2>&1 || die "python3 is required"
+
+  [[ -r /cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase/user/atlasLocalSetup.sh ]] || \
+    die "ATLASLocalRootBase setup is not visible inside the container"
+  [[ -r /cvmfs/atlas-nightlies.cern.ch/repo/data/data-art/CampaignInputs/mc23/EVNT/mc23_13p6TeV.601229.PhPy8EG_A14_ttbar_hdamp258p75_SingleLep.evgen.EVNT.e8514/EVNT.32288062._002040.pool.root.1 ]] || \
+    die "Benchmark EVNT input is not visible inside the container"
+
+  if [[ -d /afs ]]; then
+    if ls /afs >/dev/null 2>&1; then
+      log "/afs is visible and readable inside the container"
+    else
+      log "/afs is mounted inside the container but is not readable with the current credentials"
+    fi
+  else
+    log "/afs is not visible inside the container"
+  fi
+
+  log "Checking remote access to Athena base repository"
+  verify_remote_ref "${ATHENA_REPOSITORY}" "${ATHENA_BASE_REF}" || \
+    die "Could not resolve ${ATHENA_REPOSITORY}@${ATHENA_BASE_REF}"
+
+  log "Checking remote access to Athena GPU merge repository"
+  verify_remote_ref "${ATHENA_GPU_REPOSITORY}" "${ATHENA_GPU_REF}" || \
+    die "Could not resolve ${ATHENA_GPU_REPOSITORY}@${ATHENA_GPU_REF}"
+
+  log "Checking remote access to AtlasExternals repository"
+  verify_remote_ref "${ATLAS_EXTERNALS_REPOSITORY}" "${ATLAS_EXTERNALS_BASE_REF}" || \
+    die "Could not resolve ${ATLAS_EXTERNALS_REPOSITORY}@${ATLAS_EXTERNALS_BASE_REF}"
+}
+
+write_results() {
+  [[ -n "${RESULTS_FILE}" ]] || return
+
+  {
+    printf 'PERF_STATUS=%s\n' "${PERF_STATUS}"
+    printf 'MODE=%q\n' "${MODE}"
+    printf 'BUILD_ROOT=%q\n' "${BUILD_ROOT}"
+    printf 'ARTIFACTS_DIR=%q\n' "${ARTIFACTS_DIR}"
+    printf 'ADEPT_REPOSITORY=%q\n' "${ADEPT_REPOSITORY}"
+    printf 'ADEPT_REF=%q\n' "${ADEPT_REF}"
+    printf 'ATHENA_REPOSITORY=%q\n' "${ATHENA_REPOSITORY}"
+    printf 'ATHENA_BASE_REF=%q\n' "${ATHENA_BASE_REF}"
+    printf 'ATHENA_GPU_REPOSITORY=%q\n' "${ATHENA_GPU_REPOSITORY}"
+    printf 'ATHENA_GPU_REF=%q\n' "${ATHENA_GPU_REF}"
+    printf 'ATHENA_HEAD_SHA=%q\n' "${ATHENA_HEAD_SHA}"
+    printf 'ATLAS_EXTERNALS_REPOSITORY=%q\n' "${ATLAS_EXTERNALS_REPOSITORY}"
+    printf 'ATLAS_EXTERNALS_BASE_REF=%q\n' "${ATLAS_EXTERNALS_BASE_REF}"
+    printf 'ATLAS_EXTERNALS_LOCAL_SHA=%q\n' "${ATLAS_EXTERNALS_LOCAL_SHA}"
+    printf 'THREADS=%q\n' "${THREADS}"
+    printf 'EVENTS=%q\n' "${EVENTS}"
+    printf 'REPETITIONS=%q\n' "${REPETITIONS}"
+    printf 'BUILD_LOG=%q\n' "${BUILD_LOG}"
+    printf 'RUN_DIR=%q\n' "${RUN_DIR}"
+    printf 'SUMMARY_MARKDOWN_FILE=%q\n' "${SUMMARY_MARKDOWN_FILE}"
+    printf 'OVERALL_REAL_MEAN_SEC=%q\n' "${OVERALL_REAL_MEAN_SEC}"
+    printf 'OVERALL_REAL_STDDEV_SEC=%q\n' "${OVERALL_REAL_STDDEV_SEC}"
+    printf 'PER_RUN_REAL_TIMES_CSV=%q\n' "${PER_RUN_REAL_TIMES_CSV}"
+    printf 'PER_RUN_MEASUREMENT_COUNTS_CSV=%q\n' "${PER_RUN_MEASUREMENT_COUNTS_CSV}"
+  } > "${RESULTS_FILE}"
+}
+
+copy_runtime_logs() {
+  [[ -d "${RUN_DIR}" ]] || return
+  mkdir -p "${ARTIFACTS_DIR}/run-logs"
+
+  find "${RUN_DIR}" -maxdepth 1 -type f \
+    \( -name "adept_T*.log" -o -name "log.AtlasG4Tf_AdePT_T*" -o -name "run_adept.sh" -o -name "run_all_5.sh" \) \
+    -exec cp {} "${ARTIFACTS_DIR}/run-logs/" \;
+}
+
+write_failure_summary() {
+  local exit_code=$1
+
+  mkdir -p "${ARTIFACTS_DIR}"
+  SUMMARY_MARKDOWN_FILE="${ARTIFACTS_DIR}/summary.md"
+
+  cat > "${SUMMARY_MARKDOWN_FILE}" <<EOF
+### Athena Performance Benchmark (${MODE})
+
+The benchmark failed before a complete timing summary could be produced.
+
+- Mode: \`${MODE}\`
+- AdePT: \`${ADEPT_REPOSITORY}@${ADEPT_REF}\`
+- Athena base: \`${ATHENA_REPOSITORY}@${ATHENA_BASE_REF}\`
+- Athena GPU merge: \`${ATHENA_GPU_REPOSITORY}@${ATHENA_GPU_REF}\`
+- AtlasExternals base: \`${ATLAS_EXTERNALS_REPOSITORY}@${ATLAS_EXTERNALS_BASE_REF}\`
+- Exit code: \`${exit_code}\`
+- Build log: \`${BUILD_LOG}\`
+EOF
+}
+
+on_exit() {
+  local exit_code=$1
+  trap - EXIT
+
+  if [[ "${exit_code}" -ne 0 ]]; then
+    PERF_STATUS="${exit_code}"
+  fi
+
+  mkdir -p "${ARTIFACTS_DIR}"
+  copy_runtime_logs || true
+
+  if [[ -z "${SUMMARY_MARKDOWN_FILE}" || ! -f "${SUMMARY_MARKDOWN_FILE}" ]]; then
+    write_failure_summary "${exit_code}" || true
+  fi
+
+  write_results || true
+  exit "${exit_code}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      [[ $# -ge 2 ]] || die "Missing value for --mode"
+      MODE=$2
+      shift 2
+      ;;
+    --build-root)
+      [[ $# -ge 2 ]] || die "Missing value for --build-root"
+      BUILD_ROOT=$2
+      shift 2
+      ;;
+    --artifacts-dir)
+      [[ $# -ge 2 ]] || die "Missing value for --artifacts-dir"
+      ARTIFACTS_DIR=$2
+      shift 2
+      ;;
+    --results-file)
+      [[ $# -ge 2 ]] || die "Missing value for --results-file"
+      RESULTS_FILE=$2
+      shift 2
+      ;;
+    --adept-repository)
+      [[ $# -ge 2 ]] || die "Missing value for --adept-repository"
+      ADEPT_REPOSITORY=$2
+      shift 2
+      ;;
+    --adept-ref)
+      [[ $# -ge 2 ]] || die "Missing value for --adept-ref"
+      ADEPT_REF=$2
+      shift 2
+      ;;
+    --athena-repository)
+      [[ $# -ge 2 ]] || die "Missing value for --athena-repository"
+      ATHENA_REPOSITORY=$2
+      shift 2
+      ;;
+    --athena-base-ref)
+      [[ $# -ge 2 ]] || die "Missing value for --athena-base-ref"
+      ATHENA_BASE_REF=$2
+      shift 2
+      ;;
+    --athena-gpu-repository)
+      [[ $# -ge 2 ]] || die "Missing value for --athena-gpu-repository"
+      ATHENA_GPU_REPOSITORY=$2
+      shift 2
+      ;;
+    --athena-gpu-ref)
+      [[ $# -ge 2 ]] || die "Missing value for --athena-gpu-ref"
+      ATHENA_GPU_REF=$2
+      shift 2
+      ;;
+    --atlasexternals-repository)
+      [[ $# -ge 2 ]] || die "Missing value for --atlasexternals-repository"
+      ATLAS_EXTERNALS_REPOSITORY=$2
+      shift 2
+      ;;
+    --atlasexternals-base-ref)
+      [[ $# -ge 2 ]] || die "Missing value for --atlasexternals-base-ref"
+      ATLAS_EXTERNALS_BASE_REF=$2
+      shift 2
+      ;;
+    --threads)
+      [[ $# -ge 2 ]] || die "Missing value for --threads"
+      THREADS=$2
+      shift 2
+      ;;
+    --events)
+      [[ $# -ge 2 ]] || die "Missing value for --events"
+      EVENTS=$2
+      shift 2
+      ;;
+    --repetitions)
+      [[ $# -ge 2 ]] || die "Missing value for --repetitions"
+      REPETITIONS=$2
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown option: $1"
+      ;;
+  esac
+done
+
+[[ "${MODE}" == "mono" || "${MODE}" == "split" ]] || die "Expected --mode mono or split"
+[[ -n "${ADEPT_REPOSITORY}" ]] || die "--adept-repository is required"
+[[ -n "${ADEPT_REF}" ]] || die "--adept-ref is required"
+[[ -n "${ATHENA_GPU_REPOSITORY}" ]] || die "--athena-gpu-repository is required"
+[[ -n "${ATHENA_GPU_REF}" ]] || die "--athena-gpu-ref is required"
+[[ "${THREADS}" =~ ^[1-9][0-9]*$ ]] || die "Invalid --threads '${THREADS}'"
+[[ "${EVENTS}" =~ ^[1-9][0-9]*$ ]] || die "Invalid --events '${EVENTS}'"
+[[ "${REPETITIONS}" =~ ^[1-9][0-9]*$ ]] || die "Invalid --repetitions '${REPETITIONS}'"
+
+case "${MODE}" in
+  mono)
+    MODE_LABEL="Mono_NoLeaks"
+    RUN_DIR_LABEL="Mono_NoLeaks"
+    ;;
+  split)
+    MODE_LABEL="Split_NoLeaks"
+    RUN_DIR_LABEL="Split_NoLeaks"
+    ;;
+esac
+
+ADEPT_SHORT_SHA=${ADEPT_REF:0:7}
+RUN_LABEL="${MODE}-${ADEPT_SHORT_SHA}"
+
+mkdir -p "${BUILD_ROOT}" "${ARTIFACTS_DIR}"
+BUILD_ROOT=$(cd "${BUILD_ROOT}" && pwd)
+ARTIFACTS_DIR=$(cd "${ARTIFACTS_DIR}" && pwd)
+
+ATHENA_WORKTREE="${BUILD_ROOT}/athena"
+GPU_BUILD_DIR="${BUILD_ROOT}/gpu_build_${MODE_LABEL}_${ADEPT_SHORT_SHA}"
+GPU_BUILD_RELATIVE="../$(basename "${GPU_BUILD_DIR}")"
+BUILD_LOG="${ARTIFACTS_DIR}/output_build.txt"
+RUN_DIR="${BUILD_ROOT}/runs_validation_GammaRR/${RUN_DIR_LABEL}"
+SUMMARY_MARKDOWN_FILE="${ARTIFACTS_DIR}/summary.md"
+
+trap 'on_exit $?' EXIT
+
+log "Mode: ${MODE}"
+log "Build root: ${BUILD_ROOT}"
+log "Artifacts dir: ${ARTIFACTS_DIR}"
+log "AdePT under test: ${ADEPT_REPOSITORY}@${ADEPT_REF}"
+log "Athena base: ${ATHENA_REPOSITORY}@${ATHENA_BASE_REF}"
+log "Athena GPU merge: ${ATHENA_GPU_REPOSITORY}@${ATHENA_GPU_REF}"
+
+git_checkout_ref() {
+  local repo_dir=$1
+  local branch_name=$2
+  local ref=$3
+
+  if git -C "${repo_dir}" rev-parse --verify --quiet "origin/${ref}^{commit}" >/dev/null; then
+    git -C "${repo_dir}" checkout -B "${branch_name}" "origin/${ref}" >/dev/null
+  else
+    git -C "${repo_dir}" checkout -B "${branch_name}" "${ref}" >/dev/null
+  fi
+}
+
+clone_athena() {
+  retry_command 3 git clone "${ATHENA_REPOSITORY}" "${ATHENA_WORKTREE}" >/dev/null
+  git_checkout_ref "${ATHENA_WORKTREE}" ci-base "${ATHENA_BASE_REF}"
+  git -C "${ATHENA_WORKTREE}" remote add adept-gpu "${ATHENA_GPU_REPOSITORY}"
+  retry_command 3 git -C "${ATHENA_WORKTREE}" fetch --no-tags adept-gpu "${ATHENA_GPU_REF}" >/dev/null
+  git -C "${ATHENA_WORKTREE}" merge --no-edit FETCH_HEAD >/dev/null
+  ATHENA_HEAD_SHA=$(git -C "${ATHENA_WORKTREE}" rev-parse HEAD)
+}
+
+prepare_local_atlasexternals() {
+  local repo_dir="${BUILD_ROOT}/atlasexternals-under-test"
+  local cmake_file branch_name
+
+  retry_command 3 git clone "${ATLAS_EXTERNALS_REPOSITORY}" "${repo_dir}" >/dev/null
+  git_checkout_ref "${repo_dir}" ci-base "${ATLAS_EXTERNALS_BASE_REF}"
+
+  cmake_file="${repo_dir}/External/AdePT/CMakeLists.txt"
+  python3 - "${cmake_file}" "https://github.com/${ADEPT_REPOSITORY}.git" "${ADEPT_REF}" "${MODE}" <<'PY'
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(sys.argv[1])
+adept_url = sys.argv[2]
+adept_ref = sys.argv[3]
+mode = sys.argv[4]
+split_value = "TRUE" if mode == "split" else "FALSE"
+
+text = path.read_text()
+
+source_pattern = re.compile(
+    r'set\(\s*ATLAS_ADEPT_SOURCE\s*.*?CACHE STRING "The source for AdePT" \)',
+    re.S,
+)
+replacement = (
+    'set( ATLAS_ADEPT_SOURCE\n'
+    f'   "GIT_REPOSITORY;{adept_url};GIT_TAG;{adept_ref}"\n'
+    '   CACHE STRING "The source for AdePT" )'
+)
+text, source_count = source_pattern.subn(replacement, text, count=1)
+if source_count != 1:
+    raise SystemExit("Could not rewrite ATLAS_ADEPT_SOURCE")
+
+split_pattern = re.compile(r'-DADEPT_USE_SPLIT_KERNELS:BOOL=(TRUE|FALSE)')
+text, split_count = split_pattern.subn(
+    f'-DADEPT_USE_SPLIT_KERNELS:BOOL={split_value}',
+    text,
+    count=1,
+)
+if split_count != 1:
+    raise SystemExit("Could not rewrite ADEPT_USE_SPLIT_KERNELS")
+
+path.write_text(text)
+PY
+
+  branch_name="ci-athena-performance-${RUN_LABEL}"
+  git -C "${repo_dir}" config user.name "AdePT Performance CI"
+  git -C "${repo_dir}" config user.email "actions@users.noreply.github.com"
+  git -C "${repo_dir}" checkout -B "${branch_name}" >/dev/null
+  git -C "${repo_dir}" add External/AdePT/CMakeLists.txt
+  git -C "${repo_dir}" commit -m "CI performance benchmark for ${ADEPT_REF}" >/dev/null
+
+  ATLAS_EXTERNALS_LOCAL_REPO="${repo_dir}"
+  ATLAS_EXTERNALS_LOCAL_REF="${branch_name}"
+  ATLAS_EXTERNALS_LOCAL_SHA=$(git -C "${repo_dir}" rev-parse HEAD)
+}
+
+prepare_athena_gpu_env() {
+  export ATLAS_LOCAL_ROOT_BASE="/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase"
+  # shellcheck disable=SC1091
+  source "${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh" --quiet
+  asetup none,gcc14.2,cmakesetup
+  export ATLAS_NIGHTLY_PLATFORM="${BINARY_TAG:-${LCG_PLATFORM:-${CMTCONFIG}}}"
+  export ATLAS_NIGHTLY_G4PATH="${ATLAS_NIGHTLY_G4PATH:-/cvmfs/atlas-nightlies.cern.ch/repo/sw/main--simGPU_AthSimulation_${ATLAS_NIGHTLY_PLATFORM}/Geant4}"
+  export G4PATH="${ATLAS_NIGHTLY_G4PATH}"
+}
+
+build_athena() {
+  (
+    prepare_athena_gpu_env
+    export AtlasExternals_URL="${ATLAS_EXTERNALS_LOCAL_REPO}"
+    export AtlasExternals_REF="${ATLAS_EXTERNALS_LOCAL_REF}"
+    cd "${ATHENA_WORKTREE}"
+    ./Projects/AthSimulation/build_gpu.sh -b "${GPU_BUILD_RELATIVE}" > "${BUILD_LOG}" 2>&1
+  )
+}
+
+rewrite_setup_run() {
+  cat > "${GPU_BUILD_DIR}/setup_run.sh" <<EOF
+export ATLAS_LOCAL_ROOT_BASE="/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase"
+source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
+asetup none,gcc14.2,cmakesetup
+export ATLAS_NIGHTLY_PLATFORM=\${BINARY_TAG:-\${LCG_PLATFORM:-\${CMTCONFIG}}}
+export ATLAS_NIGHTLY_G4PATH=\${ATLAS_NIGHTLY_G4PATH:-/cvmfs/atlas-nightlies.cern.ch/repo/sw/main--simGPU_AthSimulation_\${ATLAS_NIGHTLY_PLATFORM}/Geant4}
+export G4PATH=\${ATLAS_NIGHTLY_G4PATH}
+source ${ATHENA_WORKTREE}/Projects/AthSimulation/build_env.sh -b ${GPU_BUILD_DIR}/externals
+source ${GPU_BUILD_DIR}/build/\${LCG_PLATFORM}/setup.sh
+EOF
+  chmod +x "${GPU_BUILD_DIR}/setup_run.sh"
+}
+
+prepare_run_dir() {
+  mkdir -p "${RUN_DIR}"
+  cp "${REPO_ROOT}/test/athena-performance/run_all_5.sh" "${RUN_DIR}/run_all_5.sh"
+  cp "${REPO_ROOT}/test/athena-performance/${MODE}/run_adept.sh" "${RUN_DIR}/run_adept.sh"
+  chmod +x "${RUN_DIR}/run_all_5.sh" "${RUN_DIR}/run_adept.sh"
+}
+
+run_benchmark() {
+  (
+    set -euo pipefail
+    # shellcheck disable=SC1091
+    source "${GPU_BUILD_DIR}/setup_run.sh"
+    cd "${RUN_DIR}"
+    export ADEPT_MAX_EVENTS="${EVENTS}"
+    export ADEPT_OUTPUT_HITS_FILE="test.CA.HITS.pool_AdePT_E${EVENTS}.root"
+    ./run_all_5.sh "${THREADS}"
+  )
+}
+
+summarize_results() {
+  local env_file="${ARTIFACTS_DIR}/summary.env"
+
+  python3 - "${RUN_DIR}" "${THREADS}" "${MODE}" "${ADEPT_REPOSITORY}" "${ADEPT_REF}" \
+    "${ATHENA_REPOSITORY}" "${ATHENA_BASE_REF}" "${ATHENA_HEAD_SHA}" \
+    "${ATHENA_GPU_REPOSITORY}" "${ATHENA_GPU_REF}" \
+    "${ATLAS_EXTERNALS_REPOSITORY}" "${ATLAS_EXTERNALS_BASE_REF}" "${ATLAS_EXTERNALS_LOCAL_SHA}" \
+    "${SUMMARY_MARKDOWN_FILE}" "${BUILD_LOG}" "${GPU_BUILD_DIR}/setup_run.sh" <<'PY' > "${env_file}"
+import math
+import pathlib
+import re
+import statistics
+import sys
+
+(
+    run_dir,
+    threads,
+    mode,
+    adept_repo,
+    adept_ref,
+    athena_repo,
+    athena_base_ref,
+    athena_head_sha,
+    athena_gpu_repo,
+    athena_gpu_ref,
+    atlasexternals_repo,
+    atlasexternals_base_ref,
+    atlasexternals_sha,
+    summary_path,
+    build_log,
+    setup_run_path,
+) = sys.argv[1:]
+
+run_dir_path = pathlib.Path(run_dir)
+summary_path = pathlib.Path(summary_path)
+real_re = re.compile(r"Real=([0-9.]+)s")
+log_pattern = f"log.AtlasG4Tf_AdePT_T{threads}_run*"
+
+per_run = []
+for atlas_log in sorted(run_dir_path.glob(log_pattern)):
+    values = []
+    for line in atlas_log.read_text(errors="ignore").splitlines():
+        match = real_re.search(line)
+        if match:
+            values.append(float(match.group(1)))
+    if len(values) <= 1:
+        continue
+    trimmed = values[1:]
+    per_run.append((atlas_log.name, sum(trimmed) / len(trimmed), len(trimmed)))
+
+if not per_run:
+    raise SystemExit("No benchmark logs with parseable Real= measurements were found")
+
+means = [item[1] for item in per_run]
+overall_mean = statistics.mean(means)
+overall_stddev = statistics.stdev(means) if len(means) > 1 else 0.0
+
+mode_label = "Mono_NoLeaks" if mode == "mono" else "Split_NoLeaks"
+build_cmd = f"./Projects/AthSimulation/build_gpu.sh -b ../gpu_build_{mode_label}_{adept_ref[:7]} > output_build.txt"
+run_cmd = f"bash -lc 'source {setup_run_path} && cd {run_dir} && ./run_all_5.sh {threads}'"
+
+lines = [
+    f"### Athena Performance Benchmark ({mode})",
+    "",
+    f"- AdePT: `{adept_repo}@{adept_ref}`",
+    f"- Athena base: `{athena_repo}@{athena_base_ref}`",
+    f"- Athena merged head: `{athena_head_sha}`",
+    f"- Athena GPU merge source: `{athena_gpu_repo}@{athena_gpu_ref}`",
+    f"- AtlasExternals base: `{atlasexternals_repo}@{atlasexternals_base_ref}`",
+    f"- AtlasExternals benchmark commit: `{atlasexternals_sha}`",
+    f"- Build command: `{build_cmd}`",
+    f"- Run command: `{run_cmd}`",
+    (
+        "- Runtime extraction: per-run average of `Real=` measurements with the first "
+        "measurement skipped, matching "
+        "`grep 'Real=' ... | sed ... | awk 'NR>1 { sum += $1; n++ } ...'`."
+    ),
+    f"- Build log: `{build_log}`",
+    "",
+    "| Run log | Average real time (s) | Measurements |",
+    "| --- | ---: | ---: |",
+]
+
+for log_name, mean_value, measurement_count in per_run:
+    lines.append(f"| `{log_name}` | {mean_value:.3f} | {measurement_count} |")
+
+lines.extend(
+    [
+        "",
+        f"- Overall average real time: `{overall_mean:.3f} s`",
+        f"- Overall standard deviation: `{overall_stddev:.3f} s`",
+    ]
+)
+
+summary_path.write_text("\n".join(lines) + "\n")
+
+print(f"OVERALL_REAL_MEAN_SEC={overall_mean:.6f}")
+print(f"OVERALL_REAL_STDDEV_SEC={overall_stddev:.6f}")
+print("PER_RUN_REAL_TIMES_CSV=" + ",".join(f"{value:.6f}" for value in means))
+print("PER_RUN_MEASUREMENT_COUNTS_CSV=" + ",".join(str(item[2]) for item in per_run))
+PY
+
+  # shellcheck disable=SC1090
+  source "${env_file}"
+}
+
+preflight_checks
+clone_athena
+prepare_local_atlasexternals
+build_athena
+rewrite_setup_run
+prepare_run_dir
+run_benchmark
+summarize_results
+
+PERF_STATUS=0
+log "Overall average real time: ${OVERALL_REAL_MEAN_SEC}s"

--- a/test/athena-performance/split/run_adept.sh
+++ b/test/athena-performance/split/run_adept.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NWORK=${1:-32}
+export ATHENA_CORE_NUMBER=${NWORK}
+MAX_EVENTS="${ADEPT_MAX_EVENTS:-1000}"
+OUTPUT_HITS_FILE="${ADEPT_OUTPUT_HITS_FILE:-test.CA.HITS.pool_AdePT_${MAX_EVENTS}.root}"
+
+echo "=== Running AdePT with ATHENA_CORE_NUMBER=${ATHENA_CORE_NUMBER}, MAX_EVENTS=${MAX_EVENTS} ==="
+
+PREEXEC_CMD=$(cat <<'EOF'
+flags.Sim.G4Commands+=[
+  "/adept/MaxWDTIterations 10",
+  "/adept/setSeed 23433452",
+  "/adept/CallUserTrackingAction true",
+  "/adept/CallUserSteppingAction false",
+  "/adept/setCovfieBfieldFile /cvmfs/atlas.cern.ch/repo/sw/database/GroupData/MagneticFieldMaps/bmagatlas_09_fullAsym20400_forGPU_v1.cvf",
+  "/adept/setVerbosity 0",
+  "/adept/addGPURegion EMB",
+  "/adept/addGPURegion EMEC",
+  "/adept/addGPURegion HEC",
+  "/adept/addGPURegion PreSampLAr",
+  "/adept/setTrackInAllRegions false",
+  "/adept/setMillionsOfTrackSlots 7",
+  "/adept/setMillionsOfHitSlots 15",
+  "/adept/setCUDAStackLimit 32192",
+  "/adept/setCUDAHeapLimit 84857600"
+];
+flags.GeoModel.EMECStandard=True
+EOF
+)
+
+AtlasG4_tf.py \
+  --multithreaded \
+  --randomSeed 1212353 \
+  --conditionsTag 'default:OFLCOND-MC21-SDR-RUN4-02' \
+  --geometryVersion 'default:ATLAS-P2-RUN4-04-00-00' \
+  --preInclude 'AtlasG4Tf:Campaigns.MC23aSimulationMultipleIoV' \
+  --postInclude 'PyJobTransforms.UseFrontier' \
+  --inputEVNTFile "/cvmfs/atlas-nightlies.cern.ch/repo/data/data-art/CampaignInputs/mc23/EVNT/mc23_13p6TeV.601229.PhPy8EG_A14_ttbar_hdamp258p75_SingleLep.evgen.EVNT.e8514/EVNT.32288062._002040.pool.root.1" \
+  --outputHITSFile "${OUTPUT_HITS_FILE}" \
+  --maxEvents "${MAX_EVENTS}" \
+  --jobNumber 1 \
+  --postExec 'with open("ConfigSimCA.pkl", "wb") as f: cfg.store(f)' \
+  --physicsList "FTFP_BERT_ATL_AdePT" \
+  --imf False \
+  --preExec "${PREEXEC_CMD}"

--- a/test/athena-performance/split/run_adept.sh
+++ b/test/athena-performance/split/run_adept.sh
@@ -12,7 +12,7 @@ echo "=== Running AdePT with ATHENA_CORE_NUMBER=${ATHENA_CORE_NUMBER}, MAX_EVENT
 PREEXEC_CMD=$(cat <<'EOF'
 flags.Sim.G4Commands+=[
   "/adept/MaxWDTIterations 10",
-  "/adept/setSeed 23433452",
+  "/adept/setSeed 2312452",
   "/adept/CallUserTrackingAction true",
   "/adept/CallUserSteppingAction false",
   "/adept/setCovfieBfieldFile /cvmfs/atlas.cern.ch/repo/sw/database/GroupData/MagneticFieldMaps/bmagatlas_09_fullAsym20400_forGPU_v1.cvf",

--- a/test/athena-performance/split/run_adept.sh
+++ b/test/athena-performance/split/run_adept.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2026 CERN
+# SPDX-License-Identifier: Apache-2.0
+
 set -euo pipefail
 
 NWORK=${1:-32}


### PR DESCRIPTION
This PR adds a workflow that can be triggered with a `/run-performance mono` or `/run-performance split` comment. It can also be triggered directly from the github actions.

In case it is triggered on a PR, it will run the performance benchmark on that PR.

The workflow will clone athena and the atlasexternals, patch the atlasexternals to use the PR AdePT branch, patch athena to use that atlasexternals, then do the build. Then, it will run the benchmark 5x and comment the average run time below the PR.
