### PR TITLE
update validation settings in CI test

### DIFF
--- a/.github/workflows/self-hosted-pr-ci.yml
+++ b/.github/workflows/self-hosted-pr-ci.yml
@@ -185,6 +185,19 @@ jobs:
             -v /cvmfs:/cvmfs:ro,rslave \
             -v "${GITHUB_WORKSPACE}:/work/AdePT" \
             -e HOME=/tmp/adeptci-home \
+            -e ADEPT_VALIDATION_NUM_EVENTS=600 \
+            -e ADEPT_VALIDATION_DEFAULT_NUM_THREADS=32 \
+            -e ADEPT_VALIDATION_DEFAULT_NUM_TRACKSLOTS=6 \
+            -e ADEPT_VALIDATION_DEFAULT_NUM_HITSLOTS=30 \
+            -e ADEPT_VALIDATION_DEFAULT_CPU_CAPACITY_FACTOR=5.0 \
+            -e ADEPT_VALIDATION_REGIONS_NUM_THREADS=32 \
+            -e ADEPT_VALIDATION_REGIONS_NUM_TRACKSLOTS=6 \
+            -e ADEPT_VALIDATION_REGIONS_NUM_HITSLOTS=30 \
+            -e ADEPT_VALIDATION_REGIONS_CPU_CAPACITY_FACTOR=5.0 \
+            -e ADEPT_VALIDATION_WDT_NUM_THREADS=32 \
+            -e ADEPT_VALIDATION_WDT_NUM_TRACKSLOTS=8 \
+            -e ADEPT_VALIDATION_WDT_NUM_HITSLOTS=30 \
+            -e ADEPT_VALIDATION_WDT_CPU_CAPACITY_FACTOR=5.0 \
             -w /work/AdePT \
             gitlab-registry.cern.ch/sft/docker/alma9 \
             bash -lc '

--- a/test/regression/scripts/example_template.mac
+++ b/test/regression/scripts/example_template.mac
@@ -20,6 +20,7 @@
 ## Total number of GPU track slots (not per thread)
 /adept/setMillionsOfTrackSlots $num_trackslots
 /adept/setMillionsOfHitSlots $num_hitslots
+/adept/setCPUCapacityFactor $cpu_capacity_factor
 /adept/setCUDAStackLimit 8192
 
 # If true, particles are transported on the GPU across the whole geometry, GPU regions are ignored

--- a/test/regression/scripts/python_scripts/macro_generator.py
+++ b/test/regression/scripts/python_scripts/macro_generator.py
@@ -35,6 +35,7 @@ def generate_macro(template_path, output_path, args):
     macro_content = macro_content.replace("$num_events", str(args.num_events))
     macro_content = macro_content.replace("$num_trackslots", str(args.num_trackslots))
     macro_content = macro_content.replace("$num_hitslots", str(args.num_hitslots))
+    macro_content = macro_content.replace("$cpu_capacity_factor", str(args.cpu_capacity_factor))
     macro_content = macro_content.replace("$detector_field", str(args.detector_field))
     macro_content = macro_content.replace("$adept_seed", str(args.adept_seed))
     macro_content = macro_content.replace("$gun_type", str(args.gun_type))
@@ -98,6 +99,8 @@ def main():
                         help="Number of trackslots in million. Should be chosen according to the GPU memory")
     parser.add_argument("--num_hitslots", type=int, default=12,
                         help="Number of hitslots in million. Should be chosen according to the GPU memory")
