### PR TITLE
Clean up HostCircularBuffer

### DIFF
--- a/include/AdePT/core/HostCircularBuffer.hh
+++ b/include/AdePT/core/HostCircularBuffer.hh
@@ -4,8 +4,6 @@
 #ifndef ADEPT_HOST_CIRCULAR_BUFFER_HH
 #define ADEPT_HOST_CIRCULAR_BUFFER_HH
 
-#include <AdePT/core/GPUStep.hh>
-
 #include <cstddef>
 #include <mutex>
 #include <string>
@@ -25,40 +23,39 @@ namespace AsyncAdePT {
 class HostCircularBuffer {
 public:
   struct Segment {
-    GPUStep *begin;
-    GPUStep *end;
+    std::size_t begin{0};
+    std::size_t end{0};
 
     bool operator<(const Segment &other) const { return begin < other.begin; }
   };
 
-  HostCircularBuffer(GPUStep *bufferStart, std::size_t capacity);
+  explicit HostCircularBuffer(std::size_t capacity);
 
   /// Adds a segment at the provided position. Ensures segments remain sorted.
-  bool addSegment(GPUStep *begin, GPUStep *end);
+  bool AddSegment(std::size_t begin, std::size_t end);
 
-  /// Removes a segment based on its starting pointer and updates fWritePtr accordingly.
-  void removeSegment(GPUStep *segmentPtr);
+  /// Removes a segment based on its starting offset.
+  void RemoveSegment(std::size_t segmentBegin);
 
-  /// Returns the contiguous free space in front of the fWritePtr (or at the beginning of the buffer in case of a
+  /// Returns the contiguous free space in front of the write offset (or at the beginning of the buffer in case of a
   /// wraparound).
-  std::size_t getFreeContiguousMemory(std::size_t transferSize);
+  std::size_t GetFreeContiguousSlots(std::size_t transferSize);
 
-  /// @brief Return the current fill fraction according to the existing transfer-manager bookkeeping.
+  /// @brief Return the fill fraction according to the existing transfer-manager bookkeeping.
   /// @details This intentionally preserves the historical semantics: the value is based on fFreeContiguousSpace,
-  /// which is updated by getFreeContiguousMemory(transferSize) and includes the pending transfer size.
-  double getFillFraction() const;
+  /// which is updated by GetFreeContiguousSlots(transferSize) and includes the pending transfer size.
+  double GetFillFractionAfterLastRequest() const;
 
-  std::size_t getOffset() const;
+  std::size_t GetWriteOffset() const;
 
 private:
   bool checkForOverlaps() const;
   void printSegments(const std::string &msg) const;
 
-  GPUStep *fBufferStart;
-  GPUStep *fBufferEnd;
-  GPUStep *fWritePtr;
+  std::size_t fCapacity{0};
+  std::size_t fWriteOffset{0};
   std::size_t fFreeContiguousSpace;
-  std::vector<Segment> fSegments; // **Sorted vector instead of set**
+  std::vector<Segment> fSegments; // sorted by segment start offset
   mutable std::mutex bufferManagerMutex;
 };
 

--- a/include/AdePT/core/PerEventScoringImpl.cuh
+++ b/include/AdePT/core/PerEventScoringImpl.cuh
@@ -164,7 +164,9 @@ class GPUStepTransferManager {
       GPUStepBatch stepBatch{begin, end};
 
       if (begin != end) {
-        fBufferManager->addSegment(begin, end);
+        const auto beginOffset = static_cast<std::size_t>(begin - handle.hostBuffer);
+        const auto endOffset   = static_cast<std::size_t>(end - handle.hostBuffer);
+        fBufferManager->AddSegment(beginOffset, endOffset);
 
         std::scoped_lock lock{fStepQueueLocks[i]};
         fStepQueues[i].push_back(std::move(stepBatch));
@@ -194,9 +196,9 @@ class GPUStepTransferManager {
 
           // If the circular Buffer is too full and the G4Worker didn't pick up the work, we have to copy out the steps
           // to the holdoutBuffer
-          if (fBufferManager->getFillFraction() > fCPUCopyFraction) {
+          if (fBufferManager->GetFillFractionAfterLastRequest() > fCPUCopyFraction) {
             if (debugLevel > 5) {
-              std::cout << BOLD_RED << "FillFraction too high: " << fBufferManager->getFillFraction()
+              std::cout << BOLD_RED << "FillFraction too high: " << fBufferManager->GetFillFractionAfterLastRequest()
                         << ", threshold: " << fCPUCopyFraction << " copying out " << numSteps << " steps for G4Worker "
                         << i << RESET << std::endl;
             }
@@ -204,7 +206,8 @@ class GPUStepTransferManager {
             std::copy(ret.begin, ret.end, ret.holdoutBuffer.begin()); // Copy data
 
             // remove the segment first, before updating the pointers to the copied out memory
-            fBufferManager->removeSegment(ret.begin);
+            const auto beginOffset = static_cast<std::size_t>(ret.begin - handle.hostBuffer);
+            fBufferManager->RemoveSegment(beginOffset);
 
             // Update pointers
             ret.begin = ret.holdoutBuffer.data();
@@ -274,7 +277,7 @@ public:
     fBuffer.hostStepCount = fGPUStepBufferCount_host.get();
     fBuffer.hostState     = BufferHandle::HostState::ReadyToBeFilled;
 
-    fBufferManager = std::make_unique<HostCircularBuffer>(fGPUStepBuffer_host.get(), hostBufferCapacity);
+    fBufferManager = std::make_unique<HostCircularBuffer>(hostBufferCapacity);
 
     ADEPT_DEVICE_API_CALL(GetSymbolAddress(&fDeviceStepBuffer_deviceAddress, gDeviceStepBuffer));
     assert(fDeviceStepBuffer_deviceAddress != nullptr);
@@ -448,7 +451,7 @@ public:
         transferSize += fBuffer.hostStepCount[i];
       }
 
-      if (fBufferManager->getFreeContiguousMemory(transferSize) < transferSize) {
+      if (fBufferManager->GetFreeContiguousSlots(transferSize) < transferSize) {
         continue;
       }
 
@@ -457,7 +460,7 @@ public:
       fBuffer.hostState.store(BufferHandle::HostState::TransferFromDevice);
 
       auto bufferBegin     = fBuffer.stepBufferViews[prevActiveDeviceBuffer].stepBuffer_dev;
-      fBuffer.offsetAtCopy = fBufferManager->getOffset();
+      fBuffer.offsetAtCopy = fBufferManager->GetWriteOffset();
 
       // Copy out the steps:
       // The start address on device is always i * fNSlot (Slots per thread), and we copy always to
@@ -520,7 +523,10 @@ public:
 #endif
 
     // if data is in the hostBuffer (and not the holdoutBuffer), update the HostCircularBuffer and release the memory
-    if (dataOnBuffer) fBufferManager->removeSegment(begin);
+    if (dataOnBuffer) {
+      const auto beginOffset = static_cast<std::size_t>(begin - fBuffer.hostBuffer);
+      fBufferManager->RemoveSegment(beginOffset);
+    }
     fStepQueues[threadId].pop_front();
   }
 };

--- a/src/HostCircularBuffer.cpp
+++ b/src/HostCircularBuffer.cpp
@@ -15,13 +15,12 @@
 
 namespace AsyncAdePT {
 
-HostCircularBuffer::HostCircularBuffer(GPUStep *bufferStart, std::size_t capacity)
-    : fBufferStart(bufferStart), fBufferEnd(bufferStart + capacity), fWritePtr(bufferStart),
-      fFreeContiguousSpace(capacity)
+HostCircularBuffer::HostCircularBuffer(std::size_t capacity)
+    : fCapacity(capacity), fWriteOffset(0), fFreeContiguousSpace(capacity)
 {
 }
 
-bool HostCircularBuffer::addSegment(GPUStep *begin, GPUStep *end)
+bool HostCircularBuffer::AddSegment(std::size_t begin, std::size_t end)
 {
   std::scoped_lock lock{bufferManagerMutex};
 
@@ -29,8 +28,9 @@ bool HostCircularBuffer::addSegment(GPUStep *begin, GPUStep *end)
   fSegments.insert(std::upper_bound(fSegments.begin(), fSegments.end(), Segment{begin, end}), {begin, end});
 
 #ifdef DEBUG
-  if (begin != fWritePtr)
-    std::cout << BOLD_RED << " Begin != fWritePTr " << begin << " fWritePtr " << fWritePtr << RESET << std::endl;
+  if (begin != fWriteOffset)
+    std::cout << BOLD_RED << " Begin != fWriteOffset " << begin << " fWriteOffset " << fWriteOffset << RESET
+              << std::endl;
   std::size_t size = end - begin;
   if (size > fFreeContiguousSpace)
     std::cout << BOLD_RED << " Not enough space! size " << size << " fFreeContiguousSpace " << fFreeContiguousSpace
@@ -38,23 +38,22 @@ bool HostCircularBuffer::addSegment(GPUStep *begin, GPUStep *end)
   if (!checkForOverlaps()) std::cout << BOLD_RED << " Overlaps after AddSegment! " << RESET << std::endl;
 #endif
 
-  fWritePtr = end;
+  fWriteOffset = end;
 
   return true;
 }
 
-void HostCircularBuffer::removeSegment(GPUStep *segmentPtr)
+void HostCircularBuffer::RemoveSegment(std::size_t segmentBegin)
 {
   std::scoped_lock lock{bufferManagerMutex};
 
   // Find the segment
   auto it = std::find_if(fSegments.begin(), fSegments.end(),
-                         [segmentPtr](const Segment &seg) { return seg.begin == segmentPtr; });
+                         [segmentBegin](const Segment &seg) { return seg.begin == segmentBegin; });
 
 #ifdef DEBUG
-  if (!segmentPtr) std::cout << BOLD_RED << " Trying to remove nullptr segment " << RESET << std::endl;
   if (it == fSegments.end())
-    std::cout << BOLD_RED << " Trying to remove segment that doesn't exist !! segment : " << segmentPtr << RESET
+    std::cout << BOLD_RED << " Trying to remove segment that doesn't exist !! segment : " << segmentBegin << RESET
               << std::endl;
   if (!checkForOverlaps()) std::cout << BOLD_RED << " Overlaps after removesegment! " << RESET << std::endl;
 #endif
@@ -63,34 +62,35 @@ void HostCircularBuffer::removeSegment(GPUStep *segmentPtr)
   fSegments.erase(it);
 }
 
-std::size_t HostCircularBuffer::getFreeContiguousMemory(std::size_t transferSize)
+std::size_t HostCircularBuffer::GetFreeContiguousSlots(std::size_t transferSize)
 {
   std::scoped_lock lock{bufferManagerMutex};
 
   if (fSegments.empty()) {
-    // if empty, reset WritePtr to Bufferstart
-    fWritePtr = fBufferStart;
-    return fBufferEnd - fBufferStart; // Everything is free
+    // If empty, reset the write offset to the beginning of the buffer.
+    fWriteOffset = 0;
+    return fCapacity; // Everything is free
   }
 
-  // Find the next segment after fWritePtr
-  auto nextSegment = std::lower_bound(fSegments.begin(), fSegments.end(), Segment{fWritePtr, nullptr},
+  // Find the next segment after fWriteOffset
+  auto nextSegment = std::lower_bound(fSegments.begin(), fSegments.end(), Segment{fWriteOffset, 0},
                                       [](const Segment &a, const Segment &b) { return a.begin < b.begin; });
 
   // Find the previous segment before nextSegment (if it exists)
   auto prevSegment = (nextSegment != fSegments.begin()) ? std::prev(nextSegment) : fSegments.end();
 
-  // If the fWritePtr was set on an end of a segment that was deleted, we can put it back to the last previous
+  // If fWriteOffset was set on an end of a segment that was deleted, we can put it back to the last previous
   // existing segment
-  if (prevSegment != fSegments.end() && fWritePtr != prevSegment->end) {
-    fWritePtr = prevSegment->end;
+  if (prevSegment != fSegments.end() && fWriteOffset != prevSegment->end) {
+    fWriteOffset = prevSegment->end;
   }
 
-  // Free space from `fWritePtr` to next segment
-  std::size_t forwardSpace = (nextSegment != fSegments.end()) ? nextSegment->begin - fWritePtr : fBufferEnd - fWritePtr;
+  // Free space from fWriteOffset to next segment
+  std::size_t forwardSpace =
+      (nextSegment != fSegments.end()) ? nextSegment->begin - fWriteOffset : fCapacity - fWriteOffset;
 
   // Free space for a wraparound
-  std::size_t wrapAroundSpace = (fSegments.front().begin > fBufferStart) ? (fSegments.front().begin - fBufferStart) : 0;
+  std::size_t wrapAroundSpace = (fSegments.front().begin > 0) ? fSegments.front().begin : 0;
 
   fFreeContiguousSpace = forwardSpace + wrapAroundSpace - transferSize;
 
@@ -99,7 +99,7 @@ std::size_t HostCircularBuffer::getFreeContiguousMemory(std::size_t transferSize
   }
 
   if (wrapAroundSpace >= transferSize) {
-    fWritePtr = fBufferStart; // Reset fWritePtr since we need to wrap around
+    fWriteOffset = 0; // Reset fWriteOffset since we need to wrap around
     return wrapAroundSpace;
   }
 
@@ -108,22 +108,21 @@ std::size_t HostCircularBuffer::getFreeContiguousMemory(std::size_t transferSize
             << "Cannot transfer from Device to Host due to lack of space in CPU HostBuffer. This should never be "
                "the case! transfersize "
             << transferSize << " forwardSpace " << forwardSpace << " wraparoundspace " << wrapAroundSpace
-            << " total space : " << (fBufferEnd - fBufferStart) << " free space " << fFreeContiguousSpace << RESET
-            << std::endl;
+            << " total space : " << fCapacity << " free space " << fFreeContiguousSpace << RESET << std::endl;
   checkForOverlaps();
 #endif
 
   return 0; // Not enough contiguous space available
 }
 
-double HostCircularBuffer::getFillFraction() const
+double HostCircularBuffer::GetFillFractionAfterLastRequest() const
 {
-  return 1. - static_cast<double>(fFreeContiguousSpace) / (fBufferEnd - fBufferStart);
+  return 1. - static_cast<double>(fFreeContiguousSpace) / fCapacity;
 }
 
-std::size_t HostCircularBuffer::getOffset() const
+std::size_t HostCircularBuffer::GetWriteOffset() const
 {
-  return fWritePtr - fBufferStart;
+  return fWriteOffset;
 }
 
 bool HostCircularBuffer::checkForOverlaps() const

--- a/test/unit/test_hostCircularBuffer.cpp
+++ b/test/unit/test_hostCircularBuffer.cpp
@@ -27,135 +27,126 @@ static bool near(double lhs, double rhs)
 
 static int test_empty_buffer_allows_exact_fit()
 {
-  std::vector<GPUStep> storage(8);
-  AsyncAdePT::HostCircularBuffer buffer(storage.data(), storage.size());
+  AsyncAdePT::HostCircularBuffer buffer(8);
 
-  CHECK(buffer.getOffset() == 0);
-  CHECK(buffer.getFreeContiguousMemory(8) == 8);
-  CHECK(buffer.getOffset() == 0);
-  CHECK(near(buffer.getFillFraction(), 0.0));
+  CHECK(buffer.GetWriteOffset() == 0);
+  CHECK(buffer.GetFreeContiguousSlots(8) == 8);
+  CHECK(buffer.GetWriteOffset() == 0);
+  CHECK(near(buffer.GetFillFractionAfterLastRequest(), 0.0));
 
   return 0;
 }
 
 static int test_segment_add_remove_and_full_buffer()
 {
-  std::vector<GPUStep> storage(10);
-  AsyncAdePT::HostCircularBuffer buffer(storage.data(), storage.size());
+  AsyncAdePT::HostCircularBuffer buffer(10);
 
-  CHECK(buffer.getFreeContiguousMemory(10) == 10);
-  CHECK(buffer.addSegment(storage.data(), storage.data() + 10));
-  CHECK(buffer.getOffset() == 10);
+  CHECK(buffer.GetFreeContiguousSlots(10) == 10);
+  CHECK(buffer.AddSegment(0, 10));
+  CHECK(buffer.GetWriteOffset() == 10);
 
-  CHECK(buffer.getFreeContiguousMemory(1) == 0);
+  CHECK(buffer.GetFreeContiguousSlots(1) == 0);
 
-  buffer.removeSegment(storage.data());
-  CHECK(buffer.getFreeContiguousMemory(10) == 10);
-  CHECK(buffer.getOffset() == 0);
+  buffer.RemoveSegment(0);
+  CHECK(buffer.GetFreeContiguousSlots(10) == 10);
+  CHECK(buffer.GetWriteOffset() == 0);
 
   return 0;
 }
 
 static int test_fill_fraction_preserves_existing_pending_transfer_semantics()
 {
-  std::vector<GPUStep> storage(10);
-  AsyncAdePT::HostCircularBuffer buffer(storage.data(), storage.size());
+  AsyncAdePT::HostCircularBuffer buffer(10);
 
-  CHECK(buffer.getFreeContiguousMemory(4) == 10);
-  CHECK(buffer.addSegment(storage.data(), storage.data() + 4));
+  CHECK(buffer.GetFreeContiguousSlots(4) == 10);
+  CHECK(buffer.AddSegment(0, 4));
 
-  // This intentionally documents the existing behavior: getFillFraction() is
-  // based on the contiguous-space bookkeeping after a transfer-size query. It
-  // is not simply occupiedSlots / capacity.
-  CHECK(buffer.getFreeContiguousMemory(3) == 6);
-  CHECK(near(buffer.getFillFraction(), 0.7));
+  // This intentionally documents the existing behavior: GetFillFractionAfterLastRequest() is based on the
+  // contiguous-space bookkeeping after a transfer-size query. It is not simply occupiedSlots / capacity.
+  CHECK(buffer.GetFreeContiguousSlots(3) == 6);
+  CHECK(near(buffer.GetFillFractionAfterLastRequest(), 0.7));
 
   return 0;
 }
 
 static int test_wraparound_after_front_segment_is_removed()
 {
-  std::vector<GPUStep> storage(10);
-  AsyncAdePT::HostCircularBuffer buffer(storage.data(), storage.size());
+  AsyncAdePT::HostCircularBuffer buffer(10);
 
-  CHECK(buffer.getFreeContiguousMemory(6) == 10);
-  CHECK(buffer.addSegment(storage.data(), storage.data() + 6));
+  CHECK(buffer.GetFreeContiguousSlots(6) == 10);
+  CHECK(buffer.AddSegment(0, 6));
 
-  CHECK(buffer.getFreeContiguousMemory(4) == 4);
-  CHECK(buffer.getOffset() == 6);
-  CHECK(buffer.addSegment(storage.data() + 6, storage.data() + 10));
+  CHECK(buffer.GetFreeContiguousSlots(4) == 4);
+  CHECK(buffer.GetWriteOffset() == 6);
+  CHECK(buffer.AddSegment(6, 10));
 
-  buffer.removeSegment(storage.data());
-  CHECK(buffer.getFreeContiguousMemory(6) == 6);
-  CHECK(buffer.getOffset() == 0);
-  CHECK(near(buffer.getFillFraction(), 1.0));
+  buffer.RemoveSegment(0);
+  CHECK(buffer.GetFreeContiguousSlots(6) == 6);
+  CHECK(buffer.GetWriteOffset() == 0);
+  CHECK(near(buffer.GetFillFractionAfterLastRequest(), 1.0));
 
   return 0;
 }
 
 static int test_tail_space_is_reused_after_tail_segment_is_removed()
 {
-  std::vector<GPUStep> storage(12);
-  AsyncAdePT::HostCircularBuffer buffer(storage.data(), storage.size());
+  AsyncAdePT::HostCircularBuffer buffer(12);
 
-  CHECK(buffer.getFreeContiguousMemory(4) == 12);
-  CHECK(buffer.addSegment(storage.data(), storage.data() + 4));
-  CHECK(buffer.getFreeContiguousMemory(4) == 8);
-  CHECK(buffer.addSegment(storage.data() + 4, storage.data() + 8));
-  CHECK(buffer.getFreeContiguousMemory(4) == 4);
-  CHECK(buffer.addSegment(storage.data() + 8, storage.data() + 12));
+  CHECK(buffer.GetFreeContiguousSlots(4) == 12);
+  CHECK(buffer.AddSegment(0, 4));
+  CHECK(buffer.GetFreeContiguousSlots(4) == 8);
+  CHECK(buffer.AddSegment(4, 8));
+  CHECK(buffer.GetFreeContiguousSlots(4) == 4);
+  CHECK(buffer.AddSegment(8, 12));
 
-  buffer.removeSegment(storage.data() + 8);
-  CHECK(buffer.getFreeContiguousMemory(4) == 4);
-  CHECK(buffer.getOffset() == 8);
+  buffer.RemoveSegment(8);
+  CHECK(buffer.GetFreeContiguousSlots(4) == 4);
+  CHECK(buffer.GetWriteOffset() == 8);
 
   return 0;
 }
 
 static int test_middle_hole_is_not_reused_from_end_write_position()
 {
-  std::vector<GPUStep> storage(12);
-  AsyncAdePT::HostCircularBuffer buffer(storage.data(), storage.size());
+  AsyncAdePT::HostCircularBuffer buffer(12);
 
-  CHECK(buffer.getFreeContiguousMemory(4) == 12);
-  CHECK(buffer.addSegment(storage.data(), storage.data() + 4));
-  CHECK(buffer.getFreeContiguousMemory(4) == 8);
-  CHECK(buffer.addSegment(storage.data() + 4, storage.data() + 8));
-  CHECK(buffer.getFreeContiguousMemory(4) == 4);
-  CHECK(buffer.addSegment(storage.data() + 8, storage.data() + 12));
+  CHECK(buffer.GetFreeContiguousSlots(4) == 12);
+  CHECK(buffer.AddSegment(0, 4));
+  CHECK(buffer.GetFreeContiguousSlots(4) == 8);
+  CHECK(buffer.AddSegment(4, 8));
+  CHECK(buffer.GetFreeContiguousSlots(4) == 4);
+  CHECK(buffer.AddSegment(8, 12));
 
-  buffer.removeSegment(storage.data() + 4);
-  CHECK(buffer.getFreeContiguousMemory(4) == 0);
-  CHECK(buffer.getOffset() == 12);
+  buffer.RemoveSegment(4);
+  CHECK(buffer.GetFreeContiguousSlots(4) == 0);
+  CHECK(buffer.GetWriteOffset() == 12);
 
   return 0;
 }
 
 static int test_fragmentation_can_block_larger_transfers()
 {
-  std::vector<GPUStep> storage(12);
-  AsyncAdePT::HostCircularBuffer buffer(storage.data(), storage.size());
+  AsyncAdePT::HostCircularBuffer buffer(12);
 
-  CHECK(buffer.getFreeContiguousMemory(4) == 12);
-  CHECK(buffer.addSegment(storage.data(), storage.data() + 4));
-  CHECK(buffer.getFreeContiguousMemory(4) == 8);
-  CHECK(buffer.addSegment(storage.data() + 4, storage.data() + 8));
-  CHECK(buffer.getFreeContiguousMemory(4) == 4);
-  CHECK(buffer.addSegment(storage.data() + 8, storage.data() + 12));
+  CHECK(buffer.GetFreeContiguousSlots(4) == 12);
+  CHECK(buffer.AddSegment(0, 4));
+  CHECK(buffer.GetFreeContiguousSlots(4) == 8);
+  CHECK(buffer.AddSegment(4, 8));
+  CHECK(buffer.GetFreeContiguousSlots(4) == 4);
+  CHECK(buffer.AddSegment(8, 12));
 
-  buffer.removeSegment(storage.data());
-  buffer.removeSegment(storage.data() + 8);
-  CHECK(buffer.getFreeContiguousMemory(5) == 0);
-  CHECK(buffer.getFreeContiguousMemory(4) == 4);
-  CHECK(buffer.getOffset() == 8);
+  buffer.RemoveSegment(0);
+  buffer.RemoveSegment(8);
+  CHECK(buffer.GetFreeContiguousSlots(5) == 0);
+  CHECK(buffer.GetFreeContiguousSlots(4) == 4);
+  CHECK(buffer.GetWriteOffset() == 8);
 
   return 0;
 }
 
 static int test_concurrent_allocation_and_release()
 {
-  std::vector<GPUStep> storage(64);
-  AsyncAdePT::HostCircularBuffer buffer(storage.data(), storage.size());
+  AsyncAdePT::HostCircularBuffer buffer(64);
 
   constexpr int nSegments = 10000;
   constexpr int nWorkers  = 4;
@@ -163,26 +154,26 @@ static int test_concurrent_allocation_and_release()
   std::atomic_bool failed{false};
   std::atomic_int removedSegments{0};
   std::atomic_int producedSegments{0};
-  std::deque<GPUStep *> pointersToRelease;
+  std::deque<std::size_t> offsetsToRelease;
   std::mutex queueMutex;
   std::condition_variable queueCondition;
   bool producerDone = false;
 
   auto worker = [&]() {
     while (true) {
-      GPUStep *segmentBegin = nullptr;
+      std::size_t offset = 0;
       {
         std::unique_lock lock{queueMutex};
-        queueCondition.wait(lock, [&]() { return producerDone || !pointersToRelease.empty(); });
-        if (pointersToRelease.empty()) {
+        queueCondition.wait(lock, [&]() { return producerDone || !offsetsToRelease.empty(); });
+        if (offsetsToRelease.empty()) {
           if (producerDone) return;
           continue;
         }
-        segmentBegin = pointersToRelease.front();
-        pointersToRelease.pop_front();
+        offset = offsetsToRelease.front();
+        offsetsToRelease.pop_front();
       }
 
-      buffer.removeSegment(segmentBegin);
+      buffer.RemoveSegment(offset);
       removedSegments.fetch_add(1, std::memory_order_relaxed);
     }
   };
@@ -194,14 +185,12 @@ static int test_concurrent_allocation_and_release()
   }
 
   for (int i = 0; i < nSegments; ++i) {
-    while (buffer.getFreeContiguousMemory(1) == 0) {
+    while (buffer.GetFreeContiguousSlots(1) == 0) {
       std::this_thread::yield();
     }
 
-    const auto offset         = buffer.getOffset();
-    GPUStep *segmentBegin     = storage.data() + offset;
-    GPUStep *const segmentEnd = segmentBegin + 1;
-    if (!buffer.addSegment(segmentBegin, segmentEnd)) {
+    const auto offset = buffer.GetWriteOffset();
+    if (!buffer.AddSegment(offset, offset + 1)) {
       failed.store(true, std::memory_order_relaxed);
       break;
     }
@@ -209,7 +198,7 @@ static int test_concurrent_allocation_and_release()
 
     {
       std::scoped_lock lock{queueMutex};
-      pointersToRelease.push_back(segmentBegin);
+      offsetsToRelease.push_back(offset);
     }
     queueCondition.notify_one();
   }
@@ -227,8 +216,8 @@ static int test_concurrent_allocation_and_release()
   CHECK(!failed.load(std::memory_order_relaxed));
   CHECK(producedSegments.load(std::memory_order_relaxed) == nSegments);
   CHECK(removedSegments.load(std::memory_order_relaxed) == nSegments);
-  CHECK(buffer.getFreeContiguousMemory(storage.size()) == storage.size());
-  CHECK(buffer.getOffset() == 0);
+  CHECK(buffer.GetFreeContiguousSlots(64) == 64);
+  CHECK(buffer.GetWriteOffset() == 0);
 
   return 0;
 }


### PR DESCRIPTION
Clean up the `HostCircularBuffer` API after the extraction in the previous PR.

The buffer now works in terms of offsets instead of raw `GPUStep*` pointers. This makes the class independent of the GPU step type and keeps the pointer arithmetic where the actual host buffer is.

This is a pure cleanup and does not change the implementation itself