### PR TITLE
Extract host circular buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -486,6 +486,7 @@ set(ADEPT_CORE_SRCS
   src/AdePTG4HepEmState.cpp
   src/AsyncAdePTTransport.cc
   src/AsyncAdePTTransport.cu
+  src/HostCircularBuffer.cpp
 )
 
 set(ADEPT_G4_INTEGRATION_SRCS

--- a/include/AdePT/core/HostCircularBuffer.hh
+++ b/include/AdePT/core/HostCircularBuffer.hh
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ADEPT_HOST_CIRCULAR_BUFFER_HH
+#define ADEPT_HOST_CIRCULAR_BUFFER_HH
+
+#include <AdePT/core/GPUStep.hh>
+
+#include <cstddef>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace AsyncAdePT {
+
+/// @brief Tracks occupied ranges in the pinned host buffer used for returned GPU steps.
+/// @details
+/// The HostCircularBuffer manages the memory of the pinned HostBuffer in returned-step transfer. It keeps track of
+/// the used space in the sorted vector of segments fSegments. The StepProcessingThread adds segments when it submits
+/// items to the StepQueue (in fact, the memory is already allocated as soon as the copy from TransferStepsToHost is
+/// done). The StepProcessingThread can delete segments when it copies the steps to the holdoutBuffer and the G4Worker
+/// finish their work. Since both StepProcessingThread and G4Workers can change the segments, a mutex is used to lock
+/// the access to fSegments. In TransferStepsToHost, the StepProcessingThread checks whether there is enough contiguous
+/// memory in the HostCircularBuffer before the copy can start.
+class HostCircularBuffer {
+public:
+  struct Segment {
+    GPUStep *begin;
+    GPUStep *end;
+
+    bool operator<(const Segment &other) const { return begin < other.begin; }
+  };
+
+  HostCircularBuffer(GPUStep *bufferStart, std::size_t capacity);
+
+  /// Adds a segment at the provided position. Ensures segments remain sorted.
+  bool addSegment(GPUStep *begin, GPUStep *end);
+
+  /// Removes a segment based on its starting pointer and updates fWritePtr accordingly.
+  void removeSegment(GPUStep *segmentPtr);
+
+  /// Returns the contiguous free space in front of the fWritePtr (or at the beginning of the buffer in case of a
+  /// wraparound).
+  std::size_t getFreeContiguousMemory(std::size_t transferSize);
+
+  /// @brief Return the current fill fraction according to the existing transfer-manager bookkeeping.
+  /// @details This intentionally preserves the historical semantics: the value is based on fFreeContiguousSpace,
+  /// which is updated by getFreeContiguousMemory(transferSize) and includes the pending transfer size.
+  double getFillFraction() const;
+
+  std::size_t getOffset() const;
+
+private:
+  bool checkForOverlaps() const;
+  void printSegments(const std::string &msg) const;
+
+  GPUStep *fBufferStart;
+  GPUStep *fBufferEnd;
+  GPUStep *fWritePtr;
+  std::size_t fFreeContiguousSpace;
+  std::vector<Segment> fSegments; // **Sorted vector instead of set**
+  mutable std::mutex bufferManagerMutex;
+};
+
+} // namespace AsyncAdePT
+
+#endif

--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -6,10 +6,12 @@
 
 #include <AdePT/base/ResourceManagement.cuh>
 #include <AdePT/core/GPUStep.hh>
+#include <AdePT/core/HostCircularBuffer.hh>
 #include <AdePT/copcore/Global.h>
 
 #include <VecGeom/navigation/NavigationState.h>
 
+#include <algorithm>
 #include <atomic>
 #include <deque>
 #include <mutex>
@@ -19,6 +21,7 @@
 #include <thread>
 #include <condition_variable>
 #include <sstream>
+#include <vector>
 
 // definitions for printouts and advanced debugging
 // #define DEBUG
@@ -120,165 +123,6 @@ struct GPUStepBatch {
   }
 };
 
