### PR TITLE
use simple unity check in ATLAS Russian Roulette

### DIFF
--- a/include/AdePT/kernels/AdePTSteppingAction.cuh
+++ b/include/AdePT/kernels/AdePTSteppingAction.cuh
@@ -215,7 +215,7 @@ struct ATLASAction {
       RanluxppDouble &rngState)
   {
     if (!originAuxData.fAtlasPhotonRussianRoulette) return {true, parentWeight};
-    if (parentWeight >= kPhotonRussianRouletteWeight) return {true, parentWeight};
+    if (parentWeight != 1.0f) return {true, parentWeight};
     if (gammaEkin >= kPhotonRussianRouletteThreshold) return {true, parentWeight};
 
     if (rngState.Rndm() > kOneOverPhotonRouletteWeight) return {false, parentWeight};


### PR DESCRIPTION
This PR improves the Russian Roulette as discussed in #578:

Instead of doing a check against the weight (which only works in athena as the weight for neutrons and gammas is the same, [see this MR](https://gitlab.cern.ch/atlas/athena/-/merge_requests/87611)), we do a simple check against unity here.

Note that the float comparison is fine here, as the weight is assigned to 1.0f and not accumulated.

This PR does not change any behavior, it simply fortifies AdePT against any possible future changes of the weights in Athena.

Note, this PR should be reviewed after #599 is merged, so the new RR CI can be triggered on this PR.