### PR TITLE
add CMS stepping action for dead regions

### DIFF
--- a/include/AdePT/core/AdePTConfiguration.hh
+++ b/include/AdePT/core/AdePTConfiguration.hh
@@ -23,6 +23,7 @@ public:
   void AddGPURegionName(std::string name) { fGPURegionNames.push_back(name); }
   void RemoveGPURegionName(std::string name) { fCPURegionNames.push_back(name); }
   void AddWDTRegionName(std::string name) { fWDTRegionNames.push_back(name); }
+  void AddDeadRegionName(std::string name) { fDeadRegionNames.push_back(name); }
   void SetVerbosity(int verbosity) { fVerbosity = verbosity; };
   void SetMillionsOfTrackSlots(double millionSlots) { fMillionsOfTrackSlots = millionSlots; }
   void SetMillionsOfHitSlots(double millionSlots) { fMillionsOfHitSlots = millionSlots; }
@@ -72,6 +73,7 @@ public:
   std::vector<std::string> *GetGPURegionNames() { return &fGPURegionNames; }
   std::vector<std::string> *GetCPURegionNames() { return &fCPURegionNames; }
   const std::vector<std::string> &GetWDTRegionNames() const { return fWDTRegionNames; }
+  const std::vector<std::string> &GetDeadRegionNames() const { return fDeadRegionNames; }
 
   // Temporary
   std::string GetVecGeomGDML() { return fVecGeomGDML; }
@@ -101,6 +103,7 @@ private:
   std::vector<std::string> fGPURegionNames{};
   std::vector<std::string> fCPURegionNames{};
   std::vector<std::string> fWDTRegionNames{};
+  std::vector<std::string> fDeadRegionNames{};
 
   std::string fVecGeomGDML{""};
   std::string fCovfieBfieldFile{""};

--- a/include/AdePT/core/GeometryAuxData.hh
+++ b/include/AdePT/core/GeometryAuxData.hh
@@ -17,6 +17,9 @@ struct VolAuxData {
   int fSensIndex{-1};   ///< index of handler for sensitive volumes (-1 means non-sensitive)
   int fMCIndex{0};      ///< material-cut couple index in G4HepEm
   int fGPUregionId{-1}; ///< GPU region index, corresponds to G4Region.instanceID if tracked on GPU, -1 otherwise
+#if defined(ADEPT_STEPACTION_TYPE) && (ADEPT_STEPACTION_TYPE == 1)
+  bool fCMSDeadRegion{false}; ///< CMS-only flag: tracks entering this volume are killed by the stepping action
+#endif
 #if defined(ADEPT_STEPACTION_TYPE) && (ADEPT_STEPACTION_TYPE == 3)
   bool fAtlasPhotonRussianRoulette{false}; ///< ATLAS-only flag: apply photon Russian Roulette to gammas born here
 #endif

--- a/include/AdePT/integration/AdePTGeometryBridge.hh
+++ b/include/AdePT/integration/AdePTGeometryBridge.hh
@@ -41,7 +41,8 @@ public:
   /// @brief Fills the auxiliary per-volume data needed by AdePT.
   static void InitVolAuxData(adeptint::VolAuxData *volAuxData, G4HepEmData const *hepEmData,
                              G4HepEmTrackingManagerSpecialized *hepEmTM, bool trackInAllRegions,
-                             std::vector<std::string> const *gpuRegionNames, adeptint::WDTHostRaw &wdtRaw);
+                             std::vector<std::string> const *gpuRegionNames,
+                             std::vector<std::string> const &deadRegionNames, adeptint::WDTHostRaw &wdtRaw);
 
   /// @brief Pack the Woodcock tracking data from the sparse host-side map into arrays that can be copied to the GPU.
   /// @param wdtRaw Raw WDT data collected during geometry traversal.

