### PR TITLE
Split AdePTTransportConfig from Geant4UI configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -489,6 +489,7 @@ set(ADEPT_CORE_SRCS
 )
 
 set(ADEPT_G4_INTEGRATION_SRCS
+  src/AdePTConfiguration.cc
   src/AdePTGeometryBridge.cpp
   src/G4HepEmTrackingManagerSpecialized.cc
   src/AdePTTrackingManager.cc

--- a/include/AdePT/core/AdePTConfiguration.hh
+++ b/include/AdePT/core/AdePTConfiguration.hh
@@ -4,18 +4,19 @@
 #ifndef ADEPT_CONFIGURATION_HH
 #define ADEPT_CONFIGURATION_HH
 
-#include <AdePT/integration/AdePTConfigurationMessenger.hh>
-
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
+
+class AdePTConfigurationMessenger;
 
 /// @brief Create and configure instances of an AdePT transport implementation.
 ///
 class AdePTConfiguration {
 public:
-  AdePTConfiguration() : fAdePTConfigurationMessenger{new AdePTConfigurationMessenger(this)} {}
-  ~AdePTConfiguration() {}
+  AdePTConfiguration();
+  ~AdePTConfiguration();
   void SetNumThreads(int numThreads) { fNumThreads = numThreads; }
   void SetTrackInAllRegions(bool trackInAllRegions) { fTrackInAllRegions = trackInAllRegions; }
   void SetCallUserSteppingAction(bool callUserSteppingAction) { fCallUserSteppingAction = callUserSteppingAction; }
@@ -50,34 +51,34 @@ public:
   // loading external magnetic field from .cf file
   void SetCovfieBfieldFile(std::string filename) { fCovfieBfieldFile = filename; }
 
-  bool GetTrackInAllRegions() { return fTrackInAllRegions; }
-  bool GetCallUserSteppingAction() { return fCallUserSteppingAction; }
-  bool GetCallUserTrackingAction() { return fCallUserTrackingAction; }
-  bool GetSpeedOfLight() { return fSpeedOfLight; }
-  bool GetMultipleStepsInMSCWithTransportation() { return fSetMultipleStepsInMSCWithTransportation; }
-  bool GetEnergyLossFluctuation() { return fSetEnergyLossFluctuation; }
-  int GetNumThreads() { return fNumThreads; };
-  int GetVerbosity() { return fVerbosity; };
-  int GetCUDAStackLimit() { return fCUDAStackLimit; }
-  int GetCUDAHeapLimit() { return fCUDAHeapLimit; }
-  uint64_t GetAdePTSeed() { return fAdePTSeed; }
+  bool GetTrackInAllRegions() const { return fTrackInAllRegions; }
+  bool GetCallUserSteppingAction() const { return fCallUserSteppingAction; }
+  bool GetCallUserTrackingAction() const { return fCallUserTrackingAction; }
+  bool GetSpeedOfLight() const { return fSpeedOfLight; }
+  bool GetMultipleStepsInMSCWithTransportation() const { return fSetMultipleStepsInMSCWithTransportation; }
+  bool GetEnergyLossFluctuation() const { return fSetEnergyLossFluctuation; }
+  int GetNumThreads() const { return fNumThreads; };
+  int GetVerbosity() const { return fVerbosity; };
+  int GetCUDAStackLimit() const { return fCUDAStackLimit; }
+  int GetCUDAHeapLimit() const { return fCUDAHeapLimit; }
+  uint64_t GetAdePTSeed() const { return fAdePTSeed; }
 
-  unsigned short GetLastNParticlesOnCPU() { return fLastNParticlesOnCPU; }
-  unsigned short GetMaxWDTIter() { return fMaxWDTIter; }
-  double GetWDTKineticEnergyLimit() { return fWDTKineticEnergyLimit; }
-  float GetHitBufferFlushThreshold() { return fHitBufferFlushThreshold; }
-  float GetCPUCapacityFactor() { return fCPUCapacityFactor; }
-  double GetHitBufferSafetyFactor() { return fHitBufferSafetyFactor; }
-  double GetMillionsOfTrackSlots() { return fMillionsOfTrackSlots; }
-  double GetMillionsOfHitSlots() { return fMillionsOfHitSlots; }
-  std::vector<std::string> *GetGPURegionNames() { return &fGPURegionNames; }
-  std::vector<std::string> *GetCPURegionNames() { return &fCPURegionNames; }
+  unsigned short GetLastNParticlesOnCPU() const { return fLastNParticlesOnCPU; }
+  unsigned short GetMaxWDTIter() const { return fMaxWDTIter; }
+  double GetWDTKineticEnergyLimit() const { return fWDTKineticEnergyLimit; }
+  float GetHitBufferFlushThreshold() const { return fHitBufferFlushThreshold; }
+  float GetCPUCapacityFactor() const { return fCPUCapacityFactor; }
+  double GetHitBufferSafetyFactor() const { return fHitBufferSafetyFactor; }
+  double GetMillionsOfTrackSlots() const { return fMillionsOfTrackSlots; }
+  double GetMillionsOfHitSlots() const { return fMillionsOfHitSlots; }
+  const std::vector<std::string> *GetGPURegionNames() const { return &fGPURegionNames; }
+  const std::vector<std::string> *GetCPURegionNames() const { return &fCPURegionNames; }
   const std::vector<std::string> &GetWDTRegionNames() const { return fWDTRegionNames; }
   const std::vector<std::string> &GetDeadRegionNames() const { return fDeadRegionNames; }
 
   // Temporary
-  std::string GetVecGeomGDML() { return fVecGeomGDML; }
-  std::string GetCovfieBfieldFile() { return fCovfieBfieldFile; } // todo add #ifdef guards?
+  std::string GetVecGeomGDML() const { return fVecGeomGDML; }
+  std::string GetCovfieBfieldFile() const { return fCovfieBfieldFile; } // todo add #ifdef guards?
 
 private:
   bool fTrackInAllRegions{false};

--- a/include/AdePT/core/AdePTTransportConfig.hh
+++ b/include/AdePT/core/AdePTTransportConfig.hh
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ADEPT_TRANSPORT_CONFIG_HH
+#define ADEPT_TRANSPORT_CONFIG_HH
+
+#include <cstdint>
+#include <string>
+
+/// @brief Plain configuration values required to initialize the AdePT transport engine.
+struct AdePTTransportConfig {
+  uint64_t adeptSeed{1234567};
+  unsigned short numThreads{0};
+  unsigned int trackCapacity{0};
+  unsigned int scoringCapacity{0};
+  int debugLevel{0};
+  int cudaStackLimit{0};
+  int cudaHeapLimit{0};
+  unsigned short lastNParticlesOnCPU{0};
+  unsigned short maxWDTIter{5};
+  bool returnAllSteps{false};
+  bool returnFirstAndLastStep{false};
+  std::string bfieldFile{};
+  double cpuCapacityFactor{2.5};
+  double cpuCopyFraction{0.5};
+  double hitBufferSafetyFactor{1.5};
+};
+
+#endif

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -8,7 +8,6 @@
 
 #include <AdePT/core/AsyncAdePTTransportStruct.cuh>
 #include <AdePT/core/AsyncAdePTTransportStruct.hh>
-#include <AdePT/core/AdePTConfiguration.hh>
 #include <AdePT/core/G4HepEmRandomEngineDeviceImpl.hh>
 #include <AdePT/core/GeometryAuxData.hh>
 #include <AdePT/core/TrackBuffer.hh>
@@ -820,7 +819,7 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
     if (!gpuState.runTransport) break;
 
     if (debugLevel > 2) {
-      G4cout << "GPU transport starting" << std::endl;
+      std::cout << "GPU transport starting" << std::endl;
     }
 
     ADEPT_DEVICE_API_CALL(StreamSynchronize(gpuState.stream));

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -9,9 +9,9 @@
 #ifndef ASYNC_ADEPT_TRANSPORT_HH
 #define ASYNC_ADEPT_TRANSPORT_HH
 
-#include <AdePT/core/AdePTConfiguration.hh>
 #include <AdePT/core/AdePTG4HepEmState.hh>
 #include <AdePT/core/AsyncAdePTTransportStruct.hh>
+#include <AdePT/core/AdePTTransportConfig.hh>
 #include <AdePT/core/GeometryAuxData.hh>
 #include <AdePT/core/ScoringCommons.hh>
 
@@ -53,10 +53,7 @@ private:
   std::condition_variable fCV_G4Workers;             ///< Communicate with G4 workers
   std::mutex fMutex_G4Workers;                       ///< Mutex associated to the condition variable
   std::vector<std::atomic<EventState>> fEventStates; ///< State machine for each G4 worker
-  bool fTrackInAllRegions = false;
-  bool fHasWDTRegions     = false;
-  std::vector<std::string> const *fGPURegionNames;
-  std::vector<std::string> const *fCPURegionNames;
+  bool fHasWDTRegions = false;
   // Flags for the kernels to return the last or all steps, needed for PostUserTrackingAction or UserSteppingAction
   bool fReturnAllSteps         = false;
   bool fReturnFirstAndLastStep = false;
@@ -76,7 +73,7 @@ private:
   bool InitializePhysics();
 
 public:
-  AsyncAdePTTransport(AdePTConfiguration &configuration, std::unique_ptr<AdePTG4HepEmState> adeptG4HepEmState,
+  AsyncAdePTTransport(const AdePTTransportConfig &configuration, std::unique_ptr<AdePTG4HepEmState> adeptG4HepEmState,
                       adeptint::VolAuxData *auxData, const adeptint::WDTHostPacked &wdtPacked,
                       const std::vector<float> &uniformFieldValues);
   AsyncAdePTTransport(const AsyncAdePTTransport &other) = delete;
@@ -86,12 +83,7 @@ public:
   void AddTrack(int pdg, uint64_t trackId, uint64_t parentId, double energy, double x, double y, double z, double dirx,
                 double diry, double dirz, double globalTime, double localTime, double properTime, float weight,
                 unsigned short stepCounter, int threadId, unsigned int eventId, vecgeom::NavigationState &&state);
-  bool GetTrackInAllRegions() const { return fTrackInAllRegions; }
-  bool GetReturnAllSteps() const { return fReturnAllSteps; }
-  bool GetReturnFirstAndLastStep() const { return fReturnFirstAndLastStep; }
   int GetDebugLevel() const { return fDebugLevel; }
-  std::vector<std::string> const *GetGPURegionNames() { return fGPURegionNames; }
-  std::vector<std::string> const *GetCPURegionNames() { return fCPURegionNames; }
   /// @brief Handle the currently available returned GPU-hit batches for one thread and event.
   /// @details
   /// Transport retains ownership of the hit-buffer lifetime. For each available

--- a/src/AdePTConfiguration.cc
+++ b/src/AdePTConfiguration.cc
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include <AdePT/core/AdePTConfiguration.hh>
+#include <AdePT/integration/AdePTConfigurationMessenger.hh>
+
+#include <memory>
+
+AdePTConfiguration::AdePTConfiguration()
+    : fAdePTConfigurationMessenger(std::make_unique<AdePTConfigurationMessenger>(this))
+{
+}
+
+AdePTConfiguration::~AdePTConfiguration() = default;

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <AdePT/integration/AdePTTrackingManager.hh>
+#include <AdePT/core/AdePTTransportConfig.hh>
 #include <AdePT/integration/AdePTGeometryBridge.hh>
 
 #include "G4Threading.hh"
@@ -46,8 +47,40 @@ std::weak_ptr<AdePTTransport> &SharedAdePTTransportStorage()
   return transport;
 }
 
+AdePTTransportConfig MakeAdePTTransportConfig(const AdePTConfiguration &configuration)
+{
+  AdePTTransportConfig transportConfig;
+  transportConfig.adeptSeed       = configuration.GetAdePTSeed();
+  transportConfig.numThreads      = static_cast<unsigned short>(configuration.GetNumThreads());
+  transportConfig.trackCapacity   = static_cast<unsigned int>(1024 * 1024 * configuration.GetMillionsOfTrackSlots());
+  transportConfig.scoringCapacity = static_cast<unsigned int>(1024 * 1024 * configuration.GetMillionsOfHitSlots());
+  transportConfig.debugLevel      = configuration.GetVerbosity();
+  transportConfig.cudaStackLimit  = configuration.GetCUDAStackLimit();
+  transportConfig.cudaHeapLimit   = configuration.GetCUDAHeapLimit();
+  transportConfig.lastNParticlesOnCPU = configuration.GetLastNParticlesOnCPU();
+  transportConfig.maxWDTIter          = configuration.GetMaxWDTIter();
+  transportConfig.returnAllSteps      = configuration.GetCallUserSteppingAction();
+  transportConfig.returnFirstAndLastStep =
+      configuration.GetCallUserTrackingAction() || configuration.GetCallUserSteppingAction();
+  transportConfig.bfieldFile            = configuration.GetCovfieBfieldFile();
+  transportConfig.cpuCapacityFactor     = configuration.GetCPUCapacityFactor();
+  transportConfig.cpuCopyFraction       = configuration.GetHitBufferFlushThreshold();
+  transportConfig.hitBufferSafetyFactor = configuration.GetHitBufferSafetyFactor();
+  return transportConfig;
+}
+
+bool ReturnAllSteps(const AdePTConfiguration &configuration)
+{
+  return configuration.GetCallUserSteppingAction();
+}
+
+bool ReturnFirstAndLastStep(const AdePTConfiguration &configuration)
+{
+  return configuration.GetCallUserTrackingAction() || configuration.GetCallUserSteppingAction();
+}
+
 std::shared_ptr<AdePTTransport> GetSharedAdePTTransport(
-    AdePTConfiguration &conf, std::unique_ptr<AsyncAdePT::AdePTG4HepEmState> adeptG4HepEmState,
+    const AdePTTransportConfig &transportConfig, std::unique_ptr<AsyncAdePT::AdePTG4HepEmState> adeptG4HepEmState,
     adeptint::VolAuxData *auxData, const adeptint::WDTHostPacked &wdtPacked,
     const std::vector<float> &uniformFieldValues)
 {
@@ -61,9 +94,9 @@ std::shared_ptr<AdePTTransport> GetSharedAdePTTransport(
   // Create the shared AdePT transport engine on the first worker thread. At
   // this point all required host-side inputs have already been prepared, so the
   // transport constructor can perform the one-time device initialization.
-  auto created =
-      std::make_shared<AdePTTransport>(conf, std::move(adeptG4HepEmState), auxData, wdtPacked, uniformFieldValues);
-  transport = created;
+  auto created = std::make_shared<AdePTTransport>(transportConfig, std::move(adeptG4HepEmState), auxData, wdtPacked,
+                                                  uniformFieldValues);
+  transport    = created;
   return created;
 }
 
@@ -135,12 +168,13 @@ void AdePTTrackingManager::InitializeSharedAdePTTransport()
       auxData, adeptG4HepEmState->GetData(), fHepEmTrackingManager.get(), fAdePTConfiguration->GetTrackInAllRegions(),
       fAdePTConfiguration->GetGPURegionNames(), fAdePTConfiguration->GetDeadRegionNames(), wdtRaw);
   adeptint::WDTHostPacked wdtPacked = AdePTGeometryBridge::PackWDT(wdtRaw);
+  auto transportConfig              = MakeAdePTTransportConfig(*fAdePTConfiguration);
 
   // Move the fully prepared host-side package into the shared transport. The
   // first worker creates the transport here; later workers only retrieve the
   // already-created shared instance.
-  fAdeptTransport = GetSharedAdePTTransport(*fAdePTConfiguration, std::move(adeptG4HepEmState), auxData, wdtPacked,
-                                            uniformFieldValues);
+  fAdeptTransport =
+      GetSharedAdePTTransport(transportConfig, std::move(adeptG4HepEmState), auxData, wdtPacked, uniformFieldValues);
 }
 
 void AdePTTrackingManager::InitializeAdePT()
@@ -222,9 +256,11 @@ void AdePTTrackingManager::InitializeAdePT()
   fAdeptTransport = GetSharedAdePTTransport();
 
   // Initialize the GPU region list
+  const auto &gpuRegionNames = *fAdePTConfiguration->GetGPURegionNames();
+  const auto &cpuRegionNames = *fAdePTConfiguration->GetCPURegionNames();
   if (!fAdePTConfiguration->GetTrackInAllRegions()) {
     // Case 1: GPU regions are explicitly listed, and CPU regions must not overlap
-    for (const std::string &regionName : *(fAdeptTransport->GetGPURegionNames())) {
+    for (const std::string &regionName : gpuRegionNames) {
       G4Region *region = G4RegionStore::GetInstance()->GetRegion(regionName);
       if (!region) {
         G4Exception("AdePTTrackingManager", "Invalid parameter", FatalErrorInArgument,
@@ -232,7 +268,7 @@ void AdePTTrackingManager::InitializeAdePT()
       }
 
       // Check for conflict with CPURegionNames
-      for (const std::string &cpuRegionName : *(fAdeptTransport->GetCPURegionNames())) {
+      for (const std::string &cpuRegionName : cpuRegionNames) {
         if (regionName == cpuRegionName) {
           G4Exception("AdePTTrackingManager", "Conflicting region assignment", FatalErrorInArgument,
                       ("Region '" + regionName + "' is defined in both /adept/addGPURegion and /adept/removeGPURegion")
@@ -246,10 +282,8 @@ void AdePTTrackingManager::InitializeAdePT()
 
     fHepEmTrackingManager->SetTrackInAllRegions(false);
 
-  } else if (!fAdeptTransport->GetCPURegionNames()->empty()) {
+  } else if (!cpuRegionNames.empty()) {
     // Case 2: Track everywhere except explicitly listed CPU regions
-    const auto &cpuRegionNames = *(fAdeptTransport->GetCPURegionNames());
-
     // First mark all regions as GPU regions
     for (G4Region *region : *G4RegionStore::GetInstance()) {
       if (region) {
@@ -331,7 +365,7 @@ void AdePTTrackingManager::PreparePhysicsTable(const G4ParticleDefinition &part)
 
 void AdePTTrackingManager::HandOverOneTrack(G4Track *aTrack)
 {
-  if (fGPURegions.empty() && !fAdeptTransport->GetTrackInAllRegions()) {
+  if (fGPURegions.empty() && !fAdePTConfiguration->GetTrackInAllRegions()) {
     // if no GPU regions, hand over directly to G4HepEmTrackingManager
     fHepEmTrackingManager->HandOverOneTrack(aTrack);
     if (aTrack->GetTrackStatus() != fStopAndKill) {
@@ -365,7 +399,9 @@ void AdePTTrackingManager::FlushEvent()
   // skipped just because the worker observed that host-visible terminal state.
   ProcessReturnedGPUHits(threadId, eventId);
 
-  auto deferredSteps = fGeant4Integration.TakeDeferredSteps();
+  auto deferredSteps                = fGeant4Integration.TakeDeferredSteps();
+  const bool returnAllSteps         = ReturnAllSteps(*fAdePTConfiguration);
+  const bool returnFirstAndLastStep = ReturnFirstAndLastStep(*fAdePTConfiguration);
 
   std::sort(deferredSteps.steps.begin(), deferredSteps.steps.end(),
             [&deferredSteps](const AdePTGeant4Integration::DeferredStep &lhs,
@@ -376,11 +412,9 @@ void AdePTTrackingManager::FlushEvent()
   for (const auto &deferredStep : deferredSteps.steps) {
     std::span<const GPUHit> gpuSteps(deferredSteps.hits.data() + deferredStep.firstHit, deferredStep.numHits);
     if (deferredStep.type == AdePTGeant4Integration::DeferredStepType::ReturnTrack) {
-      fGeant4Integration.ReturnDeferredTrack(gpuSteps, fAdeptTransport->GetReturnAllSteps() ||
-                                                           fAdeptTransport->GetReturnFirstAndLastStep());
+      fGeant4Integration.ReturnDeferredTrack(gpuSteps, returnAllSteps || returnFirstAndLastStep);
     } else {
-      fGeant4Integration.ProcessGPUStep(gpuSteps, fAdeptTransport->GetReturnAllSteps(),
-                                        fAdeptTransport->GetReturnFirstAndLastStep());
+      fGeant4Integration.ProcessGPUStep(gpuSteps, returnAllSteps, returnFirstAndLastStep);
     }
   }
   fAdeptTransport->MarkHostFlushed(threadId);
@@ -388,6 +422,9 @@ void AdePTTrackingManager::FlushEvent()
 
 void AdePTTrackingManager::ProcessReturnedGPUHits(int threadId, int eventId)
 {
+  const bool returnAllSteps         = ReturnAllSteps(*fAdePTConfiguration);
+  const bool returnFirstAndLastStep = ReturnFirstAndLastStep(*fAdePTConfiguration);
+
   // Transport owns the hit-batch lifetime and calls this lambda once
   // for each currently available returned batch. This lambda provides the
   // Geant4-side step reconstruction for the current worker and event.
@@ -423,15 +460,14 @@ void AdePTTrackingManager::ProcessReturnedGPUHits(int threadId, int eventId)
            it->fStepLimProcessId == 3) ||
           it->fStepLimProcessId == kAdePTOutOfGPURegionProcess || it->fStepLimProcessId == kAdePTFinishOnCPUProcess;
       if (isDeferredStep) {
-        const bool returnTrackDirectly = CanReturnTrackDirectly(*it, blockSize, fAdeptTransport->GetReturnAllSteps());
+        const bool returnTrackDirectly = CanReturnTrackDirectly(*it, blockSize, returnAllSteps);
         fGeant4Integration.QueueDeferredStep(std::span<const GPUHit>(&*it, blockSize),
                                              returnTrackDirectly
                                                  ? AdePTGeant4Integration::DeferredStepType::ReturnTrack
                                                  : AdePTGeant4Integration::DeferredStepType::ReplayStep);
       } else {
-        fGeant4Integration.ProcessGPUStep(std::span<const GPUHit>(&*it, blockSize),
-                                          fAdeptTransport->GetReturnAllSteps(),
-                                          fAdeptTransport->GetReturnFirstAndLastStep());
+        fGeant4Integration.ProcessGPUStep(std::span<const GPUHit>(&*it, blockSize), returnAllSteps,
+                                          returnFirstAndLastStep);
       }
       it += blockSize;
     }
@@ -443,8 +479,8 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
   G4EventManager *eventManager       = G4EventManager::GetEventManager();
   G4TrackingManager *trackManager    = eventManager->GetTrackingManager();
   G4SteppingManager *steppingManager = trackManager->GetSteppingManager();
-  const bool trackInAllRegions       = fAdeptTransport->GetTrackInAllRegions();
-  const bool callUserActions         = fAdeptTransport->GetReturnFirstAndLastStep();
+  const bool trackInAllRegions       = fAdePTConfiguration->GetTrackInAllRegions();
+  const bool callUserActions         = ReturnFirstAndLastStep(*fAdePTConfiguration);
 
   const auto eventID = eventManager->GetConstCurrentEvent()->GetEventID();
 

--- a/src/AsyncAdePTTransport.cc
+++ b/src/AsyncAdePTTransport.cc
@@ -36,23 +36,18 @@ void FreeGPU(std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> 
 
 namespace AsyncAdePT {
 
-AsyncAdePTTransport::AsyncAdePTTransport(AdePTConfiguration &configuration,
+AsyncAdePTTransport::AsyncAdePTTransport(const AdePTTransportConfig &configuration,
                                          std::unique_ptr<AdePTG4HepEmState> adeptG4HepEmState,
                                          adeptint::VolAuxData *auxData, const adeptint::WDTHostPacked &wdtPacked,
                                          const std::vector<float> &uniformFieldValues)
-    : fAdePTSeed{configuration.GetAdePTSeed()}, fNThread{(ushort)configuration.GetNumThreads()},
-      fTrackCapacity{(uint)(1024 * 1024 * configuration.GetMillionsOfTrackSlots())},
-      fScoringCapacity{(uint)(1024 * 1024 * configuration.GetMillionsOfHitSlots())},
-      fDebugLevel{configuration.GetVerbosity()}, fCUDAStackLimit{configuration.GetCUDAStackLimit()},
-      fCUDAHeapLimit{configuration.GetCUDAHeapLimit()}, fLastNParticlesOnCPU{configuration.GetLastNParticlesOnCPU()},
-      fMaxWDTIter{configuration.GetMaxWDTIter()}, fAdePTG4HepEmState(std::move(adeptG4HepEmState)),
-      fEventStates(fNThread), fTrackInAllRegions{configuration.GetTrackInAllRegions()},
-      fGPURegionNames{configuration.GetGPURegionNames()}, fCPURegionNames{configuration.GetCPURegionNames()},
-      fReturnAllSteps{configuration.GetCallUserSteppingAction()},
-      fReturnFirstAndLastStep{configuration.GetCallUserTrackingAction() || configuration.GetCallUserSteppingAction()},
-      fBfieldFile{configuration.GetCovfieBfieldFile()}, fCPUCapacityFactor{configuration.GetCPUCapacityFactor()},
-      fCPUCopyFraction{configuration.GetHitBufferFlushThreshold()},
-      fHitBufferSafetyFactor{configuration.GetHitBufferSafetyFactor()}
+    : fAdePTSeed{configuration.adeptSeed}, fNThread{configuration.numThreads},
+      fTrackCapacity{configuration.trackCapacity}, fScoringCapacity{configuration.scoringCapacity},
+      fDebugLevel{configuration.debugLevel}, fCUDAStackLimit{configuration.cudaStackLimit},
+      fCUDAHeapLimit{configuration.cudaHeapLimit}, fLastNParticlesOnCPU{configuration.lastNParticlesOnCPU},
+      fMaxWDTIter{configuration.maxWDTIter}, fAdePTG4HepEmState(std::move(adeptG4HepEmState)), fEventStates(fNThread),
+      fReturnAllSteps{configuration.returnAllSteps}, fReturnFirstAndLastStep{configuration.returnFirstAndLastStep},
+      fBfieldFile{configuration.bfieldFile}, fCPUCapacityFactor{configuration.cpuCapacityFactor},
+      fCPUCopyFraction{configuration.cpuCopyFraction}, fHitBufferSafetyFactor{configuration.hitBufferSafetyFactor}
 {
   if (fNThread > kMaxThreads)
     throw std::invalid_argument("AsyncAdePTTransport limited to " + std::to_string(kMaxThreads) + " threads");


### PR DESCRIPTION
This PR is a leftover from #516:

It splits an `AdePTTransportConfig` used by `AsyncAdePTTransport` from the user-facing `AdePTConfiguration`.

Before,  the `AdePTConfiguration` was passed to the AdePTTransport, which pulls in the Geant4 UI messenger. Therefore, the AdePT::Transport library still used implicitly some Geant4 part, which it should not.

This if fixed by creating a small clean struct `AdePTTransportConfig`, which contains exactly the data needed by the transport which is captured from the user via the general `AdePTConfiguration`. 

Further changes:
- quite a few getters were constified.
- Some region and UserAction flags were moved from the Transport to the G4 integration, where they belong
- Moved `AdePTConfiguration` constructor/destructor out of the header, so the messenger is still created automatically but no longer included directly from the AdePTConfiguration header.