-class CircularBufferManager {
-  // the CircularBufferManager manages the memory of the pinned HostBuffer fBuffer (in returned-step transfer).
-  // It keeps track of the used space in the sorted vector of segments fSegments.
-  // The StepProcessingThread adds segments when it submits items to the StepQueue (in fact, the memory is already
-  // allocated as soon as the copy from TransferStepsToHost is done). The StepProcessingThread can delete segments when
-  // it copies the steps to the holdoutBuffer and the G4Worker finish their work. Since both StepProcessingThread and
-  // G4Workers can change the segments, a mutex is used to lock the access to the fSegments. In the TransferStepsToHost,
-  // the StepProcessingThread checks whether there is enough contiguous memory in the CircularBuffer before the copy can
-  // start
-public:
-  struct Segment {
-    GPUStep *begin;
-    GPUStep *end;
-
-    bool operator<(const Segment &other) const { return begin < other.begin; }
-  };
-
-  CircularBufferManager(GPUStep *bufferStart, size_t capacity)
-      : fBufferStart(bufferStart), fBufferEnd(bufferStart + capacity), fWritePtr(bufferStart),
-        fFreeContiguousSpace(capacity)
-  {
-  }
-
-  /// Adds a segment at the provided position. Ensures segments remain sorted.
-  bool addSegment(GPUStep *begin, GPUStep *end)
-  {
-    std::scoped_lock lock{bufferManagerMutex};
-
-    // Insert the segment into sorted position
-    fSegments.insert(std::upper_bound(fSegments.begin(), fSegments.end(), Segment{begin, end}), {begin, end});
-
-#ifdef DEBUG
-    if (begin != fWritePtr)
-      std::cout << BOLD_RED << " Begin != fWritePTr " << begin << " fWritePtr " << fWritePtr << RESET << std::endl;
-    size_t size = end - begin;
-    if (size > fFreeContiguousSpace)
-      std::cout << BOLD_RED << " Not enough space! size " << size << " fFreeContiguousSpace " << fFreeContiguousSpace
-                << RESET << std::endl;
-    if (!checkForOverlaps()) std::cout << BOLD_RED << " Overlaps after AddSegment! " << RESET << std::endl;
-#endif
-
-    fWritePtr = end;
-
-    return true;
-  }
-
-  /// Removes a segment based on its starting pointer and updates fWritePtr accordingly.
-  void removeSegment(GPUStep *segmentPtr)
-  {
-    std::scoped_lock lock{bufferManagerMutex};
-
-    // Find the segment
-    auto it = std::find_if(fSegments.begin(), fSegments.end(),
-                           [segmentPtr](const Segment &seg) { return seg.begin == segmentPtr; });
-
-#ifdef DEBUG
-    if (!segmentPtr) std::cout << BOLD_RED << " Trying to remove nullptr segment " << RESET << std::endl;
-    if (it == fSegments.end())
-      std::cout << BOLD_RED << " Trying to remove segment that doesn't exist !! segment : " << segmentPtr << RESET
-                << std::endl;
-    if (!checkForOverlaps()) std::cout << BOLD_RED << " Overlaps after removesegment! " << RESET << std::endl;
-#endif
-
-    // delete it from the list
-    fSegments.erase(it);
-  }
-
-  /// Returns the contiguous free space in front of the fWritePtr (or at the beginning of the buffer in case of a
-  /// wraparound)
-  size_t getFreeContiguousMemory(size_t transferSize)
-  {
-    std::scoped_lock lock{bufferManagerMutex};
-
-    if (fSegments.empty()) {
-      // if empty, reset WritePtr to Bufferstart
-      fWritePtr = fBufferStart;
-      return fBufferEnd - fBufferStart; // Everything is free
-    }
-
-    // Find the next segment after fWritePtr
-    auto nextSegment = std::lower_bound(fSegments.begin(), fSegments.end(), Segment{fWritePtr, nullptr},
-                                        [](const Segment &a, const Segment &b) { return a.begin < b.begin; });
-
-    // Find the previous segment before nextSegment (if it exists)
-    auto prevSegment = (nextSegment != fSegments.begin()) ? std::prev(nextSegment) : fSegments.end();
-
-    // If the fWritePtr was set on an end of a segment that was deleted, we can put it back to the last previous
-    // existing segment
-    if (prevSegment != fSegments.end() && fWritePtr != prevSegment->end) {
-      fWritePtr = prevSegment->end;
-    }
-
-    // Free space from `fWritePtr` to next segment
-    size_t forwardSpace = (nextSegment != fSegments.end()) ? nextSegment->begin - fWritePtr : fBufferEnd - fWritePtr;
-
-    // Free space for a wraparound
-    size_t wrapAroundSpace = (fSegments.front().begin > fBufferStart) ? (fSegments.front().begin - fBufferStart) : 0;
-
-    fFreeContiguousSpace = forwardSpace + wrapAroundSpace - transferSize;
-
-    if (forwardSpace >= transferSize) {
-      return forwardSpace; // Enough space in the current region
-    }
-
-    if (wrapAroundSpace >= transferSize) {
-      fWritePtr = fBufferStart; // Reset fWritePtr since we need to wrap around
-      return wrapAroundSpace;
-    }
-
-#ifdef DEBUG
-    std::cout << BOLD_RED
-              << "Cannot transfer from Device to Host due to lack of space in CPU HostBuffer. This should never be "
-                 "the case! transfersize "
-              << transferSize << " forwardSpace " << forwardSpace << " wraparoundspace " << wrapAroundSpace
-              << " total space : " << (fBufferEnd - fBufferStart) << " free space " << fFreeContiguousSpace << RESET
-              << std::endl;
-    checkForOverlaps();
-#endif
-
-    return 0; // Not enough contiguous space available
-  }
-
-  double getFillFraction() { return 1. - static_cast<double>(fFreeContiguousSpace) / (fBufferEnd - fBufferStart); }
-
-  size_t getOffset() { return fWritePtr - fBufferStart; }
-
-private:
-  GPUStep *fBufferStart;
-  GPUStep *fBufferEnd;
-  GPUStep *fWritePtr;
-  size_t fFreeContiguousSpace;
-  std::vector<Segment> fSegments; // **Sorted vector instead of set**
-  mutable std::mutex bufferManagerMutex;
-
-  // Consistency check for debugging
-  bool checkForOverlaps()
-  {
-    for (size_t i = 1; i < fSegments.size(); i++) {
-      if (fSegments[i - 1].end > fSegments[i].begin) {
-        std::cerr << "ERROR: Overlapping segments detected!\n";
-        std::cerr << " Segment 1: [" << fSegments[i - 1].begin << " - " << fSegments[i - 1].end << "]\n";
-        std::cerr << " Segment 2: [" << fSegments[i].begin << " - " << fSegments[i].end << "]\n";
-        assert(false && "Overlapping segments in CircularBufferManager!");
-        return false;
-      }
-    }
-    return true;
-  }
-
-  void printSegments(const std::string &msg)
-  {
-    std::cout << msg << " | Current segments: ";
-    for (const auto &seg : fSegments) {
-      std::cout << "[" << seg.begin << " - " << seg.end << "] ";
-    }
-    std::cout << std::endl;
-  }
-};
-
 class GPUStepTransferManager {
   unique_ptr_cuda<GPUStep> fGPUStepBuffer_dev;
   unique_ptr_cuda<GPUStep, CudaHostDeleter<GPUStep>> fGPUStepBuffer_host;
@@ -287,7 +131,7 @@ class GPUStepTransferManager {
 
   BufferHandle fBuffer;
 
-  std::unique_ptr<CircularBufferManager> fBufferManager;
+  std::unique_ptr<HostCircularBuffer> fBufferManager;
 
   enum class DeviceState { Free, Filling, NeedTransferToHost, TransferToHost };
   std::array<std::atomic<DeviceState>, 2>
@@ -430,7 +274,7 @@ public:
     fBuffer.hostStepCount = fGPUStepBufferCount_host.get();
     fBuffer.hostState     = BufferHandle::HostState::ReadyToBeFilled;
 
-    fBufferManager = std::make_unique<CircularBufferManager>(fGPUStepBuffer_host.get(), hostBufferCapacity);
+    fBufferManager = std::make_unique<HostCircularBuffer>(fGPUStepBuffer_host.get(), hostBufferCapacity);
 
     ADEPT_DEVICE_API_CALL(GetSymbolAddress(&fDeviceStepBuffer_deviceAddress, gDeviceStepBuffer));
     assert(fDeviceStepBuffer_deviceAddress != nullptr);
@@ -675,7 +519,7 @@ public:
     }
 #endif
 
-    // if data is in the hostBuffer (and not the holdoutBuffer), update the CircularBufferManager and release the memory
+    // if data is in the hostBuffer (and not the holdoutBuffer), update the HostCircularBuffer and release the memory
     if (dataOnBuffer) fBufferManager->removeSegment(begin);
     fStepQueues[threadId].pop_front();
   }

