### PR TITLE
Performance CI: remove -e in scripts

### DIFF
--- a/.github/workflows/athena-performance.yml
+++ b/.github/workflows/athena-performance.yml
@@ -262,8 +262,8 @@ jobs:
 
       - name: Show runner basics
         run: |
-          set -eo pipefail
-          cat /etc/os-release | sed -n '1,6p'
+          set -o pipefail
+          cat /etc/os-release | sed -n '1,6p' || exit 1
           echo "event=${GITHUB_EVENT_NAME}"
           echo "mode=${{ needs.prepare.outputs.mode }}"
           echo "adept_repo=${{ needs.prepare.outputs.adept_repo }}"
@@ -275,12 +275,12 @@ jobs:
 
       - name: Pre-touch required CVMFS repos on host
         run: |
-          set -eo pipefail
-          ls /cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase/user/atlasLocalSetup.sh
+          set -o pipefail
+          ls /cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase/user/atlasLocalSetup.sh || exit 1
           ls /cvmfs/atlas-nightlies.cern.ch/repo/sw/main--simGPU_AthSimulation_x86_64-el9-gcc14-opt/Geant4 || true
-          ls /cvmfs/geant4.cern.ch/share/data/G4ENSDFSTATE3.0/ENSDFSTATE.dat
+          ls /cvmfs/geant4.cern.ch/share/data/G4ENSDFSTATE3.0/ENSDFSTATE.dat || exit 1
           if [ -d /afs ]; then
-            ls /afs >/dev/null
+            ls /afs >/dev/null || exit 1
             echo "/afs is present on the host and will be mounted into the container"
           else
             echo "/afs is not present on the host"
@@ -288,13 +288,13 @@ jobs:
 
       - name: Check GPU visibility
         run: |
-          set -eo pipefail
-          nvidia-smi
+          set -o pipefail
+          nvidia-smi || exit 1
 
       - name: Check Docker basics
         run: |
-          set -eo pipefail
-          docker --version
+          set -o pipefail
+          docker --version || exit 1
 
       - name: Run Athena performance benchmark in Alma 9 container
         id: run_perf
@@ -315,7 +315,7 @@ jobs:
           CERN_GITLAB_USERNAME: ${{ secrets.CERN_GITLAB_USERNAME }}
           CERN_GITLAB_TOKEN: ${{ secrets.CERN_GITLAB_TOKEN }}
         run: |
-          set -eo pipefail
+          set -o pipefail
 
           rm -f "${RESULTS_FILE}"
           rm -rf "${ARTIFACTS_DIR}"
@@ -362,7 +362,7 @@ jobs:
             -w /work/AdePT \
             gitlab-registry.cern.ch/sft/docker/alma9 \
             bash -lc '
-              set -eo pipefail
+              set -o pipefail
               mkdir -p "${HOME}"
               git config --global --add safe.directory /work/AdePT
               container_results_file="/work/AdePT/athena-performance-results.env"
@@ -388,9 +388,9 @@ jobs:
       - name: Load benchmark results
         if: always() && hashFiles(env.RESULTS_FILE) != ''
         run: |
-          set -eo pipefail
+          set -o pipefail
           # shellcheck disable=SC1091
-          source "${RESULTS_FILE}"
+          source "${RESULTS_FILE}" || exit 1
 
           host_summary_markdown_file="${SUMMARY_MARKDOWN_FILE:-}"
           case "${host_summary_markdown_file}" in

--- a/test/athena-performance/mono/run_adept.sh
+++ b/test/athena-performance/mono/run_adept.sh
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2026 CERN
 # SPDX-License-Identifier: Apache-2.0
 
-set -euo pipefail
+set -uo pipefail
 
 NWORK=${1:-32}
 export ATHENA_CORE_NUMBER=${NWORK}

--- a/test/athena-performance/run_all_5.sh
+++ b/test/athena-performance/run_all_5.sh
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2026 CERN
 # SPDX-License-Identifier: Apache-2.0
 
-set -euo pipefail
+set -uo pipefail
 
 NWORK=${1:-96}
 REPETITIONS=${2:-${ADEPT_REPETITIONS:-5}}
@@ -15,9 +15,9 @@ REPETITIONS=${2:-${ADEPT_REPETITIONS:-5}}
 
 for I in $(seq 1 "${REPETITIONS}"); do
   echo "=== Starting AdePT run ${I}, T=${NWORK} ==="
-  ./run_adept.sh "${NWORK}" > "adept_T${NWORK}_run${I}.log" 2>&1
+  ./run_adept.sh "${NWORK}" > "adept_T${NWORK}_run${I}.log" 2>&1 || exit 1
   if [ -f log.AtlasG4Tf ]; then
-    mv log.AtlasG4Tf "log.AtlasG4Tf_AdePT_T${NWORK}_run${I}"
+    mv log.AtlasG4Tf "log.AtlasG4Tf_AdePT_T${NWORK}_run${I}" || exit 1
   else
     echo "WARNING: log.AtlasG4Tf missing after AdePT run ${I}" >&2
   fi

