### PR TITLE
[mini] Allow exact-fit host buffer transfers

### DIFF
--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -602,7 +602,7 @@ public:
         transferSize += fBuffer.hostBufferCount[i];
       }
 
-      if (fBufferManager->getFreeContiguousMemory(transferSize) <= transferSize) {
+      if (fBufferManager->getFreeContiguousMemory(transferSize) < transferSize) {
         continue;
       }
 


### PR DESCRIPTION
Previously, the host-device transfer was rejected in case it was the exact free space, which should be allowed.

This mini PR fixes that