+    parser.add_argument("--cpu_capacity_factor", type=float, default=2.5,
+                        help="CPU staging capacity factor for scored hits (default: 2.5)")
     parser.add_argument("--detector_field", type=str, default="0 0 0",
                         help="Constant magnetic field vector in tesla, format: 'Bx By Bz' (default: '0 0 0')")
     parser.add_argument("--adept_seed", type=int, default=1234567,

--- a/test/regression/scripts/validation_testem3.sh
+++ b/test/regression/scripts/validation_testem3.sh
@@ -31,15 +31,27 @@ cleanup
 # Create temporary directory
 mkdir -p ${CI_TMP_DIR}
 
+num_threads=${ADEPT_VALIDATION_DEFAULT_NUM_THREADS:-${ADEPT_VALIDATION_NUM_THREADS:-4}}
+num_events=${ADEPT_VALIDATION_DEFAULT_NUM_EVENTS:-${ADEPT_VALIDATION_NUM_EVENTS:-400}}
+num_trackslots=${ADEPT_VALIDATION_DEFAULT_NUM_TRACKSLOTS:-${ADEPT_VALIDATION_NUM_TRACKSLOTS:-3}}
+num_hitslots=${ADEPT_VALIDATION_DEFAULT_NUM_HITSLOTS:-${ADEPT_VALIDATION_NUM_HITSLOTS:-12}}
+cpu_capacity_factor=${ADEPT_VALIDATION_DEFAULT_CPU_CAPACITY_FACTOR:-${ADEPT_VALIDATION_CPU_CAPACITY_FACTOR:-2.5}}
+gun_number=${ADEPT_VALIDATION_DEFAULT_GUN_NUMBER:-${ADEPT_VALIDATION_GUN_NUMBER:-100}}
+nprimaries=$((num_events * gun_number))
+
+echo "Validation settings (default): threads=${num_threads}, events=${num_events}, gun=${gun_number}, trackslots=${num_trackslots}, hitslots=${num_hitslots}, cpu_capacity_factor=${cpu_capacity_factor}"
+
 # use gun_type hepmc or setDefault
 $CI_TEST_DIR/python_scripts/macro_generator.py \
     --template ${CI_TEST_DIR}/example_template.mac \
     --output ${CI_TMP_DIR}/validation_testem3.mac \
     --gdml_name ${PROJECT_SOURCE_DIR}/examples/data/testEm3.gdml \
-    --num_threads 4 \
-    --num_events 400 \
-    --num_trackslots 3 \
-    --num_hitslots 12 \
+    --num_threads ${num_threads} \
+    --num_events ${num_events} \
+    --num_trackslots ${num_trackslots} \
+    --num_hitslots ${num_hitslots} \
+    --cpu_capacity_factor ${cpu_capacity_factor} \
+    --gun_number ${gun_number} \
     --track_in_all_regions True\
     --gun_type setDefault 
 
@@ -52,9 +64,9 @@ $ADEPT_EXECUTABLE --allsensitive --accumulated_events \
 
 # Validating the relative error per layer
 # The saved G4 benchmark file was run with --noadept and 1e7 primary 10 GeV electrons.
-# Comparing against 1e5 primary electrons (500 per event, 200 events) with AdePT should give errors below 1%.
+# Comparing against the configured AdePT validation statistics should give errors below 1%.
 # This is a compromise between run time and accuracy of the test 
 $CI_TEST_DIR/python_scripts/check_validation.py --file1 ${CI_TMP_DIR}/adept_em3_2.5e4_e-.csv \
                                                 --file2 ${CI_TEST_DIR}/benchmark_files/g4hepem_em3_10e7_e-.csv \
-                                                --n1 4e4 --n2 1e7 --tol 0.01 \
+                                                --n1 ${nprimaries} --n2 1e7 --tol 0.01 \
                                                 # --plot_file plot.png # uncomment to plot the validation plot

--- a/test/regression/scripts/validation_testem3_WDT.sh
+++ b/test/regression/scripts/validation_testem3_WDT.sh
@@ -31,15 +31,27 @@ cleanup
 # Create temporary directory
 mkdir -p ${CI_TMP_DIR}
 
+num_threads=${ADEPT_VALIDATION_WDT_NUM_THREADS:-${ADEPT_VALIDATION_NUM_THREADS:-8}}
+num_events=${ADEPT_VALIDATION_WDT_NUM_EVENTS:-${ADEPT_VALIDATION_NUM_EVENTS:-400}}
+num_trackslots=${ADEPT_VALIDATION_WDT_NUM_TRACKSLOTS:-${ADEPT_VALIDATION_NUM_TRACKSLOTS:-3}}
+num_hitslots=${ADEPT_VALIDATION_WDT_NUM_HITSLOTS:-${ADEPT_VALIDATION_NUM_HITSLOTS:-12}}
+cpu_capacity_factor=${ADEPT_VALIDATION_WDT_CPU_CAPACITY_FACTOR:-${ADEPT_VALIDATION_CPU_CAPACITY_FACTOR:-2.5}}
+gun_number=${ADEPT_VALIDATION_WDT_GUN_NUMBER:-${ADEPT_VALIDATION_GUN_NUMBER:-100}}
+nprimaries=$((num_events * gun_number))
+
+echo "Validation settings (wdt): threads=${num_threads}, events=${num_events}, gun=${gun_number}, trackslots=${num_trackslots}, hitslots=${num_hitslots}, cpu_capacity_factor=${cpu_capacity_factor}"
+
 # use gun_type hepmc or setDefault
 $CI_TEST_DIR/python_scripts/macro_generator.py \
     --template ${CI_TEST_DIR}/example_template.mac \
     --output ${CI_TMP_DIR}/validation_testem3_WDT.mac \
     --gdml_name ${PROJECT_SOURCE_DIR}/examples/data/testEm3_wdt.gdml \
-    --num_threads 8 \
-    --num_events 400 \
-    --num_trackslots 3 \
-    --num_hitslots 12 \
+    --num_threads ${num_threads} \
+    --num_events ${num_events} \
+    --num_trackslots ${num_trackslots} \
+    --num_hitslots ${num_hitslots} \
+    --cpu_capacity_factor ${cpu_capacity_factor} \
+    --gun_number ${gun_number} \
     --track_in_all_regions True\
     --gun_type setDefault\
     --wdt_regions "WDT_Region_layers_10_40,Layer5,Layer44,Layer45"
@@ -53,5 +65,5 @@ $ADEPT_EXECUTABLE --allsensitive --accumulated_events \
 # Validating the relative error per layer
 $CI_TEST_DIR/python_scripts/check_validation.py --file1 ${CI_TMP_DIR}/adept_em3_2.5e4_e-.csv \
                                                 --file2 ${CI_TEST_DIR}/benchmark_files/g4hepem_em3_10e7_e-.csv \
-                                                --n1 4e4 --n2 1e7 --tol 0.01 \
+                                                --n1 ${nprimaries} --n2 1e7 --tol 0.01 \
                                                 # --plot_file plot.png # uncomment to plot the validation plot

--- a/test/regression/scripts/validation_testem3_regions.sh
+++ b/test/regression/scripts/validation_testem3_regions.sh
@@ -31,15 +31,27 @@ cleanup
 # Create temporary directory
 mkdir -p ${CI_TMP_DIR}
 
+num_threads=${ADEPT_VALIDATION_REGIONS_NUM_THREADS:-${ADEPT_VALIDATION_NUM_THREADS:-8}}
+num_events=${ADEPT_VALIDATION_REGIONS_NUM_EVENTS:-${ADEPT_VALIDATION_NUM_EVENTS:-400}}
+num_trackslots=${ADEPT_VALIDATION_REGIONS_NUM_TRACKSLOTS:-${ADEPT_VALIDATION_NUM_TRACKSLOTS:-3}}
+num_hitslots=${ADEPT_VALIDATION_REGIONS_NUM_HITSLOTS:-${ADEPT_VALIDATION_NUM_HITSLOTS:-12}}
+cpu_capacity_factor=${ADEPT_VALIDATION_REGIONS_CPU_CAPACITY_FACTOR:-${ADEPT_VALIDATION_CPU_CAPACITY_FACTOR:-2.5}}
+gun_number=${ADEPT_VALIDATION_REGIONS_GUN_NUMBER:-${ADEPT_VALIDATION_GUN_NUMBER:-100}}
+nprimaries=$((num_events * gun_number))
+
+echo "Validation settings (regions): threads=${num_threads}, events=${num_events}, gun=${gun_number}, trackslots=${num_trackslots}, hitslots=${num_hitslots}, cpu_capacity_factor=${cpu_capacity_factor}"
+
 # use gun_type hepmc or setDefault
 $CI_TEST_DIR/python_scripts/macro_generator.py \
     --template ${CI_TEST_DIR}/example_template.mac \
     --output ${CI_TMP_DIR}/validation_testem3_regions.mac \
     --gdml_name ${PROJECT_SOURCE_DIR}/examples/data/testEm3_regions.gdml \
-    --num_threads 8 \
-    --num_events 400 \
-    --num_trackslots 3 \
-    --num_hitslots 12 \
+    --num_threads ${num_threads} \
+    --num_events ${num_events} \
+    --num_trackslots ${num_trackslots} \
+    --num_hitslots ${num_hitslots} \
+    --cpu_capacity_factor ${cpu_capacity_factor} \
+    --gun_number ${gun_number} \
     --track_in_all_regions False\
     --gun_type setDefault\
     --regions "caloregion, Layer1, Layer2, Layer3, Layer4, Layer5, Layer6, Layer7, Layer8, Layer9, Layer10,\
@@ -56,5 +68,5 @@ $ADEPT_EXECUTABLE --allsensitive --accumulated_events \
 # Validating the relative error per layer
 $CI_TEST_DIR/python_scripts/check_validation.py --file1 ${CI_TMP_DIR}/adept_em3_2.5e4_e-.csv \
                                                 --file2 ${CI_TEST_DIR}/benchmark_files/g4hepem_em3_10e7_e-.csv \
-                                                --n1 4e4 --n2 1e7 --tol 0.01 \
+                                                --n1 ${nprimaries} --n2 1e7 --tol 0.01 \
                                                 # --plot_file plot.png # uncomment to plot the validation plot


### PR DESCRIPTION
As noted in #589, the current validation tests can fail by just changing the random seed, as the fluctuations can lead to an error larger than 1%:

Seed, error:
```
1234567: pass, 0.407735%
1234568: fail, 1.038702%
1234569: pass, 0.561926%
1234570: pass, 0.556683%
1234571: pass, 0.509937%
1234572: pass, 0.500730%
1234573: pass, 0.944030%
1234574: pass, 0.642265%
1234575: pass, 0.410258%
1234576: fail, 1.347790%
```

Therefore, this PR increases the number of events from 400 to 600 to increase the statistics and reduce the error more safely below 1%.

To accelerate the CI, the GPU settings on the self-hosted runner are adjusted, such that the GPU is optimally used.