### PR TITLE
Add full validation PR CI trigger

### DIFF
--- a/.github/workflows/self-hosted-pr-ci.yml
+++ b/.github/workflows/self-hosted-pr-ci.yml
@@ -38,13 +38,14 @@ jobs:
             core.setOutput('command', body);
             core.setOutput('should_run', 'false');
 
-            if (body !== '/run-test') {
+            const supportedCommands = new Set(['/run-test', '/run-test-full']);
+            if (!supportedCommands.has(body)) {
               core.notice(`Ignoring comment '${body}'`);
               return;
             }
 
             if (!trusted) {
-              core.notice(`Ignoring /run-test from untrusted role ${assoc}`);
+              core.notice(`Ignoring ${body} from untrusted role ${assoc}`);
               return;
             }
 
@@ -68,6 +69,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_SHA: ${{ steps.prepare.outputs.pr_sha }}
           TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMAND: ${{ steps.prepare.outputs.command }}
         run: |
           set -eo pipefail
 
@@ -91,9 +93,16 @@ jobs:
                 "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${PR_SHA}" >/dev/null
           }
 
-          post_status pending "AdePT / Full CI (EL9)" "Self-hosted EL9 CI queued"
+          full_description="Self-hosted EL9 CI queued"
+          validation_description="Waiting for drift result in EL9"
+          if [ "${COMMAND}" = "/run-test-full" ]; then
+            full_description="Self-hosted EL9 CI with full validation queued"
+            validation_description="Full validation requested in EL9"
+          fi
+
+          post_status pending "AdePT / Full CI (EL9)" "${full_description}"
           post_status pending "AdePT / Drift + Unit (EL9)" "Building PR/reference and running drift in EL9"
-          post_status pending "AdePT / Validation (EL9)" "Waiting for drift result in EL9"
+          post_status pending "AdePT / Validation (EL9)" "${validation_description}"
 
   full-ci:
     name: Full CI (EL9)
@@ -163,6 +172,8 @@ jobs:
       - name: Run self-hosted PR CI in Alma 9 container
         id: run_ci
         continue-on-error: true
+        env:
+          ALWAYS_RUN_VALIDATION: ${{ needs.prepare.outputs.command == '/run-test-full' && '1' || '0' }}
         run: |
           set -eo pipefail
 
@@ -196,6 +207,7 @@ jobs:
             -v /cvmfs:/cvmfs:ro,rslave \
             -v "${GITHUB_WORKSPACE}:/work/AdePT" \
             -e HOME=/tmp/adeptci-home \
+            -e ADEPT_PR_CI_ALWAYS_RUN_VALIDATION="${ALWAYS_RUN_VALIDATION}" \
             -e ADEPT_VALIDATION_DEFAULT_NUM_THREADS=32 \
             -e ADEPT_VALIDATION_DEFAULT_NUM_TRACKSLOTS=6 \
             -e ADEPT_VALIDATION_DEFAULT_NUM_HITSLOTS=30 \
@@ -214,14 +226,20 @@ jobs:
               set -eo pipefail
               mkdir -p "${HOME}"
               git config --global --add safe.directory /work/AdePT
-              ./test/run_pr_ci.sh \
-                --build-root "/tmp/adept-self-hosted-ci/pr-${{ needs.prepare.outputs.pr_number }}" \
-                --results-file "/work/AdePT/ci-results.env" \
-                --master-ref upstream/master \
-                --no-fetch-master \
-                --cuda-arch 89 \
-                --jobs auto \
+              pr_ci_args=(
+                ./test/run_pr_ci.sh
+                --build-root "/tmp/adept-self-hosted-ci/pr-${{ needs.prepare.outputs.pr_number }}"
+                --results-file "/work/AdePT/ci-results.env"
+                --master-ref upstream/master
+                --no-fetch-master
+                --cuda-arch 89
+                --jobs auto
                 --ctest-timeout-sec 900
+              )
+              if [[ "${ADEPT_PR_CI_ALWAYS_RUN_VALIDATION:-0}" == "1" ]]; then
+                pr_ci_args+=(--always-run-validation)
+              fi
+              "${pr_ci_args[@]}"
             '
 
       - name: Publish PR contexts
@@ -230,6 +248,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_SHA: ${{ needs.prepare.outputs.pr_sha }}
           TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMAND: ${{ needs.prepare.outputs.command }}
         run: |
           set -eo pipefail
 