--- a/include/AdePT/kernels/AdePTSteppingAction.cuh
+++ b/include/AdePT/kernels/AdePTSteppingAction.cuh
@@ -41,13 +41,14 @@ struct NoAction {
   static constexpr bool kGammaRussianRoulette = false;
 
   __device__ __forceinline__ static void ElectronAction(bool &, double &, double &, vecgeom::Vector3D<double> const &,
-                                                        double const &, int const &, G4HepEmData const *,
-                                                        Params const &)
+                                                        double const &, adeptint::VolAuxData const &,
+                                                        G4HepEmData const *, Params const &)
   {
   }
 
   __device__ __forceinline__ static void GammaAction(bool &, double &, double &, vecgeom::Vector3D<double> const &,
-                                                     double const &, int const &, G4HepEmData const *, Params const &)
+                                                     double const &, adeptint::VolAuxData const &, G4HepEmData const *,
+                                                     Params const &)
   {
   }
 
@@ -71,14 +72,25 @@ struct CMSAction {
   };
   static constexpr bool kGammaRussianRoulette = false;
 
+  __device__ __forceinline__ static bool IsDeadRegion(adeptint::VolAuxData const &auxData)
+  {
+#if defined(ADEPT_STEPACTION_TYPE) && (ADEPT_STEPACTION_TYPE == 1)
+    return auxData.fCMSDeadRegion;
+#else
+    return false;
+#endif
+  }
+
   __device__ __forceinline__ static void AllParticleCheck(bool &alive, double &eKin, double &edep,
                                                           vecgeom::Vector3D<double> const &pos,
-                                                          double const &globalTime, Params const &params)
+                                                          double const &globalTime, adeptint::VolAuxData const &auxData,
+                                                          Params const &params)
   {
-    // dead-region cut:
-    // Missing: mark dead material regions in CMS
-    // Dead regions must be implemented explicitly for CMS and checked from the
-    // navigation state here if needed.
+    // Default CMSSW dead regions from SimG4Core/Application/python/g4SimHits_cfi.py.
+    if (IsDeadRegion(auxData)) {
+      KillTrack(alive, eKin, edep);
+      return;
+    }
 
     // Out-of-time and out-of-z cut
     if (globalTime > params.tmax && fabs(pos.z()) >= params.zmax) {
@@ -89,15 +101,15 @@ struct CMSAction {
 
   __device__ __forceinline__ static void ElectronAction(bool &alive, double &eKin, double &edep,
                                                         vecgeom::Vector3D<double> const &pos, double const &globalTime,
-                                                        int const &mcIndex, G4HepEmData const *g4HepEmData,
-                                                        Params const &params)
+                                                        adeptint::VolAuxData const &auxData,
+                                                        G4HepEmData const *g4HepEmData, Params const &params)
   {
     if (!alive) return;
-    AllParticleCheck(alive, eKin, edep, pos, globalTime, params);
+    AllParticleCheck(alive, eKin, edep, pos, globalTime, auxData, params);
     if (!alive) return;
 
     // e-/e+ in vacuum cut
-    const int hmi        = g4HepEmData->fTheMatCutData->fMatCutData[mcIndex].fHepEmMatIndex;
+    const int hmi        = g4HepEmData->fTheMatCutData->fMatCutData[auxData.fMCIndex].fHepEmMatIndex;
     const double density = g4HepEmData->fTheMaterialData->fMaterialData[hmi].fDensity; // g/cm^3
     if (eKin < params.ecut && density < params.density) {
       KillTrack(alive, eKin, edep);
@@ -106,11 +118,11 @@ struct CMSAction {
 
   __device__ __forceinline__ static void GammaAction(bool &alive, double &eKin, double &edep,
                                                      vecgeom::Vector3D<double> const &pos, double const &globalTime,
-                                                     int const & /*mcIndex*/, G4HepEmData const * /*g4HepEmData*/,
-                                                     Params const &params)
+                                                     adeptint::VolAuxData const &auxData,
+                                                     G4HepEmData const * /*g4HepEmData*/, Params const &params)
   {
     if (!alive) return;
-    AllParticleCheck(alive, eKin, edep, pos, globalTime, params);
+    AllParticleCheck(alive, eKin, edep, pos, globalTime, auxData, params);
   }
 
   __device__ __forceinline__ static GammaRouletteResult ApplyGammaRussianRoulette(float const &parentWeight,
@@ -137,7 +149,8 @@ struct LHCbAction {
 
   __device__ __forceinline__ static void ElectronAction(bool &alive, double &eKin, double &edep,
                                                         vecgeom::Vector3D<double> const &pos,
-                                                        double const & /*globalTime*/, int const & /*mcIndex*/,
+                                                        double const & /*globalTime*/,
+                                                        adeptint::VolAuxData const & /*auxData*/,
                                                         G4HepEmData const * /*g4HepEmData*/, Params const &params)
   {
     if (!alive) return;
@@ -151,11 +164,11 @@ struct LHCbAction {
 
   __device__ __forceinline__ static void GammaAction(bool &alive, double &eKin, double &edep,
                                                      vecgeom::Vector3D<double> const &pos,
-                                                     double const & /*globalTime*/, int const & /*mcIndex*/,
+                                                     double const & /*globalTime*/, adeptint::VolAuxData const &auxData,
                                                      G4HepEmData const *g4HepEmData, Params const &params)
   {
     // same as electron stepping action
-    ElectronAction(alive, eKin, edep, pos, /*globalTime*/ 0.0, /*mcIndex*/ 0, g4HepEmData, params);
+    ElectronAction(alive, eKin, edep, pos, /*globalTime*/ 0.0, auxData, g4HepEmData, params);
   }
 
   __device__ __forceinline__ static GammaRouletteResult ApplyGammaRussianRoulette(float const &parentWeight,
@@ -186,13 +199,14 @@ struct ATLASAction {
   static constexpr float kOneOverPhotonRouletteWeight     = 1.0f / kPhotonRussianRouletteWeight;
 
   __device__ __forceinline__ static void ElectronAction(bool &, double &, double &, vecgeom::Vector3D<double> const &,
-                                                        double const &, int const &, G4HepEmData const *,
-                                                        Params const &)
+                                                        double const &, adeptint::VolAuxData const &,
+                                                        G4HepEmData const *, Params const &)
   {
   }
 
   __device__ __forceinline__ static void GammaAction(bool &, double &, double &, vecgeom::Vector3D<double> const &,
-                                                     double const &, int const &, G4HepEmData const *, Params const &)
+                                                     double const &, adeptint::VolAuxData const &, G4HepEmData const *,
+                                                     Params const &)
   {
   }
 
@@ -217,13 +231,14 @@ struct ATLASAction {
   static constexpr bool kGammaRussianRoulette = false;
 
   __device__ __forceinline__ static void ElectronAction(bool &, double &, double &, vecgeom::Vector3D<double> const &,
-                                                        double const &, int const &, G4HepEmData const *,
-                                                        Params const &)
+                                                        double const &, adeptint::VolAuxData const &,
+                                                        G4HepEmData const *, Params const &)
   {
   }
 
   __device__ __forceinline__ static void GammaAction(bool &, double &, double &, vecgeom::Vector3D<double> const &,
-                                                     double const &, int const &, G4HepEmData const *, Params const &)
+                                                     double const &, adeptint::VolAuxData const &, G4HepEmData const *,
+                                                     Params const &)
   {
   }
 

--- a/include/AdePT/kernels/AdePTSteppingAction.cuh
+++ b/include/AdePT/kernels/AdePTSteppingAction.cuh
@@ -86,7 +86,7 @@ struct CMSAction {
                                                           double const &globalTime, adeptint::VolAuxData const &auxData,
                                                           Params const &params)
   {
-    // Default CMSSW dead regions from SimG4Core/Application/python/g4SimHits_cfi.py.
+    // Configured CMSSW dead regions from AdePTConfiguration.
     if (IsDeadRegion(auxData)) {
       KillTrack(alive, eKin, edep);
       return;

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -83,6 +83,8 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     // the MCC vector is indexed by the logical volume id
     const int lvolID          = navState.GetLogicalId();
     VolAuxData const &auxData = gVolAuxData[lvolID];
+    // Experiment stepping actions use the post-step volume, which is the auxData unless a boundary is crossed.
+    VolAuxData const *postStepAuxData = &auxData;
 
     bool trackSurvives                       = false;
     constexpr double kPushStuck              = 100 * vecgeom::kTolerance;
@@ -431,6 +433,8 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
           // Check if the next volume belongs to the GPU region and push it to the appropriate queue
           const int nextlvolID          = nextState.GetLogicalId();
           VolAuxData const &nextauxData = gVolAuxData[nextlvolID];
+          // after relocation: set volAuxData for SteppingAction to next volume
+          postStepAuxData = &nextauxData;
           // track has left GPU region
           if (nextauxData.fGPUregionId < 0) {
             // To be safe, just push a bit the track exiting the GPU region to make sure
@@ -776,7 +780,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
         eKin = 0.;
       } else {
         // call experiment-specific SteppingAction:
-        SteppingActionT::ElectronAction(trackSurvives, eKin, energyDeposit, pos, globalTime, auxData.fMCIndex,
+        SteppingActionT::ElectronAction(trackSurvives, eKin, energyDeposit, pos, globalTime, *postStepAuxData,
                                         &g4HepEmData, params);
       }
     }

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -141,7 +141,7 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
         // check for experiment-specific SteppingAction
       } else {
         SteppingActionT::ElectronAction(trackSurvives, currentTrack.eKin, energyDeposit, currentTrack.pos,
-                                        currentTrack.globalTime, auxData.fMCIndex, &g4HepEmData, params);
+                                        currentTrack.globalTime, auxData, &g4HepEmData, params);
       }
 
       // this one always needs to be last as it needs to be done only if the track survives

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -35,6 +35,8 @@ __global__ void __launch_bounds__(256, 1)
     auto navState             = currentTrack.navState;
     int lvolID                = navState.GetLogicalId();
     VolAuxData const &auxData = gVolAuxData[lvolID];
+    // Experiment stepping actions use the post-step volume, which is the auxData unless a boundary is crossed.
+    VolAuxData const *postStepAuxData = &auxData;
 
     bool trackSurvives                       = false;
     bool enterWDTRegion                      = false;
@@ -187,7 +189,9 @@ __global__ void __launch_bounds__(256, 1)
         //  Check if the next volume belongs to the GPU region and push it to the appropriate queue
         const int nextlvolID          = nextState.GetLogicalId();
         VolAuxData const &nextauxData = gVolAuxData[nextlvolID];
-        const auto regionId           = nextauxData.fGPUregionId;
+        // after relocation: set volAuxData for SteppingAction to next volume
+        postStepAuxData     = &nextauxData;
+        const auto regionId = nextauxData.fGPUregionId;
 
         // next region is a GPU region
         if (regionId >= 0) {
@@ -416,7 +420,7 @@ __global__ void __launch_bounds__(256, 1)
         eKin = 0.;
       } else {
         // call experiment-specific SteppingAction:
-        SteppingActionT::GammaAction(trackSurvives, eKin, edep, pos, globalTime, auxData.fMCIndex, &g4HepEmData,
+        SteppingActionT::GammaAction(trackSurvives, eKin, edep, pos, globalTime, *postStepAuxData, &g4HepEmData,
                                      params);
       }
     }

--- a/include/AdePT/kernels/gammasWDT.cuh
+++ b/include/AdePT/kernels/gammasWDT.cuh
@@ -612,7 +612,7 @@ __global__ void __launch_bounds__(256, 1)
         eKin = 0.;
       } else {
         // call experiment-specific SteppingAction:
-        SteppingActionT::GammaAction(trackSurvives, eKin, edep, pos, globalTime, hepEmIMC, &g4HepEmData, params);
+        SteppingActionT::GammaAction(trackSurvives, eKin, edep, pos, globalTime, nextauxData, &g4HepEmData, params);
       }
     }
 

--- a/include/AdePT/kernels/gammasWDT_split.cuh
+++ b/include/AdePT/kernels/gammasWDT_split.cuh
@@ -115,7 +115,7 @@ __global__ void __launch_bounds__(256, 1)
         // check for experiment-specific SteppingAction
       } else {
         SteppingActionT::GammaAction(trackSurvives, currentTrack.eKin, energyDeposit, currentTrack.pos,
-                                     currentTrack.globalTime, auxData.fMCIndex, &g4HepEmData, params);
+                                     currentTrack.globalTime, auxData, &g4HepEmData, params);
       }
 
       // this one always needs to be last as it needs to be done only if the track survives

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -87,7 +87,7 @@ __global__ void GammaHowFar(G4HepEmGammaTrack *hepEMTracks, ParticleManager part
         // check for experiment-specific SteppingAction
       } else {
         SteppingActionT::GammaAction(trackSurvives, currentTrack.eKin, energyDeposit, currentTrack.pos,
-                                     currentTrack.globalTime, auxData.fMCIndex, &g4HepEmData, params);
+                                     currentTrack.globalTime, auxData, &g4HepEmData, params);
       }
 
       // this one always needs to be last as it needs to be done only if the track survives

--- a/src/AdePTGeometryBridge.cpp
+++ b/src/AdePTGeometryBridge.cpp
@@ -240,6 +240,7 @@ void AdePTGeometryBridge::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4Hep
   }
 
 #if defined(ADEPT_STEPACTION_TYPE) && (ADEPT_STEPACTION_TYPE == 1)
+  // CMS stepping action: resolve configured dead-region names once on the host.
   std::vector<G4Region const *> deadRegions{};
   for (const std::string &regionName : deadRegionNames) {
     G4Region const *region = G4RegionStore::GetInstance()->GetRegion(regionName, false);
@@ -306,6 +307,7 @@ void AdePTGeometryBridge::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4Hep
     }
 
 #if defined(ADEPT_STEPACTION_TYPE) && (ADEPT_STEPACTION_TYPE == 1)
+    // CMS stepping action: flag volumes whose region kills tracks on GPU.
     bool isDeadRegion = false;
     for (G4Region const *deadRegion : deadRegions) {
       if (g4_lvol->GetRegion() == deadRegion) {

--- a/src/AdePTGeometryBridge.cpp
+++ b/src/AdePTGeometryBridge.cpp
@@ -289,6 +289,13 @@ void AdePTGeometryBridge::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4Hep
       volAuxData[vg_lvol->id()].fSensIndex = 1;
     }
 
+#if defined(ADEPT_STEPACTION_TYPE) && (ADEPT_STEPACTION_TYPE == 1)
+    // Flag volumes in CMSSW dead regions for the GPU stepping action.
+    // Note: QuadRegion and InterimRegion are the current hardcoded defaults from CMSSW.
+    const auto &regionName                   = g4_lvol->GetRegion()->GetName();
+    volAuxData[vg_lvol->id()].fCMSDeadRegion = (regionName == "QuadRegion" || regionName == "InterimRegion");
+#endif
+
 #if defined(ADEPT_STEPACTION_TYPE) && (ADEPT_STEPACTION_TYPE == 3)
     const bool atlasPhotonRR = g4_pvol->GetName().rfind("LAr", 0) == 0;
     auto &atlasPhotonRRFlag  = volAuxData[vg_lvol->id()].fAtlasPhotonRussianRoulette;

--- a/src/AdePTGeometryBridge.cpp
+++ b/src/AdePTGeometryBridge.cpp
@@ -10,6 +10,7 @@
 #include <VecGeom/navigation/NavigationState.h>
 
 #include <G4HepEmData.hh>
+#include <G4Exception.hh>
 #include <G4HepEmMatCutData.hh>
 #include <G4LogicalVolume.hh>
 #include <G4MaterialCutsCouple.hh>
@@ -218,7 +219,8 @@ void AdePTGeometryBridge::CheckGeometry(G4HepEmData const *hepEmData)
 /// @brief Fill the auxiliary per-volume transport metadata used by AdePT.
 void AdePTGeometryBridge::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4HepEmData const *hepEmData,
                                          G4HepEmTrackingManagerSpecialized *hepEmTM, bool trackInAllRegions,
-                                         std::vector<std::string> const *gpuRegionNames, adeptint::WDTHostRaw &wdtRaw)
+                                         std::vector<std::string> const *gpuRegionNames,
+                                         std::vector<std::string> const &deadRegionNames, adeptint::WDTHostRaw &wdtRaw)
 {
   // Note: the hepEmTM must be passed explicitly here, since this is now a stateless
   // global bridge helper and therefore cannot reach any per-thread integration members.
@@ -236,6 +238,20 @@ void AdePTGeometryBridge::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4Hep
       gpuRegions.push_back(G4RegionStore::GetInstance()->GetRegion(regionName));
     }
   }
