### PR TITLE
enable apply cuts for PerformNuclear

### DIFF
--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -16,6 +16,8 @@
 #include <G4StepStatus.hh>
 
 #include <G4HepEmNoProcess.hh>
+#include <G4HepEmConfig.hh>
+#include <G4HepEmParameters.hh>
 
 #include "G4Electron.hh"
 #include "G4Positron.hh"
@@ -538,9 +540,16 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
       nuclearStep->SetTrack(nuclearReactionTrack);
       nuclearReactionTrack->SetStep(nuclearStep);
 
-      // ApplyCuts must be false, as we are not in a Geant4 tracking loop here and
-      // cannot deposit any cut secondaries locally.
-      fHepEmTrackingManager->PerformNuclear(nuclearReactionTrack, nuclearStep, particleID, /*isApplyCuts=*/false);
+      // Use per-region ApplyCuts as in G4HepEmTrackingManager to cut secondaries from PerformNuclear
+      const int regionIndex =
+          nuclearReactionTrack->GetTouchable()->GetVolume()->GetLogicalVolume()->GetRegion()->GetInstanceID();
+      const bool isApplyCuts =
+          fHepEmTrackingManager->GetConfig()->GetG4HepEmParameters()->fParametersPerRegion[regionIndex].fIsApplyCuts;
+      const double cutSecondaryEdep =
+          fHepEmTrackingManager->PerformNuclear(nuclearReactionTrack, nuclearStep, particleID, isApplyCuts);
+      if (cutSecondaryEdep > 0.0) {
+        fScoringObjects->fG4Step->AddTotalEnergyDeposit(cutSecondaryEdep);
+      }
 
       if (auto *newSecondaries = nuclearStep->GetfSecondary(); newSecondaries != nullptr) {
         hadronicSecondaries.reserve(newSecondaries->size());


### PR DESCRIPTION
Before the major cleanup in #540, the `PerformNuclear` was called when the leaked tracks where returned, not when the SD code was invoked. Therefore, ApplyCuts could not be used. Now, as the `PerformNuclear` is called directly before the SD code is invoked, we can apply the cuts also to `PerformNuclear` like G4HepEm and cut low energy secondaries.

This solves #541 

### Physics behavior changes:

This PR naturally changes all drift tests, as apply cuts is used in the CI, so edep and the full history is changed.