--- a/src/HostCircularBuffer.cpp
+++ b/src/HostCircularBuffer.cpp
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2026 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include <AdePT/core/HostCircularBuffer.hh>
+
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <iterator>
+
+// definitions for printouts and advanced debugging
+// #define DEBUG
+#define RESET "\033[0m"
+#define BOLD_RED "\033[1;31m"
+
+namespace AsyncAdePT {
+
+HostCircularBuffer::HostCircularBuffer(GPUStep *bufferStart, std::size_t capacity)
+    : fBufferStart(bufferStart), fBufferEnd(bufferStart + capacity), fWritePtr(bufferStart),
+      fFreeContiguousSpace(capacity)
+{
+}
+
+bool HostCircularBuffer::addSegment(GPUStep *begin, GPUStep *end)
+{
+  std::scoped_lock lock{bufferManagerMutex};
+
+  // Insert the segment into sorted position
+  fSegments.insert(std::upper_bound(fSegments.begin(), fSegments.end(), Segment{begin, end}), {begin, end});
+
+#ifdef DEBUG
+  if (begin != fWritePtr)
+    std::cout << BOLD_RED << " Begin != fWritePTr " << begin << " fWritePtr " << fWritePtr << RESET << std::endl;
+  std::size_t size = end - begin;
+  if (size > fFreeContiguousSpace)
+    std::cout << BOLD_RED << " Not enough space! size " << size << " fFreeContiguousSpace " << fFreeContiguousSpace
+              << RESET << std::endl;
+  if (!checkForOverlaps()) std::cout << BOLD_RED << " Overlaps after AddSegment! " << RESET << std::endl;
+#endif
+
+  fWritePtr = end;
+
+  return true;
+}
+
+void HostCircularBuffer::removeSegment(GPUStep *segmentPtr)
+{
+  std::scoped_lock lock{bufferManagerMutex};
+
+  // Find the segment
+  auto it = std::find_if(fSegments.begin(), fSegments.end(),
+                         [segmentPtr](const Segment &seg) { return seg.begin == segmentPtr; });
+
+#ifdef DEBUG
+  if (!segmentPtr) std::cout << BOLD_RED << " Trying to remove nullptr segment " << RESET << std::endl;
+  if (it == fSegments.end())
+    std::cout << BOLD_RED << " Trying to remove segment that doesn't exist !! segment : " << segmentPtr << RESET
+              << std::endl;
+  if (!checkForOverlaps()) std::cout << BOLD_RED << " Overlaps after removesegment! " << RESET << std::endl;
+#endif
+
+  // delete it from the list
+  fSegments.erase(it);
+}
+
+std::size_t HostCircularBuffer::getFreeContiguousMemory(std::size_t transferSize)
+{
+  std::scoped_lock lock{bufferManagerMutex};
+
+  if (fSegments.empty()) {
+    // if empty, reset WritePtr to Bufferstart
+    fWritePtr = fBufferStart;
+    return fBufferEnd - fBufferStart; // Everything is free
+  }
+
+  // Find the next segment after fWritePtr
+  auto nextSegment = std::lower_bound(fSegments.begin(), fSegments.end(), Segment{fWritePtr, nullptr},
+                                      [](const Segment &a, const Segment &b) { return a.begin < b.begin; });
+
+  // Find the previous segment before nextSegment (if it exists)
+  auto prevSegment = (nextSegment != fSegments.begin()) ? std::prev(nextSegment) : fSegments.end();
+
+  // If the fWritePtr was set on an end of a segment that was deleted, we can put it back to the last previous
+  // existing segment
+  if (prevSegment != fSegments.end() && fWritePtr != prevSegment->end) {
+    fWritePtr = prevSegment->end;
+  }
+
+  // Free space from `fWritePtr` to next segment
+  std::size_t forwardSpace = (nextSegment != fSegments.end()) ? nextSegment->begin - fWritePtr : fBufferEnd - fWritePtr;
+
+  // Free space for a wraparound
+  std::size_t wrapAroundSpace = (fSegments.front().begin > fBufferStart) ? (fSegments.front().begin - fBufferStart) : 0;
+
+  fFreeContiguousSpace = forwardSpace + wrapAroundSpace - transferSize;
+
+  if (forwardSpace >= transferSize) {
+    return forwardSpace; // Enough space in the current region
+  }
+
+  if (wrapAroundSpace >= transferSize) {
+    fWritePtr = fBufferStart; // Reset fWritePtr since we need to wrap around
+    return wrapAroundSpace;
+  }
+
+#ifdef DEBUG
+  std::cout << BOLD_RED
+            << "Cannot transfer from Device to Host due to lack of space in CPU HostBuffer. This should never be "
+               "the case! transfersize "
+            << transferSize << " forwardSpace " << forwardSpace << " wraparoundspace " << wrapAroundSpace
+            << " total space : " << (fBufferEnd - fBufferStart) << " free space " << fFreeContiguousSpace << RESET
+            << std::endl;
+  checkForOverlaps();
+#endif
+
+  return 0; // Not enough contiguous space available
+}
+
+double HostCircularBuffer::getFillFraction() const
+{
+  return 1. - static_cast<double>(fFreeContiguousSpace) / (fBufferEnd - fBufferStart);
+}
+
+std::size_t HostCircularBuffer::getOffset() const
+{
+  return fWritePtr - fBufferStart;
+}
+
+bool HostCircularBuffer::checkForOverlaps() const
+{
+  for (std::size_t i = 1; i < fSegments.size(); i++) {
+    if (fSegments[i - 1].end > fSegments[i].begin) {
+      std::cerr << "ERROR: Overlapping segments detected!\n";
+      std::cerr << " Segment 1: [" << fSegments[i - 1].begin << " - " << fSegments[i - 1].end << "]\n";
+      std::cerr << " Segment 2: [" << fSegments[i].begin << " - " << fSegments[i].end << "]\n";
+      assert(false && "Overlapping segments in HostCircularBuffer!");
+      return false;
+    }
+  }
+  return true;
+}
+
+void HostCircularBuffer::printSegments(const std::string &msg) const
+{
+  std::cout << msg << " | Current segments: ";
+  for (const auto &seg : fSegments) {
+    std::cout << "[" << seg.begin << " - " << seg.end << "] ";
+  }
+  std::cout << std::endl;
+}
+
+} // namespace AsyncAdePT

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -49,6 +49,7 @@ set(ADEPT_UNIT_TESTS_BASE
   test_track_block.cu          # Unit test for BlockData
   test_magfieldRK.cpp          # Unit test for Mag-Field integration classes
   compare_integration_precision.cpp # Script for generating float vs double trajectories
+  test_hostCircularBuffer.cpp  # Unit test for HostCircularBuffer
   test_hostTrackDataMapper.cpp # Unit test for hostTrackDataMapper
   # test_Bfield_step_debugger.cpp # experimental test to debug single stuck rays in AdePT
 )