+
+#if defined(ADEPT_STEPACTION_TYPE) && (ADEPT_STEPACTION_TYPE == 1)
+  std::vector<G4Region const *> deadRegions{};
+  for (const std::string &regionName : deadRegionNames) {
+    G4Region const *region = G4RegionStore::GetInstance()->GetRegion(regionName, false);
+    if (!region) {
+      G4Exception("AdePTGeometryBridge", "Invalid parameter", FatalErrorInArgument,
+                  ("Region given to AdePTConfiguration::AddDeadRegionName: " + regionName + " not found\n").c_str());
+    }
+    deadRegions.push_back(region);
+  }
+#else
+  (void)deadRegionNames;
+#endif
 
 #if defined(ADEPT_STEPACTION_TYPE) && (ADEPT_STEPACTION_TYPE == 3)
   std::vector<bool> atlasPhotonRRInitialized(vecgeom::GeoManager::Instance().GetRegisteredVolumesCount(), false);
@@ -290,10 +306,14 @@ void AdePTGeometryBridge::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4Hep
     }
 
 #if defined(ADEPT_STEPACTION_TYPE) && (ADEPT_STEPACTION_TYPE == 1)
-    // Flag volumes in CMSSW dead regions for the GPU stepping action.
-    // Note: QuadRegion and InterimRegion are the current hardcoded defaults from CMSSW.
-    const auto &regionName                   = g4_lvol->GetRegion()->GetName();
-    volAuxData[vg_lvol->id()].fCMSDeadRegion = (regionName == "QuadRegion" || regionName == "InterimRegion");
+    bool isDeadRegion = false;
+    for (G4Region const *deadRegion : deadRegions) {
+      if (g4_lvol->GetRegion() == deadRegion) {
+        isDeadRegion = true;
+        break;
+      }
+    }
+    volAuxData[vg_lvol->id()].fCMSDeadRegion = isDeadRegion;
 #endif
 
 #if defined(ADEPT_STEPACTION_TYPE) && (ADEPT_STEPACTION_TYPE == 3)

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -131,9 +131,9 @@ void AdePTTrackingManager::InitializeSharedAdePTTransport()
   // Initialize auxiliary per-LV data and collect the raw WDT metadata on the Geant4 side.
   auto *auxData = new adeptint::VolAuxData[vecgeom::GeoManager::Instance().GetRegisteredVolumesCount()];
   adeptint::WDTHostRaw wdtRaw;
