### PR TITLE
Fix CPU-finish event thread id & factor out GetThreadId

### DIFF
--- a/include/AdePT/integration/AdePTThreadId.hh
+++ b/include/AdePT/integration/AdePTThreadId.hh
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ADEPT_THREAD_ID_HH
+#define ADEPT_THREAD_ID_HH
+
+#include "G4Threading.hh"
+
+namespace adept_integration {
+
+/// @brief Return the non-negative Geant4 worker slot used by AdePT per-thread host arrays.
+/// @details
+/// In sequential Geant4, `G4GetThreadId()` returns `MASTER_ID` (-1) or
+/// `SEQUENTIAL_ID` (-2). AdePT uses non-negative slot indices 0..N-1, so map
+/// any negative Geant4 thread id to slot 0.
+inline int GetThreadId()
+{
+  const auto tid = G4Threading::G4GetThreadId();
+  return (tid < 0) ? 0 : tid;
+}
+
+} // namespace adept_integration
+
+#endif

--- a/include/AdePT/integration/G4HepEmTrackingManagerSpecialized.hh
+++ b/include/AdePT/integration/G4HepEmTrackingManagerSpecialized.hh
@@ -37,7 +37,7 @@ public:
 
   void SetFinishEventOnCPU(int threadid, int eventid) { fFinishEventOnCPU[threadid] = eventid; }
 
-  int GetFinishEventOnCPU(int threadid) { return fFinishEventOnCPU[threadid]; }
+  int GetFinishEventOnCPU(int threadid) const { return fFinishEventOnCPU[threadid]; }
 
 private:
   bool fTrackInAllRegions = false;          ///< Whether the whole geometry is a GPU region

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -3,6 +3,7 @@
 
 #include <AdePT/integration/AdePTTrackingManager.hh>
 #include <AdePT/integration/AdePTGeometryBridge.hh>
+#include <AdePT/integration/AdePTThreadId.hh>
 
 #include "G4Threading.hh"
 #include "G4Track.hh"
@@ -28,14 +29,6 @@
 
 namespace {
 using AdePTTransport = AdePTTrackingManager::AdePTTransport;
-
-// In sequential Geant4, G4GetThreadId() returns MASTER_ID (-1) or SEQUENTIAL_ID (-2).
-// AdePT uses non-negative slot indices 0..N-1, so map any negative ID to slot 0.
-static inline int GetAdePTThreadId()
-{
-  auto tid = G4Threading::G4GetThreadId();
-  return (tid < 0) ? 0 : tid;
-}
 
 // Store only a weak reference here so the transport lifetime is still owned by
 // the thread-local AdePTTrackingManager instances. A static owning shared_ptr
@@ -349,7 +342,7 @@ void AdePTTrackingManager::FlushEvent()
   if (fVerbosity > 1)
     G4cout << "No more particles on the stack, triggering shower to flush the AdePT buffer." << G4endl;
 
-  auto threadId = GetAdePTThreadId();
+  auto threadId = adept_integration::GetThreadId();
   auto eventId  = G4EventManager::GetEventManager()->GetConstCurrentEvent()->GetEventID();
 
   // AdePTTrackingManager requests the flush while AdePTTransport still
@@ -449,7 +442,7 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
   const auto eventID = eventManager->GetConstCurrentEvent()->GetEventID();
 
   // Check for GPU steps, to alleviate pressure on the GPU step buffer
-  G4int threadId = GetAdePTThreadId();
+  G4int threadId = adept_integration::GetThreadId();
   ProcessReturnedGPUHits(threadId, eventID);
   auto &trackMapper = fGeant4Integration.GetHostTrackDataMapper();
 

--- a/src/G4HepEmTrackingManagerSpecialized.cc
+++ b/src/G4HepEmTrackingManagerSpecialized.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <AdePT/integration/G4HepEmTrackingManagerSpecialized.hh>
+#include <AdePT/integration/AdePTThreadId.hh>
 
 #include "G4Electron.hh"
 #include "G4Gamma.hh"
@@ -28,13 +29,14 @@ bool G4HepEmTrackingManagerSpecialized::CheckEarlyTrackingExit(G4Track *track, G
   // the current volume is not yet updated
   G4Region const *region = track->GetNextVolume()->GetLogicalVolume()->GetRegion();
 
-  G4int threadId = G4Threading::G4GetThreadId();
+  const auto threadId = adept_integration::GetThreadId();
 
   // TODO: for more efficient use, we only have to check for region within GPURegions, if the region changed.
   //       This can be checked from the pre- and post-steppoint
 
   // Not in the GPU region, continue normal tracking with G4HepEmTrackingManager
-  if ((!GetTrackInAllRegions() && fGPURegions.find(region) == fGPURegions.end()) || fFinishEventOnCPU[threadId] > 0) {
+  if ((!GetTrackInAllRegions() && fGPURegions.find(region) == fGPURegions.end()) ||
+      GetFinishEventOnCPU(threadId) >= 0) {
     return false; // Continue tracking with G4HepEmTrackingManager
   } else {
 


### PR DESCRIPTION
The check to finish an event on CPU was incorrect:
It was comparing > 0, (the default is -1 if the event is not finished on CPU), so event 0 could have not been finished on CPU.

Furthermore, the access to the vector via `G4Threading::G4GetThreadId();` was unsafe, as in sequential mode it can return a negative number. This was fixed  in #546 in most places of the code. Here, the AdePT helper `GetThreadId` is factored out and also used in the CPU event finish.