### PR TITLE
Separate GPU track into neutral and charged track

### DIFF
--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -170,6 +170,23 @@ __device__ inline uint64_t GenerateSeedFromTrackInfo(const AsyncAdePT::TrackData
   return fnv1a_hash64(input, 12);
 }
 
+template <typename SpeciesManagerT>
+__device__ inline void InitTrackToQueue(SpeciesManagerT &speciesTM, const AsyncAdePT::TrackDataWithIDs &trackInfo,
+                                        short queueIndex, adept::MParrayT<QueueIndexPair> *toBeEnqueued,
+                                        uint64_t initialSeed)
+{
+  // TODO: Delay when not enough slots?
+  const auto slot = speciesTM.NextSlot();
+  // Scramble the initial seed with track data so a particle returning from the
+  // device and being injected again does not collide with its old RNG stream.
+  auto seed = GenerateSeedFromTrackInfo(trackInfo, initialSeed);
+  speciesTM.InitTrack(slot, seed, trackInfo.eKin, trackInfo.globalTime, static_cast<float>(trackInfo.localTime),
+                      static_cast<float>(trackInfo.properTime), trackInfo.weight, trackInfo.position,
+                      trackInfo.direction, trackInfo.navState, trackInfo.eventId, trackInfo.trackId, trackInfo.parentId,
+                      trackInfo.threadId, trackInfo.stepCounter);
+  toBeEnqueued->push_back(QueueIndexPair{slot, queueIndex});
+}
+
 // Kernel function to initialize tracks comming from a Geant4 buffer
 __global__ void InitTracks(AsyncAdePT::TrackDataWithIDs *trackinfo, int ntracks, ParticleManager particleManager,
                            const vecgeom::VPlacedVolume *world, adept::MParrayT<QueueIndexPair> *toBeEnqueued,
@@ -177,39 +194,25 @@ __global__ void InitTracks(AsyncAdePT::TrackDataWithIDs *trackinfo, int ntracks,
 {
   // constexpr double tolerance = 10. * vecgeom::kTolerance;
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < ntracks; i += blockDim.x * gridDim.x) {
-    SpeciesParticleManager *speciesTM = nullptr;
-    const auto &trackInfo             = trackinfo[i];
-    short queueIndex                  = -1;
+    const auto &trackInfo = trackinfo[i];
+
     switch (trackInfo.pdg) {
     case 11:
-      speciesTM  = &particleManager.electrons;
-      queueIndex = GPUQueueIndex::Electron;
+      InitTrackToQueue(particleManager.electrons, trackInfo, GPUQueueIndex::Electron, toBeEnqueued, initialSeed);
       break;
     case -11:
-      speciesTM  = &particleManager.positrons;
-      queueIndex = GPUQueueIndex::Positron;
+      InitTrackToQueue(particleManager.positrons, trackInfo, GPUQueueIndex::Positron, toBeEnqueued, initialSeed);
       break;
     case 22:
-      speciesTM = &particleManager.gammas;
-
       // check for Woodcock tracking
-      const bool useWDT = ShouldUseWDT(trackinfo[i].navState, trackInfo.eKin);
-      queueIndex        = useWDT ? GPUQueueIndex::GammaWDT : GPUQueueIndex::Gamma;
+      InitTrackToQueue(particleManager.gammas, trackInfo,
+                       ShouldUseWDT(trackinfo[i].navState, trackInfo.eKin) ? GPUQueueIndex::GammaWDT
+                                                                           : GPUQueueIndex::Gamma,
+                       toBeEnqueued, initialSeed);
+      break;
+    default:
+      assert(false && "Unsupported pdg type");
     };
-    assert(speciesTM != nullptr && "Unsupported pdg type");
-
-    // TODO: Delay when not enough slots?
-    const auto slot = speciesTM->NextSlot();
-    // we need to scramble the initial seed with some more trackinfo to generate a unique seed.
-    // otherwise, if a particle returns from the device and is injected again (i.e., via lepton nuclear), it would have
-    // the same random number state, causing collisions in the track IDs
-    auto seed = GenerateSeedFromTrackInfo(trackInfo, initialSeed);
-    Track &track =
-        speciesTM->InitTrack(slot, seed, trackInfo.eKin, trackInfo.globalTime, static_cast<float>(trackInfo.localTime),
-                             static_cast<float>(trackInfo.properTime), trackInfo.weight, trackInfo.position,
-                             trackInfo.direction, trackinfo[i].navState, trackInfo.eventId, trackInfo.trackId,
-                             trackInfo.parentId, trackInfo.threadId, trackInfo.stepCounter);
-    toBeEnqueued->push_back(QueueIndexPair{slot, queueIndex});
   }
 }
 
@@ -329,7 +332,6 @@ __global__ void CountCurrentPopulation(AllParticleQueues all, Stats *stats, Trac
 
     // WDT gammas access the gamma tracks (but have their own queue)
     const unsigned int tracksId = particleType == GPUQueueIndex::GammaWDT ? GPUQueueIndex::Gamma : particleType;
-    Track const *const tracks   = tracksAndSlots.tracks[tracksId];
     adept::MParray const *queue = all.queues[particleType].initiallyActive;
 
     for (unsigned int i = threadIdx.x; i < N; i += blockDim.x)
@@ -340,7 +342,7 @@ __global__ void CountCurrentPopulation(AllParticleQueues all, Stats *stats, Trac
     const auto end = queue->size();
     for (unsigned int i = threadIdx.x; i < end; i += blockDim.x) {
       const auto slot     = (*queue)[i];
-      const auto threadId = tracks[slot].threadId;
+      const auto threadId = tracksAndSlots.ThreadIdAt(tracksId, slot);
       atomicAdd(sharedCount + threadId, 1u);
     }
 
@@ -614,21 +616,22 @@ std::unique_ptr<GPUstate, GPUstateDeleter> InitializeGPU(int trackCapacity, int 
   // Allocate all slot managers on device
   gpuState.slotManager_dev = nullptr;
   gpuMalloc(gpuState.slotManager_dev, gpuState.nSlotManager_dev);
-  for (int i = 0; i < GPUQueueIndex::NumSpecies; i++) {
-    // Number of slots allocated computed based on the proportions set in SpeciesState::relativeQueueSize
-    const size_t nSlot              = trackCapacity * SpeciesState::relativeQueueSize[i];
+
+  auto initializeSpecies = [&](auto &particleType, int particleIndex) {
+    // Number of slots allocated computed based on the per-species capacity fractions.
+    const size_t nSlot              = trackCapacity * kRelativeQueueSize[particleIndex];
     const size_t sizeOfQueueStorage = adept::MParray::SizeOfInstance(nSlot);
 
     // Initialize all host slot managers (This call allocates GPU memory)
-    gpuState.allmgr_h.slotManagers[i] =
+    gpuState.allmgr_h.slotManagers[particleIndex] =
         SlotManager{static_cast<SlotManager::value_type>(nSlot), static_cast<SlotManager::value_type>(nSlot)};
     // Initialize dev slotmanagers by copying the host data
-    ADEPT_DEVICE_API_CALL(Memcpy(&gpuState.slotManager_dev[i], &gpuState.allmgr_h.slotManagers[i], sizeof(SlotManager),
+    ADEPT_DEVICE_API_CALL(Memcpy(&gpuState.slotManager_dev[particleIndex],
+                                 &gpuState.allmgr_h.slotManagers[particleIndex], sizeof(SlotManager),
                                  ADEPT_DEVICE_API_SYMBOL(MemcpyDefault)));
 
     // Allocate the queues where the active track indices are stored.
-    SpeciesState &particleType = gpuState.particles[i];
-    particleType.slotManager   = &gpuState.slotManager_dev[i];
+    particleType.slotManager = &gpuState.slotManager_dev[particleIndex];
 
     void *gpuPtr = nullptr;
     gpuMalloc(gpuPtr, sizeOfQueueStorage);
@@ -650,35 +653,27 @@ std::unique_ptr<GPUstate, GPUstateDeleter> InitializeGPU(int trackCapacity, int 
 
     // Allocate the array where the tracks are stored
     // This is the largest allocation. If it does not fit, we need to try again:
-    Track *trackStorage_dev = nullptr;
-    gpuMalloc(trackStorage_dev, nSlot);
+    gpuMalloc(particleType.tracks, nSlot);
 
-    gpuState.particles[i].tracks = trackStorage_dev;
+    printf("%lu track slots allocated for particle type %d on GPU (%.2lf%% of %d total slots allocated)\n", nSlot,
+           particleIndex, kRelativeQueueSize[particleIndex] * 100, trackCapacity);
+  };
 
-    printf("%lu track slots allocated for particle type %d on GPU (%.2lf%% of %d total slots allocated)\n", nSlot, i,
-           SpeciesState::relativeQueueSize[i] * 100, trackCapacity);
+  initializeSpecies(gpuState.electrons, GPUQueueIndex::Electron);
+  initializeSpecies(gpuState.positrons, GPUQueueIndex::Positron);
+  initializeSpecies(gpuState.gammas, GPUQueueIndex::Gamma);
 
 #ifdef ADEPT_USE_SPLIT_KERNELS
-    // Allocate an array of HepEm tracks per particle type
-    switch (i) {
-    case 0: // Electrons
-      gpuMalloc(gpuState.hepEmBuffers_d.electronsHepEm, nSlot);
-      break;
-    case 1: // Positrons
-      gpuMalloc(gpuState.hepEmBuffers_d.positronsHepEm, nSlot);
-      break;
-    case 2: // Gammas
-      gpuMalloc(gpuState.hepEmBuffers_d.gammasHepEm, nSlot);
-      break;
-    default:
-      printf("Error: Undefined particle type");
-      break;
-    }
+  gpuMalloc(gpuState.hepEmBuffers_d.electronsHepEm,
+            static_cast<size_t>(trackCapacity * kRelativeQueueSize[GPUQueueIndex::Electron]));
+  gpuMalloc(gpuState.hepEmBuffers_d.positronsHepEm,
+            static_cast<size_t>(trackCapacity * kRelativeQueueSize[GPUQueueIndex::Positron]));
+  gpuMalloc(gpuState.hepEmBuffers_d.gammasHepEm,
+            static_cast<size_t>(trackCapacity * kRelativeQueueSize[GPUQueueIndex::Gamma]));
 #endif
-  }
 
   ParticleQueues &woodcockQueues  = gpuState.woodcockQueues;
-  const size_t nSlot              = trackCapacity * SpeciesState::relativeQueueSize[GPUQueueIndex::Gamma];
+  const size_t nSlot              = trackCapacity * kRelativeQueueSize[GPUQueueIndex::Gamma];
   const size_t sizeOfQueueStorage = adept::MParray::SizeOfInstance(nSlot);
   void *gpuPtr                    = nullptr;
   gpuMalloc(gpuPtr, sizeOfQueueStorage);
@@ -747,9 +742,9 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
   auto &cudaManager                             = vecgeom::cxx::CudaManager::Instance();
   const vecgeom::cuda::VPlacedVolume *world_dev = cudaManager.world_gpu();
 
-  SpeciesState &electrons        = gpuState.particles[GPUQueueIndex::Electron];
-  SpeciesState &positrons        = gpuState.particles[GPUQueueIndex::Positron];
-  SpeciesState &gammas           = gpuState.particles[GPUQueueIndex::Gamma];
+  auto &electrons                = gpuState.electrons;
+  auto &positrons                = gpuState.positrons;
+  auto &gammas                   = gpuState.gammas;
   ParticleQueues &woodcockQueues = gpuState.woodcockQueues;
 
   ADEPT_DEVICE_API_SYMBOL(Event_t) cudaEvent, cudaStatsEvent;
@@ -863,7 +858,9 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
            positrons.queues.interactionQueues[2], positrons.queues.interactionQueues[3],
            positrons.queues.interactionQueues[4]}};
 #endif
-      const TracksAndSlots tracksAndSlots = {{electrons.tracks, positrons.tracks, gammas.tracks},
+      const TracksAndSlots tracksAndSlots = {electrons.tracks,
+                                             positrons.tracks,
+                                             gammas.tracks,
                                              {electrons.slotManager, positrons.slotManager, gammas.slotManager}};
       // --------------------------
       // *** Particle injection ***

--- a/include/AdePT/core/AsyncAdePTTransportStruct.cuh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.cuh
@@ -26,21 +26,22 @@
 namespace AsyncAdePT {
 
 // A bundle of pointers to generate particles of an implicit type.
+template <typename TrackT>
 struct SpeciesParticleManager {
-  Track *fTracks;
+  TrackT *fTracks;
   SlotManager *fSlotManager;
   adept::MParray *fActiveQueue;
   adept::MParray *fNextActiveQueue;
 
 public:
-  __host__ __device__ SpeciesParticleManager(Track *tracks, SlotManager *slotManager, adept::MParray *activeQueue,
+  __host__ __device__ SpeciesParticleManager(TrackT *tracks, SlotManager *slotManager, adept::MParray *activeQueue,
                                              adept::MParray *nextActiveQueue)
       : fTracks(tracks), fSlotManager(slotManager), fActiveQueue(activeQueue), fNextActiveQueue(nextActiveQueue)
   {
   }
 
   /// Obtain track at given slot position
-  __device__ __forceinline__ Track &TrackAt(SlotManager::value_type slot) { return fTracks[slot]; }
+  __device__ __forceinline__ TrackT &TrackAt(SlotManager::value_type slot) { return fTracks[slot]; }
 
   /// Obtain a slot for a track, but don't enqueue.
   __device__ auto NextSlot() { return fSlotManager->NextSlot(); }
@@ -59,14 +60,14 @@ public:
 
   /// Construct a track at the given location, forwarding all arguments to the constructor.
   template <typename... Ts>
-  __device__ Track &InitTrack(SlotManager::value_type slot, Ts &&...args)
+  __device__ TrackT &InitTrack(SlotManager::value_type slot, Ts &&...args)
   {
-    return *new (fTracks + slot) Track{std::forward<Ts>(args)...};
+    return *new (fTracks + slot) TrackT{std::forward<Ts>(args)...};
   }
 
   /// Obtain a slot and construct a track, forwarding args to the track constructor.
   template <typename... Ts>
-  __device__ Track &NextTrack(Ts &&...args)
+  __device__ TrackT &NextTrack(Ts &&...args)
   {
     const auto slot = NextSlot();
     // next track is only visible in next GPU iteration, therefore pushed in the NextActiveQueue
@@ -78,10 +79,10 @@ public:
 
 // A bundle of generators for the three particle types.
 struct ParticleManager {
-  SpeciesParticleManager electrons;
-  SpeciesParticleManager positrons;
-  SpeciesParticleManager gammas;
-  SpeciesParticleManager gammasWDT;
+  SpeciesParticleManager<ChargedTrack> electrons;
+  SpeciesParticleManager<ChargedTrack> positrons;
+  SpeciesParticleManager<NeutralTrack> gammas;
+  SpeciesParticleManager<NeutralTrack> gammasWDT;
 };
 
 // A bundle of queues per particle type:
@@ -154,15 +155,16 @@ static_assert(GPUQueueIndex::Gamma == static_cast<int>(ParticleType::Gamma),
 
 /// @brief Holds all GPU resources needed to manage in-flight tracks of one particle species:
 ///        track buffer, slot manager, interaction queues, CUDA stream and event.
+template <typename TrackT>
 struct SpeciesState {
-  Track *tracks;
-  SlotManager *slotManager;
-  ParticleQueues queues;
-  ADEPT_DEVICE_API_SYMBOL(Stream_t) stream;
-  ADEPT_DEVICE_API_SYMBOL(Event_t) event;
-
-  static constexpr double relativeQueueSize[] = {0.35, 0.15, 0.5};
+  TrackT *tracks{nullptr};
+  SlotManager *slotManager{nullptr};
+  ParticleQueues queues{};
+  ADEPT_DEVICE_API_SYMBOL(Stream_t) stream {};
+  ADEPT_DEVICE_API_SYMBOL(Event_t) event {};
 };
+
+static constexpr double kRelativeQueueSize[GPUQueueIndex::NumSpecies] = {0.35, 0.15, 0.5};
 
 #ifdef ADEPT_USE_SPLIT_KERNELS
 struct HepEmBuffers {
@@ -179,8 +181,17 @@ struct AllInteractionQueues {
 
 // Pointers to track storage for each particle type
 struct TracksAndSlots {
-  Track *const tracks[GPUQueueIndex::NumSpecies];
+  ChargedTrack *electrons;
+  ChargedTrack *positrons;
+  NeutralTrack *gammas;
   SlotManager *const slotManagers[GPUQueueIndex::NumSpecies];
+
+  __device__ __forceinline__ short ThreadIdAt(unsigned int particleType, SlotManager::value_type slot) const
+  {
+    if (particleType == GPUQueueIndex::Electron) return electrons[slot].threadId;
+    if (particleType == GPUQueueIndex::Positron) return positrons[slot].threadId;
+    return gammas[slot].threadId;
+  }
 };
 
 // A bundle of queues for the three particle types.
@@ -237,7 +248,9 @@ struct GPUstate {
   GeneralMagneticField magneticField;
 #endif
 
-  SpeciesState particles[GPUQueueIndex::NumSpecies];
+  SpeciesState<ChargedTrack> electrons;
+  SpeciesState<ChargedTrack> positrons;
+  SpeciesState<NeutralTrack> gammas;
 
   // particle queues for gammas doing woodcock tracking. Only the `initiallyActive` and `nextActive` queues are
   // allocated.
@@ -273,10 +286,13 @@ struct GPUstate {
       if (stats) ADEPT_DEVICE_API_CALL(FreeHost(stats));
       if (stream) ADEPT_DEVICE_API_CALL(StreamDestroy(stream));
 
-      for (SpeciesState &particleType : particles) {
+      auto destroySpeciesSync = [](auto &particleType) {
         if (particleType.stream) ADEPT_DEVICE_API_CALL(StreamDestroy(particleType.stream));
         if (particleType.event) ADEPT_DEVICE_API_CALL(EventDestroy(particleType.event));
-      }
+      };
+      destroySpeciesSync(electrons);
+      destroySpeciesSync(positrons);
+      destroySpeciesSync(gammas);
       for (void *ptr : allCudaPointers) {
         ADEPT_DEVICE_API_CALL(Free(ptr));
       }

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -15,25 +15,22 @@
 #include <G4HepEmRandomEngine.hh>
 #endif
 
-// A data structure to represent a neutral particle track. The particle type is
-// implicit by the queue and not stored in memory.
-struct NeutralTrack {
+// Common state shared by neutral and charged particle tracks. The particle type
+// is implicit by the queue and not stored in memory.
+struct TrackCommon {
   RanluxppDouble rngState;
   double eKin{0.};
   double globalTime{0.};
 
-  float weight{0.};
-#ifndef ADEPT_USE_SPLIT_KERNELS
-  // Gamma interaction length state is based only on the total macroscopic cross section.
-  float numIALeft{-1.f};
-#endif
-
-  float localTime{0.f};
-  float properTime{0.f};
-
   vecgeom::Vector3D<double> pos;     ///< track position
   vecgeom::Vector3D<double> dir;     ///< track direction
+  uint64_t trackId{0};               ///< track id (non-consecutive, reproducible)
+  uint64_t parentId{0};              ///< track id of the parent
   vecgeom::NavigationState navState; ///< current navigation state
+
+  float weight{0.};
+  float localTime{0.f};
+  float properTime{0.f};
 
 #ifdef ADEPT_USE_SPLIT_KERNELS
   // Variables used to store track info needed for scoring
@@ -45,9 +42,6 @@ struct NeutralTrack {
   // Variables used to store navigation results
   long hitsurfID{0};
 #endif
-
-  uint64_t trackId{0};  ///< track id (non-consecutive, reproducible)
-  uint64_t parentId{0}; // track id of the parent
 
   unsigned int eventId{0};
   short threadId{-1};
@@ -63,18 +57,18 @@ struct NeutralTrack {
   bool stopped{false};
 #endif
 
-  __host__ __device__ NeutralTrack()                                = default;
-  __host__ __device__ NeutralTrack(const NeutralTrack &)            = default;
-  __host__ __device__ NeutralTrack &operator=(const NeutralTrack &) = default;
+  __host__ __device__ TrackCommon()                               = default;
+  __host__ __device__ TrackCommon(const TrackCommon &)            = default;
+  __host__ __device__ TrackCommon &operator=(const TrackCommon &) = default;
 
   /// Construct a new track for GPU transport.
-  __device__ NeutralTrack(uint64_t rngSeed, double eKin, double globalTime, float localTime, float properTime,
-                          float weight, double const position[3], double const direction[3],
-                          const vecgeom::NavigationState &newNavState, unsigned int eventId, uint64_t trackId,
-                          uint64_t parentId, short threadId, unsigned short stepCounter)
-      : eKin{eKin}, globalTime{globalTime}, weight{weight}, localTime{localTime}, properTime{properTime},
-        navState{newNavState}, trackId{trackId}, parentId{parentId}, eventId{eventId}, threadId{threadId},
-        stepCounter{stepCounter}, looperCounter{0}, zeroStepCounter{0}
+  __device__ TrackCommon(uint64_t rngSeed, double eKin, double globalTime, float localTime, float properTime,
+                         float weight, double const position[3], double const direction[3],
+                         const vecgeom::NavigationState &newNavState, unsigned int eventId, uint64_t trackId,
+                         uint64_t parentId, short threadId, unsigned short stepCounter)
+      : eKin{eKin}, globalTime{globalTime}, trackId{trackId}, parentId{parentId}, navState{newNavState}, weight{weight},
+        localTime{localTime}, properTime{properTime}, eventId{eventId}, threadId{threadId}, stepCounter{stepCounter},
+        looperCounter{0}, zeroStepCounter{0}
   {
     rngState.SetSeed(rngSeed);
     pos = {position[0], position[1], position[2]};
@@ -83,20 +77,20 @@ struct NeutralTrack {
 
   /// Construct a secondary from a parent track.
   /// NB: The caller is responsible to branch a new RNG state.
-  __device__ NeutralTrack(RanluxppDouble const &rng_state, double eKin, const vecgeom::Vector3D<double> &parentPos,
-                          const vecgeom::Vector3D<double> &newDirection, const vecgeom::NavigationState &newNavState,
-                          const NeutralTrack &parentTrack, const double globalTime)
-      : NeutralTrack(rng_state, eKin, parentPos, newDirection, newNavState, parentTrack, globalTime, parentTrack.weight)
+  __device__ TrackCommon(RanluxppDouble const &rng_state, double eKin, const vecgeom::Vector3D<double> &parentPos,
+                         const vecgeom::Vector3D<double> &newDirection, const vecgeom::NavigationState &newNavState,
+                         const TrackCommon &parentTrack, const double globalTime)
+      : TrackCommon(rng_state, eKin, parentPos, newDirection, newNavState, parentTrack, globalTime, parentTrack.weight)
   {
   }
 
   /// Construct a secondary from a parent track with an explicit child weight.
   /// NB: The caller is responsible to branch a new RNG state.
-  __device__ NeutralTrack(RanluxppDouble const &rng_state, double eKin, const vecgeom::Vector3D<double> &parentPos,
-                          const vecgeom::Vector3D<double> &newDirection, const vecgeom::NavigationState &newNavState,
-                          const NeutralTrack &parentTrack, const double globalTime, float childWeight)
-      : rngState{rng_state}, eKin{eKin}, globalTime{globalTime}, weight{childWeight}, pos{parentPos}, dir{newDirection},
-        navState{newNavState}, trackId{rngState.IntRndm64()}, parentId{parentTrack.trackId},
+  __device__ TrackCommon(RanluxppDouble const &rng_state, double eKin, const vecgeom::Vector3D<double> &parentPos,
+                         const vecgeom::Vector3D<double> &newDirection, const vecgeom::NavigationState &newNavState,
+                         const TrackCommon &parentTrack, const double globalTime, float childWeight)
+      : rngState{rng_state}, eKin{eKin}, globalTime{globalTime}, pos{parentPos}, dir{newDirection},
+        trackId{rngState.IntRndm64()}, parentId{parentTrack.trackId}, navState{newNavState}, weight{childWeight},
         eventId{parentTrack.eventId}, threadId{parentTrack.threadId}, stepCounter{0}, looperCounter{0},
         zeroStepCounter{0}
   {
@@ -109,6 +103,20 @@ struct NeutralTrack {
     return match_event && (itrack == trackId) && (stepCounter >= stepmin) && (stepCounter <= stepmax);
   }
 
+  __host__ __device__ double Uniform() { return rngState.Rndm(); }
+};
+
+// A data structure to represent a neutral particle track.
+struct NeutralTrack : TrackCommon {
+  using TrackCommon::TrackCommon;
+
+  __host__ __device__ NeutralTrack() = default;
+
+#ifndef ADEPT_USE_SPLIT_KERNELS
+  // Gamma interaction length state is based only on the total macroscopic cross section.
+  float numIALeft{-1.f};
+#endif
+
   __host__ __device__ void Print(const char *label) const
   {
     printf("== evt %u parentId %lu %s id %lu step %d ekin %g MeV | pos {%.19f, %.19f, %.19f} dir {%.19f, %.19f, "
@@ -117,15 +125,13 @@ struct NeutralTrack {
            dir[1], dir[2], looperCounter);
     navState.Print();
   }
-
-  __host__ __device__ double Uniform() { return rngState.Rndm(); }
 };
 
 // Charged particles extend the neutral layout with state that is only needed by
 // e-/e+ transport: cached safety, MSC/range state, magnetic-field propagation
 // state, and the split-kernel safe length.
-struct ChargedTrack : NeutralTrack {
-  using NeutralTrack::NeutralTrack;
+struct ChargedTrack : TrackCommon {
+  using TrackCommon::TrackCommon;
 
   __host__ __device__ ChargedTrack() = default;
 

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -15,34 +15,29 @@
 #include <G4HepEmRandomEngine.hh>
 #endif
 
-// A data structure to represent a particle track. The particle type is implicit
-// by the queue and not stored in memory.
-struct Track {
+// A data structure to represent a neutral particle track. The particle type is
+// implicit by the queue and not stored in memory.
+struct NeutralTrack {
   RanluxppDouble rngState;
   double eKin{0.};
   double globalTime{0.};
 
   float weight{0.};
 #ifndef ADEPT_USE_SPLIT_KERNELS
-  float numIALeft[4]{-1.f, -1.f, -1.f, -1.f};
-  // default values taken from G4HepEmMSCTrackData.hh
-  float initialRange{1.0e+21};
-  float dynamicRangeFactor{0.04};
-  float tlimitMin{1.0E-7};
+  // Gamma interaction length state is based only on the total macroscopic cross section.
+  float numIALeft{-1.f};
 #endif
 
   float localTime{0.f};
   float properTime{0.f};
 
-  vecgeom::Vector3D<double> pos;      ///< track position
-  vecgeom::Vector3D<double> dir;      ///< track direction
-  vecgeom::Vector3D<float> safetyPos; ///< last position where the safety was computed
-  // TODO: For better clarity in the split kernels, rename this to "stored safety" as opposed to the
-  // safety we get from GetSafety(), which is computed in the moment
-  float safety{0.f};                 ///< last computed safety value
+  vecgeom::Vector3D<double> pos;     ///< track position
+  vecgeom::Vector3D<double> dir;     ///< track direction
   vecgeom::NavigationState navState; ///< current navigation state
 
 #ifdef ADEPT_USE_SPLIT_KERNELS
+  bool hepEmTrackExists{false};
+
   // Variables used to store track info needed for scoring
   vecgeom::NavigationState nextState;
   vecgeom::Vector3D<double> preStepPos;
@@ -50,7 +45,6 @@ struct Track {
   double preStepEKin{0};
   double preStepGlobalTime{0.};
   // Variables used to store navigation results
-  double safeLength{0};
   long hitsurfID{0};
 #endif
 
@@ -63,25 +57,17 @@ struct Track {
   unsigned short looperCounter{0};
   unsigned short zeroStepCounter{0};
 
-#ifdef ADEPT_USE_SPLIT_KERNELS
-  bool propagated{false};
-  bool hepEmTrackExists{false};
-
-  // Variables used to store results from G4HepEM
-  bool restrictedPhysicalStepLength{false};
-  bool stopped{false};
-#endif
-
-  __host__ __device__ Track(const Track &)            = default;
-  __host__ __device__ Track &operator=(const Track &) = default;
+  __host__ __device__ NeutralTrack()                                = default;
+  __host__ __device__ NeutralTrack(const NeutralTrack &)            = default;
+  __host__ __device__ NeutralTrack &operator=(const NeutralTrack &) = default;
 
   /// Construct a new track for GPU transport.
-  __device__ Track(uint64_t rngSeed, double eKin, double globalTime, float localTime, float properTime, float weight,
-                   double const position[3], double const direction[3], const vecgeom::NavigationState &newNavState,
-                   unsigned int eventId, uint64_t trackId, uint64_t parentId, short threadId,
-                   unsigned short stepCounter)
-      : eKin{eKin}, weight{weight}, globalTime{globalTime}, localTime{localTime}, properTime{properTime},
-        navState{newNavState}, eventId{eventId}, trackId{trackId}, parentId{parentId}, threadId{threadId},
+  __device__ NeutralTrack(uint64_t rngSeed, double eKin, double globalTime, float localTime, float properTime,
+                          float weight, double const position[3], double const direction[3],
+                          const vecgeom::NavigationState &newNavState, unsigned int eventId, uint64_t trackId,
+                          uint64_t parentId, short threadId, unsigned short stepCounter)
+      : eKin{eKin}, globalTime{globalTime}, weight{weight}, localTime{localTime}, properTime{properTime},
+        navState{newNavState}, trackId{trackId}, parentId{parentId}, eventId{eventId}, threadId{threadId},
         stepCounter{stepCounter}, looperCounter{0}, zeroStepCounter{0}
   {
     rngState.SetSeed(rngSeed);
@@ -91,22 +77,22 @@ struct Track {
 
   /// Construct a secondary from a parent track.
   /// NB: The caller is responsible to branch a new RNG state.
-  __device__ Track(RanluxppDouble const &rng_state, double eKin, const vecgeom::Vector3D<double> &parentPos,
-                   const vecgeom::Vector3D<double> &newDirection, const vecgeom::NavigationState &newNavState,
-                   const Track &parentTrack, const double globalTime)
-      : Track(rng_state, eKin, parentPos, newDirection, newNavState, parentTrack, globalTime, parentTrack.weight)
+  __device__ NeutralTrack(RanluxppDouble const &rng_state, double eKin, const vecgeom::Vector3D<double> &parentPos,
+                          const vecgeom::Vector3D<double> &newDirection, const vecgeom::NavigationState &newNavState,
+                          const NeutralTrack &parentTrack, const double globalTime)
+      : NeutralTrack(rng_state, eKin, parentPos, newDirection, newNavState, parentTrack, globalTime, parentTrack.weight)
   {
   }
 
   /// Construct a secondary from a parent track with an explicit child weight.
   /// NB: The caller is responsible to branch a new RNG state.
-  __device__ Track(RanluxppDouble const &rng_state, double eKin, const vecgeom::Vector3D<double> &parentPos,
-                   const vecgeom::Vector3D<double> &newDirection, const vecgeom::NavigationState &newNavState,
-                   const Track &parentTrack, const double globalTime, float childWeight)
-      : rngState{rng_state}, eKin{eKin}, globalTime{globalTime}, pos{parentPos}, dir{newDirection},
-        navState{newNavState}, trackId{rngState.IntRndm64()}, eventId{parentTrack.eventId},
-        parentId{parentTrack.trackId}, threadId{parentTrack.threadId}, weight{childWeight}, stepCounter{0},
-        looperCounter{0}, zeroStepCounter{0}
+  __device__ NeutralTrack(RanluxppDouble const &rng_state, double eKin, const vecgeom::Vector3D<double> &parentPos,
+                          const vecgeom::Vector3D<double> &newDirection, const vecgeom::NavigationState &newNavState,
+                          const NeutralTrack &parentTrack, const double globalTime, float childWeight)
+      : rngState{rng_state}, eKin{eKin}, globalTime{globalTime}, weight{childWeight}, pos{parentPos}, dir{newDirection},
+        navState{newNavState}, trackId{rngState.IntRndm64()}, parentId{parentTrack.trackId},
+        eventId{parentTrack.eventId}, threadId{parentTrack.threadId}, stepCounter{0}, looperCounter{0},
+        zeroStepCounter{0}
   {
   }
 
@@ -120,11 +106,44 @@ struct Track {
   __host__ __device__ void Print(const char *label) const
   {
     printf("== evt %u parentId %lu %s id %lu step %d ekin %g MeV | pos {%.19f, %.19f, %.19f} dir {%.19f, %.19f, "
-           "%.19f} remain_safe %g loop %u\n| | state: ",
+           "%.19f} loop %u\n| | state: ",
            eventId, parentId, label, trackId, stepCounter, eKin / copcore::units::MeV, pos[0], pos[1], pos[2], dir[0],
-           dir[1], dir[2], GetSafety(pos), looperCounter);
+           dir[1], dir[2], looperCounter);
     navState.Print();
   }
+
+  __host__ __device__ double Uniform() { return rngState.Rndm(); }
+};
+
+// Charged particles extend the neutral layout with state that is only needed by
+// e-/e+ transport: cached safety, MSC/range state, magnetic-field propagation
+// state, and split-kernel charged step flags.
+struct ChargedTrack : NeutralTrack {
+  using NeutralTrack::NeutralTrack;
+
+  __host__ __device__ ChargedTrack() = default;
+
+  vecgeom::Vector3D<float> safetyPos; ///< last position where the safety was computed
+  // TODO: For better clarity in the split kernels, rename this to "stored safety" as opposed to the
+  // safety we get from GetSafety(), which is computed in the moment
+  float safety{0.f}; ///< last computed safety value
+
+#ifndef ADEPT_USE_SPLIT_KERNELS
+  float numIALeft[4]{-1.f, -1.f, -1.f, -1.f};
+  // default values taken from G4HepEmMSCTrackData.hh
+  float initialRange{1.0e+21};
+  float dynamicRangeFactor{0.04};
+  float tlimitMin{1.0E-7};
+#endif
+
+#ifdef ADEPT_USE_SPLIT_KERNELS
+  double safeLength{0};
+  bool propagated{false};
+
+  // Variables used to store results from G4HepEM
+  bool restrictedPhysicalStepLength{false};
+  bool stopped{false};
+#endif
 
   /// @brief Get recomputed cached safety ay a given track position
   /// @param new_pos Track position
@@ -149,6 +168,17 @@ struct Track {
     safety = vecCore::math::Max(safe, 0.f);
   }
 
-  __host__ __device__ double Uniform() { return rngState.Rndm(); }
+  __host__ __device__ void Print(const char *label) const
+  {
+    printf("== evt %u parentId %lu %s id %lu step %d ekin %g MeV | pos {%.19f, %.19f, %.19f} dir {%.19f, %.19f, "
+           "%.19f} remain_safe %g loop %u\n| | state: ",
+           eventId, parentId, label, trackId, stepCounter, eKin / copcore::units::MeV, pos[0], pos[1], pos[2], dir[0],
+           dir[1], dir[2], GetSafety(pos), looperCounter);
+    navState.Print();
+  }
 };
+
+// Compatibility alias for code paths that have not yet been made explicitly
+// charged/neutral. New storage should use NeutralTrack or ChargedTrack directly.
+using Track = ChargedTrack;
 #endif

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -51,7 +51,7 @@ struct TrackBase {
 #ifdef ADEPT_USE_SPLIT_KERNELS
   bool hepEmTrackExists{false};
   // These flags are only used by charged split kernels, but storing them here
-  // uses otherwise wasted tail padding in NeutralTrack.
+  // uses otherwise wasted tail padding in TrackBase.
   bool propagated{false};
   bool restrictedPhysicalStepLength{false};
   bool stopped{false};
@@ -127,7 +127,7 @@ struct NeutralTrack : TrackBase {
   }
 };
 
-// Charged particles extend the neutral layout with state that is only needed by
+// Charged particles extend the base layout with state that is only needed by
 // e-/e+ transport: cached safety, MSC/range state, magnetic-field propagation
 // state, and the split-kernel safe length.
 struct ChargedTrack : TrackBase {

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -36,8 +36,6 @@ struct NeutralTrack {
   vecgeom::NavigationState navState; ///< current navigation state
 
 #ifdef ADEPT_USE_SPLIT_KERNELS
-  bool hepEmTrackExists{false};
-
   // Variables used to store track info needed for scoring
   vecgeom::NavigationState nextState;
   vecgeom::Vector3D<double> preStepPos;
@@ -56,6 +54,14 @@ struct NeutralTrack {
   unsigned short stepCounter{0};
   unsigned short looperCounter{0};
   unsigned short zeroStepCounter{0};
+#ifdef ADEPT_USE_SPLIT_KERNELS
+  bool hepEmTrackExists{false};
+  // These flags are only used by charged split kernels, but storing them here
+  // uses otherwise wasted tail padding in NeutralTrack.
+  bool propagated{false};
+  bool restrictedPhysicalStepLength{false};
+  bool stopped{false};
+#endif
 
   __host__ __device__ NeutralTrack()                                = default;
   __host__ __device__ NeutralTrack(const NeutralTrack &)            = default;
@@ -117,7 +123,7 @@ struct NeutralTrack {
 
 // Charged particles extend the neutral layout with state that is only needed by
 // e-/e+ transport: cached safety, MSC/range state, magnetic-field propagation
-// state, and split-kernel charged step flags.
+// state, and the split-kernel safe length.
 struct ChargedTrack : NeutralTrack {
   using NeutralTrack::NeutralTrack;
 
@@ -138,11 +144,6 @@ struct ChargedTrack : NeutralTrack {
 
 #ifdef ADEPT_USE_SPLIT_KERNELS
   double safeLength{0};
-  bool propagated{false};
-
-  // Variables used to store results from G4HepEM
-  bool restrictedPhysicalStepLength{false};
-  bool stopped{false};
 #endif
 
   /// @brief Get recomputed cached safety ay a given track position
@@ -178,7 +179,4 @@ struct ChargedTrack : NeutralTrack {
   }
 };
 
-// Compatibility alias for code paths that have not yet been made explicitly
-// charged/neutral. New storage should use NeutralTrack or ChargedTrack directly.
-using Track = ChargedTrack;
 #endif

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -17,7 +17,7 @@
 
 // Common state shared by neutral and charged particle tracks. The particle type
 // is implicit by the queue and not stored in memory.
-struct TrackCommon {
+struct TrackBase {
   RanluxppDouble rngState;
   double eKin{0.};
   double globalTime{0.};
@@ -57,15 +57,15 @@ struct TrackCommon {
   bool stopped{false};
 #endif
 
-  __host__ __device__ TrackCommon()                               = default;
-  __host__ __device__ TrackCommon(const TrackCommon &)            = default;
-  __host__ __device__ TrackCommon &operator=(const TrackCommon &) = default;
+  __host__ __device__ TrackBase()                             = default;
+  __host__ __device__ TrackBase(const TrackBase &)            = default;
+  __host__ __device__ TrackBase &operator=(const TrackBase &) = default;
 
   /// Construct a new track for GPU transport.
-  __device__ TrackCommon(uint64_t rngSeed, double eKin, double globalTime, float localTime, float properTime,
-                         float weight, double const position[3], double const direction[3],
-                         const vecgeom::NavigationState &newNavState, unsigned int eventId, uint64_t trackId,
-                         uint64_t parentId, short threadId, unsigned short stepCounter)
+  __device__ TrackBase(uint64_t rngSeed, double eKin, double globalTime, float localTime, float properTime,
+                       float weight, double const position[3], double const direction[3],
+                       const vecgeom::NavigationState &newNavState, unsigned int eventId, uint64_t trackId,
+                       uint64_t parentId, short threadId, unsigned short stepCounter)
       : eKin{eKin}, globalTime{globalTime}, trackId{trackId}, parentId{parentId}, navState{newNavState}, weight{weight},
         localTime{localTime}, properTime{properTime}, eventId{eventId}, threadId{threadId}, stepCounter{stepCounter},
         looperCounter{0}, zeroStepCounter{0}
@@ -77,18 +77,18 @@ struct TrackCommon {
 
   /// Construct a secondary from a parent track.
   /// NB: The caller is responsible to branch a new RNG state.
-  __device__ TrackCommon(RanluxppDouble const &rng_state, double eKin, const vecgeom::Vector3D<double> &parentPos,
-                         const vecgeom::Vector3D<double> &newDirection, const vecgeom::NavigationState &newNavState,
-                         const TrackCommon &parentTrack, const double globalTime)
-      : TrackCommon(rng_state, eKin, parentPos, newDirection, newNavState, parentTrack, globalTime, parentTrack.weight)
+  __device__ TrackBase(RanluxppDouble const &rng_state, double eKin, const vecgeom::Vector3D<double> &parentPos,
+                       const vecgeom::Vector3D<double> &newDirection, const vecgeom::NavigationState &newNavState,
+                       const TrackBase &parentTrack, const double globalTime)
+      : TrackBase(rng_state, eKin, parentPos, newDirection, newNavState, parentTrack, globalTime, parentTrack.weight)
   {
   }
 
   /// Construct a secondary from a parent track with an explicit child weight.
   /// NB: The caller is responsible to branch a new RNG state.
-  __device__ TrackCommon(RanluxppDouble const &rng_state, double eKin, const vecgeom::Vector3D<double> &parentPos,
-                         const vecgeom::Vector3D<double> &newDirection, const vecgeom::NavigationState &newNavState,
-                         const TrackCommon &parentTrack, const double globalTime, float childWeight)
+  __device__ TrackBase(RanluxppDouble const &rng_state, double eKin, const vecgeom::Vector3D<double> &parentPos,
+                       const vecgeom::Vector3D<double> &newDirection, const vecgeom::NavigationState &newNavState,
+                       const TrackBase &parentTrack, const double globalTime, float childWeight)
       : rngState{rng_state}, eKin{eKin}, globalTime{globalTime}, pos{parentPos}, dir{newDirection},
         trackId{rngState.IntRndm64()}, parentId{parentTrack.trackId}, navState{newNavState}, weight{childWeight},
         eventId{parentTrack.eventId}, threadId{parentTrack.threadId}, stepCounter{0}, looperCounter{0},
@@ -107,8 +107,8 @@ struct TrackCommon {
 };
 
 // A data structure to represent a neutral particle track.
-struct NeutralTrack : TrackCommon {
-  using TrackCommon::TrackCommon;
+struct NeutralTrack : TrackBase {
+  using TrackBase::TrackBase;
 
   __host__ __device__ NeutralTrack() = default;
 
@@ -130,8 +130,8 @@ struct NeutralTrack : TrackCommon {
 // Charged particles extend the neutral layout with state that is only needed by
 // e-/e+ transport: cached safety, MSC/range state, magnetic-field propagation
 // state, and the split-kernel safe length.
-struct ChargedTrack : TrackCommon {
-  using TrackCommon::TrackCommon;
+struct ChargedTrack : TrackBase {
+  using TrackBase::TrackBase;
 
   __host__ __device__ ChargedTrack() = default;
 

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -523,7 +523,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
 #endif
 
           } else {
-            Track &secondary = particleManager.electrons.NextTrack(
+            ChargedTrack &secondary = particleManager.electrons.NextTrack(
                 newRNG, deltaEkin, pos, vecgeom::Vector3D<double>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
                 navState, currentTrack, globalTime);
 

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -76,8 +76,8 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
 
   const int activeSize = electronsOrPositrons.ActiveSize();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
-    const auto slot     = electronsOrPositrons.ActiveAt(i);
-    Track &currentTrack = electronsOrPositrons.TrackAt(slot);
+    const auto slot            = electronsOrPositrons.ActiveAt(i);
+    ChargedTrack &currentTrack = electronsOrPositrons.TrackAt(slot);
 
     auto navState = currentTrack.navState;
     // the MCC vector is indexed by the logical volume id
@@ -587,7 +587,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
               const bool useWDT      = ShouldUseWDT(navState, deltaEkin);
               auto &gammaPartManager = useWDT ? particleManager.gammasWDT : particleManager.gammas;
 
-              Track &gamma = gammaPartManager.NextTrack(
+              auto &gamma = gammaPartManager.NextTrack(
                   newRNG, deltaEkin, pos, vecgeom::Vector3D<double>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
                   navState, currentTrack, globalTime, gammaWeight);
 
@@ -652,7 +652,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
             if (createGamma1) {
               const bool useWDT      = ShouldUseWDT(navState, theGamma1Ekin);
               auto &gammaPartManager = useWDT ? particleManager.gammasWDT : particleManager.gammas;
-              Track &gamma1          = gammaPartManager.NextTrack(
+              auto &gamma1           = gammaPartManager.NextTrack(
                   newRNG, theGamma1Ekin, pos,
                   vecgeom::Vector3D<double>{theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]}, navState, currentTrack,
                   globalTime, gamma1Weight);
@@ -679,7 +679,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
             if (createGamma2) {
               const bool useWDT      = ShouldUseWDT(navState, theGamma2Ekin);
               auto &gammaPartManager = useWDT ? particleManager.gammasWDT : particleManager.gammas;
-              Track &gamma2          = gammaPartManager.NextTrack(
+              auto &gamma2           = gammaPartManager.NextTrack(
                   currentTrack.rngState, theGamma2Ekin, pos,
                   vecgeom::Vector3D<double>{theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]}, navState, currentTrack,
                   globalTime, gamma2Weight);
@@ -729,13 +729,13 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
           const bool useWDT      = ShouldUseWDT(navState, double{copcore::units::kElectronMassC2});
           auto &gammaPartManager = useWDT ? particleManager.gammasWDT : particleManager.gammas;
 
-          Track &gamma1 = gammaPartManager.NextTrack(newRNG2, double{copcore::units::kElectronMassC2}, pos,
-                                                     vecgeom::Vector3D<double>{sint * cosPhi, sint * sinPhi, cost},
-                                                     navState, currentTrack, globalTime);
+          auto &gamma1 = gammaPartManager.NextTrack(newRNG2, double{copcore::units::kElectronMassC2}, pos,
+                                                    vecgeom::Vector3D<double>{sint * cosPhi, sint * sinPhi, cost},
+                                                    navState, currentTrack, globalTime);
 
           // Reuse the RNG state of the dying track.
-          Track &gamma2 = gammaPartManager.NextTrack(currentTrack.rngState, double{copcore::units::kElectronMassC2},
-                                                     pos, -gamma1.dir, navState, currentTrack, globalTime);
+          auto &gamma2 = gammaPartManager.NextTrack(currentTrack.rngState, double{copcore::units::kElectronMassC2}, pos,
+                                                    -gamma1.dir, navState, currentTrack, globalTime);
 
           // if tracking or stepping action is called, return initial step
           if (returnLastStep) {

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -71,8 +71,8 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
 
   const int activeSize = electronsOrPositrons.ActiveSize();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
-    const auto slot     = electronsOrPositrons.ActiveAt(i);
-    Track &currentTrack = electronsOrPositrons.TrackAt(slot);
+    const auto slot            = electronsOrPositrons.ActiveAt(i);
+    ChargedTrack &currentTrack = electronsOrPositrons.TrackAt(slot);
     // the MCC vector is indexed by the logical volume id
     const int lvolID = currentTrack.navState.GetLogicalId();
 
@@ -286,7 +286,7 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
 }
 
 template <bool IsElectron>
-__global__ void ElectronPropagation(Track *electronsOrPositrons, G4HepEmElectronTrack *hepEMTracks,
+__global__ void ElectronPropagation(ChargedTrack *electronsOrPositrons, G4HepEmElectronTrack *hepEMTracks,
                                     const adept::MParray *propagationQueue)
 {
   constexpr double kPushDistance           = 1000 * vecgeom::kTolerance;
@@ -310,8 +310,8 @@ __global__ void ElectronPropagation(Track *electronsOrPositrons, G4HepEmElectron
 
   int activeSize = propagationQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
-    const int slot      = (*propagationQueue)[i];
-    Track &currentTrack = electronsOrPositrons[slot];
+    const int slot             = (*propagationQueue)[i];
+    ChargedTrack &currentTrack = electronsOrPositrons[slot];
     // the MCC vector is indexed by the logical volume id
     const int lvolID = currentTrack.navState.GetLogicalId();
 
@@ -379,7 +379,7 @@ __global__ void ElectronPropagation(Track *electronsOrPositrons, G4HepEmElectron
 }
 
 template <bool IsElectron>
-__global__ void ElectronMSC(Track *electrons, G4HepEmElectronTrack *hepEMTracks, const adept::MParray *active)
+__global__ void ElectronMSC(ChargedTrack *electrons, G4HepEmElectronTrack *hepEMTracks, const adept::MParray *active)
 {
   constexpr double restMass = copcore::units::kElectronMassC2;
 
@@ -387,7 +387,7 @@ __global__ void ElectronMSC(Track *electrons, G4HepEmElectronTrack *hepEMTracks,
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot = (*active)[i];
 
-    Track &currentTrack = electrons[slot];
+    ChargedTrack &currentTrack = electrons[slot];
     // the MCC vector is indexed by the logical volume id
     const int lvolID = currentTrack.navState.GetLogicalId();
 
@@ -467,8 +467,8 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
 
   int activeSize = propagationQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
-    const int slot      = (*propagationQueue)[i];
-    Track &currentTrack = electronsOrPositrons.TrackAt(slot);
+    const int slot             = (*propagationQueue)[i];
+    ChargedTrack &currentTrack = electronsOrPositrons.TrackAt(slot);
     // the MCC vector is indexed by the logical volume id
     const int lvolID = currentTrack.navState.GetLogicalId();
 
@@ -611,8 +611,8 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
   SlotManager &slotManager = *electronsOrPositrons.fSlotManager;
   int activeSize           = relocatingQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
-    const int slot      = (*relocatingQueue)[i];
-    Track &currentTrack = electronsOrPositrons.TrackAt(slot);
+    const int slot             = (*relocatingQueue)[i];
+    ChargedTrack &currentTrack = electronsOrPositrons.TrackAt(slot);
     // the MCC vector is indexed by the logical volume id
     const int lvolID = currentTrack.navState.GetLogicalId();
 
@@ -714,7 +714,7 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
   }
 }
 
-__device__ __forceinline__ void PerformStoppedAnnihilation(const int slot, Track &currentTrack,
+__device__ __forceinline__ void PerformStoppedAnnihilation(const int slot, ChargedTrack &currentTrack,
                                                            ParticleManager &particleManager, double &energyDeposit,
                                                            const bool ApplyCuts, const double theGammaCut,
                                                            SecondaryInitData *secondaryData, unsigned int &nSecondaries,
@@ -743,12 +743,12 @@ __device__ __forceinline__ void PerformStoppedAnnihilation(const int slot, Track
 
     const bool useWDT      = ShouldUseWDT(currentTrack.navState, double{copcore::units::kElectronMassC2});
     auto &gammaPartManager = useWDT ? particleManager.gammasWDT : particleManager.gammas;
-    Track &gamma1 = gammaPartManager.NextTrack(newRNG, double{copcore::units::kElectronMassC2}, currentTrack.pos,
-                                               vecgeom::Vector3D<double>{sint * cosPhi, sint * sinPhi, cost},
-                                               currentTrack.navState, currentTrack, currentTrack.globalTime);
+    auto &gamma1 = gammaPartManager.NextTrack(newRNG, double{copcore::units::kElectronMassC2}, currentTrack.pos,
+                                              vecgeom::Vector3D<double>{sint * cosPhi, sint * sinPhi, cost},
+                                              currentTrack.navState, currentTrack, currentTrack.globalTime);
 
     // Reuse the RNG state of the dying track.
-    Track &gamma2 =
+    auto &gamma2 =
         gammaPartManager.NextTrack(currentTrack.rngState, double{copcore::units::kElectronMassC2}, currentTrack.pos,
                                    -gamma1.dir, currentTrack.navState, currentTrack, currentTrack.globalTime);
 
@@ -772,8 +772,8 @@ __global__ void ElectronIonization(G4HepEmElectronTrack *hepEMTracks, ParticleMa
   int activeSize             = interactingQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     // const int slot           = (*active)[i];
-    const int slot      = (*interactingQueue)[i];
-    Track &currentTrack = electronsOrPositrons.TrackAt(slot);
+    const int slot             = (*interactingQueue)[i];
+    ChargedTrack &currentTrack = electronsOrPositrons.TrackAt(slot);
     // the MCC vector is indexed by the logical volume id
     const int lvolID = currentTrack.navState.GetLogicalId();
 
@@ -826,7 +826,7 @@ __global__ void ElectronIonization(G4HepEmElectronTrack *hepEMTracks, ParticleMa
       energyDeposit += deltaEkin;
 
     } else {
-      Track &secondary = particleManager.electrons.NextTrack(
+      auto &secondary = particleManager.electrons.NextTrack(
           newRNG, deltaEkin, currentTrack.pos,
           vecgeom::Vector3D<double>{dirSecondary[0], dirSecondary[1], dirSecondary[2]}, currentTrack.navState,
           currentTrack, currentTrack.globalTime);
@@ -899,8 +899,8 @@ __global__ void ElectronBremsstrahlung(G4HepEmElectronTrack *hepEMTracks, Partic
   int activeSize             = interactingQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     // const int slot           = (*active)[i];
-    const int slot      = (*interactingQueue)[i];
-    Track &currentTrack = electronsOrPositrons.TrackAt(slot);
+    const int slot             = (*interactingQueue)[i];
+    ChargedTrack &currentTrack = electronsOrPositrons.TrackAt(slot);
     // the MCC vector is indexed by the logical volume id
     const int lvolID = currentTrack.navState.GetLogicalId();
 
@@ -966,7 +966,7 @@ __global__ void ElectronBremsstrahlung(G4HepEmElectronTrack *hepEMTracks, Partic
       if (createGamma) {
         const bool useWDT      = ShouldUseWDT(currentTrack.navState, deltaEkin);
         auto &gammaPartManager = useWDT ? particleManager.gammasWDT : particleManager.gammas;
-        Track &gamma =
+        auto &gamma =
             gammaPartManager.NextTrack(newRNG, deltaEkin, currentTrack.pos,
                                        vecgeom::Vector3D<double>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
                                        currentTrack.navState, currentTrack, currentTrack.globalTime, gammaWeight);
@@ -1039,7 +1039,7 @@ __global__ void PositronAnnihilation(G4HepEmElectronTrack *hepEMTracks, Particle
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot = (*interactingQueue)[i];
 
-    Track &currentTrack = particleManager.positrons.TrackAt(slot);
+    ChargedTrack &currentTrack = particleManager.positrons.TrackAt(slot);
     // the MCC vector is indexed by the logical volume id
     const int lvolID = currentTrack.navState.GetLogicalId();
 
@@ -1094,7 +1094,7 @@ __global__ void PositronAnnihilation(G4HepEmElectronTrack *hepEMTracks, Particle
       if (createGamma1) {
         const bool useWDT      = ShouldUseWDT(currentTrack.navState, theGamma1Ekin);
         auto &gammaPartManager = useWDT ? particleManager.gammasWDT : particleManager.gammas;
-        Track &gamma1 =
+        auto &gamma1 =
             gammaPartManager.NextTrack(newRNG, theGamma1Ekin, currentTrack.pos,
                                        vecgeom::Vector3D<double>{theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]},
                                        currentTrack.navState, currentTrack, currentTrack.globalTime, gamma1Weight);
@@ -1121,7 +1121,7 @@ __global__ void PositronAnnihilation(G4HepEmElectronTrack *hepEMTracks, Particle
       if (createGamma2) {
         const bool useWDT      = ShouldUseWDT(currentTrack.navState, theGamma2Ekin);
         auto &gammaPartManager = useWDT ? particleManager.gammasWDT : particleManager.gammas;
-        Track &gamma2 =
+        auto &gamma2 =
             gammaPartManager.NextTrack(currentTrack.rngState, theGamma2Ekin, currentTrack.pos,
                                        vecgeom::Vector3D<double>{theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]},
                                        currentTrack.navState, currentTrack, currentTrack.globalTime, gamma2Weight);
@@ -1177,7 +1177,7 @@ __global__ void PositronStoppedAnnihilation(G4HepEmElectronTrack *hepEMTracks, P
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot = (*interactingQueue)[i];
 
-    Track &currentTrack = particleManager.positrons.TrackAt(slot);
+    ChargedTrack &currentTrack = particleManager.positrons.TrackAt(slot);
     // the MCC vector is indexed by the logical volume id
     const int lvolID = currentTrack.navState.GetLogicalId();
 

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -29,8 +29,8 @@ __global__ void __launch_bounds__(256, 1)
   auto &slotManager                 = *particleManager.gammas.fSlotManager;
   const int activeSize              = particleManager.gammas.ActiveSize();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
-    const auto slot     = particleManager.gammas.ActiveAt(i);
-    Track &currentTrack = particleManager.gammas.TrackAt(slot);
+    const auto slot            = particleManager.gammas.ActiveAt(i);
+    NeutralTrack &currentTrack = particleManager.gammas.TrackAt(slot);
 
     auto navState             = currentTrack.navState;
     int lvolID                = navState.GetLogicalId();
@@ -92,11 +92,11 @@ __global__ void __launch_bounds__(256, 1)
 
     // Re-sample the `number-of-interaction-left` (if needed, otherwise use stored numIALeft) and put it into the
     // G4HepEmTrack. Use index 0 since numIALeft for gammas is based only on the total macroscopic cross section. The
-    // currentTrack.numIALeft[0] are updated later
-    if (currentTrack.numIALeft[0] <= 0.0) {
+    // currentTrack.numIALeft is updated later
+    if (currentTrack.numIALeft <= 0.0) {
       theTrack->SetNumIALeft(-std::log(currentTrack.Uniform()), 0);
     } else {
-      theTrack->SetNumIALeft(currentTrack.numIALeft[0], 0);
+      theTrack->SetNumIALeft(currentTrack.numIALeft, 0);
     }
 
     // Call G4HepEm to compute the physics step limit.
@@ -168,8 +168,8 @@ __global__ void __launch_bounds__(256, 1)
 
         // Save the `number-of-interaction-left` in our track.
         // Use index 0 since numIALeft stores for gammas only the total macroscopic cross section
-        double numIALeft          = theTrack->GetNumIALeft(0);
-        currentTrack.numIALeft[0] = numIALeft;
+        double numIALeft       = theTrack->GetNumIALeft(0);
+        currentTrack.numIALeft = numIALeft;
 
 #ifdef ADEPT_USE_SURF
         AdePTNavigator::RelocateToNextVolume(pos, dir, hitsurf_index, nextState);
@@ -231,7 +231,7 @@ __global__ void __launch_bounds__(256, 1)
 
       // Reset number of interaction left for the winner discrete process also in the currentTrack
       // (SampleInteraction() resets it for theTrack), will be resampled in the next iteration.
-      currentTrack.numIALeft[0] = -1.0;
+      currentTrack.numIALeft = -1.0;
 
       // Perform the discrete interaction.
       G4HepEmRandomEngine rnge(&currentTrack.rngState);
@@ -275,7 +275,7 @@ __global__ void __launch_bounds__(256, 1)
           // Deposit the energy here and kill the secondary
           edep = elKinEnergy;
         } else {
-          Track &electron = particleManager.electrons.NextTrack(
+          auto &electron = particleManager.electrons.NextTrack(
               newRNG, elKinEnergy, pos,
               vecgeom::Vector3D<double>{dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]}, navState,
               currentTrack, globalTime);
@@ -291,7 +291,7 @@ __global__ void __launch_bounds__(256, 1)
           // Deposit: posKinEnergy + 2 * copcore::units::kElectronMassC2 and kill the secondary
           edep += posKinEnergy + 2 * copcore::units::kElectronMassC2;
         } else {
-          Track &positron = particleManager.positrons.NextTrack(
+          auto &positron = particleManager.positrons.NextTrack(
               currentTrack.rngState, posKinEnergy, pos,
               vecgeom::Vector3D<double>{dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]}, navState,
               currentTrack, globalTime);
@@ -328,7 +328,7 @@ __global__ void __launch_bounds__(256, 1)
         // Check the cuts and deposit energy in this volume if needed
         if (ApplyCuts ? energyEl > theElCut : energyEl > LowEnergyThreshold) {
           // Create a secondary electron and sample/compute directions.
-          Track &electron = particleManager.electrons.NextTrack(
+          auto &electron = particleManager.electrons.NextTrack(
               newRNG, energyEl, pos, eKin * dir - newEnergyGamma * newDirGamma, navState, currentTrack, globalTime);
 
           electron.dir.Normalize();
@@ -375,7 +375,7 @@ __global__ void __launch_bounds__(256, 1)
           G4HepEmGammaInteractionPhotoelectric::SamplePhotoElectronDirection(photoElecE, dirGamma, dirPhotoElec, &rnge);
 
           // Create a secondary electron and sample directions.
-          Track &electron = particleManager.electrons.NextTrack(
+          auto &electron = particleManager.electrons.NextTrack(
               newRNG, photoElecE, pos, vecgeom::Vector3D<double>{dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]},
               navState, currentTrack, globalTime);
 

--- a/include/AdePT/kernels/gammasWDT.cuh
+++ b/include/AdePT/kernels/gammasWDT.cuh
@@ -39,8 +39,8 @@ __global__ void __launch_bounds__(256, 1)
   auto &slotManager                 = *particleManager.gammasWDT.fSlotManager;
   const int activeSize              = particleManager.gammasWDT.ActiveSize();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
-    const auto slot     = particleManager.gammasWDT.ActiveAt(i);
-    Track &currentTrack = particleManager.gammasWDT.TrackAt(slot);
+    const auto slot            = particleManager.gammasWDT.ActiveAt(i);
+    NeutralTrack &currentTrack = particleManager.gammasWDT.TrackAt(slot);
 
     // Setup of the advanced debug printouts
     bool printErrors = true;
@@ -335,7 +335,7 @@ __global__ void __launch_bounds__(256, 1)
     // In both cases: reset the number of interaction length left to trigger
     // resampling in the next call to `HowFar` and prevent its update in this step.
     thePrimaryTrack->SetNumIALeft(-1, 0);
-    currentTrack.numIALeft[0] = -1; // reset also in the GPU track
+    currentTrack.numIALeft = -1; // reset also in the GPU track
 
     // The track has the total, i.e. the WDT step length.
     // However, `thePrimaryTrack` has zero which results in: the number of interaction length left is
@@ -473,7 +473,7 @@ __global__ void __launch_bounds__(256, 1)
           // Deposit the energy here and kill the secondary
           edep = elKinEnergy;
         } else {
-          Track &electron = particleManager.electrons.NextTrack(
+          auto &electron = particleManager.electrons.NextTrack(
               newRNG, elKinEnergy, pos,
               vecgeom::Vector3D<double>{dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]}, navState,
               currentTrack, globalTime);
@@ -489,7 +489,7 @@ __global__ void __launch_bounds__(256, 1)
           // Deposit: posKinEnergy + 2 * copcore::units::kElectronMassC2 and kill the secondary
           edep += posKinEnergy + 2 * copcore::units::kElectronMassC2;
         } else {
-          Track &positron = particleManager.positrons.NextTrack(
+          auto &positron = particleManager.positrons.NextTrack(
               currentTrack.rngState, posKinEnergy, pos,
               vecgeom::Vector3D<double>{dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]}, navState,
               currentTrack, globalTime);
@@ -526,7 +526,7 @@ __global__ void __launch_bounds__(256, 1)
         // Check the cuts and deposit energy in this volume if needed
         if (ApplyCuts ? energyEl > theElCut : energyEl > LowEnergyThreshold) {
           // Create a secondary electron and sample/compute directions.
-          Track &electron = particleManager.electrons.NextTrack(
+          auto &electron = particleManager.electrons.NextTrack(
               newRNG, energyEl, pos, eKin * dir - newEnergyGamma * newDirGamma, navState, currentTrack, globalTime);
 
           electron.dir.Normalize();
@@ -573,7 +573,7 @@ __global__ void __launch_bounds__(256, 1)
           G4HepEmGammaInteractionPhotoelectric::SamplePhotoElectronDirection(photoElecE, dirGamma, dirPhotoElec, &rnge);
 
           // Create a secondary electron and sample directions.
-          Track &electron = particleManager.electrons.NextTrack(
+          auto &electron = particleManager.electrons.NextTrack(
               newRNG, photoElecE, pos, vecgeom::Vector3D<double>{dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]},
               navState, currentTrack, globalTime);
 

--- a/include/AdePT/kernels/gammasWDT_split.cuh
+++ b/include/AdePT/kernels/gammasWDT_split.cuh
@@ -41,8 +41,8 @@ __global__ void __launch_bounds__(256, 1)
   auto &slotManager                        = *particleManager.gammasWDT.fSlotManager;
   const int activeSize                     = particleManager.gammasWDT.ActiveSize();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
-    const auto slot     = particleManager.gammasWDT.ActiveAt(i);
-    Track &currentTrack = particleManager.gammasWDT.TrackAt(slot);
+    const auto slot            = particleManager.gammasWDT.ActiveAt(i);
+    NeutralTrack &currentTrack = particleManager.gammasWDT.TrackAt(slot);
 
     // Setup of the advanced debug printouts
     bool printErrors = true;

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -31,8 +31,8 @@ __global__ void GammaHowFar(G4HepEmGammaTrack *hepEMTracks, ParticleManager part
 
   const int activeSize = particleManager.gammas.ActiveSize();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
-    const auto slot     = particleManager.gammas.ActiveAt(i);
-    Track &currentTrack = particleManager.gammas.TrackAt(slot);
+    const auto slot            = particleManager.gammas.ActiveAt(i);
+    NeutralTrack &currentTrack = particleManager.gammas.TrackAt(slot);
 
     int lvolID                = currentTrack.navState.GetLogicalId();
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID];
@@ -175,7 +175,7 @@ __global__ void GammaHowFar(G4HepEmGammaTrack *hepEMTracks, ParticleManager part
   }
 }
 
-__global__ void GammaPropagation(Track *gammas, G4HepEmGammaTrack *hepEMTracks, const adept::MParray *active)
+__global__ void GammaPropagation(NeutralTrack *gammas, G4HepEmGammaTrack *hepEMTracks, const adept::MParray *active)
 {
   constexpr double kPushDistance           = 1000 * vecgeom::kTolerance;
   constexpr double kPushStuck              = 100 * vecgeom::kTolerance;
@@ -183,8 +183,8 @@ __global__ void GammaPropagation(Track *gammas, G4HepEmGammaTrack *hepEMTracks, 
 
   int activeSize = active->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
-    const int slot      = (*active)[i];
-    Track &currentTrack = gammas[slot];
+    const int slot             = (*active)[i];
+    NeutralTrack &currentTrack = gammas[slot];
 
     int lvolID = currentTrack.navState.GetLogicalId();
 
@@ -237,8 +237,8 @@ __global__ void GammaSetupInteractions(G4HepEmGammaTrack *hepEMTracks, const ade
   auto &slotManager = *particleManager.gammas.fSlotManager;
   int activeSize    = propagationQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
-    const int slot      = (*propagationQueue)[i];
-    Track &currentTrack = particleManager.gammas.TrackAt(slot);
+    const int slot             = (*propagationQueue)[i];
+    NeutralTrack &currentTrack = particleManager.gammas.TrackAt(slot);
 
     int lvolID = currentTrack.navState.GetLogicalId();
 
@@ -249,8 +249,6 @@ __global__ void GammaSetupInteractions(G4HepEmGammaTrack *hepEMTracks, const ade
       interactionQueues.queues[4]->push_back(slot);
       continue;
     } else {
-      currentTrack.restrictedPhysicalStepLength = false;
-
       // NOTE: This may be moved to the next kernel
       G4HepEmGammaManager::SampleInteraction(&g4HepEmData, &gammaTrack, currentTrack.Uniform());
 
@@ -302,8 +300,8 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
   auto &slotManager              = *particleManager.gammas.fSlotManager;
   int activeSize                 = relocatingQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
-    const int slot      = (*relocatingQueue)[i];
-    Track &currentTrack = particleManager.gammas.TrackAt(slot);
+    const int slot             = (*relocatingQueue)[i];
+    NeutralTrack &currentTrack = particleManager.gammas.TrackAt(slot);
 
     int lvolID          = currentTrack.navState.GetLogicalId();
     bool enterWDTRegion = false;
@@ -321,7 +319,6 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
     G4HepEmGammaTrack &gammaTrack = hepEMTracks[slot];
     G4HepEmTrack *theTrack        = gammaTrack.GetTrack();
 
-    currentTrack.restrictedPhysicalStepLength = true;
     // For now, just count that we hit something.
 
     // Kill the particle if it left the world.
@@ -437,8 +434,8 @@ __global__ void GammaConversion(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
   auto &slotManager = *particleManager.gammas.fSlotManager;
   int activeSize    = interactingQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
-    const int slot      = (*interactingQueue)[i];
-    Track &currentTrack = particleManager.gammas.TrackAt(slot);
+    const int slot             = (*interactingQueue)[i];
+    NeutralTrack &currentTrack = particleManager.gammas.TrackAt(slot);
 
     int lvolID                = currentTrack.navState.GetLogicalId();
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID];
@@ -497,7 +494,7 @@ __global__ void GammaConversion(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
       // Deposit the energy here and kill the secondary
       edep = elKinEnergy;
     } else {
-      Track &electron = particleManager.electrons.NextTrack(
+      auto &electron = particleManager.electrons.NextTrack(
           newRNG, elKinEnergy, currentTrack.pos,
           vecgeom::Vector3D<double>{dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]}, currentTrack.navState,
           currentTrack, currentTrack.globalTime);
@@ -513,7 +510,7 @@ __global__ void GammaConversion(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
       // Deposit: posKinEnergy + 2 * copcore::units::kElectronMassC2 and kill the secondary
       edep += posKinEnergy + 2 * copcore::units::kElectronMassC2;
     } else {
-      Track &positron = particleManager.positrons.NextTrack(
+      auto &positron = particleManager.positrons.NextTrack(
           currentTrack.rngState, posKinEnergy, currentTrack.pos,
           vecgeom::Vector3D<double>{dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]}, currentTrack.navState,
           currentTrack, currentTrack.globalTime);
@@ -567,8 +564,8 @@ __global__ void GammaCompton(G4HepEmGammaTrack *hepEMTracks, ParticleManager par
   auto &slotManager = *particleManager.gammas.fSlotManager;
   int activeSize    = interactingQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
-    const int slot      = (*interactingQueue)[i];
-    Track &currentTrack = particleManager.gammas.TrackAt(slot);
+    const int slot             = (*interactingQueue)[i];
+    NeutralTrack &currentTrack = particleManager.gammas.TrackAt(slot);
 
     int lvolID                = currentTrack.navState.GetLogicalId();
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID];
@@ -624,7 +621,7 @@ __global__ void GammaCompton(G4HepEmGammaTrack *hepEMTracks, ParticleManager par
     // Check the cuts and deposit energy in this volume if needed
     if (ApplyCuts ? energyEl > theElCut : energyEl > LowEnergyThreshold) {
       // Create a secondary electron and sample/compute directions.
-      Track &electron = particleManager.electrons.NextTrack(
+      auto &electron = particleManager.electrons.NextTrack(
           newRNG, energyEl, currentTrack.pos, currentTrack.eKin * currentTrack.dir - newEnergyGamma * newDirGamma,
           currentTrack.navState, currentTrack, currentTrack.globalTime);
       electron.dir.Normalize();
@@ -696,8 +693,8 @@ __global__ void GammaPhotoelectric(G4HepEmGammaTrack *hepEMTracks, ParticleManag
   auto &slotManager = *particleManager.gammas.fSlotManager;
   int activeSize    = interactingQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
-    const int slot      = (*interactingQueue)[i];
-    Track &currentTrack = particleManager.gammas.TrackAt(slot);
+    const int slot             = (*interactingQueue)[i];
+    NeutralTrack &currentTrack = particleManager.gammas.TrackAt(slot);
 
     int lvolID                = currentTrack.navState.GetLogicalId();
     VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID];
@@ -739,7 +736,7 @@ __global__ void GammaPhotoelectric(G4HepEmGammaTrack *hepEMTracks, ParticleManag
       G4HepEmGammaInteractionPhotoelectric::SamplePhotoElectronDirection(photoElecE, dirGamma, dirPhotoElec, &rnge);
 
       // Create a secondary electron and sample directions.
-      Track &electron = particleManager.electrons.NextTrack(
+      auto &electron = particleManager.electrons.NextTrack(
           newRNG, photoElecE, currentTrack.pos,
           vecgeom::Vector3D<double>{dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]}, currentTrack.navState,
           currentTrack, currentTrack.globalTime);


### PR DESCRIPTION
This PR reduces the memory footprint of the tracks by splitting the track into a neutral track and a charged track (similarly to what G4HepEm does).

As the track size depends also on the NavigationState size, this is the table for before and after:

| Nav mode | NavigationState size | Mode | Master Track | PR NeutralTrack | PR ChargedTrack |
|---|---:|---|---:|---:|---:|
| NavIndex | 12 B | monolithic | 248 B | 200 B | 240 B |
| NavIndex | 12 B | split | 312 B | 288 B | 312 B |
| NavTuple depth 3 | 36 B | monolithic | 272 B | 224 B | 264 B |
| NavTuple depth 3 | 36 B | split | 360 B | 336 B | 360 B |
| NavTuple depth 4 | 44 B | monolithic | 280 B | 232 B | 272 B |
| NavTuple depth 4 | 44 B | split | 376 B | 352 B | 376 B |


While ncu shows some lower memory traffic, it did not translate into a measurable speedup (tested with ttbar events in example1 with the LHCb geometry).

Note: Now there is no array over the tracks possible anymore, as they differ, so the tracksAndSlots struct was changed as well as some loops were replaced by lambda function calls.