-  AdePTGeometryBridge::InitVolAuxData(auxData, adeptG4HepEmState->GetData(), fHepEmTrackingManager.get(),
-                                      fAdePTConfiguration->GetTrackInAllRegions(),
-                                      fAdePTConfiguration->GetGPURegionNames(), wdtRaw);
+  AdePTGeometryBridge::InitVolAuxData(
+      auxData, adeptG4HepEmState->GetData(), fHepEmTrackingManager.get(), fAdePTConfiguration->GetTrackInAllRegions(),
+      fAdePTConfiguration->GetGPURegionNames(), fAdePTConfiguration->GetDeadRegionNames(), wdtRaw);
   adeptint::WDTHostPacked wdtPacked = AdePTGeometryBridge::PackWDT(wdtRaw);
 
   // Move the fully prepared host-side package into the shared transport. The


### PR DESCRIPTION
This PR adds the CMS-specific stepping action which kills tracks in so-called dead regions.
Similarly to the ATLAS Russian Roulette, the VolAuxData gets an additional flag for the volumes in that region and based on that flag tracks are killed.

This changes the interface to pass the full volAuxData to the SteppingAction instead of just the `volAuxData.fMCIndex`.

Note: additionally, a small bug was fixed:
In the monolithic kernels, the volAuxData of the initial volume was used. However, in case of the relocation, this is not correct, so the volAuxData must be updated.

The dead regions can be configured in the AdePTConfiguration (currently, for CMS only), via
```c++
fAdePTConfiguration->AddDeadRegionName("QuadRegion");
fAdePTConfiguration->AddDeadRegionName("InterimRegion");
```