--- a/test/athena-performance/run_athena_performance.sh
+++ b/test/athena-performance/run_athena_performance.sh
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2026 CERN
 # SPDX-License-Identifier: Apache-2.0
 
-set -euo pipefail
+set -o pipefail
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
@@ -495,8 +495,8 @@ PY
 prepare_athena_gpu_env() {
   export ATLAS_LOCAL_ROOT_BASE="/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase"
   # shellcheck disable=SC1091
-  source "${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh" --quiet
-  asetup none,gcc14.2,cmakesetup
+  source "${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh" --quiet || return 1
+  asetup none,gcc14.2,cmakesetup || return 1
   export ATLAS_NIGHTLY_PLATFORM="${BINARY_TAG:-${LCG_PLATFORM:-${CMTCONFIG}}}"
   export ATLAS_NIGHTLY_G4PATH="${ATLAS_NIGHTLY_G4PATH:-/cvmfs/atlas-nightlies.cern.ch/repo/sw/main--simGPU_AthSimulation_${ATLAS_NIGHTLY_PLATFORM}/Geant4}"
   export G4PATH="${ATLAS_NIGHTLY_G4PATH}"
@@ -504,10 +504,10 @@ prepare_athena_gpu_env() {
 
 build_athena() {
   (
-    prepare_athena_gpu_env
+    prepare_athena_gpu_env || exit 1
     export AtlasExternals_URL="${ATLAS_EXTERNALS_LOCAL_REPO}"
     export AtlasExternals_REF="${ATLAS_EXTERNALS_LOCAL_REF}"
-    cd "${ATHENA_WORKTREE}"
+    cd "${ATHENA_WORKTREE}" || exit 1
     ./Projects/AthSimulation/build_gpu.sh -b "${GPU_BUILD_RELATIVE}" > "${BUILD_LOG}" 2>&1
   )
 }
@@ -515,13 +515,13 @@ build_athena() {
 rewrite_setup_run() {
   cat > "${GPU_BUILD_DIR}/setup_run.sh" <<EOF
 export ATLAS_LOCAL_ROOT_BASE="/cvmfs/atlas.cern.ch/repo/ATLASLocalRootBase"
-source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh
-asetup none,gcc14.2,cmakesetup
+source \${ATLAS_LOCAL_ROOT_BASE}/user/atlasLocalSetup.sh || return 1
+asetup none,gcc14.2,cmakesetup || return 1
 export ATLAS_NIGHTLY_PLATFORM=\${BINARY_TAG:-\${LCG_PLATFORM:-\${CMTCONFIG}}}
 export ATLAS_NIGHTLY_G4PATH=\${ATLAS_NIGHTLY_G4PATH:-/cvmfs/atlas-nightlies.cern.ch/repo/sw/main--simGPU_AthSimulation_\${ATLAS_NIGHTLY_PLATFORM}/Geant4}
 export G4PATH=\${ATLAS_NIGHTLY_G4PATH}
-source ${ATHENA_WORKTREE}/Projects/AthSimulation/build_env.sh -b ${GPU_BUILD_DIR}/externals
-source ${GPU_BUILD_DIR}/build/\${LCG_PLATFORM}/setup.sh
+source ${ATHENA_WORKTREE}/Projects/AthSimulation/build_env.sh -b ${GPU_BUILD_DIR}/externals || return 1
+source ${GPU_BUILD_DIR}/build/\${LCG_PLATFORM}/setup.sh || return 1
 EOF
   chmod +x "${GPU_BUILD_DIR}/setup_run.sh"
 }
@@ -535,14 +535,14 @@ prepare_run_dir() {
 
 run_benchmark() {
   (
-    set -euo pipefail
+    set -o pipefail
     # shellcheck disable=SC1091
-    source "${GPU_BUILD_DIR}/setup_run.sh"
-    cd "${RUN_DIR}"
+    source "${GPU_BUILD_DIR}/setup_run.sh" || exit 1
+    cd "${RUN_DIR}" || exit 1
     export ADEPT_MAX_EVENTS="${EVENTS}"
     export ADEPT_REPETITIONS="${REPETITIONS}"
     export ADEPT_OUTPUT_HITS_FILE="test.CA.HITS.pool_AdePT_E${EVENTS}.root"
-    ./run_all_5.sh "${THREADS}" "${REPETITIONS}"
+    ./run_all_5.sh "${THREADS}" "${REPETITIONS}" || exit 1
   )
 }
 

--- a/test/athena-performance/split/run_adept.sh
+++ b/test/athena-performance/split/run_adept.sh
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2026 CERN
 # SPDX-License-Identifier: Apache-2.0
 
-set -euo pipefail
+set -uo pipefail
 
 NWORK=${1:-32}
 export ATHENA_CORE_NUMBER=${NWORK}


### PR DESCRIPTION
The athena scripts are sensitive to -e and will fail right away. Therefore, the flag is removed from the workflow.