@@ -241,6 +260,11 @@ jobs:
           : "${DRIFT_STATUS:=1}"
           : "${UNIT_STATUS:=1}"
           : "${VALIDATION_RAN:=1}"
+          if [ "${COMMAND}" = "/run-test-full" ]; then
+            : "${VALIDATION_FORCED:=1}"
+          else
+            : "${VALIDATION_FORCED:=0}"
+          fi
           : "${VALIDATION_STATUS:=1}"
           : "${FULL_CI_STATUS:=1}"
 
@@ -258,6 +282,9 @@ jobs:
           if [ "${VALIDATION_RAN}" -eq 0 ] && [ "${DRIFT_STATUS}" -eq 0 ]; then
             validation_state="success"
             validation_description="Skipped: drift matched master"
+          elif [ "${VALIDATION_STATUS}" -eq 0 ] && [ "${VALIDATION_FORCED}" -eq 1 ] && [ "${DRIFT_STATUS}" -eq 0 ]; then
+            validation_state="success"
+            validation_description="Full validation passed"
           elif [ "${VALIDATION_STATUS}" -eq 0 ]; then
             validation_state="success"
             validation_description="Validation tests passed"
@@ -266,9 +293,12 @@ jobs:
             validation_description="Validation tests failed"
           fi
 
-          if [ "${FULL_CI_STATUS}" -eq 0 ] && [ "${DRIFT_STATUS}" -eq 0 ]; then
+          if [ "${FULL_CI_STATUS}" -eq 0 ] && [ "${VALIDATION_RAN}" -eq 0 ]; then
             full_state="success"
             full_description="Drift matched master; validation skipped"
+          elif [ "${FULL_CI_STATUS}" -eq 0 ] && [ "${DRIFT_STATUS}" -eq 0 ]; then
+            full_state="success"
+            full_description="Drift matched master; validation passed"
           elif [ "${FULL_CI_STATUS}" -eq 0 ]; then
             full_state="success"
             full_description="Validation passed after drift mismatch"
@@ -326,6 +356,7 @@ jobs:
             echo "- Drift status: \`${DRIFT_STATUS:-missing}\`"
             echo "- Unit status: \`${UNIT_STATUS:-missing}\`"
             echo "- Validation ran: \`${VALIDATION_RAN:-missing}\`"
+            echo "- Validation forced: \`${VALIDATION_FORCED:-missing}\`"
             echo "- Validation status: \`${VALIDATION_STATUS:-missing}\`"
             echo "- Full CI status: \`${FULL_CI_STATUS:-missing}\`"
             echo "- Build root: \`/tmp/adept-self-hosted-ci/pr-${{ needs.prepare.outputs.pr_number }}\`"

--- a/test/run_pr_ci.sh
+++ b/test/run_pr_ci.sh
@@ -26,6 +26,7 @@ JOBS="auto"
 FETCH_MASTER=1
 FORCE_REBUILD=0
 REFRESH_MASTER=0
+RUN_VALIDATION_ALWAYS=0
 
 log() {
   printf '[pr-ci] %s\n' "$*"
@@ -44,7 +45,7 @@ Runs the AdePT PR CI flow on a self-hosted runner:
   1. build PR and upstream master reference for async/split/mixed
   2. run physics drift comparisons
   3. always run unit tests on async
-  4. run validation on async + split only when drift differs from master
+  4. run validation on async + split when drift differs from master, or when requested
 
 Options:
   --build-root <path>        Build/cache root (default: ${DEFAULT_BUILD_ROOT})
@@ -57,6 +58,7 @@ Options:
   --ctest-timeout-sec <sec>  Optional per-test timeout passed to ctest --timeout
   --force-rebuild            Force clean rebuilds in the matrix runner
   --refresh-master           Refresh cached master worktree/builds
+  --always-run-validation    Run validation even when drift matches master
   -h, --help                 Show this help
 EOF
 }
@@ -115,6 +117,7 @@ write_results() {
     printf 'DRIFT_STATUS=%s\n' "${DRIFT_STATUS}"
     printf 'UNIT_STATUS=%s\n' "${UNIT_STATUS}"
     printf 'VALIDATION_RAN=%s\n' "${VALIDATION_RAN}"
+    printf 'VALIDATION_FORCED=%s\n' "${RUN_VALIDATION_ALWAYS}"
     printf 'VALIDATION_STATUS=%s\n' "${VALIDATION_STATUS}"
     printf 'FULL_CI_STATUS=%s\n' "${FULL_CI_STATUS}"
   } > "${RESULTS_FILE}"
