### PR TITLE
Rename returned GPU hits to GPU steps

### DIFF
--- a/include/AdePT/core/AdePTTransportConfig.hh
+++ b/include/AdePT/core/AdePTTransportConfig.hh
@@ -12,7 +12,7 @@ struct AdePTTransportConfig {
   uint64_t adeptSeed{1234567};
   unsigned short numThreads{0};
   unsigned int trackCapacity{0};
-  unsigned int scoringCapacity{0};
+  unsigned int stepCapacity{0};
   int debugLevel{0};
   int cudaStackLimit{0};
   int cudaHeapLimit{0};
@@ -23,7 +23,7 @@ struct AdePTTransportConfig {
   std::string bfieldFile{};
   double cpuCapacityFactor{2.5};
   double cpuCopyFraction{0.5};
-  double hitBufferSafetyFactor{1.5};
+  double stepBufferSafetyFactor{1.5};
 };
 
 #endif

--- a/include/AdePT/core/AsyncAdePTTransport.cuh
+++ b/include/AdePT/core/AsyncAdePTTransport.cuh
@@ -67,9 +67,9 @@ using SteppingAction = adept::SteppingAction::Action;
 
 using namespace AsyncAdePT;
 
-/// Communication with the hit processing thread.
-struct HitProcessingContext {
-  ADEPT_DEVICE_API_SYMBOL(Stream_t) hitTransferStream;
+/// Communication with the step processing thread.
+struct StepProcessingContext {
+  ADEPT_DEVICE_API_SYMBOL(Stream_t) stepTransferStream;
   std::condition_variable cv{};
   std::mutex mutex{};
   std::atomic_bool keepRunning = true;
@@ -286,8 +286,8 @@ __global__ void FinishIteration(AllParticleQueues all, Stats *stats, TracksAndSl
     }
   } else if (blockIdx.x == 2) {
     if (threadIdx.x == 0) {
-      // Note: hitBufferOccupancy gives the maximum occupancy of all threads combined
-      stats->hitBufferOccupancy = AsyncAdePT::gHitScoringBuffer_dev.GetMaxSlotCount();
+      // Note: stepBufferOccupancy gives the maximum occupancy of all threads combined
+      stats->stepBufferOccupancy = AsyncAdePT::gDeviceStepBuffer.GetMaxSlotCount();
     }
   }
 
@@ -548,7 +548,7 @@ void FreeWDTOnDevice(adeptint::WDTDeviceBuffers &dev)
 /// If successful, this will initialise the member fGPUState.
 /// If memory allocation fails, an exception is thrown. In this case, the caller has to
 /// try again after some wait time or with less transport slots.
-std::unique_ptr<GPUstate, GPUstateDeleter> InitializeGPU(int trackCapacity, int scoringCapacity, int numThreads,
+std::unique_ptr<GPUstate, GPUstateDeleter> InitializeGPU(int trackCapacity, int stepCapacity, int numThreads,
                                                          TrackBuffer &trackBuffer, double CPUCapacityFactor,
                                                          double CPUCopyFraction, std::string &generalBfieldFile,
                                                          const std::vector<float> &uniformBfieldValues)
@@ -691,7 +691,8 @@ std::unique_ptr<GPUstate, GPUstateDeleter> InitializeGPU(int trackCapacity, int 
   InitializeTrackDebug();
 #endif
 
-  gpuState.fHitScoring.reset(new HitScoring(scoringCapacity, numThreads, CPUCapacityFactor, CPUCopyFraction));
+  gpuState.fGPUStepTransferManager.reset(
+      new GPUStepTransferManager(stepCapacity, numThreads, CPUCapacityFactor, CPUCopyFraction));
 
   const auto injectQueueSize = adept::MParrayT<QueueIndexPair>::SizeOfInstance(trackBuffer.fNumToDevice);
   gpuMalloc(gpuPtr, injectQueueSize);
@@ -709,32 +710,32 @@ void AdvanceEventStates(EventState oldState, EventState newState, std::vector<st
   }
 }
 
-void HitProcessingLoop(HitProcessingContext *const context, GPUstate &gpuState,
-                       std::vector<std::atomic<EventState>> &eventStates, std::condition_variable &cvG4Workers,
-                       int debugLevel)
+void StepProcessingLoop(StepProcessingContext *const context, GPUstate &gpuState,
+                        std::vector<std::atomic<EventState>> &eventStates, std::condition_variable &cvG4Workers,
+                        int debugLevel)
 {
   while (context->keepRunning) {
     std::unique_lock lock(context->mutex);
     context->cv.wait(lock);
 
-    AdvanceEventStates(EventState::SwappingHitBuffers, EventState::FlushingHits, eventStates);
-    gpuState.fHitScoring->TransferHitsToHost(context->hitTransferStream);
-    const bool haveNewHits = gpuState.fHitScoring->ProcessHits(cvG4Workers, debugLevel);
+    AdvanceEventStates(EventState::SwappingStepBuffers, EventState::FlushingSteps, eventStates);
+    gpuState.fGPUStepTransferManager->TransferStepsToHost(context->stepTransferStream);
+    const bool haveNewSteps = gpuState.fGPUStepTransferManager->ProcessSteps(cvG4Workers, debugLevel);
 
-    if (haveNewHits) {
-      AdvanceEventStates(EventState::FlushingHits, EventState::HitsFlushed, eventStates);
+    if (haveNewSteps) {
+      AdvanceEventStates(EventState::FlushingSteps, EventState::StepsFlushed, eventStates);
     }
 
-    // Notify all even without newHits because the HitProcessingThread could have been woken up because the Event
+    // Notify all even without new steps because the StepProcessingThread could have been woken up because the Event
     // finished
     cvG4Workers.notify_all();
   }
 }
 
-void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, TrackBuffer &trackBuffer, GPUstate &gpuState,
+void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuffer &trackBuffer, GPUstate &gpuState,
                    std::vector<std::atomic<EventState>> &eventStates, std::condition_variable &cvG4Workers,
                    int adeptSeed, int debugLevel, bool returnAllSteps, bool returnLastStep,
-                   unsigned short lastNParticlesOnCPU, const double hitBufferSafetyFactor, bool hasWDTRegions)
+                   unsigned short lastNParticlesOnCPU, const double stepBufferSafetyFactor, bool hasWDTRegions)
 {
 
   using InjectState                             = GPUstate::InjectState;
@@ -747,15 +748,15 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
   ParticleQueues &woodcockQueues = gpuState.woodcockQueues;
 
   ADEPT_DEVICE_API_SYMBOL(Event_t) cudaEvent, cudaStatsEvent;
-  ADEPT_DEVICE_API_SYMBOL(Stream_t) hitTransferStream, injectStream, statsStream;
+  ADEPT_DEVICE_API_SYMBOL(Stream_t) stepTransferStream, injectStream, statsStream;
   ADEPT_DEVICE_API_CALL(EventCreateWithFlags(&cudaEvent, ADEPT_DEVICE_API_SYMBOL(EventDisableTiming)));
   ADEPT_DEVICE_API_CALL(EventCreateWithFlags(&cudaStatsEvent, ADEPT_DEVICE_API_SYMBOL(EventDisableTiming)));
   unique_ptr_cuda<ADEPT_DEVICE_API_SYMBOL(Event_t)> cudaEventCleanup{&cudaEvent};
   unique_ptr_cuda<ADEPT_DEVICE_API_SYMBOL(Event_t)> cudaStatsEventCleanup{&cudaStatsEvent};
-  ADEPT_DEVICE_API_CALL(StreamCreate(&hitTransferStream));
+  ADEPT_DEVICE_API_CALL(StreamCreate(&stepTransferStream));
   ADEPT_DEVICE_API_CALL(StreamCreate(&injectStream));
   ADEPT_DEVICE_API_CALL(StreamCreate(&statsStream));
-  unique_ptr_cuda<ADEPT_DEVICE_API_SYMBOL(Stream_t)> cudaStreamCleanup{&hitTransferStream};
+  unique_ptr_cuda<ADEPT_DEVICE_API_SYMBOL(Stream_t)> cudaStreamCleanup{&stepTransferStream};
   unique_ptr_cuda<ADEPT_DEVICE_API_SYMBOL(Stream_t)> cudaInjectStreamCleanup{&injectStream};
   unique_ptr_cuda<ADEPT_DEVICE_API_SYMBOL(Stream_t)> cudaStatsStreamCleanup{&statsStream};
   auto waitForOtherStream = [&cudaEvent](ADEPT_DEVICE_API_SYMBOL(Stream_t) waitingStream,
@@ -767,10 +768,10 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
   // default constructed stepping action parameters (different for CMS or LHCb)
   adept::SteppingAction::Params steppingActionParams;
 
-  std::unique_ptr<HitProcessingContext> hitProcessing{new HitProcessingContext{hitTransferStream}};
-  std::thread hitProcessingThread{&HitProcessingLoop,    (HitProcessingContext *)hitProcessing.get(),
-                                  std::ref(gpuState),    std::ref(eventStates),
-                                  std::ref(cvG4Workers), std::ref(debugLevel)};
+  std::unique_ptr<StepProcessingContext> stepProcessing{new StepProcessingContext{stepTransferStream}};
+  std::thread stepProcessingThread{&StepProcessingLoop,   (StepProcessingContext *)stepProcessing.get(),
+                                   std::ref(gpuState),    std::ref(eventStates),
+                                   std::ref(cvG4Workers), std::ref(debugLevel)};
 
   auto computeThreadsAndBlocks = [](unsigned int nParticles) -> std::pair<unsigned int, unsigned int> {
     constexpr int TransportThreads = 32;
@@ -803,7 +804,7 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
     unsigned int particlesInFlight[GPUQueueIndex::NumSpecies] = {1, 1, 1};
 
     auto needTransport = [](std::atomic<EventState> const &state) {
-      return state.load(std::memory_order_acquire) < EventState::HitsFlushed;
+      return state.load(std::memory_order_acquire) < EventState::StepsFlushed;
     };
     // Wait for work from G4 workers:
     while (gpuState.runTransport && std::none_of(eventStates.begin(), eventStates.end(), needTransport)) {
@@ -951,8 +952,9 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
       // *** ELECTRONS ***
       {
 
-        // wait for swapping of hit buffers
-        ADEPT_DEVICE_API_CALL(StreamWaitEvent(electrons.stream, gpuState.fHitScoring->getSwapDoneEvent(), 0));
+        // wait for swapping of step buffers
+        ADEPT_DEVICE_API_CALL(
+            StreamWaitEvent(electrons.stream, gpuState.fGPUStepTransferManager->getSwapDoneEvent(), 0));
 
         const auto [threads, blocks] = computeThreadsAndBlocks(particlesInFlight[GPUQueueIndex::Electron]);
 #ifdef ADEPT_USE_SPLIT_KERNELS
@@ -987,8 +989,9 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
       // *** POSITRONS ***
       {
 
-        // wait for swapping of hit buffers
-        ADEPT_DEVICE_API_CALL(StreamWaitEvent(positrons.stream, gpuState.fHitScoring->getSwapDoneEvent(), 0));
+        // wait for swapping of step buffers
+        ADEPT_DEVICE_API_CALL(
+            StreamWaitEvent(positrons.stream, gpuState.fGPUStepTransferManager->getSwapDoneEvent(), 0));
 
         const auto [threads, blocks] = computeThreadsAndBlocks(particlesInFlight[GPUQueueIndex::Positron]);
 #ifdef ADEPT_USE_SPLIT_KERNELS
@@ -1030,8 +1033,8 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
       // *** GAMMAS ***
       {
 
-        // wait for swapping of hit buffers
-        ADEPT_DEVICE_API_CALL(StreamWaitEvent(gammas.stream, gpuState.fHitScoring->getSwapDoneEvent(), 0));
+        // wait for swapping of step buffers
+        ADEPT_DEVICE_API_CALL(StreamWaitEvent(gammas.stream, gpuState.fGPUStepTransferManager->getSwapDoneEvent(), 0));
 
         const auto [threads, blocks] = computeThreadsAndBlocks(particlesInFlight[GPUQueueIndex::Gamma]);
 #ifdef ADEPT_USE_SPLIT_KERNELS
@@ -1133,13 +1136,13 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
             // Freeing of slots has to run exclusively
             // FIXME: Revise this code and make sure all three streams actually need to be synchronized
             // with gpuState.stream
-            waitForOtherStream(gpuState.stream, hitTransferStream);
+            waitForOtherStream(gpuState.stream, stepTransferStream);
             waitForOtherStream(gpuState.stream, injectStream);
             static_assert(gpuState.nSlotManager_dev == GPUQueueIndex::NumSpecies,
                           "The below launches assume there is a slot manager per particle type.");
             FreeSlots1<<<10, 256, 0, gpuState.stream>>>(gpuState.slotManager_dev + i);
             FreeSlots2<<<1, 1, 0, gpuState.stream>>>(gpuState.slotManager_dev + i);
-            waitForOtherStream(hitTransferStream, gpuState.stream);
+            waitForOtherStream(stepTransferStream, gpuState.stream);
             waitForOtherStream(injectStream, gpuState.stream);
           }
         }
@@ -1176,9 +1179,9 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
         for (unsigned short threadId = 0; threadId < numThreads; ++threadId) {
           const auto state = eventStates[threadId].load(std::memory_order_acquire);
           if (state == EventState::WaitingForTransportToFinish && gpuState.stats->perEventInFlight[threadId] == 0) {
-            eventStates[threadId] = EventState::RequestHitFlush;
+            eventStates[threadId] = EventState::RequestStepFlush;
           }
-          if (state >= EventState::RequestHitFlush && gpuState.stats->perEventInFlight[threadId] != 0) {
+          if (state >= EventState::RequestStepFlush && gpuState.stats->perEventInFlight[threadId] != 0) {
             // FIXME: this case should not happen and is related to some late injection that shows up too late in the
             // perEventInFlight for now, just reset state to WaitingForTransportToFinish and notify with a error message
             std::cerr << "ERROR thread " << threadId << " is in state " << static_cast<unsigned int>(state)
@@ -1188,84 +1191,87 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
           }
         }
 
-        // *** Hit management ***
+        // *** Step management ***
 
         // check the maximum number of tracks in flight per thread
         unsigned int maxInFlight =
             *std::max_element(gpuState.stats->perEventInFlight, gpuState.stats->perEventInFlight + numThreads);
 
-        // if there are more tracks in flight than the total HitCapacity, it could fail at any step!
-        // This is really dangerous and requires a larger hit capacity
-        if (1.2 * maxInFlight > gpuState.fHitScoring->HitCapacity() / numThreads)
-          std::cerr << "WARNING: particles in flight ( " << maxInFlight << " ) is close or above the HitCapacity ( "
-                    << gpuState.fHitScoring->HitCapacity() / numThreads
+        // if there are more tracks in flight than the total StepCapacity, it could fail at any step!
+        // This is really dangerous and requires a larger step capacity
+        if (1.2 * maxInFlight > gpuState.fGPUStepTransferManager->StepCapacity() / numThreads)
+          std::cerr << "WARNING: particles in flight ( " << maxInFlight << " ) is close or above the StepCapacity ( "
+                    << gpuState.fGPUStepTransferManager->StepCapacity() / numThreads
                     << " )! Must increase "
                        "/adept/setMillionsOfHitSlots or reduce /run/numberOfThreads!"
                     << std::endl;
 
-        // next step could fail because there are too tracks in flight. A track can cause multiple hits (one for each
-        // secondary and one for itself). The safety factor should be as low as possible to prevent stalling, but must
-        // be as high as needed to avoid crashes.
-        bool nextStepMightFail = gpuState.stats->hitBufferOccupancy + hitBufferSafetyFactor * maxInFlight >=
-                                 gpuState.fHitScoring->HitCapacity() / numThreads;
+        // next step could fail because there are too many tracks in flight. A track can cause multiple returned steps
+        // (one for itself and one for each secondary). The safety factor should be as low as possible to prevent
+        // stalling, but must be as high as needed to avoid crashes.
+        bool nextStepMightFail = gpuState.stats->stepBufferOccupancy + stepBufferSafetyFactor * maxInFlight >=
+                                 gpuState.fGPUStepTransferManager->StepCapacity() / numThreads;
 
-        if (!gpuState.fHitScoring->ReadyToSwapBuffers() && !nextStepMightFail) {
-          hitProcessing->cv.notify_one();
+        if (!gpuState.fGPUStepTransferManager->ReadyToSwapBuffers() && !nextStepMightFail) {
+          stepProcessing->cv.notify_one();
         } else {
 
           // if the next step might fail, one has to wait until the buffers are ready to swap again.
           if (nextStepMightFail) {
             // Wait until swap becomes available
-            std::cerr << "Warning: stalling transport loop because HitBuffers are overflowing: HitSlots left: "
-                      << (gpuState.fHitScoring->HitCapacity() / numThreads - gpuState.stats->hitBufferOccupancy)
+            std::cerr << "Warning: stalling transport loop because StepBuffers are overflowing: StepSlots left: "
+                      << (gpuState.fGPUStepTransferManager->StepCapacity() / numThreads -
+                          gpuState.stats->stepBufferOccupancy)
                       << " Max particles in flight: " << maxInFlight
-                      << "  | Waiting for HitBuffers to be freed by worker " << std::endl;
+                      << "  | Waiting for StepBuffers to be freed by worker " << std::endl;
 
             auto start = std::chrono::steady_clock::now();
-            while (!gpuState.fHitScoring->ReadyToSwapBuffers()) {
-              hitProcessing->cv.notify_one();
+            while (!gpuState.fGPUStepTransferManager->ReadyToSwapBuffers()) {
+              stepProcessing->cv.notify_one();
               std::this_thread::sleep_for(std::chrono::microseconds(100));
               // guard to avoid infinite stalls
               auto now = std::chrono::steady_clock::now();
               if (std::chrono::duration_cast<std::chrono::seconds>(now - start).count() > 5) {
-                std::cerr << "Error: Timed out waiting for hit buffer to become available.\n";
+                std::cerr << "Error: Timed out waiting for step buffer to become available.\n";
                 std::terminate();
               }
             }
             if (debugLevel >= 3) {
-              std::cerr << "Hit buffers freed, resuming with swapping of the buffers " << std::endl;
+              std::cerr << "Step buffers freed, resuming with swapping of the buffers " << std::endl;
             }
           }
 
-          if (gpuState.stats->hitBufferOccupancy >= gpuState.fHitScoring->HitCapacity() / numThreads / 2 ||
-              gpuState.stats->hitBufferOccupancy >= 10000 || nextStepMightFail ||
+          if (gpuState.stats->stepBufferOccupancy >=
+                  gpuState.fGPUStepTransferManager->StepCapacity() / numThreads / 2 ||
+              gpuState.stats->stepBufferOccupancy >= 10000 || nextStepMightFail ||
               std::any_of(eventStates.begin(), eventStates.end(), [](const auto &state) {
-                return state.load(std::memory_order_acquire) == EventState::RequestHitFlush;
+                return state.load(std::memory_order_acquire) == EventState::RequestStepFlush;
               })) {
-            // Reset hitBufferOccupancy to 0 when we swap, as the delay of updating it could cause another unwanted swap
+            // Reset stepBufferOccupancy to 0 when we swap, as the delay of updating it could cause another unwanted
+            // swap
             ADEPT_DEVICE_API_CALL(
-                MemsetAsync(&(gpuState.stats_dev->hitBufferOccupancy), 0, sizeof(unsigned int), gpuState.stream));
-            gpuState.fHitScoring->SwapDeviceBuffers(gpuState.stream);
-            AdvanceEventStates(EventState::RequestHitFlush, EventState::SwappingHitBuffers, eventStates);
-            hitProcessing->cv.notify_one();
+                MemsetAsync(&(gpuState.stats_dev->stepBufferOccupancy), 0, sizeof(unsigned int), gpuState.stream));
+            gpuState.fGPUStepTransferManager->SwapDeviceBuffers(gpuState.stream);
+            AdvanceEventStates(EventState::RequestStepFlush, EventState::SwappingStepBuffers, eventStates);
+            stepProcessing->cv.notify_one();
           }
         }
 
-        // A flush request can also arrive after all returned hit batches have
+        // A flush request can also arrive after all returned step batches have
         // already been drained on the host. In that case there is nothing left
         // to swap, but the worker still needs a terminal host-visible state.
-        if (gpuState.stats->hitBufferOccupancy == 0 && gpuState.fHitScoring->ReadyToSwapBuffers()) {
-          AdvanceEventStates(EventState::RequestHitFlush, EventState::HitsFlushed, eventStates);
+        if (gpuState.stats->stepBufferOccupancy == 0 && gpuState.fGPUStepTransferManager->ReadyToSwapBuffers()) {
+          AdvanceEventStates(EventState::RequestStepFlush, EventState::StepsFlushed, eventStates);
         }
       }
 
       // *** Notify G4 workers if their events completed ***
       if (std::any_of(eventStates.begin(), eventStates.end(), [](const std::atomic<EventState> &state) {
-            return state.load(std::memory_order_acquire) >= EventState::HitsFlushed;
+            return state.load(std::memory_order_acquire) >= EventState::StepsFlushed;
           })) {
-        // Notify HitProcessingThread to notify the workers. Do not notify workers directly, as this could bypass the
-        // processing of hits
-        hitProcessing->cv.notify_one();
+        // Notify StepProcessingThread to notify the workers. Do not notify workers directly, as this could bypass the
+        // processing of steps
+        stepProcessing->cv.notify_one();
       }
 
       if (debugLevel >= 3 && inFlight > 0 || (debugLevel >= 2 && iteration % 500 == 0)) {
@@ -1282,10 +1288,10 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
         std::cerr << "\t slots [e-, e+, gamma]: [" << gpuState.stats->slotFillLevel[0] << ", "
                   << gpuState.stats->slotFillLevel[1] << ", " << gpuState.stats->slotFillLevel[2] << "]"
                   << "\tInjectState: " << static_cast<unsigned int>(gpuState.injectState.load())
-                  << "\tHitBuffer: " << gpuState.stats->hitBufferOccupancy
-                  << "\tHitBufferReadyToSwap: " << gpuState.fHitScoring->ReadyToSwapBuffers();
-        gpuState.fHitScoring->PrintHostBufferState();
-        gpuState.fHitScoring->PrintDeviceBufferStates();
+                  << "\tStepBuffer: " << gpuState.stats->stepBufferOccupancy
+                  << "\tStepBufferReadyToSwap: " << gpuState.fGPUStepTransferManager->ReadyToSwapBuffers();
+        gpuState.fGPUStepTransferManager->PrintHostBufferState();
+        gpuState.fGPUStepTransferManager->PrintDeviceBufferStates();
         if (debugLevel >= 4) {
           std::cerr << "\tper event: ";
           for (unsigned int i = 0; i < numThreads; ++i) {
@@ -1335,38 +1341,38 @@ void TransportLoop(int trackCapacity, int scoringCapacity, int numThreads, Track
     if (debugLevel > 2) std::cout << "End transport loop.\n";
   }
 
-  hitProcessing->keepRunning = false;
-  hitProcessing->cv.notify_one();
-  hitProcessingThread.join();
+  stepProcessing->keepRunning = false;
+  stepProcessing->cv.notify_one();
+  stepProcessingThread.join();
 }
 
-std::pair<GPUHit *, GPUHit *> GetGPUHitsFromBuffer(unsigned int threadId, unsigned int eventId, GPUstate &gpuState,
-                                                   bool &dataOnBuffer)
+std::pair<GPUStep *, GPUStep *> GetGPUStepBatchFromBuffer(unsigned int threadId, unsigned int eventId,
+                                                          GPUstate &gpuState, bool &dataOnBuffer)
 {
-  HitQueueItem *hitItem = gpuState.fHitScoring->GetNextHitsHandle(threadId, dataOnBuffer);
-  if (hitItem) {
-    return {hitItem->begin, hitItem->end};
+  GPUStepBatch *stepBatch = gpuState.fGPUStepTransferManager->GetNextStepBatch(threadId, dataOnBuffer);
+  if (stepBatch) {
+    return {stepBatch->begin, stepBatch->end};
   } else {
     return {nullptr, nullptr};
   }
 }
 
-void CloseGPUBuffer(unsigned int threadId, GPUstate &gpuState, GPUHit *begin, const bool dataOnBuffer)
+void CloseGPUStepBatch(unsigned int threadId, GPUstate &gpuState, GPUStep *begin, const bool dataOnBuffer)
 {
-  gpuState.fHitScoring->CloseHitsHandle(threadId, begin, dataOnBuffer);
+  gpuState.fGPUStepTransferManager->CloseStepBatch(threadId, begin, dataOnBuffer);
 }
 
 // TODO: Make it clear that this will initialize and return the GPUState or make a
 // separate init function that will compile here and be called from the .icc
-std::thread LaunchGPUWorker(int trackCapacity, int scoringCapacity, int numThreads, TrackBuffer &trackBuffer,
+std::thread LaunchGPUWorker(int trackCapacity, int stepCapacity, int numThreads, TrackBuffer &trackBuffer,
                             GPUstate &gpuState, std::vector<std::atomic<EventState>> &eventStates,
                             std::condition_variable &cvG4Workers, int adeptSeed, int debugLevel, bool returnAllSteps,
-                            bool returnLastStep, unsigned short lastNParticlesOnCPU, const double hitBufferSafetyFactor,
-                            bool hasWDTRegions)
+                            bool returnLastStep, unsigned short lastNParticlesOnCPU,
+                            const double stepBufferSafetyFactor, bool hasWDTRegions)
 {
   return std::thread{&TransportLoop,
                      trackCapacity,
-                     scoringCapacity,
+                     stepCapacity,
                      numThreads,
                      std::ref(trackBuffer),
                      std::ref(gpuState),
@@ -1377,7 +1383,7 @@ std::thread LaunchGPUWorker(int trackCapacity, int scoringCapacity, int numThrea
                      returnAllSteps,
                      returnLastStep,
                      lastNParticlesOnCPU,
-                     hitBufferSafetyFactor,
+                     stepBufferSafetyFactor,
                      hasWDTRegions};
 }
 

--- a/include/AdePT/core/AsyncAdePTTransport.hh
+++ b/include/AdePT/core/AsyncAdePTTransport.hh
@@ -13,7 +13,7 @@
 #include <AdePT/core/AsyncAdePTTransportStruct.hh>
 #include <AdePT/core/AdePTTransportConfig.hh>
 #include <AdePT/core/GeometryAuxData.hh>
-#include <AdePT/core/ScoringCommons.hh>
+#include <AdePT/core/GPUStep.hh>
 
 #include <VecGeom/base/Config.h>
 #include <VecGeom/management/CudaManager.h> // forward declares vecgeom::cxx::VPlacedVolume
@@ -38,7 +38,7 @@ public:
 private:
   unsigned short fNThread{0};             ///< Number of G4 workers
   unsigned int fTrackCapacity{0};         ///< Number of track slots to allocate on device
-  unsigned int fScoringCapacity{0};       ///< Number of hit slots to allocate on device
+  unsigned int fStepCapacity{0};          ///< Number of step slots to allocate on device
   int fDebugLevel{0};                     ///< Debug level
   int fCUDAStackLimit{0};                 ///< CUDA device stack limit
   int fCUDAHeapLimit{0};                  ///< CUDA device heap limit
@@ -59,12 +59,11 @@ private:
   bool fReturnFirstAndLastStep = false;
   std::string fBfieldFile{""}; ///< Path to magnetic field file (in the covfie format)
   double fCPUCapacityFactor{
-      2.5}; ///< Factor by which the ScoringCapacity on Host is larger than on Device. Must be at least 2
-  ///< Filling fraction of the ScoringCapacity on host when the hits are copied out and not taken directly by the
-  ///< G4workers
+      2.5}; ///< Factor by which the host step buffer is larger than the device step buffer. Must be at least 2
+  ///< Filling fraction of the host step buffer when the steps are copied out and not taken directly by the G4 workers
   double fCPUCopyFraction{0.5};
-  ///< Needed to stall the GPU, in case the nPartInFlight * fHitBufferSafetyFactor > available HitSlots
-  double fHitBufferSafetyFactor{1.5};
+  ///< Needed to stall the GPU, in case the nPartInFlight * fStepBufferSafetyFactor > available StepSlots
+  double fStepBufferSafetyFactor{1.5};
 
   void Initialize(adeptint::VolAuxData *auxData, const adeptint::WDTHostPacked &wdtPacked,
                   const std::vector<float> &uniformFieldValues);
@@ -84,22 +83,22 @@ public:
                 double diry, double dirz, double globalTime, double localTime, double properTime, float weight,
                 unsigned short stepCounter, int threadId, unsigned int eventId, vecgeom::NavigationState &&state);
   int GetDebugLevel() const { return fDebugLevel; }
-  /// @brief Handle the currently available returned GPU-hit batches for one thread and event.
+  /// @brief Handle the currently available returned GPU-step batches for one thread and event.
   /// @details
-  /// Transport retains ownership of the hit-buffer lifetime. For each available
-  /// batch, `callback` is invoked with a `std::span<const GPUHit>` view and the
+  /// Transport retains ownership of the step-buffer lifetime. For each available
+  /// batch, `callback` is invoked with a `std::span<const GPUStep>` view and the
   /// batch is released again when the callback returns.
   ///
   /// In this code path, the callback is the `AdePTTrackingManager` logic that
-  /// reconstructs Geant4 steps from the returned GPU hits.
+  /// reconstructs Geant4 steps from the returned GPU steps.
   template <typename Callback>
-  void HandleReturnedGPUHitBatchesWith(int threadId, int eventId, Callback &&callback);
+  void HandleGPUStepBatchesWith(int threadId, int eventId, Callback &&callback);
   /// @brief Request that the device flush all pending work for the given worker.
   void RequestFlush(int threadId);
   /// @brief Wait until the transport threads make further flush progress.
   void WaitForFlushProgress();
-  /// @brief Check whether all returned GPU-hit batches have been made available on the host.
-  bool IsHitsFlushed(int threadId) const;
+  /// @brief Check whether all returned GPU-step batches have been made available on the host.
+  bool AreReturnedStepsFlushed(int threadId) const;
   /// @brief Mark the worker event as fully handled on the host side after replaying the returned steps.
   void MarkHostFlushed(int threadId);
 };

--- a/include/AdePT/core/AsyncAdePTTransport.icc
+++ b/include/AdePT/core/AsyncAdePTTransport.icc
@@ -3,37 +3,37 @@
 
 #include <AdePT/core/AsyncAdePTTransport.hh>
 
-/// Forward declarations for the transport-owned hit-batch accessors that remain
-/// header-visible because `HandleReturnedGPUHitBatchesWith(...)` is templated.
+/// Forward declarations for the transport-owned step-batch accessors that remain
+/// header-visible because `HandleGPUStepBatchesWith(...)` is templated.
 namespace async_adept_impl {
-std::pair<GPUHit *, GPUHit *> GetGPUHitsFromBuffer(unsigned int, unsigned int, AsyncAdePT::GPUstate &, bool &);
-void CloseGPUBuffer(unsigned int, AsyncAdePT::GPUstate &, GPUHit *, const bool);
+std::pair<GPUStep *, GPUStep *> GetGPUStepBatchFromBuffer(unsigned int, unsigned int, AsyncAdePT::GPUstate &, bool &);
+void CloseGPUStepBatch(unsigned int, AsyncAdePT::GPUstate &, GPUStep *, const bool);
 } // namespace async_adept_impl
 
 namespace AsyncAdePT {
 
 template <typename Callback>
-inline void AsyncAdePTTransport::HandleReturnedGPUHitBatchesWith(int threadId, int eventId, Callback &&callback)
+inline void AsyncAdePTTransport::HandleGPUStepBatchesWith(int threadId, int eventId, Callback &&callback)
 {
-  std::pair<GPUHit *, GPUHit *> range;
+  std::pair<GPUStep *, GPUStep *> range;
   bool dataOnBuffer;
 
-  while ((range = async_adept_impl::GetGPUHitsFromBuffer(threadId, eventId, *fGPUstate, dataOnBuffer)).first !=
+  while ((range = async_adept_impl::GetGPUStepBatchFromBuffer(threadId, eventId, *fGPUstate, dataOnBuffer)).first !=
          nullptr) {
-    // Transport still owns the hit-batch lifetime here. The callback only gets
+    // Transport still owns the step-batch lifetime here. The callback only gets
     // a temporary `std::span` view while the batch is valid.
-    struct CloseGPUHitBatch {
+    struct CloseGPUStepBatch {
       int threadId;
       GPUstate &gpuState;
-      GPUHit *begin;
+      GPUStep *begin;
       bool dataOnBuffer;
-      ~CloseGPUHitBatch() { async_adept_impl::CloseGPUBuffer(threadId, gpuState, begin, dataOnBuffer); }
+      ~CloseGPUStepBatch() { async_adept_impl::CloseGPUStepBatch(threadId, gpuState, begin, dataOnBuffer); }
     } closeBatch{threadId, *fGPUstate, range.first, dataOnBuffer};
 
-    // The callback runs the Geant4-side hit reconstruction for this batch.
+    // The callback runs the Geant4-side step reconstruction for this batch.
     // When it returns, `closeBatch` goes out of scope and releases the batch
     // back to transport automatically.
-    callback(std::span<const GPUHit>(range.first, range.second));
+    callback(std::span<const GPUStep>(range.first, range.second));
   }
 }
 

--- a/include/AdePT/core/AsyncAdePTTransportStruct.cuh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.cuh
@@ -131,7 +131,7 @@ dynamic allocations
 /// @brief Named array-index enum for the per-species GPU state arrays in @ref SpeciesState.
 ///
 /// Carries the three physical species plus Woodcock-tracking sentinels (GammaWDT,
-/// NumParticleQueues).  For physics data (hits, scoring) use the free @ref ParticleType
+/// NumParticleQueues).  For physics data (steps, tracks) use the free @ref ParticleType
 /// enum class instead; a static_assert below guarantees the numeric values stay in sync.
 enum GPUQueueIndex {
   Electron = 0,
@@ -211,7 +211,7 @@ struct Stats {
   float slotFillLevel[GPUQueueIndex::NumSpecies];
   unsigned int perEventInFlight[kMaxThreads];         // Updated asynchronously
   unsigned int perEventInFlightPrevious[kMaxThreads]; // Used in transport kernels
-  unsigned int hitBufferOccupancy;
+  unsigned int stepBufferOccupancy;
 };
 
 /// Host-only counters accumulating transport-loop stop/stall/flush action reasons across the full run.
@@ -221,12 +221,12 @@ struct TransportLoopCounters {
   unsigned long long leakExtractionByQueuePressure{0}; ///< Iterations where leak queue exceeded 50% threshold
   unsigned long long leakExtractionByEventFlush{0};    ///< Iterations where an event flush requested leak extraction
   unsigned long long leakExtractionBlocked{0};         ///< Times transport stalled waiting for in-progress extraction
-  unsigned long long eventDrainedToHitFlush{0};        ///< Events that transitioned to RequestHitFlush (queues drained)
-  unsigned long long hitBufferSwaps{0};                ///< Total hit-buffer swaps performed
-  unsigned long long hitBufferSwapByOccupancy{0};      ///< Swaps triggered by occupancy >= half capacity
-  unsigned long long hitBufferSwapByOccupancy10k{0};   ///< Swaps triggered by occupancy >= 10000
-  unsigned long long hitBufferSwapByPressure{0};       ///< Swaps triggered by nextStepMightFail (overflow risk)
-  unsigned long long hitBufferSwapByEventFlush{0};     ///< Swaps triggered by event RequestHitFlush
+  unsigned long long eventDrainedToStepFlush{0};      ///< Events that transitioned to RequestStepFlush (queues drained)
+  unsigned long long stepBufferSwaps{0};              ///< Total step-buffer swaps performed
+  unsigned long long stepBufferSwapByOccupancy{0};    ///< Swaps triggered by occupancy >= half capacity
+  unsigned long long stepBufferSwapByOccupancy10k{0}; ///< Swaps triggered by occupancy >= 10000
+  unsigned long long stepBufferSwapByPressure{0};     ///< Swaps triggered by nextStepMightFail (overflow risk)
+  unsigned long long stepBufferSwapByEventFlush{0};   ///< Swaps triggered by event RequestStepFlush
 };
 
 /// @brief Array of flags whether the event can be finished off
@@ -272,7 +272,7 @@ struct GPUstate {
   Stats *stats_dev{nullptr}; ///< statistics object pointer on device
   Stats *stats{nullptr};     ///< statistics object pointer on host
 
-  std::unique_ptr<HitScoring> fHitScoring;
+  std::unique_ptr<GPUStepTransferManager> fGPUStepTransferManager;
 
   adept::MParrayT<QueueIndexPair> *injectionQueue;
 

--- a/include/AdePT/core/AsyncAdePTTransportStruct.hh
+++ b/include/AdePT/core/AsyncAdePTTransportStruct.hh
@@ -22,10 +22,10 @@ enum class EventState : unsigned char {
   InjectionCompleted,
   Transporting,
   WaitingForTransportToFinish,
-  RequestHitFlush,
-  SwappingHitBuffers,
-  FlushingHits,
-  HitsFlushed,
+  RequestStepFlush,
+  SwappingStepBuffers,
+  FlushingSteps,
+  StepsFlushed,
   DeviceFlushed
 };
 

--- a/include/AdePT/core/GPUStep.hh
+++ b/include/AdePT/core/GPUStep.hh
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2024 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-// This file contains elements that can be shared between several scoring implementations
+// This file contains the step data returned from GPU transport to the host.
 
-#ifndef SCORING_COMMONS_HH
-#define SCORING_COMMONS_HH
+#ifndef ADEPT_GPU_STEP_HH
+#define ADEPT_GPU_STEP_HH
 
 #include <AdePT/core/ParticleTypes.hh>
 #include "VecGeom/navigation/NavigationState.h"
@@ -17,9 +17,8 @@ struct GPUStepPoint {
   vecgeom::NavigationState fNavigationState{0}; // VecGeom navigation state, used to identify the touchable
 };
 
-// Stores the necessary data to reconstruct GPU hits on the host , and
-// call the user-defined Geant4 sensitive detector code
-struct GPUHit {
+// Stores the data needed to reconstruct a Geant4 step on the host.
+struct GPUStep {
   // Data needed to reconstruct pre-post step points
   GPUStepPoint fPreStepPoint;
   GPUStepPoint fPostStepPoint;
@@ -41,7 +40,7 @@ struct GPUHit {
   ParticleType fParticleType{ParticleType::Electron};
   unsigned char fNumSecondaries{0};
 
-  bool operator<(GPUHit const &other) const
+  bool operator<(GPUStep const &other) const
   {
     const auto pdgFromParticleType = [](ParticleType particleType) {
       switch (particleType) {
@@ -82,7 +81,7 @@ struct GPUHit {
   }
 };
 
-/// @brief AdePT-specific step-limiting process ids stored in GPUHit::fStepLimProcessId.
+/// @brief AdePT-specific step-limiting process ids stored in GPUStep::fStepLimProcessId.
 constexpr short kAdePTTransportationProcess = 10;
 /// @brief Returned step for a track that leaves the GPU region and continues on the CPU.
 constexpr short kAdePTOutOfGPURegionProcess = 11;
@@ -108,9 +107,9 @@ __device__ __forceinline__ void Copy3DVector(vecgeom::Vector3D<double> const &so
   destination.z() = source.z();
 };
 
-/// @brief Fill the provided hit with the given data
-__device__ __forceinline__ void FillHit(
-    GPUHit &aGPUHit, uint64_t aTrackID, uint64_t aParentID, short aStepLimProcessId, ParticleType aParticleType,
+/// @brief Fill the provided GPU step with the given data
+__device__ __forceinline__ void FillGPUStep(
+    GPUStep &aGPUStep, uint64_t aTrackID, uint64_t aParentID, short aStepLimProcessId, ParticleType aParticleType,
     double aStepLength, double aTotalEnergyDeposit, float aTrackWeight, vecgeom::NavigationState const &aPreState,
     vecgeom::Vector3D<double> const &aPrePosition, vecgeom::Vector3D<double> const &aPreMomentumDirection,
     double aPreEKin, vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<double> const &aPostPosition,
@@ -118,34 +117,34 @@ __device__ __forceinline__ void FillHit(
     float aProperTime, double aPreGlobalTime, unsigned int eventID, short threadID, bool isLastStep,
     unsigned short stepCounter, unsigned char aNumSecondaries)
 {
-  aGPUHit.fEventId = eventID;
-  aGPUHit.threadId = threadID;
+  aGPUStep.fEventId = eventID;
+  aGPUStep.threadId = threadID;
 
-  aGPUHit.fStepCounter     = stepCounter;
-  aGPUHit.fLastStepOfTrack = isLastStep;
+  aGPUStep.fStepCounter     = stepCounter;
+  aGPUStep.fLastStepOfTrack = isLastStep;
   // Fill the required data
-  aGPUHit.fTrackID            = aTrackID;
-  aGPUHit.fParentID           = aParentID;
-  aGPUHit.fStepLimProcessId   = aStepLimProcessId;
-  aGPUHit.fParticleType       = aParticleType;
-  aGPUHit.fStepLength         = aStepLength;
-  aGPUHit.fTotalEnergyDeposit = aTotalEnergyDeposit;
-  aGPUHit.fTrackWeight        = aTrackWeight;
-  aGPUHit.fGlobalTime         = aGlobalTime;
-  aGPUHit.fLocalTime          = aLocalTime;
-  aGPUHit.fProperTime         = aProperTime;
-  aGPUHit.fPreGlobalTime      = aPreGlobalTime;
-  aGPUHit.fNumSecondaries     = aNumSecondaries;
+  aGPUStep.fTrackID            = aTrackID;
+  aGPUStep.fParentID           = aParentID;
+  aGPUStep.fStepLimProcessId   = aStepLimProcessId;
+  aGPUStep.fParticleType       = aParticleType;
+  aGPUStep.fStepLength         = aStepLength;
+  aGPUStep.fTotalEnergyDeposit = aTotalEnergyDeposit;
+  aGPUStep.fTrackWeight        = aTrackWeight;
+  aGPUStep.fGlobalTime         = aGlobalTime;
+  aGPUStep.fLocalTime          = aLocalTime;
+  aGPUStep.fProperTime         = aProperTime;
+  aGPUStep.fPreGlobalTime      = aPreGlobalTime;
+  aGPUStep.fNumSecondaries     = aNumSecondaries;
   // Pre step point
-  aGPUHit.fPreStepPoint.fNavigationState = aPreState;
-  Copy3DVector(aPrePosition, aGPUHit.fPreStepPoint.fPosition);
-  Copy3DVector(aPreMomentumDirection, aGPUHit.fPreStepPoint.fMomentumDirection);
-  aGPUHit.fPreStepPoint.fEKin = aPreEKin;
+  aGPUStep.fPreStepPoint.fNavigationState = aPreState;
+  Copy3DVector(aPrePosition, aGPUStep.fPreStepPoint.fPosition);
+  Copy3DVector(aPreMomentumDirection, aGPUStep.fPreStepPoint.fMomentumDirection);
+  aGPUStep.fPreStepPoint.fEKin = aPreEKin;
   // Post step point
-  aGPUHit.fPostStepPoint.fNavigationState = aPostState;
-  Copy3DVector(aPostPosition, aGPUHit.fPostStepPoint.fPosition);
-  Copy3DVector(aPostMomentumDirection, aGPUHit.fPostStepPoint.fMomentumDirection);
-  aGPUHit.fPostStepPoint.fEKin = aPostEKin;
+  aGPUStep.fPostStepPoint.fNavigationState = aPostState;
+  Copy3DVector(aPostPosition, aGPUStep.fPostStepPoint.fPosition);
+  Copy3DVector(aPostMomentumDirection, aGPUStep.fPostStepPoint.fMomentumDirection);
+  aGPUStep.fPostStepPoint.fEKin = aPostEKin;
 };
 
 #endif

--- a/include/AdePT/core/ParticleTypes.hh
+++ b/include/AdePT/core/ParticleTypes.hh
@@ -6,7 +6,7 @@
 
 /// @brief Strongly-typed enum for the three EM particle species tracked by AdePT.
 ///
-/// Used in GPUHit, SecondaryInitData, HostTrackData, and anywhere a step or track
+/// Used in GPUStep, SecondaryInitData, HostTrackData, and anywhere a step or track
 /// needs to carry its particle species as data.
 ///
 /// Note: The numeric values (0, 1, 2) intentionally match `GPUQueueIndex`
@@ -14,7 +14,7 @@
 /// state arrays. Both enums represent the same three species, but
 /// `GPUQueueIndex` also carries `NumSpecies` / `GammaWDT` /
 /// `NumParticleQueues` sentinels for loop bounds and array sizing.
-/// Use `ParticleType` for physics data (hits, tracks, scoring); use
+/// Use `ParticleType` for physics data (steps, tracks); use
 /// `GPUQueueIndex::{Electron,Positron,Gamma}` for GPU state array indexing.
 /// A static_assert in `AsyncAdePTTransportStruct.cuh` guarantees the values
 /// stay in sync.

--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -5,7 +5,7 @@
 #define PER_EVENT_SCORING_CUH
 
 #include <AdePT/base/ResourceManagement.cuh>
-#include <AdePT/core/ScoringCommons.hh>
+#include <AdePT/core/GPUStep.hh>
 #include <AdePT/copcore/Global.h>
 
 #include <VecGeom/navigation/NavigationState.h>
@@ -27,15 +27,15 @@
 #define BOLD_BLUE "\033[1;34m"
 
 // Comparison for sorting tracks into events on device:
-struct CompareGPUHits {
-  __device__ bool operator()(const GPUHit &lhs, const GPUHit &rhs) const { return lhs.threadId < rhs.threadId; }
+struct CompareGPUSteps {
+  __device__ bool operator()(const GPUStep &lhs, const GPUStep &rhs) const { return lhs.threadId < rhs.threadId; }
 };
 
 namespace AsyncAdePT {
 
-/// Struct holding GPU hits to be used both on host and device.
-struct HitScoringBuffer {
-  GPUHit *hitBuffer_dev      = nullptr;
+/// Struct holding GPU steps to be used both on host and device.
+struct DeviceStepBufferView {
+  GPUStep *stepBuffer_dev    = nullptr;
   unsigned int *fSlotCounter = nullptr; // Array of per-thread counters
   unsigned int fNSlot        = 0;
   unsigned int fNThreads     = 0;
@@ -49,70 +49,71 @@ struct HitScoringBuffer {
     return maxVal;
   }
 
-  __device__ unsigned int ReserveHitSlots(unsigned int threadId, unsigned int nSlots)
+  __device__ unsigned int ReserveStepSlots(unsigned int threadId, unsigned int nSlots)
   {
     const auto slotStartIndex = atomicAdd(&fSlotCounter[threadId], nSlots);
     if (slotStartIndex + nSlots > fNSlot) {
-      printf("Trying to score hit #%d with only %d slots\n", slotStartIndex, fNSlot);
-      COPCORE_EXCEPTION("Out of slots in HitScoringBuffer::NextSlot");
+      printf("Trying to record step #%d with only %d slots\n", slotStartIndex, fNSlot);
+      COPCORE_EXCEPTION("Out of slots in DeviceStepBufferView::NextSlot");
     }
     return slotStartIndex;
   }
 
-  __device__ GPUHit &GetSlot(unsigned int threadId, unsigned int slot)
+  __device__ GPUStep &GetSlot(unsigned int threadId, unsigned int slot)
   {
-    return hitBuffer_dev[threadId * fNSlot + slot];
+    return stepBuffer_dev[threadId * fNSlot + slot];
   }
 };
 
-__device__ HitScoringBuffer gHitScoringBuffer_dev;
+__device__ DeviceStepBufferView gDeviceStepBuffer;
 
 struct BufferHandle {
-  std::array<HitScoringBuffer, 2> hitScoringInfo;
-  GPUHit *hostBuffer;
-  unsigned int *hostBufferCount;
+  std::array<DeviceStepBufferView, 2> stepBufferViews;
+  GPUStep *hostBuffer;
+  unsigned int *hostStepCount;
   enum class HostState { ReadyToBeFilled, AwaitingDeviceTransfer, TransferFromDevice, TransferFromDeviceFinished };
 
-  // the hostState is changed by the HitProcessingThread but also by the cudaHostFunction launch, so it must be atomic
+  // the hostState is changed by the StepProcessingThread but also by the cudaHostFunction launch, so it must be atomic
   std::atomic<HostState> hostState;
   // offset in the buffer at the time of the copy (maybe redundant now?)
   unsigned int offsetAtCopy = 0;
 };
 
-struct HitQueueItem {
-  // HitQueueItems are pushed into the HitQueue. They contain the begin and end pointers of the data that needs to be
-  // processed. If the G4Workers are too slow to respond, the HitProcessingThread copies the data from the buffer into
-  // the holdoutBuffer, so that the hostbuffer in pinned memory can be released.
-  GPUHit *begin;                           // begin of GPUHit pointer
-  GPUHit *end;                             // end of GPUHit pointer
-  std::atomic_bool ScoringStarted = false; // whether the scoring has started. If it has not, the HitProcessingThread
-                                           // will copy the data from the pinned memory host buffer to the holdoutBuffer
+struct GPUStepBatch {
+  // GPUStepBatch objects are pushed into the StepQueue. They contain the begin and end pointers of the data that needs
+  // to be processed. If the G4Workers are too slow to respond, the StepProcessingThread copies the data from the buffer
+  // into the holdoutBuffer, so that the host buffer in pinned memory can be released.
+  GPUStep *begin; // begin of GPUStep pointer
+  GPUStep *end;   // end of GPUStep pointer
+  std::atomic_bool ProcessingStarted =
+      false; // whether the processing has started. If it has not, the StepProcessingThread
+             // will copy the data from the pinned memory host buffer to the holdoutBuffer
   std::atomic_bool IsDataOnHostBuffer =
-      true; // whether the data resides in the HostBuffer in pinned memory (if false, it it is in the holdoutBuffer)
-  std::vector<GPUHit>
-      holdoutBuffer; // holdout buffer where the hits are copied to if the G4Worker is too slow to respond
+      true; // whether the data resides in the HostBuffer in pinned memory (if false, it is in the holdoutBuffer)
+  std::vector<GPUStep>
+      holdoutBuffer; // holdout buffer where the steps are copied to if the G4Worker is too slow to respond
 
-  HitQueueItem(GPUHit *begin_, GPUHit *end_) : begin(begin_), end(end_) {}
+  GPUStepBatch(GPUStep *begin_, GPUStep *end_) : begin(begin_), end(end_) {}
 
-  ~HitQueueItem() = default;
+  ~GPUStepBatch() = default;
 
-  // remove copy constructor and assigment operator
-  HitQueueItem(const HitQueueItem &)            = delete;
-  HitQueueItem &operator=(const HitQueueItem &) = delete;
+  // remove copy constructor and assignment operator
+  GPUStepBatch(const GPUStepBatch &)            = delete;
+  GPUStepBatch &operator=(const GPUStepBatch &) = delete;
 
   // write custom move constructor and assignment operator
-  HitQueueItem(HitQueueItem &&other) noexcept
-      : begin(other.begin), end(other.end), ScoringStarted(other.ScoringStarted.load()),
+  GPUStepBatch(GPUStepBatch &&other) noexcept
+      : begin(other.begin), end(other.end), ProcessingStarted(other.ProcessingStarted.load()),
         holdoutBuffer(std::move(other.holdoutBuffer))
   {
   }
 
-  HitQueueItem &operator=(HitQueueItem &&other) noexcept
+  GPUStepBatch &operator=(GPUStepBatch &&other) noexcept
   {
     if (this != &other) {
       begin = other.begin;
       end   = other.end;
-      ScoringStarted.store(other.ScoringStarted.load());
+      ProcessingStarted.store(other.ProcessingStarted.load());
       holdoutBuffer = std::move(other.holdoutBuffer);
     }
     return *this;
@@ -120,30 +121,30 @@ struct HitQueueItem {
 };
 
 class CircularBufferManager {
-  // the CircularBufferManager manages the memory of the pinned HostBuffer fBuffer (in HostScoring).
+  // the CircularBufferManager manages the memory of the pinned HostBuffer fBuffer (in returned-step transfer).
   // It keeps track of the used space in the sorted vector of segments fSegments.
-  // The HitProcessingThread adds segments when it submits items to the HitQueue (in fact, the memory is already
-  // allocated as soon as the copy from TransferHitsToHost is done). The HitProcessingThread can delete segments when it
-  // copies the hits to the holdoutBuffer and the G4Worker finish their work. Since both HitProcessingThread and
-  // G4Workers can change the segments, a mutex is used to lock the access to the fSegments. In the TransferHitsToHost,
-  // the HitProcessingThread checks whether there is enough contiguous memory in the CircularBuffer before the copy can
+  // The StepProcessingThread adds segments when it submits items to the StepQueue (in fact, the memory is already
+  // allocated as soon as the copy from TransferStepsToHost is done). The StepProcessingThread can delete segments when
+  // it copies the steps to the holdoutBuffer and the G4Worker finish their work. Since both StepProcessingThread and
+  // G4Workers can change the segments, a mutex is used to lock the access to the fSegments. In the TransferStepsToHost,
+  // the StepProcessingThread checks whether there is enough contiguous memory in the CircularBuffer before the copy can
   // start
 public:
   struct Segment {
-    GPUHit *begin;
-    GPUHit *end;
+    GPUStep *begin;
+    GPUStep *end;
 
     bool operator<(const Segment &other) const { return begin < other.begin; }
   };
 
-  CircularBufferManager(GPUHit *bufferStart, size_t capacity)
+  CircularBufferManager(GPUStep *bufferStart, size_t capacity)
       : fBufferStart(bufferStart), fBufferEnd(bufferStart + capacity), fWritePtr(bufferStart),
         fFreeContiguousSpace(capacity)
   {
   }
 
   /// Adds a segment at the provided position. Ensures segments remain sorted.
-  bool addSegment(GPUHit *begin, GPUHit *end)
+  bool addSegment(GPUStep *begin, GPUStep *end)
   {
     std::scoped_lock lock{bufferManagerMutex};
 
@@ -166,7 +167,7 @@ public:
   }
 
   /// Removes a segment based on its starting pointer and updates fWritePtr accordingly.
-  void removeSegment(GPUHit *segmentPtr)
+  void removeSegment(GPUStep *segmentPtr)
   {
     std::scoped_lock lock{bufferManagerMutex};
 
@@ -246,9 +247,9 @@ public:
   size_t getOffset() { return fWritePtr - fBufferStart; }
 
 private:
-  GPUHit *fBufferStart;
-  GPUHit *fBufferEnd;
-  GPUHit *fWritePtr;
+  GPUStep *fBufferStart;
+  GPUStep *fBufferEnd;
+  GPUStep *fWritePtr;
   size_t fFreeContiguousSpace;
   std::vector<Segment> fSegments; // **Sorted vector instead of set**
   mutable std::mutex bufferManagerMutex;
@@ -278,12 +279,11 @@ private:
   }
 };
 
-// TODO: Rename this. Maybe ScoringState? Check usage in GPUstate
-class HitScoring {
-  unique_ptr_cuda<GPUHit> fGPUHitBuffer_dev;
-  unique_ptr_cuda<GPUHit, CudaHostDeleter<GPUHit>> fGPUHitBuffer_host;
-  unique_ptr_cuda<unsigned int> fGPUHitBufferCount_dev;
-  unique_ptr_cuda<unsigned int, CudaHostDeleter<unsigned int>> fGPUHitBufferCount_host;
+class GPUStepTransferManager {
+  unique_ptr_cuda<GPUStep> fGPUStepBuffer_dev;
+  unique_ptr_cuda<GPUStep, CudaHostDeleter<GPUStep>> fGPUStepBuffer_host;
+  unique_ptr_cuda<unsigned int> fGPUStepBufferCount_dev;
+  unique_ptr_cuda<unsigned int, CudaHostDeleter<unsigned int>> fGPUStepBufferCount_host;
 
   BufferHandle fBuffer;
 
@@ -291,72 +291,72 @@ class HitScoring {
 
   enum class DeviceState { Free, Filling, NeedTransferToHost, TransferToHost };
   std::array<std::atomic<DeviceState>, 2>
-      fDeviceState; // the device state must be atomic as it is touched by both the HitProcesingThread in
-                    // TransferHitsToHost and by the TransportThread in SwapDeviceBuffers
+      fDeviceState; // the device state must be atomic as it is touched by both the StepProcessingThread in
+                    // TransferStepsToHost and by the TransportThread in SwapDeviceBuffers
 
-  void *fHitScoringBuffer_deviceAddress = nullptr;
-  unsigned int fHitCapacity;
+  void *fDeviceStepBuffer_deviceAddress = nullptr;
+  unsigned int fStepCapacity;
   double fCPUCapacityFactor;
   double fCPUCopyFraction;
   unsigned short fActiveBuffer = 0;
   ADEPT_DEVICE_API_SYMBOL(Event_t)
   fSwapDoneEvent; // cuda event to synchronize the swapping of the device buffers with the transport
 
-  // HitQueue with one lock per queue
-  std::vector<std::deque<HitQueueItem>> fHitQueues;
-  std::vector<std::shared_mutex> fHitQueueLocks;
+  // StepQueue with one lock per queue
+  std::vector<std::deque<GPUStepBatch>> fStepQueues;
+  std::vector<std::shared_mutex> fStepQueueLocks;
 
   void ProcessBuffer(BufferHandle &handle, std::condition_variable &cvG4Workers, int debugLevel)
   {
 
-    // Loop over HitQueue and add HitQueueItems that contain the begin and end of the GPUhits in the HostBuffer.
-    // Add the used segments in the BufferManager
+    // Loop over StepQueue and add GPUStepBatch objects that contain the begin and end of the GPUSteps in the
+    // HostBuffer. Add the used segments in the BufferManager
     unsigned int offset = 0;
-    for (int i = 0; i < fHitQueues.size(); i++) {
+    for (int i = 0; i < fStepQueues.size(); i++) {
 
-      GPUHit *begin = handle.hostBuffer + offset + handle.offsetAtCopy;
-      GPUHit *end   = handle.hostBuffer + offset + handle.offsetAtCopy + handle.hostBufferCount[i];
+      GPUStep *begin = handle.hostBuffer + offset + handle.offsetAtCopy;
+      GPUStep *end   = handle.hostBuffer + offset + handle.offsetAtCopy + handle.hostStepCount[i];
 
-      HitQueueItem hitItem{begin, end};
+      GPUStepBatch stepBatch{begin, end};
 
       if (begin != end) {
         fBufferManager->addSegment(begin, end);
 
-        std::scoped_lock lock{fHitQueueLocks[i]};
-        fHitQueues[i].push_back(std::move(hitItem));
+        std::scoped_lock lock{fStepQueueLocks[i]};
+        fStepQueues[i].push_back(std::move(stepBatch));
       }
-      offset += handle.hostBufferCount[i];
+      offset += handle.hostStepCount[i];
     }
     // release HostBuffer and notify G4Workers
     fBuffer.hostState.store(BufferHandle::HostState::ReadyToBeFilled);
     cvG4Workers.notify_all();
 
-    for (int i = 0; i < fHitQueues.size(); i++) {
+    for (int i = 0; i < fStepQueues.size(); i++) {
 
-      std::unique_lock lock{fHitQueueLocks[i]};
+      std::unique_lock lock{fStepQueueLocks[i]};
 
-      if (!fHitQueues[i].empty()) {
-        // Check whether the last item in the HitQueue is already taken by the G4Worker
-        auto &ret = fHitQueues[i].back();
+      if (!fStepQueues[i].empty()) {
+        // Check whether the last item in the StepQueue is already taken by the G4Worker
+        auto &ret = fStepQueues[i].back();
 
-        if (ret.ScoringStarted.load(std::memory_order_acquire) == true) {
-          // if G4Worker has alreay started working, all good
+        if (ret.ProcessingStarted.load(std::memory_order_acquire) == true) {
+          // if G4Worker has already started working, all good
           if (debugLevel > 5)
             std::cout << BOLD_BLUE << "G4worker " << i << " has taken their task and started working on "
-                      << (ret.end - ret.begin) << " hits " << RESET << std::endl;
+                      << (ret.end - ret.begin) << " steps " << RESET << std::endl;
         } else {
 
-          size_t numHits = ret.end - ret.begin;
+          size_t numSteps = ret.end - ret.begin;
 
-          // If the circular Buffer is too full and the G4Worker didn't pick up the work, we have to copy out the hits
+          // If the circular Buffer is too full and the G4Worker didn't pick up the work, we have to copy out the steps
           // to the holdoutBuffer
           if (fBufferManager->getFillFraction() > fCPUCopyFraction) {
             if (debugLevel > 5) {
               std::cout << BOLD_RED << "FillFraction too high: " << fBufferManager->getFillFraction()
-                        << ", threshold: " << fCPUCopyFraction << " copying out " << numHits << " hits for G4Worker "
+                        << ", threshold: " << fCPUCopyFraction << " copying out " << numSteps << " steps for G4Worker "
                         << i << RESET << std::endl;
             }
-            ret.holdoutBuffer.resize(numHits);                        // Allocate correct size
+            ret.holdoutBuffer.resize(numSteps);                       // Allocate correct size
             std::copy(ret.begin, ret.end, ret.holdoutBuffer.begin()); // Copy data
 
             // remove the segment first, before updating the pointers to the copied out memory
@@ -366,7 +366,7 @@ class HitScoring {
             ret.begin = ret.holdoutBuffer.data();
             ret.end   = ret.holdoutBuffer.data() + ret.holdoutBuffer.size();
 
-            ret.ScoringStarted     = true;
+            ret.ProcessingStarted  = true;
             ret.IsDataOnHostBuffer = false;
           }
         }
@@ -375,9 +375,10 @@ class HitScoring {
   }
 
 public:
-  HitScoring(unsigned int hitCapacity, unsigned int nThread, double CPUCapacityFactor, double CPUCopyFraction)
-      : fHitCapacity{hitCapacity}, fHitQueues(nThread), fHitQueueLocks(nThread), fCPUCapacityFactor(CPUCapacityFactor),
-        fCPUCopyFraction(CPUCopyFraction)
+  GPUStepTransferManager(unsigned int stepCapacity, unsigned int nThread, double CPUCapacityFactor,
+                         double CPUCopyFraction)
+      : fStepCapacity{stepCapacity}, fStepQueues(nThread), fStepQueueLocks(nThread),
+        fCPUCapacityFactor(CPUCapacityFactor), fCPUCopyFraction(CPUCopyFraction)
   {
 
     if (fCPUCapacityFactor <= 2.0) {
@@ -393,48 +394,48 @@ public:
     }
 
     // We allocate one (circular) HostBuffer in pinned memory
-    GPUHit *gpuHits = nullptr;
+    GPUStep *gpuSteps = nullptr;
 
-    // The HostBuffer is set to be fCPUCapacityFactor times the GPU buffer HitCapacity. Normally, maximally 2x of the
-    // GPU hitbuffer should reside in the hostbuffer: once a full buffer that is currently processed by the G4 workers
-    // and second another full buffer that is just copied from the GPU. Due to sparsity, we add another factor of .5 to
-    // prevent running out of buffer. Also, the filling quota of the CPU buffer decides whether hits are processed
-    // directly by the G4 workers or if they are copied out
-    unsigned int hostBufferCapacity = fCPUCapacityFactor * fHitCapacity;
-    ADEPT_DEVICE_API_CALL(MallocHost(&gpuHits, sizeof(GPUHit) * hostBufferCapacity));
-    fGPUHitBuffer_host.reset(gpuHits);
+    // The HostBuffer is set to be fCPUCapacityFactor times the GPU buffer StepCapacity. Normally, maximally 2x of the
+    // GPU step buffer should reside in the host buffer: once a full buffer that is currently processed by the G4
+    // workers and then another full buffer that is just copied from the GPU. Due to sparsity, we add another factor of
+    // .5 to prevent running out of buffer. Also, the filling quota of the CPU buffer decides whether steps are
+    // processed directly by the G4 workers or if they are copied out
+    unsigned int hostBufferCapacity = fCPUCapacityFactor * fStepCapacity;
+    ADEPT_DEVICE_API_CALL(MallocHost(&gpuSteps, sizeof(GPUStep) * hostBufferCapacity));
+    fGPUStepBuffer_host.reset(gpuSteps);
 
     // We use a single allocation for both GPU buffers:
-    auto result = ADEPT_DEVICE_API_SYMBOL(Malloc)(&gpuHits, sizeof(GPUHit) * fDeviceState.size() * fHitCapacity);
-    if (result != ADEPT_DEVICE_API_SYMBOL(Success)) throw std::invalid_argument{"No space to allocate hit buffer."};
-    fGPUHitBuffer_dev.reset(gpuHits);
+    auto result = ADEPT_DEVICE_API_SYMBOL(Malloc)(&gpuSteps, sizeof(GPUStep) * fDeviceState.size() * fStepCapacity);
+    if (result != ADEPT_DEVICE_API_SYMBOL(Success)) throw std::invalid_argument{"No space to allocate step buffer."};
+    fGPUStepBuffer_dev.reset(gpuSteps);
 
-    unsigned int *buffer_count = nullptr;
-    ADEPT_DEVICE_API_CALL(MallocHost(&buffer_count, sizeof(unsigned int) * nThread));
-    fGPUHitBufferCount_host.reset(buffer_count);
+    unsigned int *step_count = nullptr;
+    ADEPT_DEVICE_API_CALL(MallocHost(&step_count, sizeof(unsigned int) * nThread));
+    fGPUStepBufferCount_host.reset(step_count);
 
-    result = ADEPT_DEVICE_API_SYMBOL(Malloc)(&buffer_count, sizeof(unsigned int) * fDeviceState.size() * nThread);
-    if (result != ADEPT_DEVICE_API_SYMBOL(Success)) throw std::invalid_argument{"No space to allocate hit buffer."};
-    fGPUHitBufferCount_dev.reset(buffer_count);
+    result = ADEPT_DEVICE_API_SYMBOL(Malloc)(&step_count, sizeof(unsigned int) * fDeviceState.size() * nThread);
+    if (result != ADEPT_DEVICE_API_SYMBOL(Success)) throw std::invalid_argument{"No space to allocate step buffer."};
+    fGPUStepBufferCount_dev.reset(step_count);
 
     fDeviceState[0] = DeviceState::Filling;
     fDeviceState[1] = DeviceState::Free;
 
-    fBuffer.hitScoringInfo[0] =
-        HitScoringBuffer{fGPUHitBuffer_dev.get(), fGPUHitBufferCount_dev.get(), fHitCapacity / nThread, nThread};
-    fBuffer.hitScoringInfo[1] =
-        HitScoringBuffer{fGPUHitBuffer_dev.get() + fHitCapacity, fGPUHitBufferCount_dev.get() + nThread,
-                         fHitCapacity / nThread, nThread};
-    fBuffer.hostBuffer      = fGPUHitBuffer_host.get();
-    fBuffer.hostBufferCount = fGPUHitBufferCount_host.get();
-    fBuffer.hostState       = BufferHandle::HostState::ReadyToBeFilled;
+    fBuffer.stepBufferViews[0] =
+        DeviceStepBufferView{fGPUStepBuffer_dev.get(), fGPUStepBufferCount_dev.get(), fStepCapacity / nThread, nThread};
+    fBuffer.stepBufferViews[1] =
+        DeviceStepBufferView{fGPUStepBuffer_dev.get() + fStepCapacity, fGPUStepBufferCount_dev.get() + nThread,
+                             fStepCapacity / nThread, nThread};
+    fBuffer.hostBuffer    = fGPUStepBuffer_host.get();
+    fBuffer.hostStepCount = fGPUStepBufferCount_host.get();
+    fBuffer.hostState     = BufferHandle::HostState::ReadyToBeFilled;
 
-    fBufferManager = std::make_unique<CircularBufferManager>(fGPUHitBuffer_host.get(), hostBufferCapacity);
+    fBufferManager = std::make_unique<CircularBufferManager>(fGPUStepBuffer_host.get(), hostBufferCapacity);
 
-    ADEPT_DEVICE_API_CALL(GetSymbolAddress(&fHitScoringBuffer_deviceAddress, gHitScoringBuffer_dev));
-    assert(fHitScoringBuffer_deviceAddress != nullptr);
-    ADEPT_DEVICE_API_CALL(Memcpy(fHitScoringBuffer_deviceAddress, &fBuffer.hitScoringInfo, sizeof(HitScoringBuffer),
-                                 ADEPT_DEVICE_API_SYMBOL(MemcpyHostToDevice)));
+    ADEPT_DEVICE_API_CALL(GetSymbolAddress(&fDeviceStepBuffer_deviceAddress, gDeviceStepBuffer));
+    assert(fDeviceStepBuffer_deviceAddress != nullptr);
+    ADEPT_DEVICE_API_CALL(Memcpy(fDeviceStepBuffer_deviceAddress, &fBuffer.stepBufferViews,
+                                 sizeof(DeviceStepBufferView), ADEPT_DEVICE_API_SYMBOL(MemcpyHostToDevice)));
 
     // create cuda event needed to tell the transport that the swap of the device buffers is executed
     ADEPT_DEVICE_API_CALL(EventCreateWithFlags(&fSwapDoneEvent, ADEPT_DEVICE_API_SYMBOL(EventDisableTiming)));
@@ -442,7 +443,7 @@ public:
 
   ADEPT_DEVICE_API_SYMBOL(Event_t) getSwapDoneEvent() const { return fSwapDoneEvent; }
 
-  unsigned int HitCapacity() const { return fHitCapacity; }
+  unsigned int StepCapacity() const { return fStepCapacity; }
 
   void SwapDeviceBuffers(ADEPT_DEVICE_API_SYMBOL(Stream_t) cudaStream)
   {
@@ -455,12 +456,12 @@ public:
       throw std::logic_error(__FILE__ + std::to_string(__LINE__) + ": On-device buffer in wrong state");
 #endif
 
-    // Get new HitBufferCounts from device:
-    ADEPT_DEVICE_API_CALL(MemcpyAsync(fBuffer.hostBufferCount, fBuffer.hitScoringInfo[fActiveBuffer].fSlotCounter,
-                                      sizeof(unsigned int) * fBuffer.hitScoringInfo[fActiveBuffer].fNThreads,
+    // Get new StepBufferCounts from device:
+    ADEPT_DEVICE_API_CALL(MemcpyAsync(fBuffer.hostStepCount, fBuffer.stepBufferViews[fActiveBuffer].fSlotCounter,
+                                      sizeof(unsigned int) * fBuffer.stepBufferViews[fActiveBuffer].fNThreads,
                                       ADEPT_DEVICE_API_SYMBOL(MemcpyDefault), cudaStream));
-    ADEPT_DEVICE_API_CALL(MemsetAsync(fBuffer.hitScoringInfo[fActiveBuffer].fSlotCounter, 0,
-                                      sizeof(unsigned int) * fBuffer.hitScoringInfo[fActiveBuffer].fNThreads,
+    ADEPT_DEVICE_API_CALL(MemsetAsync(fBuffer.stepBufferViews[fActiveBuffer].fSlotCounter, 0,
+                                      sizeof(unsigned int) * fBuffer.stepBufferViews[fActiveBuffer].fNThreads,
                                       cudaStream));
 
     // Execute the swap:
@@ -470,25 +471,26 @@ public:
     if (fDeviceState[fActiveBuffer].load(std::memory_order_acquire) != DeviceState::Free)
       throw std::logic_error(__FILE__ + std::to_string(__LINE__) + ": Next on-device buffer in wrong state");
 
-    // adjust pointers to hitbuffer and slotcounter array to next active GPUbuffer
-    fBuffer.hitScoringInfo[fActiveBuffer].hitBuffer_dev = fGPUHitBuffer_dev.get() + fActiveBuffer * fHitCapacity;
-    fBuffer.hitScoringInfo[fActiveBuffer].fSlotCounter =
-        fGPUHitBufferCount_dev.get() + fActiveBuffer * fBuffer.hitScoringInfo[fActiveBuffer].fNThreads;
+    // adjust pointers to step buffer and slotcounter array to next active GPUbuffer
+    fBuffer.stepBufferViews[fActiveBuffer].stepBuffer_dev = fGPUStepBuffer_dev.get() + fActiveBuffer * fStepCapacity;
+    fBuffer.stepBufferViews[fActiveBuffer].fSlotCounter =
+        fGPUStepBufferCount_dev.get() + fActiveBuffer * fBuffer.stepBufferViews[fActiveBuffer].fNThreads;
 
-    ADEPT_DEVICE_API_CALL(MemcpyAsync(fHitScoringBuffer_deviceAddress, &fBuffer.hitScoringInfo[fActiveBuffer],
-                                      sizeof(HitScoringBuffer), ADEPT_DEVICE_API_SYMBOL(MemcpyDefault), cudaStream));
+    ADEPT_DEVICE_API_CALL(MemcpyAsync(fDeviceStepBuffer_deviceAddress, &fBuffer.stepBufferViews[fActiveBuffer],
+                                      sizeof(DeviceStepBufferView), ADEPT_DEVICE_API_SYMBOL(MemcpyDefault),
+                                      cudaStream));
     ADEPT_DEVICE_API_CALL(
         EventRecord(fSwapDoneEvent, cudaStream)); // record event that the transport kernels must wait for
 
-    // need to set the hostState to awaiting device, this prevents the next swap until the hits in the hostBuffer are
-    // send to the HitQueue
+    // Need to set the hostState to awaiting device. This prevents the next swap until the steps in the host buffer are
+    // sent to the StepQueue.
     fBuffer.hostState.store(BufferHandle::HostState::AwaitingDeviceTransfer, std::memory_order_release);
 
     // the current active buffer can be set directly to block it from being seen as free
     fDeviceState[fActiveBuffer].store(DeviceState::Filling, std::memory_order_release);
 
     // However, the prevActiveDeviceBuffer state can only be advanced when the transfer is finished,
-    // otherwise the TransferHitsToHost may call the transfer before the correct hostBufferCount has arrived
+    // otherwise the TransferStepsToHost may call the transfer before the correct hostStepCount has arrived
     ADEPT_DEVICE_API_CALL(LaunchHostFunc(
         cudaStream,
         [](void *arg) {
@@ -498,10 +500,10 @@ public:
         &fDeviceState[prevActiveDeviceBuffer]));
   }
 
-  bool ProcessHits(std::condition_variable &cvG4Workers, int debugLevel)
+  bool ProcessSteps(std::condition_variable &cvG4Workers, int debugLevel)
   {
 
-    bool haveNewHits = false;
+    bool haveNewSteps = false;
 
     // here we need to do atomic checks on the hostState, as it is modified from the cudaLaunchHostFunc
     while (fBuffer.hostState.load(std::memory_order_acquire) == BufferHandle::HostState::TransferFromDevice ||
@@ -510,19 +512,19 @@ public:
       if (fBuffer.hostState.load(std::memory_order_acquire) == BufferHandle::HostState::TransferFromDeviceFinished) {
 
         ProcessBuffer(fBuffer, cvG4Workers, debugLevel);
-        haveNewHits = true;
+        haveNewSteps = true;
       }
       // sleep shortly to reduce pressure on atomic reads
       using namespace std::chrono_literals;
       std::this_thread::sleep_for(50us);
     }
 
-    return haveNewHits;
+    return haveNewSteps;
   }
 
   bool ReadyToSwapBuffers() const
   {
-    // we can swap if the next device state is free and the hostBuffer has been submitted to the HitQueue
+    // we can swap if the next device state is free and the hostBuffer has been submitted to the StepQueue
     return (std::any_of(fDeviceState.begin(), fDeviceState.end(),
                         [](const auto &deviceState) {
                           return deviceState.load(std::memory_order_acquire) == DeviceState::Free;
@@ -578,8 +580,8 @@ public:
     std::cout << std::endl;
   }
 
-  /// Copy the current contents of the GPU hit buffer to host.
-  void TransferHitsToHost(ADEPT_DEVICE_API_SYMBOL(Stream_t) cudaStreamForHitCopy)
+  /// Copy the current contents of the GPU step buffer to host.
+  void TransferStepsToHost(ADEPT_DEVICE_API_SYMBOL(Stream_t) cudaStreamForStepCopy)
   {
 
     while (std::any_of(fDeviceState.begin(), fDeviceState.end(),
@@ -598,8 +600,8 @@ public:
       }
 
       unsigned int transferSize = 0;
-      for (int i = 0; i < fBuffer.hitScoringInfo[fActiveBuffer].fNThreads; i++) {
-        transferSize += fBuffer.hostBufferCount[i];
+      for (int i = 0; i < fBuffer.stepBufferViews[fActiveBuffer].fNThreads; i++) {
+        transferSize += fBuffer.hostStepCount[i];
       }
 
       if (fBufferManager->getFreeContiguousMemory(transferSize) < transferSize) {
@@ -610,34 +612,34 @@ public:
       fDeviceState[prevActiveDeviceBuffer].store(DeviceState::TransferToHost, std::memory_order_release);
       fBuffer.hostState.store(BufferHandle::HostState::TransferFromDevice);
 
-      auto bufferBegin     = fBuffer.hitScoringInfo[prevActiveDeviceBuffer].hitBuffer_dev;
+      auto bufferBegin     = fBuffer.stepBufferViews[prevActiveDeviceBuffer].stepBuffer_dev;
       fBuffer.offsetAtCopy = fBufferManager->getOffset();
 
-      // Copy out the hits:
+      // Copy out the steps:
       // The start address on device is always i * fNSlot (Slots per thread), and we copy always to
       // the offset of the previous copy, to get a compact buffer on host.
       unsigned int offset = 0;
-      for (int i = 0; i < fBuffer.hitScoringInfo[prevActiveDeviceBuffer].fNThreads; i++) {
-        if (fBuffer.hostBufferCount[i] > 0) {
+      for (int i = 0; i < fBuffer.stepBufferViews[prevActiveDeviceBuffer].fNThreads; i++) {
+        if (fBuffer.hostStepCount[i] > 0) {
           ADEPT_DEVICE_API_CALL(MemcpyAsync(fBuffer.hostBuffer + fBuffer.offsetAtCopy + offset,
-                                            bufferBegin + i * fBuffer.hitScoringInfo[prevActiveDeviceBuffer].fNSlot,
-                                            sizeof(GPUHit) * fBuffer.hostBufferCount[i],
-                                            ADEPT_DEVICE_API_SYMBOL(MemcpyDefault), cudaStreamForHitCopy));
-          offset += fBuffer.hostBufferCount[i];
+                                            bufferBegin + i * fBuffer.stepBufferViews[prevActiveDeviceBuffer].fNSlot,
+                                            sizeof(GPUStep) * fBuffer.hostStepCount[i],
+                                            ADEPT_DEVICE_API_SYMBOL(MemcpyDefault), cudaStreamForStepCopy));
+          offset += fBuffer.hostStepCount[i];
         }
       }
 
       // Launch the host function to set the states correctly
 
       ADEPT_DEVICE_API_CALL(LaunchHostFunc(
-          cudaStreamForHitCopy,
+          cudaStreamForStepCopy,
           [](void *arg) {
             static_cast<std::atomic<DeviceState> *>(arg)->store(DeviceState::Free, std::memory_order_release);
           },
           &fDeviceState[prevActiveDeviceBuffer]));
 
       ADEPT_DEVICE_API_CALL(LaunchHostFunc(
-          cudaStreamForHitCopy,
+          cudaStreamForStepCopy,
           [](void *arg) {
             static_cast<BufferHandle *>(arg)->hostState.store(BufferHandle::HostState::TransferFromDeviceFinished,
                                                               std::memory_order_release);
@@ -646,53 +648,54 @@ public:
     }
   }
 
-  HitQueueItem *GetNextHitsHandle(unsigned int threadId, bool &dataOnBuffer)
+  GPUStepBatch *GetNextStepBatch(unsigned int threadId, bool &dataOnBuffer)
   {
-    assert(threadId < fHitQueues.size());
-    std::unique_lock lock{fHitQueueLocks[threadId]}; // setting scoring started flag, need unique lock
+    assert(threadId < fStepQueues.size());
+    std::unique_lock lock{fStepQueueLocks[threadId]}; // setting processing started flag, need unique lock
 
-    if (fHitQueues[threadId].empty()) {
+    if (fStepQueues[threadId].empty()) {
       return nullptr;
     } else {
-      auto &ret    = fHitQueues[threadId].front();
+      auto &ret    = fStepQueues[threadId].front();
       dataOnBuffer = ret.IsDataOnHostBuffer.load();
-      ret.ScoringStarted.store(true, std::memory_order_release);
+      ret.ProcessingStarted.store(true, std::memory_order_release);
       lock.unlock(); // Unlock before returning pointer
       return &ret;
     }
   }
 
-  void CloseHitsHandle(unsigned int threadId, GPUHit *begin, const bool dataOnBuffer)
+  void CloseStepBatch(unsigned int threadId, GPUStep *begin, const bool dataOnBuffer)
   {
-    assert(threadId < fHitQueues.size());
-    std::unique_lock lock{fHitQueueLocks[threadId]}; // popping queue, requires unique lock
+    assert(threadId < fStepQueues.size());
+    std::unique_lock lock{fStepQueueLocks[threadId]}; // popping queue, requires unique lock
 
 #ifdef DEBUG
-    if (fHitQueues[threadId].empty()) {
-      std::cout << BOLD_RED << "ERROR no HitQueueItem to pop, this should nevre be the case! " << RESET << std::endl;
+    if (fStepQueues[threadId].empty()) {
+      std::cout << BOLD_RED << "ERROR no GPUStepBatch to pop, this should never be the case! " << RESET << std::endl;
     }
 #endif
 
     // if data is in the hostBuffer (and not the holdoutBuffer), update the CircularBufferManager and release the memory
     if (dataOnBuffer) fBufferManager->removeSegment(begin);
-    fHitQueues[threadId].pop_front();
+    fStepQueues[threadId].pop_front();
   }
 };
 
 } // namespace AsyncAdePT
 
-namespace adept_scoring {
+namespace adept_step_recording {
 
-/// @brief Record a hit
-__device__ void RecordHit(uint64_t aTrackID, uint64_t aParentID, short stepLimProcessId, ParticleType aParticleType,
-                          double aStepLength, double aTotalEnergyDeposit, float aTrackWeight,
-                          vecgeom::NavigationState const &aPreState, vecgeom::Vector3D<double> const &aPrePosition,
-                          vecgeom::Vector3D<double> const &aPreMomentumDirection, double aPreEKin,
-                          vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<double> const &aPostPosition,
-                          vecgeom::Vector3D<double> const &aPostMomentumDirection, double aPostEKin, double aGlobalTime,
-                          float aLocalTime, float aProperTime, double aPreGlobalTime, unsigned int eventID,
-                          short threadID, bool isLastStep, unsigned short stepCounter,
-                          SecondaryInitData const *secondaryData, unsigned int nSecondaries)
+/// @brief Record a GPU step
+__device__ void RecordGPUStep(uint64_t aTrackID, uint64_t aParentID, short stepLimProcessId, ParticleType aParticleType,
+                              double aStepLength, double aTotalEnergyDeposit, float aTrackWeight,
+                              vecgeom::NavigationState const &aPreState, vecgeom::Vector3D<double> const &aPrePosition,
+                              vecgeom::Vector3D<double> const &aPreMomentumDirection, double aPreEKin,
+                              vecgeom::NavigationState const &aPostState,
+                              vecgeom::Vector3D<double> const &aPostPosition,
+                              vecgeom::Vector3D<double> const &aPostMomentumDirection, double aPostEKin,
+                              double aGlobalTime, float aLocalTime, float aProperTime, double aPreGlobalTime,
+                              unsigned int eventID, short threadID, bool isLastStep, unsigned short stepCounter,
+                              SecondaryInitData const *secondaryData, unsigned int nSecondaries)
 {
 
   // defensive check
@@ -700,31 +703,32 @@ __device__ void RecordHit(uint64_t aTrackID, uint64_t aParentID, short stepLimPr
     COPCORE_EXCEPTION("secondaryData is null but nSecondaries > 0");
   }
 
-  // allocate hit slots: one for the parent and then one for each secondary
-  auto slotStartIndex = AsyncAdePT::gHitScoringBuffer_dev.ReserveHitSlots(threadID, 1u + nSecondaries);
+  // allocate step slots: one for the parent and then one for each secondary
+  auto slotStartIndex = AsyncAdePT::gDeviceStepBuffer.ReserveStepSlots(threadID, 1u + nSecondaries);
 
   // The ProcessGPUSteps on the Host expects the step of the parent track first, and then all secondaries
   // that were generated in that step.
-  GPUHit &parentStep = AsyncAdePT::gHitScoringBuffer_dev.GetSlot(threadID, slotStartIndex);
+  GPUStep &parentStep = AsyncAdePT::gDeviceStepBuffer.GetSlot(threadID, slotStartIndex);
   // Fill the required data for the parent step
-  FillHit(parentStep, aTrackID, aParentID, stepLimProcessId, aParticleType, aStepLength, aTotalEnergyDeposit,
-          aTrackWeight, aPreState, aPrePosition, aPreMomentumDirection, aPreEKin, aPostState, aPostPosition,
-          aPostMomentumDirection, aPostEKin, aGlobalTime, aLocalTime, aProperTime, aPreGlobalTime, eventID, threadID,
-          isLastStep, stepCounter, nSecondaries);
+  FillGPUStep(parentStep, aTrackID, aParentID, stepLimProcessId, aParticleType, aStepLength, aTotalEnergyDeposit,
+              aTrackWeight, aPreState, aPrePosition, aPreMomentumDirection, aPreEKin, aPostState, aPostPosition,
+              aPostMomentumDirection, aPostEKin, aGlobalTime, aLocalTime, aProperTime, aPreGlobalTime, eventID,
+              threadID, isLastStep, stepCounter, nSecondaries);
 
   // Fill the steps for the secondaries
   for (unsigned int i = 0; i < nSecondaries; ++i) {
     // The index is the startIndex + 1 (for the parent) + i for the current secondary
-    GPUHit &secondaryStep = AsyncAdePT::gHitScoringBuffer_dev.GetSlot(threadID, slotStartIndex + 1u + i);
-    FillHit(secondaryStep, secondaryData[i].trackId, aTrackID, secondaryData[i].creatorProcessId,
-            secondaryData[i].particleType,
-            /*steplength*/ 0., /*energydeposit*/ 0., aTrackWeight, aPostState, aPostPosition, secondaryData[i].dir,
-            secondaryData[i].eKin, aPostState, aPostPosition, secondaryData[i].dir, secondaryData[i].eKin, aGlobalTime,
-            /*localTime*/ 0.f, /*properTime*/ 0.f, aGlobalTime, eventID, threadID, /*isLastStep*/ false,
-            /*stepCounter*/ 0, /*nSecondaries*/ 0);
+    GPUStep &secondaryStep = AsyncAdePT::gDeviceStepBuffer.GetSlot(threadID, slotStartIndex + 1u + i);
+    FillGPUStep(secondaryStep, secondaryData[i].trackId, aTrackID, secondaryData[i].creatorProcessId,
+                secondaryData[i].particleType,
+                /*steplength*/ 0., /*energydeposit*/ 0., aTrackWeight, aPostState, aPostPosition, secondaryData[i].dir,
+                secondaryData[i].eKin, aPostState, aPostPosition, secondaryData[i].dir, secondaryData[i].eKin,
+                aGlobalTime,
+                /*localTime*/ 0.f, /*properTime*/ 0.f, aGlobalTime, eventID, threadID, /*isLastStep*/ false,
+                /*stepCounter*/ 0, /*nSecondaries*/ 0);
   }
 }
 
-} // namespace adept_scoring
+} // namespace adept_step_recording
 
 #endif

--- a/include/AdePT/core/Track.cuh
+++ b/include/AdePT/core/Track.cuh
@@ -33,7 +33,7 @@ struct TrackBase {
   float properTime{0.f};
 
 #ifdef ADEPT_USE_SPLIT_KERNELS
-  // Variables used to store track info needed for scoring
+  // Variables used to store track info needed when returning GPU steps
   vecgeom::NavigationState nextState;
   vecgeom::Vector3D<double> preStepPos;
   vecgeom::Vector3D<double> preStepDir;

--- a/include/AdePT/integration/AdePTGeant4Integration.hh
+++ b/include/AdePT/integration/AdePTGeant4Integration.hh
@@ -3,13 +3,13 @@
 
 ///   The AdePT-Geant4 integration layer
 ///   - Initialization and checking of VecGeom geometry
-///   - G4Hit reconstruction from GPU hits
-///   - Processing of reconstructed hits using the G4 Sensitive Detector
+///   - G4Step reconstruction from GPU steps
+///   - Processing of reconstructed steps using the Geant4 sensitive detector
 
 #ifndef ADEPTGEANT4_INTEGRATION_H
 #define ADEPTGEANT4_INTEGRATION_H
 
-#include <AdePT/core/ScoringCommons.hh>
+#include <AdePT/core/GPUStep.hh>
 #include <AdePT/integration/G4HepEmTrackingManagerSpecialized.hh>
 #include <AdePT/integration/HostTrackDataMapper.hh>
 
@@ -21,9 +21,9 @@
 #include <vector>
 
 namespace AdePTGeant4Integration_detail {
-struct ScoringObjects;
+struct StepReconstructionObjects;
 struct Deleter {
-  void operator()(ScoringObjects *ptr);
+  void operator()(StepReconstructionObjects *ptr);
 };
 } // namespace AdePTGeant4Integration_detail
 
@@ -33,18 +33,18 @@ public:
 
   /// @brief Stored work for a returned step that is replayed later on the host.
   /// @details
-  /// The host collects returned GPU-hit blocks during transport and replays
+  /// The host collects returned GPU-step blocks during transport and replays
   /// them later in one fixed order, so the Geant4-side work stays
   /// reproducible from run to run.
   struct DeferredStep {
-    std::size_t firstHit{0};
-    std::size_t numHits{0};
+    std::size_t firstGPUStep{0};
+    std::size_t numGPUSteps{0};
     DeferredStepType type{DeferredStepType::ReplayStep};
   };
 
   /// @brief Owns the deferred returned-step data drained from the integration.
   struct DeferredStepStore {
-    std::vector<GPUHit> hits{};
+    std::vector<GPUStep> gpuSteps{};
     std::vector<DeferredStep> steps{};
   };
 
@@ -57,17 +57,17 @@ public:
   AdePTGeant4Integration(AdePTGeant4Integration &&)            = default;
   AdePTGeant4Integration &operator=(AdePTGeant4Integration &&) = default;
 
-  /// @brief Reconstructs GPU hits on host and calls the user-defined sensitive detector code
-  void ProcessGPUStep(std::span<const GPUHit> gpuSteps, bool const callUserSteppingAction = false,
+  /// @brief Reconstructs GPU steps on host and calls the user-defined sensitive detector code
+  void ProcessGPUStep(std::span<const GPUStep> gpuSteps, bool const callUserSteppingAction = false,
                       bool const callUserTrackingaction = false);
 
   /// @brief Return a deferred parent track to Geant4 without rebuilding the visible G4 step.
   /// @details
-  /// This is only used for returned gamma handoff steps with one parent hit,
+  /// This is only used for returned gamma handoff steps with one parent step,
   /// no secondaries, and zero deposited energy. In that case there is no GPU
-  /// step to score on the host, so only the parent G4Track is rebuilt from the
+  /// step to process on the host, so only the parent G4Track is rebuilt from the
   /// post-step state and pushed back to the Geant4 stack.
-  void ReturnDeferredTrack(std::span<const GPUHit> gpuSteps, bool const callUserActions = false);
+  void ReturnDeferredTrack(std::span<const GPUStep> gpuSteps, bool const callUserActions = false);
 
   /// @brief Returns the Z value of the user-defined uniform magnetic field
   /// @details This function can only be called when the user-defined field is a G4UniformMagField
@@ -80,11 +80,11 @@ public:
   HostTrackDataMapper &GetHostTrackDataMapper() { return *fHostTrackDataMapper; }
 
   /// @brief Defer a returned step for later sorted replay on the host.
-  void QueueDeferredStep(std::span<const GPUHit> gpuSteps, DeferredStepType type = DeferredStepType::ReplayStep);
+  void QueueDeferredStep(std::span<const GPUStep> gpuSteps, DeferredStepType type = DeferredStepType::ReplayStep);
 
   /// @brief Transfer ownership of the currently queued deferred steps.
   /// @details
-  /// This drains the integration-local deferred-hit storage without copying it.
+  /// This drains the integration-local deferred-step storage without copying it.
   DeferredStepStore TakeDeferredSteps();
 
   void SetHepEmTrackingManager(G4HepEmTrackingManagerSpecialized *hepEmTrackingManager)
@@ -100,15 +100,15 @@ private:
   G4TouchableHandle MakeTouchableFromNavState(vecgeom::NavigationState const &navState) const;
 
   /// @brief Construct the temporary secondary track that is attached to the secondary vector of the parent step
-  G4Track *ConstructSecondaryTrackInPlace(GPUHit const *secHit) const;
+  G4Track *ConstructSecondaryTrackInPlace(GPUStep const *secStep) const;
 
-  void InitSecondaryHostTrackDataFromParent(GPUHit const *secHit, HostTrackData &secTData, int g4ParentID,
+  void InitSecondaryHostTrackDataFromParent(GPUStep const *secStep, HostTrackData &secTData, int g4ParentID,
                                             G4TouchableHandle &preTouchable) const;
 
-  void FillG4Track(GPUHit const *aGPUHit, G4Track *aG4Track, const HostTrackData &hostTData,
+  void FillG4Track(GPUStep const *aGPUStep, G4Track *aG4Track, const HostTrackData &hostTData,
                    G4TouchableHandle &aPreG4TouchableHandle, G4TouchableHandle &aPostG4TouchableHandle) const;
 
-  void FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step, const HostTrackData &hostTData,
+  void FillG4Step(GPUStep const *aGPUStep, G4Step *aG4Step, const HostTrackData &hostTData,
                   G4TouchableHandle &aPreG4TouchableHandle, G4TouchableHandle &aPostG4TouchableHandle,
                   G4StepStatus aPreStepStatus, G4StepStatus aPostStepStatus, bool callUserTrackingAction,
                   bool callUserSteppingAction) const;
@@ -128,7 +128,7 @@ private:
   /// track built from the post-step state. The visible reconstructed step keeps
   /// the transported GPU-step data, but the continued CPU track must still
   /// match that old current-state handoff.
-  G4Track *MakeReturnedTrackFromStep(GPUHit const &parentStep, const HostTrackData &hostTData,
+  G4Track *MakeReturnedTrackFromStep(GPUStep const &parentStep, const HostTrackData &hostTData,
                                      bool setStopButAlive) const;
 
   // pointer to specialized G4HepEmTrackingManager. Owned by AdePTTrackingManager,
@@ -138,10 +138,10 @@ private:
   // helper class to provide the CPU-only data for the returning GPU tracks
   std::unique_ptr<HostTrackDataMapper> fHostTrackDataMapper;
 
-  std::unique_ptr<AdePTGeant4Integration_detail::ScoringObjects, AdePTGeant4Integration_detail::Deleter>
-      fScoringObjects{nullptr};
+  std::unique_ptr<AdePTGeant4Integration_detail::StepReconstructionObjects, AdePTGeant4Integration_detail::Deleter>
+      fStepReconstructionObjects{nullptr};
 
-  std::vector<GPUHit> fDeferredHits;
+  std::vector<GPUStep> fDeferredGPUSteps;
   std::vector<DeferredStep> fDeferredSteps;
 };
 

--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -75,13 +75,13 @@ private:
   /// corresponding one-time device initialization and upload.
   void InitializeSharedAdePTTransport();
 
-  /// @brief Drain returned GPU-hit batches from transport and reconstruct the
+  /// @brief Drain returned GPU-step batches from transport and reconstruct the
   /// corresponding Geant4 steps on the CPU.
   /// @details
   /// Transport still owns the batch lifetime and iterates over the available
   /// batches. This helper provides the Geant4-side reconstruction logic for
   /// each batch.
-  void ProcessReturnedGPUHits(int threadId, int eventId);
+  void ProcessReturnedGPUSteps(int threadId, int eventId);
 
   std::unique_ptr<G4HepEmTrackingManagerSpecialized> fHepEmTrackingManager;
   AdePTGeant4Integration fGeant4Integration;

--- a/include/AdePT/kernels/electrons.cuh
+++ b/include/AdePT/kernels/electrons.cuh
@@ -384,7 +384,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
 
     if (nextState.IsOnBoundary()) {
       // if the particle hit a boundary, and is neither stopped or outside, relocate to have the correct next state
-      // before RecordHit is called
+      // before RecordGPUStep is called
       if (!stopped && !nextState.IsOutside()) {
 #if ADEPT_DEBUG_TRACK > 0
         if (verbose) {
@@ -813,28 +813,28 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     // Record the step. Edep includes the continuous energy loss and edep from secondaries which were cut
     if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU ||
         (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
-      adept_scoring::RecordHit(currentTrack.trackId, currentTrack.parentId, returnedProcessId,
-                               IsElectron ? ParticleType::Electron : ParticleType::Positron,
-                               elTrack.GetPStepLength(),                    // Step length
-                               energyDeposit,                               // Total Edep
-                               currentTrack.weight,                         // Track weight
-                               navState,                                    // Pre-step point navstate
-                               preStepPos,                                  // Pre-step point position
-                               preStepDir,                                  // Pre-step point momentum direction
-                               preStepEnergy,                               // Pre-step point kinetic energy
-                               nextState,                                   // Post-step point navstate
-                               pos,                                         // Post-step point position
-                               dir,                                         // Post-step point momentum direction
-                               eKin,                                        // Post-step point kinetic energy
-                               globalTime,                                  // global time
-                               localTime,                                   // local time
-                               properTime,                                  // proper time
-                               preStepGlobalTime,                           // global time at preStepPoint
-                               currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                               !trackSurvives && !continuesOnCPU,           // whether this was the last step
-                               currentTrack.stepCounter,                    // stepcounter
-                               secondaryData,                               // pointer to secondary init data
-                               nSecondaries);                               // number of secondaries
+      adept_step_recording::RecordGPUStep(currentTrack.trackId, currentTrack.parentId, returnedProcessId,
+                                          IsElectron ? ParticleType::Electron : ParticleType::Positron,
+                                          elTrack.GetPStepLength(), // Step length
+                                          energyDeposit,            // Total Edep
+                                          currentTrack.weight,      // Track weight
+                                          navState,                 // Pre-step point navstate
+                                          preStepPos,               // Pre-step point position
+                                          preStepDir,               // Pre-step point momentum direction
+                                          preStepEnergy,            // Pre-step point kinetic energy
+                                          nextState,                // Post-step point navstate
+                                          pos,                      // Post-step point position
+                                          dir,                      // Post-step point momentum direction
+                                          eKin,                     // Post-step point kinetic energy
+                                          globalTime,               // global time
+                                          localTime,                // local time
+                                          properTime,               // proper time
+                                          preStepGlobalTime,        // global time at preStepPoint
+                                          currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                          !trackSurvives && !continuesOnCPU,           // whether this was the last step
+                                          currentTrack.stepCounter,                    // stepcounter
+                                          secondaryData,                               // pointer to secondary init data
+                                          nSecondaries);                               // number of secondaries
     }
   }
 }

--- a/include/AdePT/kernels/electrons_split.cuh
+++ b/include/AdePT/kernels/electrons_split.cuh
@@ -158,30 +158,31 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
 
           slotManager.MarkSlotForFreeing(slot);
 
-          adept_scoring::RecordHit(currentTrack.trackId,     // Track ID
-                                   currentTrack.parentId,    // parent Track ID
-                                   kAdePTFinishOnCPUProcess, // step limiting process
-                                   IsElectron ? ParticleType::Electron : ParticleType::Positron, // Particle type
-                                   0.,                                                           // Step length
-                                   0.,                                                           // Total Edep
-                                   currentTrack.weight,                                          // Track weight
-                                   currentTrack.navState,                       // Pre-step point navstate
-                                   currentTrack.preStepPos,                     // Pre-step point position
-                                   currentTrack.preStepDir,                     // Pre-step point momentum direction
-                                   currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                                   currentTrack.navState,                       // Post-step point navstate
-                                   currentTrack.pos,                            // Post-step point position
-                                   currentTrack.dir,                            // Post-step point momentum direction
-                                   currentTrack.eKin,                           // Post-step point kinetic energy
-                                   currentTrack.globalTime,                     // global time
-                                   currentTrack.localTime,                      // local time
-                                   currentTrack.properTime,                     // proper time
-                                   currentTrack.preStepGlobalTime,              // preStep global time
-                                   currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                                   false,                                       // parent continues on CPU
-                                   currentTrack.stepCounter,                    // stepcounter
-                                   nullptr,                                     // pointer to secondary init data
-                                   0);                                          // number of secondaries
+          adept_step_recording::RecordGPUStep(currentTrack.trackId,     // Track ID
+                                              currentTrack.parentId,    // parent Track ID
+                                              kAdePTFinishOnCPUProcess, // step limiting process
+                                              IsElectron ? ParticleType::Electron
+                                                         : ParticleType::Positron, // Particle type
+                                              0.,                                  // Step length
+                                              0.,                                  // Total Edep
+                                              currentTrack.weight,                 // Track weight
+                                              currentTrack.navState,               // Pre-step point navstate
+                                              currentTrack.preStepPos,             // Pre-step point position
+                                              currentTrack.preStepDir,             // Pre-step point momentum direction
+                                              currentTrack.preStepEKin,            // Pre-step point kinetic energy
+                                              currentTrack.navState,               // Post-step point navstate
+                                              currentTrack.pos,                    // Post-step point position
+                                              currentTrack.dir,                    // Post-step point momentum direction
+                                              currentTrack.eKin,                   // Post-step point kinetic energy
+                                              currentTrack.globalTime,             // global time
+                                              currentTrack.localTime,              // local time
+                                              currentTrack.properTime,             // proper time
+                                              currentTrack.preStepGlobalTime,      // preStep global time
+                                              currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                              false,                                       // parent continues on CPU
+                                              currentTrack.stepCounter,                    // stepcounter
+                                              nullptr, // pointer to secondary init data
+                                              0);      // number of secondaries
           continue;
         }
       } else {
@@ -190,31 +191,31 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
 
         // In case the last steps are recorded, record it now, as this track is killed
         if (returnLastStep) {
-          adept_scoring::RecordHit(currentTrack.trackId,   // Track ID
-                                   currentTrack.parentId,  // parent Track ID
-                                   static_cast<short>(10), // step limiting process ID
-                                   IsElectron ? ParticleType::Electron : ParticleType::Positron,
-                                   0.,                       // Step length is 0, as post and prestep point are the same
-                                   energyDeposit,            // Total Edep
-                                   currentTrack.weight,      // Track weight
-                                   currentTrack.navState,    // Pre-step point navstate
-                                   currentTrack.preStepPos,  // Pre-step point position
-                                   currentTrack.preStepDir,  // Pre-step point momentum direction
-                                   currentTrack.preStepEKin, // Pre-step point kinetic energy
-                                   currentTrack.navState,    // Post-step point navstate
-                                   currentTrack.pos,         // Post-step point position
-                                   currentTrack.dir,         // Post-step point momentum direction
-                                   currentTrack.eKin,        // Post-step point kinetic energy
-                                   currentTrack.globalTime,  // global time
-                                   currentTrack.localTime,   // local time
-                                   currentTrack.properTime,  // proper time
-                                   currentTrack.preStepGlobalTime, // preStep global time
-                                   currentTrack.eventId,           // eventID
-                                   currentTrack.threadId,          // threadID
-                                   true,                           // whether this was the last step
-                                   currentTrack.stepCounter,       // stepcounter
-                                   nullptr,                        // pointer to secondary init data
-                                   0);                             // number of secondaries
+          adept_step_recording::RecordGPUStep(currentTrack.trackId,   // Track ID
+                                              currentTrack.parentId,  // parent Track ID
+                                              static_cast<short>(10), // step limiting process ID
+                                              IsElectron ? ParticleType::Electron : ParticleType::Positron,
+                                              0.,            // Step length is 0, as post and prestep point are the same
+                                              energyDeposit, // Total Edep
+                                              currentTrack.weight,            // Track weight
+                                              currentTrack.navState,          // Pre-step point navstate
+                                              currentTrack.preStepPos,        // Pre-step point position
+                                              currentTrack.preStepDir,        // Pre-step point momentum direction
+                                              currentTrack.preStepEKin,       // Pre-step point kinetic energy
+                                              currentTrack.navState,          // Post-step point navstate
+                                              currentTrack.pos,               // Post-step point position
+                                              currentTrack.dir,               // Post-step point momentum direction
+                                              currentTrack.eKin,              // Post-step point kinetic energy
+                                              currentTrack.globalTime,        // global time
+                                              currentTrack.localTime,         // local time
+                                              currentTrack.properTime,        // proper time
+                                              currentTrack.preStepGlobalTime, // preStep global time
+                                              currentTrack.eventId,           // eventID
+                                              currentTrack.threadId,          // threadID
+                                              true,                           // whether this was the last step
+                                              currentTrack.stepCounter,       // stepcounter
+                                              nullptr,                        // pointer to secondary init data
+                                              0);                             // number of secondaries
         }
         continue; // track is killed, can stop here
       }
@@ -522,7 +523,7 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
       if (IsElectron) {
         reached_interaction = false;
         trackSurvives       = false;
-        // Ekin = 0 for correct scoring
+        // Ekin = 0 for the returned stopping step
         currentTrack.eKin = 0;
         // Particle is killed by not enqueuing it for the next iteration. Free the slot it occupies
         slotManager.MarkSlotForFreeing(slot);
@@ -571,30 +572,31 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
       // Score the edep for particles that didn't reach the interaction
       if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU ||
           (returnLastStep && (!trackSurvives || continuesOnCPU))) {
-        adept_scoring::RecordHit(currentTrack.trackId,                                         // Track ID
-                                 currentTrack.parentId,                                        // parent Track ID
-                                 static_cast<short>(winnerProcessIndex),                       // step defining process
-                                 IsElectron ? ParticleType::Electron : ParticleType::Positron, // Particle type
-                                 elTrack.GetPStepLength(),                                     // Step length
-                                 energyDeposit,                                                // Total Edep
-                                 currentTrack.weight,                                          // Track weight
-                                 currentTrack.navState,                       // Pre-step point navstate
-                                 currentTrack.preStepPos,                     // Pre-step point position
-                                 currentTrack.preStepDir,                     // Pre-step point momentum direction
-                                 currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                                 currentTrack.nextState,                      // Post-step point navstate
-                                 currentTrack.pos,                            // Post-step point position
-                                 currentTrack.dir,                            // Post-step point momentum direction
-                                 currentTrack.eKin,                           // Post-step point kinetic energy
-                                 currentTrack.globalTime,                     // global time
-                                 currentTrack.localTime,                      // local time
-                                 currentTrack.properTime,                     // proper time
-                                 currentTrack.preStepGlobalTime,              // preStep global time
-                                 currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                                 !trackSurvives && !continuesOnCPU,           // whether this was the last step
-                                 currentTrack.stepCounter,                    // stepcounter
-                                 nullptr,                                     // pointer to secondary init data
-                                 0);                                          // number of secondaries
+        adept_step_recording::RecordGPUStep(currentTrack.trackId,                   // Track ID
+                                            currentTrack.parentId,                  // parent Track ID
+                                            static_cast<short>(winnerProcessIndex), // step defining process
+                                            IsElectron ? ParticleType::Electron
+                                                       : ParticleType::Positron, // Particle type
+                                            elTrack.GetPStepLength(),            // Step length
+                                            energyDeposit,                       // Total Edep
+                                            currentTrack.weight,                 // Track weight
+                                            currentTrack.navState,               // Pre-step point navstate
+                                            currentTrack.preStepPos,             // Pre-step point position
+                                            currentTrack.preStepDir,             // Pre-step point momentum direction
+                                            currentTrack.preStepEKin,            // Pre-step point kinetic energy
+                                            currentTrack.nextState,              // Post-step point navstate
+                                            currentTrack.pos,                    // Post-step point position
+                                            currentTrack.dir,                    // Post-step point momentum direction
+                                            currentTrack.eKin,                   // Post-step point kinetic energy
+                                            currentTrack.globalTime,             // global time
+                                            currentTrack.localTime,              // local time
+                                            currentTrack.properTime,             // proper time
+                                            currentTrack.preStepGlobalTime,      // preStep global time
+                                            currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                            !trackSurvives && !continuesOnCPU, // whether this was the last step
+                                            currentTrack.stepCounter,          // stepcounter
+                                            nullptr,                           // pointer to secondary init data
+                                            0);                                // number of secondaries
       }
     }
   }
@@ -631,10 +633,10 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
     bool cross_boundary = false;
     bool returnsToCPU   = false;
 
-    // Relocate to have the correct next state before RecordHit is called
+    // Relocate to have the correct next state before RecordGPUStep is called
 
     // - Kill loopers stuck at a boundary
-    // - Set cross boundary flag in order to set the correct navstate after scoring
+    // - Set cross boundary flag in order to set the correct navstate for the returned step
     // - Kill particles that left the world
 
     ++currentTrack.looperCounter;
@@ -673,30 +675,30 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
 
     if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnsToCPU ||
         (!trackSurvives && returnLastStep))
-      adept_scoring::RecordHit(currentTrack.trackId,                                         // Track ID
-                               currentTrack.parentId,                                        // parent Track ID
-                               stepProcessId,                                                // step limiting process ID
-                               IsElectron ? ParticleType::Electron : ParticleType::Positron, // Particle type
-                               elTrack.GetPStepLength(),                                     // Step length
-                               energyDeposit,                                                // Total Edep
-                               currentTrack.weight,                                          // Track weight
-                               currentTrack.navState,                                        // Pre-step point navstate
-                               currentTrack.preStepPos,                                      // Pre-step point position
-                               currentTrack.preStepDir,                     // Pre-step point momentum direction
-                               currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                               currentTrack.nextState,                      // Post-step point navstate
-                               currentTrack.pos,                            // Post-step point position
-                               currentTrack.dir,                            // Post-step point momentum direction
-                               currentTrack.eKin,                           // Post-step point kinetic energy
-                               currentTrack.globalTime,                     // global time
-                               currentTrack.localTime,                      // local time
-                               currentTrack.properTime,                     // proper time
-                               currentTrack.preStepGlobalTime,              // preStep global time
-                               currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                               isLastStep,                                  // whether this was the last step
-                               currentTrack.stepCounter,                    // stepcounter
-                               nullptr,                                     // pointer to secondary init data
-                               0);                                          // number of secondaries
+      adept_step_recording::RecordGPUStep(currentTrack.trackId,  // Track ID
+                                          currentTrack.parentId, // parent Track ID
+                                          stepProcessId,         // step limiting process ID
+                                          IsElectron ? ParticleType::Electron : ParticleType::Positron, // Particle type
+                                          elTrack.GetPStepLength(),                                     // Step length
+                                          energyDeposit,                                                // Total Edep
+                                          currentTrack.weight,                                          // Track weight
+                                          currentTrack.navState,          // Pre-step point navstate
+                                          currentTrack.preStepPos,        // Pre-step point position
+                                          currentTrack.preStepDir,        // Pre-step point momentum direction
+                                          currentTrack.preStepEKin,       // Pre-step point kinetic energy
+                                          currentTrack.nextState,         // Post-step point navstate
+                                          currentTrack.pos,               // Post-step point position
+                                          currentTrack.dir,               // Post-step point momentum direction
+                                          currentTrack.eKin,              // Post-step point kinetic energy
+                                          currentTrack.globalTime,        // global time
+                                          currentTrack.localTime,         // local time
+                                          currentTrack.properTime,        // proper time
+                                          currentTrack.preStepGlobalTime, // preStep global time
+                                          currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                          isLastStep,                                  // whether this was the last step
+                                          currentTrack.stepCounter,                    // stepcounter
+                                          nullptr,                                     // pointer to secondary init data
+                                          0);                                          // number of secondaries
 
     if (cross_boundary) {
       // Check if the next volume belongs to the GPU region and push it to the appropriate queue
@@ -861,30 +863,30 @@ __global__ void ElectronIonization(G4HepEmElectronTrack *hepEMTracks, ParticleMa
     // Note: step must be returned if track dies or secondaries have been generated
     if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps ||
         (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
-      adept_scoring::RecordHit(currentTrack.trackId,                                         // Track ID
-                               currentTrack.parentId,                                        // parent Track ID
-                               static_cast<short>(0),                                        // step limiting process ID
-                               IsElectron ? ParticleType::Electron : ParticleType::Positron, // Particle type
-                               elTrack.GetPStepLength(),                                     // Step length
-                               energyDeposit,                                                // Total Edep
-                               currentTrack.weight,                                          // Track weight
-                               currentTrack.navState,                                        // Pre-step point navstate
-                               currentTrack.preStepPos,                                      // Pre-step point position
-                               currentTrack.preStepDir,                     // Pre-step point momentum direction
-                               currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                               currentTrack.nextState,                      // Post-step point navstate
-                               currentTrack.pos,                            // Post-step point position
-                               currentTrack.dir,                            // Post-step point momentum direction
-                               currentTrack.eKin,                           // Post-step point kinetic energy
-                               currentTrack.globalTime,                     // global time
-                               currentTrack.localTime,                      // local time
-                               currentTrack.properTime,                     // proper time
-                               currentTrack.preStepGlobalTime,              // preStep global time
-                               currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                               !trackSurvives,                              // whether this was the last step
-                               currentTrack.stepCounter,                    // stepcounter
-                               secondaryData,                               // pointer to secondary init data
-                               nSecondaries);                               // number of secondaries
+      adept_step_recording::RecordGPUStep(currentTrack.trackId,  // Track ID
+                                          currentTrack.parentId, // parent Track ID
+                                          static_cast<short>(0), // step limiting process ID
+                                          IsElectron ? ParticleType::Electron : ParticleType::Positron, // Particle type
+                                          elTrack.GetPStepLength(),                                     // Step length
+                                          energyDeposit,                                                // Total Edep
+                                          currentTrack.weight,                                          // Track weight
+                                          currentTrack.navState,          // Pre-step point navstate
+                                          currentTrack.preStepPos,        // Pre-step point position
+                                          currentTrack.preStepDir,        // Pre-step point momentum direction
+                                          currentTrack.preStepEKin,       // Pre-step point kinetic energy
+                                          currentTrack.nextState,         // Post-step point navstate
+                                          currentTrack.pos,               // Post-step point position
+                                          currentTrack.dir,               // Post-step point momentum direction
+                                          currentTrack.eKin,              // Post-step point kinetic energy
+                                          currentTrack.globalTime,        // global time
+                                          currentTrack.localTime,         // local time
+                                          currentTrack.properTime,        // proper time
+                                          currentTrack.preStepGlobalTime, // preStep global time
+                                          currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                          !trackSurvives,                              // whether this was the last step
+                                          currentTrack.stepCounter,                    // stepcounter
+                                          secondaryData,                               // pointer to secondary init data
+                                          nSecondaries);                               // number of secondaries
     }
   }
 }
@@ -1002,30 +1004,30 @@ __global__ void ElectronBremsstrahlung(G4HepEmElectronTrack *hepEMTracks, Partic
     // Note: step must be returned if track dies or secondaries were generated
     if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps ||
         (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
-      adept_scoring::RecordHit(currentTrack.trackId,                                         // Track ID
-                               currentTrack.parentId,                                        // parent Track ID
-                               static_cast<short>(1),                                        // step limiting process ID
-                               IsElectron ? ParticleType::Electron : ParticleType::Positron, // Particle type
-                               elTrack.GetPStepLength(),                                     // Step length
-                               energyDeposit,                                                // Total Edep
-                               currentTrack.weight,                                          // Track weight
-                               currentTrack.navState,                                        // Pre-step point navstate
-                               currentTrack.preStepPos,                                      // Pre-step point position
-                               currentTrack.preStepDir,                     // Pre-step point momentum direction
-                               currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                               currentTrack.nextState,                      // Post-step point navstate
-                               currentTrack.pos,                            // Post-step point position
-                               currentTrack.dir,                            // Post-step point momentum direction
-                               currentTrack.eKin,                           // Post-step point kinetic energy
-                               currentTrack.globalTime,                     // global time
-                               currentTrack.localTime,                      // local time
-                               currentTrack.properTime,                     // proper time
-                               currentTrack.preStepGlobalTime,              // preStep global time
-                               currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                               !trackSurvives,                              // whether this was the last step
-                               currentTrack.stepCounter,                    // stepcounter
-                               secondaryData,                               // pointer to secondary init data
-                               nSecondaries);                               // number of secondaries
+      adept_step_recording::RecordGPUStep(currentTrack.trackId,  // Track ID
+                                          currentTrack.parentId, // parent Track ID
+                                          static_cast<short>(1), // step limiting process ID
+                                          IsElectron ? ParticleType::Electron : ParticleType::Positron, // Particle type
+                                          elTrack.GetPStepLength(),                                     // Step length
+                                          energyDeposit,                                                // Total Edep
+                                          currentTrack.weight,                                          // Track weight
+                                          currentTrack.navState,          // Pre-step point navstate
+                                          currentTrack.preStepPos,        // Pre-step point position
+                                          currentTrack.preStepDir,        // Pre-step point momentum direction
+                                          currentTrack.preStepEKin,       // Pre-step point kinetic energy
+                                          currentTrack.nextState,         // Post-step point navstate
+                                          currentTrack.pos,               // Post-step point position
+                                          currentTrack.dir,               // Post-step point momentum direction
+                                          currentTrack.eKin,              // Post-step point kinetic energy
+                                          currentTrack.globalTime,        // global time
+                                          currentTrack.localTime,         // local time
+                                          currentTrack.properTime,        // proper time
+                                          currentTrack.preStepGlobalTime, // preStep global time
+                                          currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                          !trackSurvives,                              // whether this was the last step
+                                          currentTrack.stepCounter,                    // stepcounter
+                                          secondaryData,                               // pointer to secondary init data
+                                          nSecondaries);                               // number of secondaries
     }
   }
 }
@@ -1140,30 +1142,31 @@ __global__ void PositronAnnihilation(G4HepEmElectronTrack *hepEMTracks, Particle
 
     // Record the step. Edep includes the continuous energy loss and edep from secondaries which were cut
     if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep) {
-      adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
-                               currentTrack.parentId,                       // parent Track ID
-                               static_cast<short>(2),                       // step limiting process ID
-                               ParticleType::Positron,                      // Particle type
-                               elTrack.GetPStepLength(),                    // Step length
-                               energyDeposit,                               // Total Edep
-                               currentTrack.weight,                         // Track weight
-                               currentTrack.navState,                       // Pre-step point navstate
-                               currentTrack.preStepPos,                     // Pre-step point position
-                               currentTrack.preStepDir,                     // Pre-step point momentum direction
-                               currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                               currentTrack.nextState,                      // Post-step point navstate
-                               currentTrack.pos,                            // Post-step point position
-                               currentTrack.dir,                            // Post-step point momentum direction
-                               currentTrack.eKin,                           // Post-step point kinetic energy
-                               currentTrack.globalTime,                     // global time
-                               currentTrack.localTime,                      // local time
-                               currentTrack.properTime,                     // proper time
-                               currentTrack.preStepGlobalTime,              // preStep global time
-                               currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                               true, // whether this was the last step: always true for annihilating positrons
-                               currentTrack.stepCounter, // stepcounter
-                               secondaryData,            // pointer to secondary init data
-                               nSecondaries);            // number of secondaries
+      adept_step_recording::RecordGPUStep(
+          currentTrack.trackId,                        // Track ID
+          currentTrack.parentId,                       // parent Track ID
+          static_cast<short>(2),                       // step limiting process ID
+          ParticleType::Positron,                      // Particle type
+          elTrack.GetPStepLength(),                    // Step length
+          energyDeposit,                               // Total Edep
+          currentTrack.weight,                         // Track weight
+          currentTrack.navState,                       // Pre-step point navstate
+          currentTrack.preStepPos,                     // Pre-step point position
+          currentTrack.preStepDir,                     // Pre-step point momentum direction
+          currentTrack.preStepEKin,                    // Pre-step point kinetic energy
+          currentTrack.nextState,                      // Post-step point navstate
+          currentTrack.pos,                            // Post-step point position
+          currentTrack.dir,                            // Post-step point momentum direction
+          currentTrack.eKin,                           // Post-step point kinetic energy
+          currentTrack.globalTime,                     // global time
+          currentTrack.localTime,                      // local time
+          currentTrack.properTime,                     // proper time
+          currentTrack.preStepGlobalTime,              // preStep global time
+          currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+          true,                     // whether this was the last step: always true for annihilating positrons
+          currentTrack.stepCounter, // stepcounter
+          secondaryData,            // pointer to secondary init data
+          nSecondaries);            // number of secondaries
     }
   }
 }
@@ -1212,30 +1215,31 @@ __global__ void PositronStoppedAnnihilation(G4HepEmElectronTrack *hepEMTracks, P
 
     // Record the step. Edep includes the continuous energy loss and edep from secondaries which were cut
     if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep) {
-      adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
-                               currentTrack.parentId,                       // parent Track ID
-                               static_cast<short>(2),                       // step limiting process ID
-                               ParticleType::Positron,                      // Particle type
-                               elTrack.GetPStepLength(),                    // Step length
-                               energyDeposit,                               // Total Edep
-                               currentTrack.weight,                         // Track weight
-                               currentTrack.navState,                       // Pre-step point navstate
-                               currentTrack.preStepPos,                     // Pre-step point position
-                               currentTrack.preStepDir,                     // Pre-step point momentum direction
-                               currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                               currentTrack.nextState,                      // Post-step point navstate
-                               currentTrack.pos,                            // Post-step point position
-                               currentTrack.dir,                            // Post-step point momentum direction
-                               currentTrack.eKin,                           // Post-step point kinetic energy
-                               currentTrack.globalTime,                     // global time
-                               currentTrack.localTime,                      // local time
-                               currentTrack.properTime,                     // proper time
-                               currentTrack.preStepGlobalTime,              // preStep global time
-                               currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                               true, // whether this was the last step: always true for annihilating positrons
-                               currentTrack.stepCounter, // stepcounter
-                               secondaryData,            // pointer to secondary init data
-                               nSecondaries);            // number of secondaries
+      adept_step_recording::RecordGPUStep(
+          currentTrack.trackId,                        // Track ID
+          currentTrack.parentId,                       // parent Track ID
+          static_cast<short>(2),                       // step limiting process ID
+          ParticleType::Positron,                      // Particle type
+          elTrack.GetPStepLength(),                    // Step length
+          energyDeposit,                               // Total Edep
+          currentTrack.weight,                         // Track weight
+          currentTrack.navState,                       // Pre-step point navstate
+          currentTrack.preStepPos,                     // Pre-step point position
+          currentTrack.preStepDir,                     // Pre-step point momentum direction
+          currentTrack.preStepEKin,                    // Pre-step point kinetic energy
+          currentTrack.nextState,                      // Post-step point navstate
+          currentTrack.pos,                            // Post-step point position
+          currentTrack.dir,                            // Post-step point momentum direction
+          currentTrack.eKin,                           // Post-step point kinetic energy
+          currentTrack.globalTime,                     // global time
+          currentTrack.localTime,                      // local time
+          currentTrack.properTime,                     // proper time
+          currentTrack.preStepGlobalTime,              // preStep global time
+          currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+          true,                     // whether this was the last step: always true for annihilating positrons
+          currentTrack.stepCounter, // stepcounter
+          secondaryData,            // pointer to secondary init data
+          nSecondaries);            // number of secondaries
     }
   }
 }

--- a/include/AdePT/kernels/gammas.cuh
+++ b/include/AdePT/kernels/gammas.cuh
@@ -457,30 +457,31 @@ __global__ void __launch_bounds__(256, 1)
     // If there is some edep from cutting particles, record the step
     if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU || winnerProcessIndex == 3 ||
         (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
-      adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
-                               currentTrack.parentId,                       // parent Track ID
-                               stepDefinedProcessId,                        // step-defining process id
-                               ParticleType::Gamma,                         // Particle type
-                               geometryStepLength,                          // Step length
-                               edep,                                        // Total Edep
-                               currentTrack.weight,                         // Track weight
-                               navState,                                    // Pre-step point navstate
-                               preStepPos,                                  // Pre-step point position
-                               preStepDir,                                  // Pre-step point momentum direction
-                               preStepEnergy,                               // Pre-step point kinetic energy
-                               nextState,                                   // Post-step point navstate
-                               pos,                                         // Post-step point position
-                               dir,                                         // Post-step point momentum direction
-                               eKin,                                        // Post-step point kinetic energy
-                               globalTime,                                  // global time
-                               localTime,                                   // local time
-                               properTime,                                  // proper time
-                               preStepGlobalTime,                           // global time at preStepPoint
-                               currentTrack.eventId, currentTrack.threadId, // event and thread ID
-                               !trackSurvives && !continuesOnCPU, // whether this is the last step of the track
-                               currentTrack.stepCounter,          // stepcounter
-                               secondaryData,                     // pointer to secondary init data
-                               nSecondaries);                     // number of secondaries
+      adept_step_recording::RecordGPUStep(currentTrack.trackId,  // Track ID
+                                          currentTrack.parentId, // parent Track ID
+                                          stepDefinedProcessId,  // step-defining process id
+                                          ParticleType::Gamma,   // Particle type
+                                          geometryStepLength,    // Step length
+                                          edep,                  // Total Edep
+                                          currentTrack.weight,   // Track weight
+                                          navState,              // Pre-step point navstate
+                                          preStepPos,            // Pre-step point position
+                                          preStepDir,            // Pre-step point momentum direction
+                                          preStepEnergy,         // Pre-step point kinetic energy
+                                          nextState,             // Post-step point navstate
+                                          pos,                   // Post-step point position
+                                          dir,                   // Post-step point momentum direction
+                                          eKin,                  // Post-step point kinetic energy
+                                          globalTime,            // global time
+                                          localTime,             // local time
+                                          properTime,            // proper time
+                                          preStepGlobalTime,     // global time at preStepPoint
+                                          currentTrack.eventId, currentTrack.threadId, // event and thread ID
+                                          !trackSurvives &&
+                                              !continuesOnCPU,      // whether this is the last step of the track
+                                          currentTrack.stepCounter, // stepcounter
+                                          secondaryData,            // pointer to secondary init data
+                                          nSecondaries);            // number of secondaries
     }
   } // end for loop over tracks
 }

--- a/include/AdePT/kernels/gammasWDT.cuh
+++ b/include/AdePT/kernels/gammasWDT.cuh
@@ -653,30 +653,31 @@ __global__ void __launch_bounds__(256, 1)
     // If there is some edep from cutting particles or if it is the last step, record the step
     if ((edep > 0 && nextauxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU || winnerProcessIndex == 3 ||
         (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
-      adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
-                               currentTrack.parentId,                       // parent Track ID
-                               stepDefinedProcessId,                        // step-defining process id
-                               ParticleType::Gamma,                         // Particle type
-                               wdtStepLength,                               // Step length
-                               edep,                                        // Total Edep
-                               currentTrack.weight,                         // Track weight
-                               navState,                                    // Pre-step point navstate
-                               preStepPos,                                  // Pre-step point position
-                               preStepDir,                                  // Pre-step point momentum direction
-                               preStepEnergy,                               // Pre-step point kinetic energy
-                               nextState,                                   // Post-step point navstate
-                               pos,                                         // Post-step point position
-                               dir,                                         // Post-step point momentum direction
-                               eKin,                                        // Post-step point kinetic energy
-                               globalTime,                                  // global time
-                               localTime,                                   // local time
-                               properTime,                                  // proper time
-                               preStepGlobalTime,                           // global time at preStepPoint
-                               currentTrack.eventId, currentTrack.threadId, // event and thread ID
-                               !trackSurvives && !continuesOnCPU, // whether this is the last step of the track
-                               currentTrack.stepCounter,          // stepcounter
-                               secondaryData,                     // pointer to secondary init data
-                               nSecondaries);                     // number of secondaries
+      adept_step_recording::RecordGPUStep(currentTrack.trackId,  // Track ID
+                                          currentTrack.parentId, // parent Track ID
+                                          stepDefinedProcessId,  // step-defining process id
+                                          ParticleType::Gamma,   // Particle type
+                                          wdtStepLength,         // Step length
+                                          edep,                  // Total Edep
+                                          currentTrack.weight,   // Track weight
+                                          navState,              // Pre-step point navstate
+                                          preStepPos,            // Pre-step point position
+                                          preStepDir,            // Pre-step point momentum direction
+                                          preStepEnergy,         // Pre-step point kinetic energy
+                                          nextState,             // Post-step point navstate
+                                          pos,                   // Post-step point position
+                                          dir,                   // Post-step point momentum direction
+                                          eKin,                  // Post-step point kinetic energy
+                                          globalTime,            // global time
+                                          localTime,             // local time
+                                          properTime,            // proper time
+                                          preStepGlobalTime,     // global time at preStepPoint
+                                          currentTrack.eventId, currentTrack.threadId, // event and thread ID
+                                          !trackSurvives &&
+                                              !continuesOnCPU,      // whether this is the last step of the track
+                                          currentTrack.stepCounter, // stepcounter
+                                          secondaryData,            // pointer to secondary init data
+                                          nSecondaries);            // number of secondaries
     }
   } // end for loop over tracks
 }

--- a/include/AdePT/kernels/gammasWDT_split.cuh
+++ b/include/AdePT/kernels/gammasWDT_split.cuh
@@ -132,30 +132,30 @@ __global__ void __launch_bounds__(256, 1)
 
           slotManager.MarkSlotForFreeing(slot);
 
-          adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
-                                   currentTrack.parentId,                       // parent Track ID
-                                   kAdePTFinishOnCPUProcess,                    // step limiting process ID
-                                   ParticleType::Gamma,                         // Particle type
-                                   0.,                                          // Step length
-                                   0.,                                          // Total Edep
-                                   currentTrack.weight,                         // Track weight
-                                   currentTrack.navState,                       // Pre-step point navstate
-                                   currentTrack.preStepPos,                     // Pre-step point position
-                                   currentTrack.preStepDir,                     // Pre-step point momentum direction
-                                   currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                                   currentTrack.navState,                       // Post-step point navstate
-                                   currentTrack.pos,                            // Post-step point position
-                                   currentTrack.dir,                            // Post-step point momentum direction
-                                   currentTrack.eKin,                           // Post-step point kinetic energy
-                                   currentTrack.globalTime,                     // global time
-                                   currentTrack.localTime,                      // local time
-                                   currentTrack.properTime,                     // proper time
-                                   currentTrack.preStepGlobalTime,              // preStep global time
-                                   currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                                   false,                                       // parent continues on CPU
-                                   currentTrack.stepCounter,                    // stepcounter
-                                   nullptr,                                     // pointer to secondary init data
-                                   0);                                          // number of secondaries
+          adept_step_recording::RecordGPUStep(currentTrack.trackId,           // Track ID
+                                              currentTrack.parentId,          // parent Track ID
+                                              kAdePTFinishOnCPUProcess,       // step limiting process ID
+                                              ParticleType::Gamma,            // Particle type
+                                              0.,                             // Step length
+                                              0.,                             // Total Edep
+                                              currentTrack.weight,            // Track weight
+                                              currentTrack.navState,          // Pre-step point navstate
+                                              currentTrack.preStepPos,        // Pre-step point position
+                                              currentTrack.preStepDir,        // Pre-step point momentum direction
+                                              currentTrack.preStepEKin,       // Pre-step point kinetic energy
+                                              currentTrack.navState,          // Post-step point navstate
+                                              currentTrack.pos,               // Post-step point position
+                                              currentTrack.dir,               // Post-step point momentum direction
+                                              currentTrack.eKin,              // Post-step point kinetic energy
+                                              currentTrack.globalTime,        // global time
+                                              currentTrack.localTime,         // local time
+                                              currentTrack.properTime,        // proper time
+                                              currentTrack.preStepGlobalTime, // preStep global time
+                                              currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                              false,                                       // parent continues on CPU
+                                              currentTrack.stepCounter,                    // stepcounter
+                                              nullptr, // pointer to secondary init data
+                                              0);      // number of secondaries
           continue;
         }
       } else {
@@ -164,30 +164,30 @@ __global__ void __launch_bounds__(256, 1)
 
         // In case the last steps are recorded, record it now, as this track is killed
         if (returnLastStep) {
-          adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
-                                   currentTrack.parentId,                       // parent Track ID
-                                   static_cast<short>(10),                      // step limiting process ID
-                                   ParticleType::Gamma,                         // Particle type
-                                   thePrimaryTrack->GetGStepLength(),           // Step length
-                                   energyDeposit,                               // Total Edep
-                                   currentTrack.weight,                         // Track weight
-                                   currentTrack.navState,                       // Pre-step point navstate
-                                   currentTrack.preStepPos,                     // Pre-step point position
-                                   currentTrack.preStepDir,                     // Pre-step point momentum direction
-                                   currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                                   currentTrack.navState,                       // Post-step point navstate
-                                   currentTrack.pos,                            // Post-step point position
-                                   currentTrack.dir,                            // Post-step point momentum direction
-                                   currentTrack.eKin,                           // Post-step point kinetic energy
-                                   currentTrack.globalTime,                     // global time
-                                   currentTrack.localTime,                      // local time
-                                   currentTrack.properTime,                     // proper time
-                                   currentTrack.preStepGlobalTime,              // preStep global time
-                                   currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                                   true,                                        // whether this was the last step
-                                   currentTrack.stepCounter,                    // stepcounter
-                                   nullptr,                                     // pointer to secondary init data
-                                   0);                                          // number of secondaries
+          adept_step_recording::RecordGPUStep(currentTrack.trackId,              // Track ID
+                                              currentTrack.parentId,             // parent Track ID
+                                              static_cast<short>(10),            // step limiting process ID
+                                              ParticleType::Gamma,               // Particle type
+                                              thePrimaryTrack->GetGStepLength(), // Step length
+                                              energyDeposit,                     // Total Edep
+                                              currentTrack.weight,               // Track weight
+                                              currentTrack.navState,             // Pre-step point navstate
+                                              currentTrack.preStepPos,           // Pre-step point position
+                                              currentTrack.preStepDir,           // Pre-step point momentum direction
+                                              currentTrack.preStepEKin,          // Pre-step point kinetic energy
+                                              currentTrack.navState,             // Post-step point navstate
+                                              currentTrack.pos,                  // Post-step point position
+                                              currentTrack.dir,                  // Post-step point momentum direction
+                                              currentTrack.eKin,                 // Post-step point kinetic energy
+                                              currentTrack.globalTime,           // global time
+                                              currentTrack.localTime,            // local time
+                                              currentTrack.properTime,           // proper time
+                                              currentTrack.preStepGlobalTime,    // preStep global time
+                                              currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                              true,                     // whether this was the last step
+                                              currentTrack.stepCounter, // stepcounter
+                                              nullptr,                  // pointer to secondary init data
+                                              0);                       // number of secondaries
         }
         continue; // track is killed, can stop here
       }
@@ -501,30 +501,30 @@ __global__ void __launch_bounds__(256, 1)
 #endif
 
           slotManager.MarkSlotForFreeing(slot);
-          adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
-                                   currentTrack.parentId,                       // parent Track ID
-                                   kAdePTOutOfGPURegionProcess,                 // step limiting process ID
-                                   ParticleType::Gamma,                         // Particle type
-                                   thePrimaryTrack->GetGStepLength(),           // Step length
-                                   0.,                                          // Total Edep
-                                   currentTrack.weight,                         // Track weight
-                                   currentTrack.navState,                       // Pre-step point navstate
-                                   currentTrack.preStepPos,                     // Pre-step point position
-                                   currentTrack.preStepDir,                     // Pre-step point momentum direction
-                                   currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                                   currentTrack.nextState,                      // Post-step point navstate
-                                   currentTrack.pos,                            // Post-step point position
-                                   currentTrack.dir,                            // Post-step point momentum direction
-                                   currentTrack.eKin,                           // Post-step point kinetic energy
-                                   currentTrack.globalTime,                     // global time
-                                   currentTrack.localTime,                      // local time
-                                   currentTrack.properTime,                     // proper time
-                                   currentTrack.preStepGlobalTime,              // preStep global time
-                                   currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                                   false,                                       // parent continues on CPU
-                                   currentTrack.stepCounter,                    // stepcounter
-                                   nullptr,                                     // pointer to secondary init data
-                                   0);                                          // number of secondaries
+          adept_step_recording::RecordGPUStep(currentTrack.trackId,              // Track ID
+                                              currentTrack.parentId,             // parent Track ID
+                                              kAdePTOutOfGPURegionProcess,       // step limiting process ID
+                                              ParticleType::Gamma,               // Particle type
+                                              thePrimaryTrack->GetGStepLength(), // Step length
+                                              0.,                                // Total Edep
+                                              currentTrack.weight,               // Track weight
+                                              currentTrack.navState,             // Pre-step point navstate
+                                              currentTrack.preStepPos,           // Pre-step point position
+                                              currentTrack.preStepDir,           // Pre-step point momentum direction
+                                              currentTrack.preStepEKin,          // Pre-step point kinetic energy
+                                              currentTrack.nextState,            // Post-step point navstate
+                                              currentTrack.pos,                  // Post-step point position
+                                              currentTrack.dir,                  // Post-step point momentum direction
+                                              currentTrack.eKin,                 // Post-step point kinetic energy
+                                              currentTrack.globalTime,           // global time
+                                              currentTrack.localTime,            // local time
+                                              currentTrack.properTime,           // proper time
+                                              currentTrack.preStepGlobalTime,    // preStep global time
+                                              currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                              false,                                       // parent continues on CPU
+                                              currentTrack.stepCounter,                    // stepcounter
+                                              nullptr, // pointer to secondary init data
+                                              0);      // number of secondaries
           continue;
         }
       } // else particle has left the world

--- a/include/AdePT/kernels/gammas_split.cuh
+++ b/include/AdePT/kernels/gammas_split.cuh
@@ -104,30 +104,30 @@ __global__ void GammaHowFar(G4HepEmGammaTrack *hepEMTracks, ParticleManager part
 
           slotManager.MarkSlotForFreeing(slot);
 
-          adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
-                                   currentTrack.parentId,                       // parent Track ID
-                                   kAdePTFinishOnCPUProcess,                    // step limiting process ID
-                                   ParticleType::Gamma,                         // Particle type
-                                   0.,                                          // Step length
-                                   0.,                                          // Total Edep
-                                   currentTrack.weight,                         // Track weight
-                                   currentTrack.navState,                       // Pre-step point navstate
-                                   currentTrack.preStepPos,                     // Pre-step point position
-                                   currentTrack.preStepDir,                     // Pre-step point momentum direction
-                                   currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                                   currentTrack.navState,                       // Post-step point navstate
-                                   currentTrack.pos,                            // Post-step point position
-                                   currentTrack.dir,                            // Post-step point momentum direction
-                                   currentTrack.eKin,                           // Post-step point kinetic energy
-                                   currentTrack.globalTime,                     // global time
-                                   currentTrack.localTime,                      // local time
-                                   currentTrack.properTime,                     // proper time
-                                   currentTrack.preStepGlobalTime,              // preStep global time
-                                   currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                                   false,                                       // parent continues on CPU
-                                   currentTrack.stepCounter,                    // stepcounter
-                                   nullptr,                                     // pointer to secondary init data
-                                   0);                                          // number of secondaries
+          adept_step_recording::RecordGPUStep(currentTrack.trackId,           // Track ID
+                                              currentTrack.parentId,          // parent Track ID
+                                              kAdePTFinishOnCPUProcess,       // step limiting process ID
+                                              ParticleType::Gamma,            // Particle type
+                                              0.,                             // Step length
+                                              0.,                             // Total Edep
+                                              currentTrack.weight,            // Track weight
+                                              currentTrack.navState,          // Pre-step point navstate
+                                              currentTrack.preStepPos,        // Pre-step point position
+                                              currentTrack.preStepDir,        // Pre-step point momentum direction
+                                              currentTrack.preStepEKin,       // Pre-step point kinetic energy
+                                              currentTrack.navState,          // Post-step point navstate
+                                              currentTrack.pos,               // Post-step point position
+                                              currentTrack.dir,               // Post-step point momentum direction
+                                              currentTrack.eKin,              // Post-step point kinetic energy
+                                              currentTrack.globalTime,        // global time
+                                              currentTrack.localTime,         // local time
+                                              currentTrack.properTime,        // proper time
+                                              currentTrack.preStepGlobalTime, // preStep global time
+                                              currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                              false,                                       // parent continues on CPU
+                                              currentTrack.stepCounter,                    // stepcounter
+                                              nullptr, // pointer to secondary init data
+                                              0);      // number of secondaries
           continue;
         }
       } else {
@@ -136,30 +136,30 @@ __global__ void GammaHowFar(G4HepEmGammaTrack *hepEMTracks, ParticleManager part
 
         // In case the last steps are recorded, record it now, as this track is killed
         if (returnLastStep) {
-          adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
-                                   currentTrack.parentId,                       // parent Track ID
-                                   static_cast<short>(10),                      // step limiting process ID
-                                   ParticleType::Gamma,                         // Particle type
-                                   theTrack->GetGStepLength(),                  // Step length
-                                   energyDeposit,                               // Total Edep
-                                   currentTrack.weight,                         // Track weight
-                                   currentTrack.navState,                       // Pre-step point navstate
-                                   currentTrack.preStepPos,                     // Pre-step point position
-                                   currentTrack.preStepDir,                     // Pre-step point momentum direction
-                                   currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                                   currentTrack.navState,                       // Post-step point navstate
-                                   currentTrack.pos,                            // Post-step point position
-                                   currentTrack.dir,                            // Post-step point momentum direction
-                                   currentTrack.eKin,                           // Post-step point kinetic energy
-                                   currentTrack.globalTime,                     // global time
-                                   currentTrack.localTime,                      // local time
-                                   currentTrack.properTime,                     // proper time
-                                   currentTrack.preStepGlobalTime,              // preStep global time
-                                   currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                                   true,                                        // whether this was the last step
-                                   currentTrack.stepCounter,                    // stepcounter
-                                   nullptr,                                     // pointer to secondary init data
-                                   0);                                          // number of secondaries
+          adept_step_recording::RecordGPUStep(currentTrack.trackId,           // Track ID
+                                              currentTrack.parentId,          // parent Track ID
+                                              static_cast<short>(10),         // step limiting process ID
+                                              ParticleType::Gamma,            // Particle type
+                                              theTrack->GetGStepLength(),     // Step length
+                                              energyDeposit,                  // Total Edep
+                                              currentTrack.weight,            // Track weight
+                                              currentTrack.navState,          // Pre-step point navstate
+                                              currentTrack.preStepPos,        // Pre-step point position
+                                              currentTrack.preStepDir,        // Pre-step point momentum direction
+                                              currentTrack.preStepEKin,       // Pre-step point kinetic energy
+                                              currentTrack.navState,          // Post-step point navstate
+                                              currentTrack.pos,               // Post-step point position
+                                              currentTrack.dir,               // Post-step point momentum direction
+                                              currentTrack.eKin,              // Post-step point kinetic energy
+                                              currentTrack.globalTime,        // global time
+                                              currentTrack.localTime,         // local time
+                                              currentTrack.properTime,        // proper time
+                                              currentTrack.preStepGlobalTime, // preStep global time
+                                              currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                              true,                     // whether this was the last step
+                                              currentTrack.stepCounter, // stepcounter
+                                              nullptr,                  // pointer to secondary init data
+                                              0);                       // number of secondaries
         }
         continue; // track is killed, can stop here
       }
@@ -264,30 +264,30 @@ __global__ void GammaSetupInteractions(G4HepEmGammaTrack *hepEMTracks, const ade
 
         // Gamma-nuclear must always return the step so the host can replay the
         // interaction even when user callbacks are disabled.
-        adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
-                                 currentTrack.parentId,                       // parent Track ID
-                                 static_cast<short>(3),                       // step defining process ID
-                                 ParticleType::Gamma,                         // Particle type
-                                 theTrack->GetGStepLength(),                  // Step length
-                                 0,                                           // Total Edep
-                                 currentTrack.weight,                         // Track weight
-                                 currentTrack.navState,                       // Pre-step point navstate
-                                 currentTrack.preStepPos,                     // Pre-step point position
-                                 currentTrack.preStepDir,                     // Pre-step point momentum direction
-                                 currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                                 currentTrack.nextState,                      // Post-step point navstate
-                                 currentTrack.pos,                            // Post-step point position
-                                 currentTrack.dir,                            // Post-step point momentum direction
-                                 currentTrack.eKin,                           // Post-step point kinetic energy
-                                 currentTrack.globalTime,                     // global time
-                                 currentTrack.localTime,                      // local time
-                                 currentTrack.properTime,                     // proper time
-                                 currentTrack.preStepGlobalTime,              // preStep global time
-                                 currentTrack.eventId, currentTrack.threadId, // event and thread ID
-                                 true,                                        // gamma nuclear kills the parent
-                                 currentTrack.stepCounter,                    // stepcounter
-                                 nullptr,                                     // pointer to secondary init data
-                                 0);                                          // number of secondaries
+        adept_step_recording::RecordGPUStep(currentTrack.trackId,           // Track ID
+                                            currentTrack.parentId,          // parent Track ID
+                                            static_cast<short>(3),          // step defining process ID
+                                            ParticleType::Gamma,            // Particle type
+                                            theTrack->GetGStepLength(),     // Step length
+                                            0,                              // Total Edep
+                                            currentTrack.weight,            // Track weight
+                                            currentTrack.navState,          // Pre-step point navstate
+                                            currentTrack.preStepPos,        // Pre-step point position
+                                            currentTrack.preStepDir,        // Pre-step point momentum direction
+                                            currentTrack.preStepEKin,       // Pre-step point kinetic energy
+                                            currentTrack.nextState,         // Post-step point navstate
+                                            currentTrack.pos,               // Post-step point position
+                                            currentTrack.dir,               // Post-step point momentum direction
+                                            currentTrack.eKin,              // Post-step point kinetic energy
+                                            currentTrack.globalTime,        // global time
+                                            currentTrack.localTime,         // local time
+                                            currentTrack.properTime,        // proper time
+                                            currentTrack.preStepGlobalTime, // preStep global time
+                                            currentTrack.eventId, currentTrack.threadId, // event and thread ID
+                                            true,                     // gamma nuclear kills the parent
+                                            currentTrack.stepCounter, // stepcounter
+                                            nullptr,                  // pointer to secondary init data
+                                            0);                       // number of secondaries
       }
     }
   }
@@ -346,30 +346,30 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
       }
 
       if (returnAllSteps || returnsToCPU)
-        adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
-                                 currentTrack.parentId,                       // parent Track ID
-                                 stepProcessId,                               // step defining process ID
-                                 ParticleType::Gamma,                         // Particle type
-                                 theTrack->GetGStepLength(),                  // Step length
-                                 0,                                           // Total Edep
-                                 currentTrack.weight,                         // Track weight
-                                 currentTrack.navState,                       // Pre-step point navstate
-                                 currentTrack.preStepPos,                     // Pre-step point position
-                                 currentTrack.preStepDir,                     // Pre-step point momentum direction
-                                 currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                                 currentTrack.nextState,                      // Post-step point navstate
-                                 currentTrack.pos,                            // Post-step point position
-                                 currentTrack.dir,                            // Post-step point momentum direction
-                                 currentTrack.eKin,                           // Post-step point kinetic energy
-                                 currentTrack.globalTime,                     // global time
-                                 currentTrack.localTime,                      // local time
-                                 currentTrack.properTime,                     // proper time
-                                 currentTrack.preStepGlobalTime,              // preStep global time
-                                 currentTrack.eventId, currentTrack.threadId, // event and thread ID
-                                 false,                    // whether this is the last step of the track
-                                 currentTrack.stepCounter, // stepcounter
-                                 nullptr,                  // pointer to secondary init data
-                                 0);                       // number of secondaries
+        adept_step_recording::RecordGPUStep(currentTrack.trackId,           // Track ID
+                                            currentTrack.parentId,          // parent Track ID
+                                            stepProcessId,                  // step defining process ID
+                                            ParticleType::Gamma,            // Particle type
+                                            theTrack->GetGStepLength(),     // Step length
+                                            0,                              // Total Edep
+                                            currentTrack.weight,            // Track weight
+                                            currentTrack.navState,          // Pre-step point navstate
+                                            currentTrack.preStepPos,        // Pre-step point position
+                                            currentTrack.preStepDir,        // Pre-step point momentum direction
+                                            currentTrack.preStepEKin,       // Pre-step point kinetic energy
+                                            currentTrack.nextState,         // Post-step point navstate
+                                            currentTrack.pos,               // Post-step point position
+                                            currentTrack.dir,               // Post-step point momentum direction
+                                            currentTrack.eKin,              // Post-step point kinetic energy
+                                            currentTrack.globalTime,        // global time
+                                            currentTrack.localTime,         // local time
+                                            currentTrack.properTime,        // proper time
+                                            currentTrack.preStepGlobalTime, // preStep global time
+                                            currentTrack.eventId, currentTrack.threadId, // event and thread ID
+                                            false,                    // whether this is the last step of the track
+                                            currentTrack.stepCounter, // stepcounter
+                                            nullptr,                  // pointer to secondary init data
+                                            0);                       // number of secondaries
 
       // Check if the next volume belongs to the GPU region and push it to the appropriate queue.
       if (!returnsToCPU) {
@@ -398,7 +398,7 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
 
       // particle has left the world, record hit if last or all steps are returned
       if (returnAllSteps || returnLastStep)
-        adept_scoring::RecordHit(
+        adept_step_recording::RecordGPUStep(
             currentTrack.trackId,                        // Track ID
             currentTrack.parentId,                       // parent Track ID
             kAdePTTransportationProcess,                 // step defining process ID
@@ -529,7 +529,7 @@ __global__ void GammaConversion(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
 
     // If there is some edep from cutting particles, record the step
     if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep) {
-      adept_scoring::RecordHit(
+      adept_step_recording::RecordGPUStep(
           currentTrack.trackId,                        // Track ID
           currentTrack.parentId,                       // parent Track ID
           static_cast<short>(0),                       // step defining process ID
@@ -658,30 +658,30 @@ __global__ void GammaCompton(G4HepEmGammaTrack *hepEMTracks, ParticleManager par
     // Note: step must be returned even if track dies or secondaries are generated
     if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps ||
         (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
-      adept_scoring::RecordHit(currentTrack.trackId,                        // Track ID
-                               currentTrack.parentId,                       // parent Track ID
-                               static_cast<short>(1),                       // step defining process ID
-                               ParticleType::Gamma,                         // Particle type
-                               theTrack->GetGStepLength(),                  // Step length
-                               edep,                                        // Total Edep
-                               currentTrack.weight,                         // Track weight
-                               currentTrack.navState,                       // Pre-step point navstate
-                               currentTrack.preStepPos,                     // Pre-step point position
-                               currentTrack.preStepDir,                     // Pre-step point momentum direction
-                               currentTrack.preStepEKin,                    // Pre-step point kinetic energy
-                               currentTrack.nextState,                      // Post-step point navstate
-                               currentTrack.pos,                            // Post-step point position
-                               currentTrack.dir,                            // Post-step point momentum direction
-                               newEnergyGamma,                              // Post-step point kinetic energy
-                               currentTrack.globalTime,                     // global time
-                               currentTrack.localTime,                      // local time
-                               currentTrack.properTime,                     // proper time
-                               currentTrack.preStepGlobalTime,              // preStep global time
-                               currentTrack.eventId, currentTrack.threadId, // event and thread ID
-                               !trackSurvives,           // whether this is the last step of the track
-                               currentTrack.stepCounter, // stepcounter
-                               secondaryData,            // pointer to secondary init data
-                               nSecondaries);            // number of secondaries
+      adept_step_recording::RecordGPUStep(currentTrack.trackId,           // Track ID
+                                          currentTrack.parentId,          // parent Track ID
+                                          static_cast<short>(1),          // step defining process ID
+                                          ParticleType::Gamma,            // Particle type
+                                          theTrack->GetGStepLength(),     // Step length
+                                          edep,                           // Total Edep
+                                          currentTrack.weight,            // Track weight
+                                          currentTrack.navState,          // Pre-step point navstate
+                                          currentTrack.preStepPos,        // Pre-step point position
+                                          currentTrack.preStepDir,        // Pre-step point momentum direction
+                                          currentTrack.preStepEKin,       // Pre-step point kinetic energy
+                                          currentTrack.nextState,         // Post-step point navstate
+                                          currentTrack.pos,               // Post-step point position
+                                          currentTrack.dir,               // Post-step point momentum direction
+                                          newEnergyGamma,                 // Post-step point kinetic energy
+                                          currentTrack.globalTime,        // global time
+                                          currentTrack.localTime,         // local time
+                                          currentTrack.properTime,        // proper time
+                                          currentTrack.preStepGlobalTime, // preStep global time
+                                          currentTrack.eventId, currentTrack.threadId, // event and thread ID
+                                          !trackSurvives,           // whether this is the last step of the track
+                                          currentTrack.stepCounter, // stepcounter
+                                          secondaryData,            // pointer to secondary init data
+                                          nSecondaries);            // number of secondaries
     }
   }
 }
@@ -760,31 +760,31 @@ __global__ void GammaPhotoelectric(G4HepEmGammaTrack *hepEMTracks, ParticleManag
 
     // If there is some edep from cutting particles, record the step
     if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep) {
-      adept_scoring::RecordHit(currentTrack.trackId,           // Track ID
-                               currentTrack.parentId,          // parent Track ID
-                               static_cast<short>(2),          // step defining process ID
-                               ParticleType::Gamma,            // Particle type
-                               theTrack->GetGStepLength(),     // Step length
-                               edep,                           // Total Edep
-                               currentTrack.weight,            // Track weight
-                               currentTrack.navState,          // Pre-step point navstate
-                               currentTrack.preStepPos,        // Pre-step point position
-                               currentTrack.preStepDir,        // Pre-step point momentum direction
-                               currentTrack.preStepEKin,       // Pre-step point kinetic energy
-                               currentTrack.nextState,         // Post-step point navstate
-                               currentTrack.pos,               // Post-step point position
-                               currentTrack.dir,               // Post-step point momentum direction
-                               0.,                             // Post-step point kinetic energy (0 after photoelectric)
-                               currentTrack.globalTime,        // global time
-                               currentTrack.localTime,         // local time
-                               currentTrack.properTime,        // proper time
-                               currentTrack.preStepGlobalTime, // preStep global time
-                               currentTrack.eventId, currentTrack.threadId, // event and thread ID
-                               true, // whether this is the last step of the track: always true as gammas undergoing the
-                                     // PhotoElectric effect are killed
-                               currentTrack.stepCounter, // stepcounter
-                               secondaryData,            // pointer to secondary init data
-                               nSecondaries);            // number of secondaries
+      adept_step_recording::RecordGPUStep(currentTrack.trackId,       // Track ID
+                                          currentTrack.parentId,      // parent Track ID
+                                          static_cast<short>(2),      // step defining process ID
+                                          ParticleType::Gamma,        // Particle type
+                                          theTrack->GetGStepLength(), // Step length
+                                          edep,                       // Total Edep
+                                          currentTrack.weight,        // Track weight
+                                          currentTrack.navState,      // Pre-step point navstate
+                                          currentTrack.preStepPos,    // Pre-step point position
+                                          currentTrack.preStepDir,    // Pre-step point momentum direction
+                                          currentTrack.preStepEKin,   // Pre-step point kinetic energy
+                                          currentTrack.nextState,     // Post-step point navstate
+                                          currentTrack.pos,           // Post-step point position
+                                          currentTrack.dir,           // Post-step point momentum direction
+                                          0., // Post-step point kinetic energy (0 after photoelectric)
+                                          currentTrack.globalTime,                     // global time
+                                          currentTrack.localTime,                      // local time
+                                          currentTrack.properTime,                     // proper time
+                                          currentTrack.preStepGlobalTime,              // preStep global time
+                                          currentTrack.eventId, currentTrack.threadId, // event and thread ID
+                                          true, // whether this is the last step of the track: always true as gammas
+                                                // undergoing the PhotoElectric effect are killed
+                                          currentTrack.stepCounter, // stepcounter
+                                          secondaryData,            // pointer to secondary init data
+                                          nSecondaries);            // number of secondaries
     }
   }
 }

--- a/src/AdePTConfigurationMessenger.cc
+++ b/src/AdePTConfigurationMessenger.cc
@@ -51,7 +51,7 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
 
   fSetCPUCapacityFactorCmd = std::make_unique<G4UIcmdWithADouble>("/adept/setCPUCapacityFactor", this);
   fSetCPUCapacityFactorCmd->SetGuidance(
-      "Sets the CPUCapacity factor for scoring with respect to the GPU (see: /adept/setMillionsOfHitSlots). "
+      "Sets the CPUCapacity factor for returned GPU steps with respect to the GPU (see: /adept/setMillionsOfHitSlots). "
       "Must at least be 2.5");
   fSetCPUCapacityFactorCmd->SetParameterName("CPUCapacityFactor", false);
   fSetCPUCapacityFactorCmd->SetRange("CPUCapacityFactor>=2.5");

--- a/src/AdePTGeant4Integration.cpp
+++ b/src/AdePTGeant4Integration.cpp
@@ -27,12 +27,12 @@
 #include <type_traits>
 
 namespace AdePTGeant4Integration_detail {
-/// This struct holds temporary scoring objects that are needed to send hits to Geant4.
+/// This struct holds temporary Geant4 objects needed to replay GPU steps on the host.
 /// These are allocated as members or using placement new to go around G4's pool allocators,
 /// which cause a destruction order fiasco when the pools are destroyed before the objects,
 /// and then the objects' destructors are called.
 /// This also keeps all these objects much closer in memory.
-struct ScoringObjects {
+struct StepReconstructionObjects {
 
   static constexpr int kMaxSecElectrons     = 1;
   static constexpr int kMaxSecPositrons     = 1;
@@ -59,8 +59,8 @@ struct ScoringObjects {
   // only be set at construction time. Similarly, we can only set the dynamic particle for a track when creating it
   // For this reason we create one track per particle type for the parent track and up to kMaxTotalSecondaries tracks
   // for the secondary tracks that could be processed for each parent step, to be reused We set position to nullptr and
-  // kinetic energy to 0 for the dynamic particle since they need to be updated per hit The same goes for the G4Track
-  // global time and position
+  // kinetic energy to 0 for the dynamic particle since they need to be updated per step. The same goes for the G4Track
+  // global time and position.
   std::aligned_storage<sizeof(G4DynamicParticle), alignof(G4DynamicParticle)>::type dynParticleStorage[3];
   std::aligned_storage<sizeof(G4DynamicParticle), alignof(G4DynamicParticle)>::type secDynStorage[kMaxTotalSecondaries];
   std::aligned_storage<sizeof(G4Track), alignof(G4Track)>::type trackStorage[3];
@@ -92,7 +92,7 @@ struct ScoringObjects {
     secGUsed = 0;
   }
 
-  ScoringObjects()
+  StepReconstructionObjects()
   {
 
     // Cache particle definitions once
@@ -152,7 +152,7 @@ struct ScoringObjects {
   // Note: no destructor needed since we’re intentionally *not* calling dtors on the placement-new'ed objects
 };
 
-void Deleter::operator()(ScoringObjects *ptr)
+void Deleter::operator()(StepReconstructionObjects *ptr)
 {
   delete ptr;
 }
@@ -200,31 +200,31 @@ void MergeNuclearReplayIntoVisibleStep(const G4Track &scratchTrack, const G4Step
 
 AdePTGeant4Integration::~AdePTGeant4Integration() {}
 
-void AdePTGeant4Integration::QueueDeferredStep(std::span<const GPUHit> gpuSteps, DeferredStepType type)
+void AdePTGeant4Integration::QueueDeferredStep(std::span<const GPUStep> gpuSteps, DeferredStepType type)
 {
   if (gpuSteps.empty()) return;
 
   DeferredStep deferred;
-  deferred.firstHit = fDeferredHits.size();
-  deferred.numHits  = gpuSteps.size();
-  deferred.type     = type;
-  fDeferredHits.insert(fDeferredHits.end(), gpuSteps.begin(), gpuSteps.end());
+  deferred.firstGPUStep = fDeferredGPUSteps.size();
+  deferred.numGPUSteps  = gpuSteps.size();
+  deferred.type         = type;
+  fDeferredGPUSteps.insert(fDeferredGPUSteps.end(), gpuSteps.begin(), gpuSteps.end());
   fDeferredSteps.push_back(deferred);
 }
 
 AdePTGeant4Integration::DeferredStepStore AdePTGeant4Integration::TakeDeferredSteps()
 {
   DeferredStepStore deferred;
-  deferred.hits.swap(fDeferredHits);
+  deferred.gpuSteps.swap(fDeferredGPUSteps);
   deferred.steps.swap(fDeferredSteps);
   return deferred;
 }
 
-void AdePTGeant4Integration::ReturnDeferredTrack(std::span<const GPUHit> gpuSteps, bool const callUserActions)
+void AdePTGeant4Integration::ReturnDeferredTrack(std::span<const GPUStep> gpuSteps, bool const callUserActions)
 {
   assert(gpuSteps.size() == 1);
 
-  const GPUHit &parentStep = gpuSteps.front();
+  const GPUStep &parentStep = gpuSteps.front();
   assert(parentStep.fParticleType == ParticleType::Gamma);
   assert(parentStep.fStepLimProcessId == kAdePTOutOfGPURegionProcess ||
          parentStep.fStepLimProcessId == kAdePTFinishOnCPUProcess);
@@ -268,7 +268,7 @@ G4Track *AdePTGeant4Integration::MakeTrackForCPUStacking(const G4Track &track) c
   return clone;
 }
 
-G4Track *AdePTGeant4Integration::MakeReturnedTrackFromStep(GPUHit const &parentStep, const HostTrackData &hostTData,
+G4Track *AdePTGeant4Integration::MakeReturnedTrackFromStep(GPUStep const &parentStep, const HostTrackData &hostTData,
                                                            bool setStopButAlive) const
 {
   constexpr double tolerance = 10. * vecgeom::kTolerance;
@@ -311,11 +311,11 @@ G4Track *AdePTGeant4Integration::MakeReturnedTrackFromStep(GPUHit const &parentS
   return track;
 }
 
-G4Track *AdePTGeant4Integration::ConstructSecondaryTrackInPlace(GPUHit const *secHit) const
+G4Track *AdePTGeant4Integration::ConstructSecondaryTrackInPlace(GPUStep const *secStep) const
 {
-  auto &so = *fScoringObjects;
+  auto &so = *fStepReconstructionObjects;
 
-  const ParticleType ptype = secHit->fParticleType;
+  const ParticleType ptype = secStep->fParticleType;
 
   if (ptype == ParticleType::Electron) {
     if (so.secEUsed >= so.kMaxSecElectrons) std::abort();
@@ -335,40 +335,40 @@ G4Track *AdePTGeant4Integration::ConstructSecondaryTrackInPlace(GPUHit const *se
   std::abort();
 }
 
-void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bool const callUserSteppingAction,
+void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUStep> gpuSteps, bool const callUserSteppingAction,
                                             bool const callUserTrackingAction)
 {
   // FIXME: to be removed, as it is not needed with the direct VecGeom to G4 NavState.
   // needed here only temporarily to match exactly the behavior of returning nuclear interaction steps as tracks
   constexpr double tolerance = 10. * vecgeom::kTolerance;
-  if (!fScoringObjects) {
-    fScoringObjects.reset(new AdePTGeant4Integration_detail::ScoringObjects());
+  if (!fStepReconstructionObjects) {
+    fStepReconstructionObjects.reset(new AdePTGeant4Integration_detail::StepReconstructionObjects());
   }
 
   // Reset secondary tracks, as their dynamic properties change from returned step to step
-  fScoringObjects->ResetSecondaryTracks();
+  fStepReconstructionObjects->ResetSecondaryTracks();
   // Clear the persistent secondary vector
-  fScoringObjects->fSecondaryVector->clear();
+  fStepReconstructionObjects->fSecondaryVector->clear();
 
   // first step in the span is the parent step
-  const GPUHit &parentStep = gpuSteps[0];
+  const GPUStep &parentStep = gpuSteps[0];
 
   assert(gpuSteps.size() == 1 + parentStep.fNumSecondaries);
 
-  // Reconstruct G4NavigationHistory and G4Step, and call the SD code for each hit
+  // Reconstruct G4NavigationHistory and G4Step, then call the SD code for the returned step
   vecgeom::NavigationState const &preNavState = parentStep.fPreStepPoint.fNavigationState;
   // Reconstruct Pre-Step point G4NavigationHistory
-  FillG4NavigationHistory(preNavState, fScoringObjects->fPreG4NavigationHistory);
-  (*fScoringObjects->fPreG4TouchableHistoryHandle)
-      ->UpdateYourself(fScoringObjects->fPreG4NavigationHistory.GetTopVolume(),
-                       &fScoringObjects->fPreG4NavigationHistory);
+  FillG4NavigationHistory(preNavState, fStepReconstructionObjects->fPreG4NavigationHistory);
+  (*fStepReconstructionObjects->fPreG4TouchableHistoryHandle)
+      ->UpdateYourself(fStepReconstructionObjects->fPreG4NavigationHistory.GetTopVolume(),
+                       &fStepReconstructionObjects->fPreG4NavigationHistory);
   // Reconstruct Post-Step point G4NavigationHistory
   vecgeom::NavigationState const &postNavState = parentStep.fPostStepPoint.fNavigationState;
   if (!postNavState.IsOutside()) {
-    FillG4NavigationHistory(postNavState, fScoringObjects->fPostG4NavigationHistory);
-    (*fScoringObjects->fPostG4TouchableHistoryHandle)
-        ->UpdateYourself(fScoringObjects->fPostG4NavigationHistory.GetTopVolume(),
-                         &fScoringObjects->fPostG4NavigationHistory);
+    FillG4NavigationHistory(postNavState, fStepReconstructionObjects->fPostG4NavigationHistory);
+    (*fStepReconstructionObjects->fPostG4TouchableHistoryHandle)
+        ->UpdateYourself(fStepReconstructionObjects->fPostG4NavigationHistory.GetTopVolume(),
+                         &fStepReconstructionObjects->fPostG4NavigationHistory);
   }
 
   // Get step status
@@ -413,25 +413,27 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
   // Fill the G4Step, fill the G4Track, and intertwine them
   switch (parentStep.fParticleType) {
   case ParticleType::Electron:
-    fScoringObjects->fG4Step->SetTrack(fScoringObjects->fElectronTrack);
+    fStepReconstructionObjects->fG4Step->SetTrack(fStepReconstructionObjects->fElectronTrack);
     break;
   case ParticleType::Positron:
-    fScoringObjects->fG4Step->SetTrack(fScoringObjects->fPositronTrack);
+    fStepReconstructionObjects->fG4Step->SetTrack(fStepReconstructionObjects->fPositronTrack);
     break;
   case ParticleType::Gamma:
-    fScoringObjects->fG4Step->SetTrack(fScoringObjects->fGammaTrack);
+    fStepReconstructionObjects->fG4Step->SetTrack(fStepReconstructionObjects->fGammaTrack);
     break;
   default:
     std::cerr << "Error: unknown particle type " << static_cast<int>(parentStep.fParticleType) << "\n";
     std::abort();
   }
 
-  FillG4Step(&parentStep, fScoringObjects->fG4Step, parentTData, *fScoringObjects->fPreG4TouchableHistoryHandle,
-             *fScoringObjects->fPostG4TouchableHistoryHandle, preStepStatus, postStepStatus, callUserTrackingAction,
-             callUserSteppingAction);
-  FillG4Track(&parentStep, fScoringObjects->fG4Step->GetTrack(), parentTData,
-              *fScoringObjects->fPreG4TouchableHistoryHandle, *fScoringObjects->fPostG4TouchableHistoryHandle);
-  fScoringObjects->fG4Step->GetTrack()->SetStep(fScoringObjects->fG4Step);
+  FillG4Step(&parentStep, fStepReconstructionObjects->fG4Step, parentTData,
+             *fStepReconstructionObjects->fPreG4TouchableHistoryHandle,
+             *fStepReconstructionObjects->fPostG4TouchableHistoryHandle, preStepStatus, postStepStatus,
+             callUserTrackingAction, callUserSteppingAction);
+  FillG4Track(&parentStep, fStepReconstructionObjects->fG4Step->GetTrack(), parentTData,
+              *fStepReconstructionObjects->fPreG4TouchableHistoryHandle,
+              *fStepReconstructionObjects->fPostG4TouchableHistoryHandle);
+  fStepReconstructionObjects->fG4Step->GetTrack()->SetStep(fStepReconstructionObjects->fG4Step);
 
   // Create and attach secondaries.
   // User tracking callbacks for the secondaries are delayed until after the
@@ -442,27 +444,27 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
     const auto parentID = parentTData.g4id;
 
     // the steps after the first one in the span are the initializing steps for the secondaries
-    std::span<const GPUHit> secondaries = gpuSteps.subspan(1);
+    std::span<const GPUStep> secondaries = gpuSteps.subspan(1);
     // Loop over secondaries, create and fill info, and attach to secondary vector of the GPUStep
-    for (const GPUHit &secStep : secondaries) {
+    for (const GPUStep &secStep : secondaries) {
 
       // 1. Create HostTrackData
       HostTrackData &secTData = fHostTrackDataMapper->create(secStep.fTrackID);
 
       // 2. Initialize from parent
       InitSecondaryHostTrackDataFromParent(&secStep, secTData, parentID,
-                                           *fScoringObjects->fPreG4TouchableHistoryHandle);
+                                           *fStepReconstructionObjects->fPreG4TouchableHistoryHandle);
 
       // 3. Construct G4Track in place
       G4Track *secTrack = ConstructSecondaryTrackInPlace(&secStep);
 
       // 4. Fill data for secondary track
-      FillG4Track(&secStep, secTrack, secTData, *fScoringObjects->fPreG4TouchableHistoryHandle,
-                  *fScoringObjects->fPostG4TouchableHistoryHandle);
+      FillG4Track(&secStep, secTrack, secTData, *fStepReconstructionObjects->fPreG4TouchableHistoryHandle,
+                  *fStepReconstructionObjects->fPostG4TouchableHistoryHandle);
 
       // 5. Attach secondaries to G4Step: the fSecondaryVector is the persistent
       // storage for the G4Step->SecondaryVector.
-      fScoringObjects->fSecondaryVector->push_back(secTrack);
+      fStepReconstructionObjects->fSecondaryVector->push_back(secTrack);
     }
   }
 
@@ -502,8 +504,8 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
                              parentStep.fPostStepPoint.fPosition.z());
       position += tolerance * direction;
 
-      auto *dynamic = new G4DynamicParticle(fScoringObjects->fG4Step->GetTrack()->GetParticleDefinition(), direction,
-                                            parentStep.fPostStepPoint.fEKin);
+      auto *dynamic = new G4DynamicParticle(fStepReconstructionObjects->fG4Step->GetTrack()->GetParticleDefinition(),
+                                            direction, parentStep.fPostStepPoint.fEKin);
 
       auto *nuclearReactionTrack = new G4Track(dynamic, parentStep.fGlobalTime, position);
       nuclearReactionTrack->IncrementCurrentStepNumber();
@@ -527,7 +529,7 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
             MakeTouchableFromNavState(parentTDataAfterSecondaries.originNavState));
 #endif
       }
-      if (const auto postVolume = (*fScoringObjects->fPostG4TouchableHistoryHandle)->GetVolume();
+      if (const auto postVolume = (*fStepReconstructionObjects->fPostG4TouchableHistoryHandle)->GetVolume();
           postVolume != nullptr) {
         postTouchable = MakeTouchableFromNavState(parentStep.fPostStepPoint.fNavigationState);
         nuclearReactionTrack->SetTouchableHandle(postTouchable);
@@ -548,20 +550,20 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
       const double cutSecondaryEdep =
           fHepEmTrackingManager->PerformNuclear(nuclearReactionTrack, nuclearStep, particleID, isApplyCuts);
       if (cutSecondaryEdep > 0.0) {
-        fScoringObjects->fG4Step->AddTotalEnergyDeposit(cutSecondaryEdep);
+        fStepReconstructionObjects->fG4Step->AddTotalEnergyDeposit(cutSecondaryEdep);
       }
 
       if (auto *newSecondaries = nuclearStep->GetfSecondary(); newSecondaries != nullptr) {
         hadronicSecondaries.reserve(newSecondaries->size());
         for (auto *secondary : *newSecondaries) {
           hadronicSecondaries.push_back(secondary);
-          fScoringObjects->fSecondaryVector->push_back(secondary);
+          fStepReconstructionObjects->fSecondaryVector->push_back(secondary);
         }
       }
 
       // The visible step remains the transported GPU step. Only the nuclear
       // final state is merged back from the scratch replay object.
-      MergeNuclearReplayIntoVisibleStep(*nuclearReactionTrack, *nuclearStep, *fScoringObjects->fG4Step,
+      MergeNuclearReplayIntoVisibleStep(*nuclearReactionTrack, *nuclearStep, *fStepReconstructionObjects->fG4Step,
                                         isLeptonNuclearStep);
 
       if (isLeptonNuclearStep) {
@@ -578,7 +580,7 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
       // Fallback only for the case without an attached Geant4 nuclear process:
       // there is then no temporary nuclear-replay track that can be continued
       // on the CPU, so we create a separate heap-owned track for the stack.
-      returnedParentTrack   = MakeTrackForCPUStacking(*fScoringObjects->fG4Step->GetTrack());
+      returnedParentTrack   = MakeTrackForCPUStacking(*fStepReconstructionObjects->fG4Step->GetTrack());
       returnParentTrackToG4 = true;
     }
   } else if (isOutOfGPURegionStep || isFinishOnCPUStep) {
@@ -588,28 +590,29 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
 
   // Now, the G4Step is fully initialized and also contains the secondaries created in that step.
 
-  // Call scoring if SD is defined and it is not the initializing step.
+  // Call the sensitive detector if it is defined and this is not the initializing step.
   // As in G4, this is called before the SteppingAction
   G4VSensitiveDetector *aSensitiveDetector =
-      fScoringObjects->fPreG4NavigationHistory.GetVolume(fScoringObjects->fPreG4NavigationHistory.GetDepth())
+      fStepReconstructionObjects->fPreG4NavigationHistory
+          .GetVolume(fStepReconstructionObjects->fPreG4NavigationHistory.GetDepth())
           ->GetLogicalVolume()
           ->GetSensitiveDetector();
 
   if (aSensitiveDetector != nullptr && parentStep.fStepCounter != 0) {
-    aSensitiveDetector->Hit(fScoringObjects->fG4Step);
+    aSensitiveDetector->Hit(fStepReconstructionObjects->fG4Step);
   }
 
   if (callUserSteppingAction) {
     auto *evtMgr             = G4EventManager::GetEventManager();
     auto *userSteppingAction = evtMgr->GetUserSteppingAction();
-    if (userSteppingAction) userSteppingAction->UserSteppingAction(fScoringObjects->fG4Step);
+    if (userSteppingAction) userSteppingAction->UserSteppingAction(fStepReconstructionObjects->fG4Step);
   }
 
   // call UserTrackingAction if required
   if (parentStep.fLastStepOfTrack && !returnParentTrackToG4 && (callUserTrackingAction)) {
     auto *evtMgr             = G4EventManager::GetEventManager();
     auto *userTrackingAction = evtMgr->GetUserTrackingAction();
-    if (userTrackingAction) userTrackingAction->PostUserTrackingAction(fScoringObjects->fG4Step->GetTrack());
+    if (userTrackingAction) userTrackingAction->PostUserTrackingAction(fStepReconstructionObjects->fG4Step->GetTrack());
   }
 
   // GPU-born secondaries only get the PreUserTracking callback after the parent
@@ -620,9 +623,9 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
     auto *evtMgr             = G4EventManager::GetEventManager();
     auto *userTrackingAction = evtMgr->GetUserTrackingAction();
     if (userTrackingAction) {
-      std::span<const GPUHit> secondaries = gpuSteps.subspan(1);
+      std::span<const GPUStep> secondaries = gpuSteps.subspan(1);
       for (size_t i = 0; i < secondaries.size(); ++i) {
-        auto *secondary = (*fScoringObjects->fSecondaryVector)[i];
+        auto *secondary = (*fStepReconstructionObjects->fSecondaryVector)[i];
         if (secondary == nullptr) continue;
 
         userTrackingAction->PreUserTrackingAction(secondary);
@@ -647,7 +650,7 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
   // If this was the last step of a track, the hostTrackData of that track can be safely deleted.
   // Note: This deletes the AdePT-owned UserTrackInfo data
   if (isDeferredStep) {
-    auto *parentTrack = fScoringObjects->fG4Step->GetTrack();
+    auto *parentTrack = fStepReconstructionObjects->fG4Step->GetTrack();
     parentTrack->SetUserInformation(nullptr);
     if (returnParentTrackToG4) {
       fHostTrackDataMapper->retireToCPU(parentStep.fTrackID);
@@ -655,7 +658,7 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUHit> gpuSteps, bo
       fHostTrackDataMapper->removeTrack(parentStep.fTrackID);
     }
   } else if (parentStep.fLastStepOfTrack) {
-    fScoringObjects->fG4Step->GetTrack()->SetUserInformation(nullptr);
+    fStepReconstructionObjects->fG4Step->GetTrack()->SetUserInformation(nullptr);
     fHostTrackDataMapper->removeTrack(parentStep.fTrackID);
   }
 }
@@ -730,44 +733,44 @@ G4TouchableHandle AdePTGeant4Integration::MakeTouchableFromNavState(vecgeom::Nav
   return G4TouchableHandle(touchableHistory.release());
 }
 
-void AdePTGeant4Integration::InitSecondaryHostTrackDataFromParent(GPUHit const *secHit, HostTrackData &secTData,
+void AdePTGeant4Integration::InitSecondaryHostTrackDataFromParent(GPUStep const *secStep, HostTrackData &secTData,
                                                                   int g4ParentID, G4TouchableHandle &preTouchable) const
 {
 #ifdef DEBUG
-  if (secHit->fStepCounter != 0) {
+  if (secStep->fStepCounter != 0) {
     std::cerr << "\033[1;31mERROR: secondary init called with stepCounter != 0\033[0m\n";
     std::abort();
   }
-  if (secHit->fParentID == 0) {
+  if (secStep->fParentID == 0) {
     std::cerr << "\033[1;31mERROR: secondary init called with parentID == 0\033[0m\n";
     std::abort();
   }
-  if (secHit->fStepCounter == 0 && fHostTrackDataMapper->contains(secHit->fTrackID)) {
-    std::cerr << "\033[1;31mERROR: TRACK ALREADY HAS AN ENTRY (trackID = " << secHit->fTrackID
-              << ", parentID = " << secHit->fParentID << ") "
-              << " stepLimProcessId " << secHit->fStepLimProcessId << " pdg charge "
-              << static_cast<int>(secHit->fParticleType) << " stepCounter " << secHit->fStepCounter << "\033[0m"
+  if (secStep->fStepCounter == 0 && fHostTrackDataMapper->contains(secStep->fTrackID)) {
+    std::cerr << "\033[1;31mERROR: TRACK ALREADY HAS AN ENTRY (trackID = " << secStep->fTrackID
+              << ", parentID = " << secStep->fParentID << ") "
+              << " stepLimProcessId " << secStep->fStepLimProcessId << " pdg charge "
+              << static_cast<int>(secStep->fParticleType) << " stepCounter " << secStep->fStepCounter << "\033[0m"
               << std::endl;
     std::abort();
   }
 #endif
 
-  secTData.particleType = secHit->fParticleType;
+  secTData.particleType = secStep->fParticleType;
   secTData.g4parentid   = g4ParentID;
 
 #ifdef ADEPT_USE_ORIGINNAVSTATE
-  secTData.originNavState = secHit->fPostStepPoint.fNavigationState;
+  secTData.originNavState = secStep->fPostStepPoint.fNavigationState;
 #endif
   secTData.logicalVolumeAtVertex = preTouchable->GetVolume()->GetLogicalVolume();
-  secTData.vertexPosition = G4ThreeVector(secHit->fPostStepPoint.fPosition.x(), secHit->fPostStepPoint.fPosition.y(),
-                                          secHit->fPostStepPoint.fPosition.z());
+  secTData.vertexPosition = G4ThreeVector(secStep->fPostStepPoint.fPosition.x(), secStep->fPostStepPoint.fPosition.y(),
+                                          secStep->fPostStepPoint.fPosition.z());
   secTData.vertexMomentumDirection =
-      G4ThreeVector(secHit->fPostStepPoint.fMomentumDirection.x(), secHit->fPostStepPoint.fMomentumDirection.y(),
-                    secHit->fPostStepPoint.fMomentumDirection.z());
-  secTData.vertexKineticEnergy = secHit->fPostStepPoint.fEKin;
+      G4ThreeVector(secStep->fPostStepPoint.fMomentumDirection.x(), secStep->fPostStepPoint.fMomentumDirection.y(),
+                    secStep->fPostStepPoint.fMomentumDirection.z());
+  secTData.vertexKineticEnergy = secStep->fPostStepPoint.fEKin;
 
   // For the initializing step, the step defining process ID is the creator process
-  const int stepId = secHit->fStepLimProcessId;
+  const int stepId = secStep->fStepLimProcessId;
   assert(stepId >= 0);
   const ParticleType ptype = secTData.particleType;
   if (ptype == ParticleType::Electron || ptype == ParticleType::Positron) {
@@ -777,29 +780,29 @@ void AdePTGeant4Integration::InitSecondaryHostTrackDataFromParent(GPUHit const *
   }
 }
 
-void AdePTGeant4Integration::FillG4Track(GPUHit const *aGPUHit, G4Track *aTrack, const HostTrackData &hostTData,
+void AdePTGeant4Integration::FillG4Track(GPUStep const *aGPUStep, G4Track *aTrack, const HostTrackData &hostTData,
                                          G4TouchableHandle &aPreG4TouchableHandle,
                                          G4TouchableHandle &aPostG4TouchableHandle) const
 {
 
-  const G4ThreeVector aPostStepPointMomentumDirection(aGPUHit->fPostStepPoint.fMomentumDirection.x(),
-                                                      aGPUHit->fPostStepPoint.fMomentumDirection.y(),
-                                                      aGPUHit->fPostStepPoint.fMomentumDirection.z());
-  const G4ThreeVector aPostStepPointPosition(aGPUHit->fPostStepPoint.fPosition.x(),
-                                             aGPUHit->fPostStepPoint.fPosition.y(),
-                                             aGPUHit->fPostStepPoint.fPosition.z());
+  const G4ThreeVector aPostStepPointMomentumDirection(aGPUStep->fPostStepPoint.fMomentumDirection.x(),
+                                                      aGPUStep->fPostStepPoint.fMomentumDirection.y(),
+                                                      aGPUStep->fPostStepPoint.fMomentumDirection.z());
+  const G4ThreeVector aPostStepPointPosition(aGPUStep->fPostStepPoint.fPosition.x(),
+                                             aGPUStep->fPostStepPoint.fPosition.y(),
+                                             aGPUStep->fPostStepPoint.fPosition.z());
 
   // must const-cast as GetDynamicParticle only returns const
   aTrack->SetCreatorProcess(hostTData.creatorProcess);
   auto *dyn = const_cast<G4DynamicParticle *>(aTrack->GetDynamicParticle());
   dyn->SetPrimaryParticle(hostTData.primary);
 
-  aTrack->SetTrackID(hostTData.g4id);          // Real data
-  aTrack->SetParentID(hostTData.g4parentid);   // ID of the initial particle that entered AdePT
-  aTrack->SetPosition(aPostStepPointPosition); // Real data
-  aTrack->SetGlobalTime(aGPUHit->fGlobalTime); // Real data
-  aTrack->SetLocalTime(aGPUHit->fLocalTime);   // Real data
-  aTrack->SetProperTime(aGPUHit->fProperTime); // Real data
+  aTrack->SetTrackID(hostTData.g4id);           // Real data
+  aTrack->SetParentID(hostTData.g4parentid);    // ID of the initial particle that entered AdePT
+  aTrack->SetPosition(aPostStepPointPosition);  // Real data
+  aTrack->SetGlobalTime(aGPUStep->fGlobalTime); // Real data
+  aTrack->SetLocalTime(aGPUStep->fLocalTime);   // Real data
+  aTrack->SetProperTime(aGPUStep->fProperTime); // Real data
   if (const auto preVolume = aPreG4TouchableHandle->GetVolume();
       preVolume != nullptr) {                          // protect against nullptr if NavState is outside
     aTrack->SetTouchableHandle(aPreG4TouchableHandle); // Real data
@@ -809,14 +812,14 @@ void AdePTGeant4Integration::FillG4Track(GPUHit const *aGPUHit, G4Track *aTrack,
     aTrack->SetNextTouchableHandle(aPostG4TouchableHandle); // Real data
   }
   // aTrack->SetOriginTouchableHandle(nullptr);                                               // Missing data
-  aTrack->SetKineticEnergy(aGPUHit->fPostStepPoint.fEKin);       // Real data
+  aTrack->SetKineticEnergy(aGPUStep->fPostStepPoint.fEKin);      // Real data
   aTrack->SetMomentumDirection(aPostStepPointMomentumDirection); // Real data
   // aTrack->SetVelocity(0);                                                                  // Missing data
   // aTrack->SetPolarization(); // Missing Data data
   // aTrack->SetTrackStatus(G4TrackStatus::fAlive);                                           // Missing data
   // aTrack->SetBelowThresholdFlag(false);                                                    // Missing data
   // aTrack->SetGoodForTrackingFlag(false);                                                   // Missing data
-  aTrack->SetStepLength(aGPUHit->fStepLength);                           // Real data
+  aTrack->SetStepLength(aGPUStep->fStepLength);                          // Real data
   aTrack->SetVertexPosition(hostTData.vertexPosition);                   // Real data
   aTrack->SetVertexMomentumDirection(hostTData.vertexMomentumDirection); // Real data
   aTrack->SetVertexKineticEnergy(hostTData.vertexKineticEnergy);         // Real data
@@ -824,32 +827,32 @@ void AdePTGeant4Integration::FillG4Track(GPUHit const *aGPUHit, G4Track *aTrack,
   // aTrack->SetCreatorModelID(0);                                                            // Missing data
   // aTrack->SetParentResonanceDef(nullptr);                                                  // Missing data
   // aTrack->SetParentResonanceID(0);                                                         // Missing data
-  aTrack->SetWeight(aGPUHit->fTrackWeight);
+  aTrack->SetWeight(aGPUStep->fTrackWeight);
   // if it exists, add UserTrackInfo
   aTrack->SetUserInformation(hostTData.userTrackInfo); // Real data
   // aTrack->SetAuxiliaryTrackInformation(0, nullptr);                                        // Missing data
 }
 
-void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step, const HostTrackData &hostTData,
+void AdePTGeant4Integration::FillG4Step(GPUStep const *aGPUStep, G4Step *aG4Step, const HostTrackData &hostTData,
                                         G4TouchableHandle &aPreG4TouchableHandle,
                                         G4TouchableHandle &aPostG4TouchableHandle, G4StepStatus aPreStepStatus,
                                         G4StepStatus aPostStepStatus, bool callUserTrackingAction,
                                         bool callUserSteppingAction) const
 {
-  const G4ThreeVector aPostStepPointMomentumDirection(aGPUHit->fPostStepPoint.fMomentumDirection.x(),
-                                                      aGPUHit->fPostStepPoint.fMomentumDirection.y(),
-                                                      aGPUHit->fPostStepPoint.fMomentumDirection.z());
-  const G4ThreeVector aPostStepPointPosition(aGPUHit->fPostStepPoint.fPosition.x(),
-                                             aGPUHit->fPostStepPoint.fPosition.y(),
-                                             aGPUHit->fPostStepPoint.fPosition.z());
+  const G4ThreeVector aPostStepPointMomentumDirection(aGPUStep->fPostStepPoint.fMomentumDirection.x(),
+                                                      aGPUStep->fPostStepPoint.fMomentumDirection.y(),
+                                                      aGPUStep->fPostStepPoint.fMomentumDirection.z());
+  const G4ThreeVector aPostStepPointPosition(aGPUStep->fPostStepPoint.fPosition.x(),
+                                             aGPUStep->fPostStepPoint.fPosition.y(),
+                                             aGPUStep->fPostStepPoint.fPosition.z());
 
   // G4Step
-  aG4Step->SetStepLength(aGPUHit->fStepLength);                 // Real data
-  aG4Step->SetTotalEnergyDeposit(aGPUHit->fTotalEnergyDeposit); // Real data
+  aG4Step->SetStepLength(aGPUStep->fStepLength);                 // Real data
+  aG4Step->SetTotalEnergyDeposit(aGPUStep->fTotalEnergyDeposit); // Real data
   // aG4Step->SetNonIonizingEnergyDeposit(0);                      // Missing data
   // aG4Step->SetControlFlag(G4SteppingControl::NormalCondition);  // Missing data
-  if (aGPUHit->fStepCounter == 1) aG4Step->SetFirstStepFlag(); // Real data
-  if (aGPUHit->fLastStepOfTrack) aG4Step->SetLastStepFlag();   // Real data
+  if (aGPUStep->fStepCounter == 1) aG4Step->SetFirstStepFlag(); // Real data
+  if (aGPUStep->fLastStepOfTrack) aG4Step->SetLastStepFlag();   // Real data
   // aG4Step->SetPointerToVectorOfAuxiliaryPoints(nullptr);        // Missing data
 
   // G4Track
@@ -857,9 +860,9 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step, 
 
   // set the step-defining process for non-initializing steps
   G4VProcess *stepDefiningProcess = nullptr;
-  if (aGPUHit->fStepCounter != 0) {
+  if (aGPUStep->fStepCounter != 0) {
     // not an initial step, therefore setting the step defining process:
-    const int stepId         = aGPUHit->fStepLimProcessId;
+    const int stepId         = aGPUStep->fStepLimProcessId;
     const ParticleType ptype = hostTData.particleType;
 
     if (ptype == ParticleType::Electron || ptype == ParticleType::Positron) {
@@ -888,15 +891,15 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step, 
 
   // Pre-Step Point
   G4StepPoint *aPreStepPoint = aG4Step->GetPreStepPoint();
-  aPreStepPoint->SetPosition(G4ThreeVector(aGPUHit->fPreStepPoint.fPosition.x(), aGPUHit->fPreStepPoint.fPosition.y(),
-                                           aGPUHit->fPreStepPoint.fPosition.z())); // Real data
+  aPreStepPoint->SetPosition(G4ThreeVector(aGPUStep->fPreStepPoint.fPosition.x(), aGPUStep->fPreStepPoint.fPosition.y(),
+                                           aGPUStep->fPreStepPoint.fPosition.z())); // Real data
   // aPreStepPoint->SetLocalTime(0);                                                                // Missing data
-  aPreStepPoint->SetGlobalTime(aGPUHit->fPreGlobalTime); // Real data
+  aPreStepPoint->SetGlobalTime(aGPUStep->fPreGlobalTime); // Real data
   // aPreStepPoint->SetProperTime(0);                                                               // Missing data
-  aPreStepPoint->SetMomentumDirection(G4ThreeVector(aGPUHit->fPreStepPoint.fMomentumDirection.x(),
-                                                    aGPUHit->fPreStepPoint.fMomentumDirection.y(),
-                                                    aGPUHit->fPreStepPoint.fMomentumDirection.z())); // Real data
-  aPreStepPoint->SetKineticEnergy(aGPUHit->fPreStepPoint.fEKin);                                     // Real data
+  aPreStepPoint->SetMomentumDirection(G4ThreeVector(aGPUStep->fPreStepPoint.fMomentumDirection.x(),
+                                                    aGPUStep->fPreStepPoint.fMomentumDirection.y(),
+                                                    aGPUStep->fPreStepPoint.fMomentumDirection.z())); // Real data
+  aPreStepPoint->SetKineticEnergy(aGPUStep->fPreStepPoint.fEKin);                                     // Real data
   // aPreStepPoint->SetVelocity(0);                                                                 // Missing data
   aPreStepPoint->SetTouchableHandle(aPreG4TouchableHandle);                                          // Real data
   aPreStepPoint->SetMaterial(aPreG4TouchableHandle->GetVolume()->GetLogicalVolume()->GetMaterial()); // Real data
@@ -914,11 +917,11 @@ void AdePTGeant4Integration::FillG4Step(GPUHit const *aGPUHit, G4Step *aG4Step, 
   // Post-Step Point
   G4StepPoint *aPostStepPoint = aG4Step->GetPostStepPoint();
   aPostStepPoint->SetPosition(aPostStepPointPosition);                   // Real data
-  aPostStepPoint->SetLocalTime(aGPUHit->fLocalTime);                     // Real data
-  aPostStepPoint->SetGlobalTime(aGPUHit->fGlobalTime);                   // Real data
-  aPostStepPoint->SetProperTime(aGPUHit->fProperTime);                   // Real data
+  aPostStepPoint->SetLocalTime(aGPUStep->fLocalTime);                    // Real data
+  aPostStepPoint->SetGlobalTime(aGPUStep->fGlobalTime);                  // Real data
+  aPostStepPoint->SetProperTime(aGPUStep->fProperTime);                  // Real data
   aPostStepPoint->SetMomentumDirection(aPostStepPointMomentumDirection); // Real data
-  aPostStepPoint->SetKineticEnergy(aGPUHit->fPostStepPoint.fEKin);       // Real data
+  aPostStepPoint->SetKineticEnergy(aGPUStep->fPostStepPoint.fEKin);      // Real data
   // aPostStepPoint->SetVelocity(0);                                                                  // Missing data
   if (const auto postVolume = aPostG4TouchableHandle->GetVolume();
       postVolume != nullptr) {                                  // protect against nullptr if postNavState is outside

--- a/src/AdePTTrackingManager.cc
+++ b/src/AdePTTrackingManager.cc
@@ -43,22 +43,22 @@ std::weak_ptr<AdePTTransport> &SharedAdePTTransportStorage()
 AdePTTransportConfig MakeAdePTTransportConfig(const AdePTConfiguration &configuration)
 {
   AdePTTransportConfig transportConfig;
-  transportConfig.adeptSeed       = configuration.GetAdePTSeed();
-  transportConfig.numThreads      = static_cast<unsigned short>(configuration.GetNumThreads());
-  transportConfig.trackCapacity   = static_cast<unsigned int>(1024 * 1024 * configuration.GetMillionsOfTrackSlots());
-  transportConfig.scoringCapacity = static_cast<unsigned int>(1024 * 1024 * configuration.GetMillionsOfHitSlots());
-  transportConfig.debugLevel      = configuration.GetVerbosity();
-  transportConfig.cudaStackLimit  = configuration.GetCUDAStackLimit();
-  transportConfig.cudaHeapLimit   = configuration.GetCUDAHeapLimit();
+  transportConfig.adeptSeed      = configuration.GetAdePTSeed();
+  transportConfig.numThreads     = static_cast<unsigned short>(configuration.GetNumThreads());
+  transportConfig.trackCapacity  = static_cast<unsigned int>(1024 * 1024 * configuration.GetMillionsOfTrackSlots());
+  transportConfig.stepCapacity   = static_cast<unsigned int>(1024 * 1024 * configuration.GetMillionsOfHitSlots());
+  transportConfig.debugLevel     = configuration.GetVerbosity();
+  transportConfig.cudaStackLimit = configuration.GetCUDAStackLimit();
+  transportConfig.cudaHeapLimit  = configuration.GetCUDAHeapLimit();
   transportConfig.lastNParticlesOnCPU = configuration.GetLastNParticlesOnCPU();
   transportConfig.maxWDTIter          = configuration.GetMaxWDTIter();
   transportConfig.returnAllSteps      = configuration.GetCallUserSteppingAction();
   transportConfig.returnFirstAndLastStep =
       configuration.GetCallUserTrackingAction() || configuration.GetCallUserSteppingAction();
-  transportConfig.bfieldFile            = configuration.GetCovfieBfieldFile();
-  transportConfig.cpuCapacityFactor     = configuration.GetCPUCapacityFactor();
-  transportConfig.cpuCopyFraction       = configuration.GetHitBufferFlushThreshold();
-  transportConfig.hitBufferSafetyFactor = configuration.GetHitBufferSafetyFactor();
+  transportConfig.bfieldFile             = configuration.GetCovfieBfieldFile();
+  transportConfig.cpuCapacityFactor      = configuration.GetCPUCapacityFactor();
+  transportConfig.cpuCopyFraction        = configuration.GetHitBufferFlushThreshold();
+  transportConfig.stepBufferSafetyFactor = configuration.GetHitBufferSafetyFactor();
   return transportConfig;
 }
 
@@ -104,7 +104,7 @@ std::shared_ptr<AdePTTransport> GetSharedAdePTTransport()
   return transport;
 }
 
-bool CanReturnTrackDirectly(const GPUHit &step, unsigned int blockSize, bool callUserSteppingAction)
+bool CanReturnTrackDirectly(const GPUStep &step, unsigned int blockSize, bool callUserSteppingAction)
 {
   if (callUserSteppingAction) return false;
   if (step.fParticleType != ParticleType::Gamma) return false;
@@ -382,15 +382,15 @@ void AdePTTrackingManager::FlushEvent()
   // AdePTTrackingManager requests the flush while AdePTTransport still
   // owns the underlying state machine and buffer lifetime.
   fAdeptTransport->RequestFlush(threadId);
-  while (!fAdeptTransport->IsHitsFlushed(threadId)) {
+  while (!fAdeptTransport->AreReturnedStepsFlushed(threadId)) {
     fAdeptTransport->WaitForFlushProgress();
-    ProcessReturnedGPUHits(threadId, eventId);
+    ProcessReturnedGPUSteps(threadId, eventId);
   }
 
-  // Transport stops at HitsFlushed once the last returned hit batches are
+  // Transport stops at StepsFlushed once the last returned step batches are
   // available on the host. Drain once more here so the final batches are not
   // skipped just because the worker observed that host-visible terminal state.
-  ProcessReturnedGPUHits(threadId, eventId);
+  ProcessReturnedGPUSteps(threadId, eventId);
 
   auto deferredSteps                = fGeant4Integration.TakeDeferredSteps();
   const bool returnAllSteps         = ReturnAllSteps(*fAdePTConfiguration);
@@ -399,11 +399,12 @@ void AdePTTrackingManager::FlushEvent()
   std::sort(deferredSteps.steps.begin(), deferredSteps.steps.end(),
             [&deferredSteps](const AdePTGeant4Integration::DeferredStep &lhs,
                              const AdePTGeant4Integration::DeferredStep &rhs) {
-              return deferredSteps.hits[lhs.firstHit] < deferredSteps.hits[rhs.firstHit];
+              return deferredSteps.gpuSteps[lhs.firstGPUStep] < deferredSteps.gpuSteps[rhs.firstGPUStep];
             });
 
   for (const auto &deferredStep : deferredSteps.steps) {
-    std::span<const GPUHit> gpuSteps(deferredSteps.hits.data() + deferredStep.firstHit, deferredStep.numHits);
+    std::span<const GPUStep> gpuSteps(deferredSteps.gpuSteps.data() + deferredStep.firstGPUStep,
+                                      deferredStep.numGPUSteps);
     if (deferredStep.type == AdePTGeant4Integration::DeferredStepType::ReturnTrack) {
       fGeant4Integration.ReturnDeferredTrack(gpuSteps, returnAllSteps || returnFirstAndLastStep);
     } else {
@@ -413,15 +414,15 @@ void AdePTTrackingManager::FlushEvent()
   fAdeptTransport->MarkHostFlushed(threadId);
 }
 
-void AdePTTrackingManager::ProcessReturnedGPUHits(int threadId, int eventId)
+void AdePTTrackingManager::ProcessReturnedGPUSteps(int threadId, int eventId)
 {
   const bool returnAllSteps         = ReturnAllSteps(*fAdePTConfiguration);
   const bool returnFirstAndLastStep = ReturnFirstAndLastStep(*fAdePTConfiguration);
 
-  // Transport owns the hit-batch lifetime and calls this lambda once
+  // Transport owns the step-batch lifetime and calls this lambda once
   // for each currently available returned batch. This lambda provides the
   // Geant4-side step reconstruction for the current worker and event.
-  fAdeptTransport->HandleReturnedGPUHitBatchesWith(threadId, eventId, [&](std::span<const GPUHit> gpuSteps) {
+  fAdeptTransport->HandleGPUStepBatchesWith(threadId, eventId, [&](std::span<const GPUStep> gpuSteps) {
     // The batch contains a flat sequence of parent-step records followed by
     // their secondaries:
     // [parent1][secondary1_1][secondary1_2][parent2][parent3][secondary3_1]
@@ -434,14 +435,14 @@ void AdePTTrackingManager::ProcessReturnedGPUHits(int threadId, int eventId)
     // entries belong to the same step. Therefore the iterator advances by
     // 1 + fNumSecondaries each time.
     for (auto it = gpuSteps.begin(); it != gpuSteps.end();) {
-      // important sanity check: thread should only process its own hits and
+      // important sanity check: thread should only process its own GPU steps and
       // only from the current event
       if (it->threadId != threadId)
         std::cerr << "\033[1;31mError, threadId doesn't match it->threadId " << it->threadId << " threadId " << threadId
                   << "\033[0m" << std::endl;
       if (it->fEventId != eventId) {
         std::cerr << "\033[1;31mError, eventId doesn't match it->fEventId " << it->fEventId << " eventId " << eventId
-                  << " num hits to be processed " << gpuSteps.size() << " trackID " << it->fTrackID << " parentID "
+                  << " num GPU steps to be processed " << gpuSteps.size() << " trackID " << it->fTrackID << " parentID "
                   << it->fParentID << " StepNumber " << it->fStepCounter << " ptype "
                   << static_cast<short>(it->fParticleType) << " stepLimit / creator process " << it->fStepLimProcessId
                   << "\033[0m" << std::endl;
@@ -454,12 +455,12 @@ void AdePTTrackingManager::ProcessReturnedGPUHits(int threadId, int eventId)
           it->fStepLimProcessId == kAdePTOutOfGPURegionProcess || it->fStepLimProcessId == kAdePTFinishOnCPUProcess;
       if (isDeferredStep) {
         const bool returnTrackDirectly = CanReturnTrackDirectly(*it, blockSize, returnAllSteps);
-        fGeant4Integration.QueueDeferredStep(std::span<const GPUHit>(&*it, blockSize),
+        fGeant4Integration.QueueDeferredStep(std::span<const GPUStep>(&*it, blockSize),
                                              returnTrackDirectly
                                                  ? AdePTGeant4Integration::DeferredStepType::ReturnTrack
                                                  : AdePTGeant4Integration::DeferredStepType::ReplayStep);
       } else {
-        fGeant4Integration.ProcessGPUStep(std::span<const GPUHit>(&*it, blockSize), returnAllSteps,
+        fGeant4Integration.ProcessGPUStep(std::span<const GPUStep>(&*it, blockSize), returnAllSteps,
                                           returnFirstAndLastStep);
       }
       it += blockSize;
@@ -479,7 +480,7 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
 
   // Check for GPU steps, to alleviate pressure on the GPU step buffer
   G4int threadId = adept_integration::GetThreadId();
-  ProcessReturnedGPUHits(threadId, eventID);
+  ProcessReturnedGPUSteps(threadId, eventID);
   auto &trackMapper = fGeant4Integration.GetHostTrackDataMapper();
 
   if (fCurrentEventID != eventID) trackMapper.beginEvent(eventID);

--- a/src/AsyncAdePTTransport.cc
+++ b/src/AsyncAdePTTransport.cc
@@ -27,9 +27,8 @@ std::thread LaunchGPUWorker(int, int, int, AsyncAdePT::TrackBuffer &, AsyncAdePT
                             std::vector<std::atomic<AsyncAdePT::EventState>> &, std::condition_variable &, int, int,
                             bool, bool, unsigned short, const double, bool);
 std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> InitializeGPU(
-    int trackCapacity, int scoringCapacity, int numThreads, AsyncAdePT::TrackBuffer &trackBuffer,
-    double CPUCapacityFactor, double CPUCopyFraction, std::string &generalBfieldFile,
-    const std::vector<float> &uniformBfieldValues);
+    int trackCapacity, int stepCapacity, int numThreads, AsyncAdePT::TrackBuffer &trackBuffer, double CPUCapacityFactor,
+    double CPUCopyFraction, std::string &generalBfieldFile, const std::vector<float> &uniformBfieldValues);
 void FreeGPU(std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> &, std::thread &,
              adeptint::WDTDeviceBuffers &);
 } // namespace async_adept_impl
@@ -41,13 +40,13 @@ AsyncAdePTTransport::AsyncAdePTTransport(const AdePTTransportConfig &configurati
                                          adeptint::VolAuxData *auxData, const adeptint::WDTHostPacked &wdtPacked,
                                          const std::vector<float> &uniformFieldValues)
     : fAdePTSeed{configuration.adeptSeed}, fNThread{configuration.numThreads},
-      fTrackCapacity{configuration.trackCapacity}, fScoringCapacity{configuration.scoringCapacity},
+      fTrackCapacity{configuration.trackCapacity}, fStepCapacity{configuration.stepCapacity},
       fDebugLevel{configuration.debugLevel}, fCUDAStackLimit{configuration.cudaStackLimit},
       fCUDAHeapLimit{configuration.cudaHeapLimit}, fLastNParticlesOnCPU{configuration.lastNParticlesOnCPU},
       fMaxWDTIter{configuration.maxWDTIter}, fAdePTG4HepEmState(std::move(adeptG4HepEmState)), fEventStates(fNThread),
       fReturnAllSteps{configuration.returnAllSteps}, fReturnFirstAndLastStep{configuration.returnFirstAndLastStep},
       fBfieldFile{configuration.bfieldFile}, fCPUCapacityFactor{configuration.cpuCapacityFactor},
-      fCPUCopyFraction{configuration.cpuCopyFraction}, fHitBufferSafetyFactor{configuration.hitBufferSafetyFactor}
+      fCPUCopyFraction{configuration.cpuCopyFraction}, fStepBufferSafetyFactor{configuration.stepBufferSafetyFactor}
 {
   if (fNThread > kMaxThreads)
     throw std::invalid_argument("AsyncAdePTTransport limited to " + std::to_string(kMaxThreads) + " threads");
@@ -166,11 +165,11 @@ void AsyncAdePTTransport::Initialize(adeptint::VolAuxData *auxData, const adepti
 
   assert(fBuffer != nullptr);
 
-  fGPUstate  = async_adept_impl::InitializeGPU(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, fCPUCapacityFactor,
+  fGPUstate  = async_adept_impl::InitializeGPU(fTrackCapacity, fStepCapacity, fNThread, *fBuffer, fCPUCapacityFactor,
                                                fCPUCopyFraction, fBfieldFile, uniformFieldValues);
-  fGPUWorker = async_adept_impl::LaunchGPUWorker(fTrackCapacity, fScoringCapacity, fNThread, *fBuffer, *fGPUstate,
+  fGPUWorker = async_adept_impl::LaunchGPUWorker(fTrackCapacity, fStepCapacity, fNThread, *fBuffer, *fGPUstate,
                                                  fEventStates, fCV_G4Workers, fAdePTSeed, fDebugLevel, fReturnAllSteps,
-                                                 fReturnFirstAndLastStep, fLastNParticlesOnCPU, fHitBufferSafetyFactor,
+                                                 fReturnFirstAndLastStep, fLastNParticlesOnCPU, fStepBufferSafetyFactor,
                                                  fHasWDTRegions);
 }
 
@@ -192,9 +191,9 @@ void AsyncAdePTTransport::WaitForFlushProgress()
   fCV_G4Workers.wait_for(lock, 1ms);
 }
 
-bool AsyncAdePTTransport::IsHitsFlushed(int threadId) const
+bool AsyncAdePTTransport::AreReturnedStepsFlushed(int threadId) const
 {
-  return fEventStates[threadId].load(std::memory_order_acquire) >= EventState::HitsFlushed;
+  return fEventStates[threadId].load(std::memory_order_acquire) >= EventState::StepsFlushed;
 }
 
 void AsyncAdePTTransport::MarkHostFlushed(int threadId)


### PR DESCRIPTION
This PR cleans up the internal naming around the GPU steps returned.

Previously, they were called GPUHits, as there was scoring done on the GPU, or only the SD code was invoked.

Now, as UserActions etc are invoked, and steps can be returned even if no SD is attached, we are really returning GPU steps.
The GPU records step information, transfers it back to the host, and the Geant4 integration then reconstructs a `G4Step` and calls the sensitive detector on the CPU. So the internal names should say `step`, not `hit` or `scoring`.

The renames are:

- ScoringCommons.hh -> GPUStep.hh
- GPUHit -> GPUStep
- FillHit -> FillGPUStep
- RecordHit -> RecordGPUStep
- adept_scoring -> adept_step_recording
- HitScoringBuffer -> DeviceStepBufferView
- gHitScoringBuffer_dev -> gDeviceStepBuffer
- HitQueueItem -> GPUStepBatch
- HitScoring -> GPUStepTransferManager
- HandleReturnedGPUHitBatchesWith -> HandleGPUStepBatchesWith
- GetGPUHitsFromBuffer -> GetGPUStepBatchFromBuffer
- ProcessReturnedGPUHits -> ProcessReturnedGPUSteps
- IsHitsFlushed -> AreReturnedStepsFlushed
- RequestHitFlush -> RequestStepFlush
- SwappingHitBuffers -> SwappingStepBuffers
- FlushingHits -> FlushingSteps
- HitsFlushed -> StepsFlushed
- hitBufferOccupancy -> stepBufferOccupancy
- scoringCapacity / fScoringCapacity -> stepCapacity / fStepCapacity
- hitBufferSafetyFactor / fHitBufferSafetyFactor -> stepBufferSafetyFactor / fStepBufferSafetyFactor

The existing UI command names are kept unchanged in this PR,  like `/adept/setMillionsOfHitSlots`, since those are user-facing and would break all current input scripts.

No behavior change is intended here. This is only the vocabulary cleanup before splitting the returned-step transfer/buffer code out of `PerEventScoringImpl.cuh`.