### PR TITLE
Performance CI: fix git permission

### DIFF
--- a/.github/workflows/athena-performance.yml
+++ b/.github/workflows/athena-performance.yml
@@ -47,7 +47,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: athena-performance-el9


### PR DESCRIPTION
While the performance CI is setup and runs, it did not write back the report under the PR. The issue was most likely that the permissions were not set to write for the PR, which is fixed in this PR.