@@ -167,6 +170,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --refresh-master)
       REFRESH_MASTER=1
+      shift
+      ;;
+    --always-run-validation)
+      RUN_VALIDATION_ALWAYS=1
       shift
       ;;
     -h|--help)
@@ -225,6 +232,7 @@ log "Build root: ${BUILD_ROOT}"
 log "Master reference: ${MASTER_REF}"
 log "CUDA arch: ${CUDA_ARCH}"
 log "Build jobs: ${JOBS}"
+log "Always run validation: ${RUN_VALIDATION_ALWAYS}"
 log "Running drift matrix for async/split/mixed"
 
 for cfg in async split mixed; do
@@ -236,9 +244,11 @@ done
 
 MONOL_BUILD_DIR="${BUILD_ROOT}/BUILD_MONOL"
 SPLIT_BUILD_DIR="${BUILD_ROOT}/BUILD_SPLIT_ON"
+MONOL_BUILD_READY=0
 
 log "Ensuring async build has all test targets"
 if build_all_targets "${MONOL_BUILD_DIR}"; then
+  MONOL_BUILD_READY=1
   log "Running async unit tests"
   run_and_capture UNIT_STATUS run_ctest --test-dir "${MONOL_BUILD_DIR}" --output-on-failure -L unit -j1
 else
@@ -246,18 +256,24 @@ else
   UNIT_STATUS=1
 fi
 
-if [[ "${DRIFT_STATUS}" -ne 0 ]]; then
+if [[ "${DRIFT_STATUS}" -ne 0 || "${RUN_VALIDATION_ALWAYS}" -eq 1 ]]; then
   VALIDATION_RAN=1
 
   validation_monol_status=1
   validation_split_status=1
 
-  log "Drift differs from master; running validation on async and split"
-
-  if [[ "${UNIT_STATUS}" -eq 0 ]]; then
-    run_and_capture validation_monol_status run_ctest --test-dir "${MONOL_BUILD_DIR}" --output-on-failure -L validation -j1
+  if [[ "${DRIFT_STATUS}" -ne 0 ]]; then
+    log "Drift differs from master; running validation on async and split"
   else
-    log "Skipping async validation because the async build or unit stage failed"
+    log "Full validation requested; running validation on async and split"
+  fi
+
+  if [[ "${MONOL_BUILD_READY}" -eq 1 && ( "${UNIT_STATUS}" -eq 0 || "${RUN_VALIDATION_ALWAYS}" -eq 1 ) ]]; then
+    run_and_capture validation_monol_status run_ctest --test-dir "${MONOL_BUILD_DIR}" --output-on-failure -L validation -j1
+  elif [[ "${MONOL_BUILD_READY}" -ne 1 ]]; then
+    log "Skipping async validation because the async build is unavailable"
+  else
+    log "Skipping async validation because the unit stage failed"
   fi
 
   if build_all_targets "${SPLIT_BUILD_DIR}"; then
@@ -277,7 +293,7 @@ else
   VALIDATION_STATUS=0
 fi
 
-if [[ "${UNIT_STATUS}" -eq 0 && ( "${DRIFT_STATUS}" -eq 0 || "${VALIDATION_STATUS}" -eq 0 ) ]]; then
+if [[ "${UNIT_STATUS}" -eq 0 && ( "${VALIDATION_RAN}" -eq 0 || "${VALIDATION_STATUS}" -eq 0 ) ]]; then
   FULL_CI_STATUS=0
 else
   FULL_CI_STATUS=1
@@ -288,6 +304,7 @@ write_results
 log "Drift status: ${DRIFT_STATUS}"
 log "Unit status: ${UNIT_STATUS}"
 log "Validation ran: ${VALIDATION_RAN}"
+log "Validation forced: ${RUN_VALIDATION_ALWAYS}"
 log "Validation status: ${VALIDATION_STATUS}"
 log "Full CI status: ${FULL_CI_STATUS}"
 


### PR DESCRIPTION
Previously, the `run-test` suite runs the drift and unit tests and then skips the full validation if the drift test passes.

This PR adds the new command `run-test-all`, which always runs the drift test, unit tests, and the full validation.

The reason is that in some upcoming PRs, it might be useful to test and stress the machinery. E.g., changing things in the circular buffer on the host should not be tested only with unit tests, but also in a full integration under heavy load, which is not what the unit tests or drift tests provide.