@@ -65,6 +66,7 @@ set(ADEPT_UNIT_TEST_NAMES
   test_track_block
   test_magfieldRK
   compare_integration_precision
+  test_hostCircularBuffer
   test_hostTrackDataMapper
 )
 set_tests_properties(${ADEPT_UNIT_TEST_NAMES} PROPERTIES LABELS "unit")

--- a/test/unit/test_hostCircularBuffer.cpp
+++ b/test/unit/test_hostCircularBuffer.cpp
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: 2026 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include <AdePT/core/HostCircularBuffer.hh>
+
+#include <atomic>
+#include <cmath>
+#include <condition_variable>
+#include <deque>
+#include <iostream>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#define CHECK(expr)                                                                         \
+  do {                                                                                      \
+    if (!(expr)) {                                                                          \
+      std::cerr << "CHECK failed: " #expr << " at " << __FILE__ << ":" << __LINE__ << "\n"; \
+      return 1;                                                                             \
+    }                                                                                       \
+  } while (0)
+
+static bool near(double lhs, double rhs)
+{
+  return std::abs(lhs - rhs) < 1e-12;
+}
+
+static int test_empty_buffer_allows_exact_fit()
+{
+  std::vector<GPUStep> storage(8);
+  AsyncAdePT::HostCircularBuffer buffer(storage.data(), storage.size());
+
+  CHECK(buffer.getOffset() == 0);
+  CHECK(buffer.getFreeContiguousMemory(8) == 8);
+  CHECK(buffer.getOffset() == 0);
+  CHECK(near(buffer.getFillFraction(), 0.0));
+
+  return 0;
+}
+
+static int test_segment_add_remove_and_full_buffer()
+{
+  std::vector<GPUStep> storage(10);
+  AsyncAdePT::HostCircularBuffer buffer(storage.data(), storage.size());
+
+  CHECK(buffer.getFreeContiguousMemory(10) == 10);
+  CHECK(buffer.addSegment(storage.data(), storage.data() + 10));
+  CHECK(buffer.getOffset() == 10);
+
+  CHECK(buffer.getFreeContiguousMemory(1) == 0);
+
+  buffer.removeSegment(storage.data());
+  CHECK(buffer.getFreeContiguousMemory(10) == 10);
+  CHECK(buffer.getOffset() == 0);
+
+  return 0;
+}
+
+static int test_fill_fraction_preserves_existing_pending_transfer_semantics()
+{
+  std::vector<GPUStep> storage(10);
+  AsyncAdePT::HostCircularBuffer buffer(storage.data(), storage.size());
+
+  CHECK(buffer.getFreeContiguousMemory(4) == 10);
+  CHECK(buffer.addSegment(storage.data(), storage.data() + 4));
+
+  // This intentionally documents the existing behavior: getFillFraction() is
+  // based on the contiguous-space bookkeeping after a transfer-size query. It
+  // is not simply occupiedSlots / capacity.
+  CHECK(buffer.getFreeContiguousMemory(3) == 6);
+  CHECK(near(buffer.getFillFraction(), 0.7));
+
+  return 0;
+}
+
+static int test_wraparound_after_front_segment_is_removed()
+{
+  std::vector<GPUStep> storage(10);
+  AsyncAdePT::HostCircularBuffer buffer(storage.data(), storage.size());
+
+  CHECK(buffer.getFreeContiguousMemory(6) == 10);
+  CHECK(buffer.addSegment(storage.data(), storage.data() + 6));
+
+  CHECK(buffer.getFreeContiguousMemory(4) == 4);
+  CHECK(buffer.getOffset() == 6);
+  CHECK(buffer.addSegment(storage.data() + 6, storage.data() + 10));
+
+  buffer.removeSegment(storage.data());
+  CHECK(buffer.getFreeContiguousMemory(6) == 6);
+  CHECK(buffer.getOffset() == 0);
+  CHECK(near(buffer.getFillFraction(), 1.0));
+
+  return 0;
+}
+
+static int test_tail_space_is_reused_after_tail_segment_is_removed()
+{
+  std::vector<GPUStep> storage(12);
+  AsyncAdePT::HostCircularBuffer buffer(storage.data(), storage.size());
+
+  CHECK(buffer.getFreeContiguousMemory(4) == 12);
+  CHECK(buffer.addSegment(storage.data(), storage.data() + 4));
+  CHECK(buffer.getFreeContiguousMemory(4) == 8);
+  CHECK(buffer.addSegment(storage.data() + 4, storage.data() + 8));
+  CHECK(buffer.getFreeContiguousMemory(4) == 4);
+  CHECK(buffer.addSegment(storage.data() + 8, storage.data() + 12));
+
+  buffer.removeSegment(storage.data() + 8);
+  CHECK(buffer.getFreeContiguousMemory(4) == 4);
+  CHECK(buffer.getOffset() == 8);
+
+  return 0;
+}
+
+static int test_middle_hole_is_not_reused_from_end_write_position()
+{
+  std::vector<GPUStep> storage(12);
+  AsyncAdePT::HostCircularBuffer buffer(storage.data(), storage.size());
+
+  CHECK(buffer.getFreeContiguousMemory(4) == 12);
+  CHECK(buffer.addSegment(storage.data(), storage.data() + 4));
+  CHECK(buffer.getFreeContiguousMemory(4) == 8);
+  CHECK(buffer.addSegment(storage.data() + 4, storage.data() + 8));
+  CHECK(buffer.getFreeContiguousMemory(4) == 4);
+  CHECK(buffer.addSegment(storage.data() + 8, storage.data() + 12));
+
+  buffer.removeSegment(storage.data() + 4);
+  CHECK(buffer.getFreeContiguousMemory(4) == 0);
+  CHECK(buffer.getOffset() == 12);
+
+  return 0;
+}
+
+static int test_fragmentation_can_block_larger_transfers()
+{
+  std::vector<GPUStep> storage(12);
+  AsyncAdePT::HostCircularBuffer buffer(storage.data(), storage.size());
+
+  CHECK(buffer.getFreeContiguousMemory(4) == 12);
+  CHECK(buffer.addSegment(storage.data(), storage.data() + 4));
+  CHECK(buffer.getFreeContiguousMemory(4) == 8);
+  CHECK(buffer.addSegment(storage.data() + 4, storage.data() + 8));
+  CHECK(buffer.getFreeContiguousMemory(4) == 4);
+  CHECK(buffer.addSegment(storage.data() + 8, storage.data() + 12));
+
+  buffer.removeSegment(storage.data());
+  buffer.removeSegment(storage.data() + 8);
+  CHECK(buffer.getFreeContiguousMemory(5) == 0);
+  CHECK(buffer.getFreeContiguousMemory(4) == 4);
+  CHECK(buffer.getOffset() == 8);
+
+  return 0;
+}
+
+static int test_concurrent_allocation_and_release()
+{
+  std::vector<GPUStep> storage(64);
+  AsyncAdePT::HostCircularBuffer buffer(storage.data(), storage.size());
+
+  constexpr int nSegments = 10000;
+  constexpr int nWorkers  = 4;
+
+  std::atomic_bool failed{false};
+  std::atomic_int removedSegments{0};
+  std::atomic_int producedSegments{0};
+  std::deque<GPUStep *> pointersToRelease;
+  std::mutex queueMutex;
+  std::condition_variable queueCondition;
+  bool producerDone = false;
+
+  auto worker = [&]() {
+    while (true) {
+      GPUStep *segmentBegin = nullptr;
+      {
+        std::unique_lock lock{queueMutex};
+        queueCondition.wait(lock, [&]() { return producerDone || !pointersToRelease.empty(); });
+        if (pointersToRelease.empty()) {
+          if (producerDone) return;
+          continue;
+        }
+        segmentBegin = pointersToRelease.front();
+        pointersToRelease.pop_front();
+      }
+
+      buffer.removeSegment(segmentBegin);
+      removedSegments.fetch_add(1, std::memory_order_relaxed);
+    }
+  };
+
+  std::vector<std::thread> workers;
+  workers.reserve(nWorkers);
+  for (int i = 0; i < nWorkers; ++i) {
+    workers.emplace_back(worker);
+  }
+
+  for (int i = 0; i < nSegments; ++i) {
+    while (buffer.getFreeContiguousMemory(1) == 0) {
+      std::this_thread::yield();
+    }
+
+    const auto offset         = buffer.getOffset();
+    GPUStep *segmentBegin     = storage.data() + offset;
+    GPUStep *const segmentEnd = segmentBegin + 1;
+    if (!buffer.addSegment(segmentBegin, segmentEnd)) {
+      failed.store(true, std::memory_order_relaxed);
+      break;
+    }
+    producedSegments.fetch_add(1, std::memory_order_relaxed);
+
+    {
+      std::scoped_lock lock{queueMutex};
+      pointersToRelease.push_back(segmentBegin);
+    }
+    queueCondition.notify_one();
+  }
+
+  {
+    std::scoped_lock lock{queueMutex};
+    producerDone = true;
+  }
+  queueCondition.notify_all();
+
+  for (auto &thread : workers) {
+    thread.join();
+  }
+
+  CHECK(!failed.load(std::memory_order_relaxed));
+  CHECK(producedSegments.load(std::memory_order_relaxed) == nSegments);
+  CHECK(removedSegments.load(std::memory_order_relaxed) == nSegments);
+  CHECK(buffer.getFreeContiguousMemory(storage.size()) == storage.size());
+  CHECK(buffer.getOffset() == 0);
+
+  return 0;
+}
+
+int main()
+{
+  if (int result = test_empty_buffer_allows_exact_fit()) return result;
+  if (int result = test_segment_add_remove_and_full_buffer()) return result;
+  if (int result = test_fill_fraction_preserves_existing_pending_transfer_semantics()) return result;
+  if (int result = test_wraparound_after_front_segment_is_removed()) return result;
+  if (int result = test_tail_space_is_reused_after_tail_segment_is_removed()) return result;
+  if (int result = test_middle_hole_is_not_reused_from_end_write_position()) return result;
+  if (int result = test_fragmentation_can_block_larger_transfers()) return result;
+  if (int result = test_concurrent_allocation_and_release()) return result;
+
+  std::cout << "All HostCircularBuffer tests passed.\n";
+  return 0;
+}


### PR DESCRIPTION
This PR extracts the host circular buffer for the GPUSteps from the `PerEventScoringImpl.cuh`

It is moved into its .cpp files, as it is pure CPU code. A unit test is added, testing for multi threaded access and other functionalities.

Note: this PR does not change any behavior, it is on purpose split into a pure extraction.