### PR TITLE
Split GeometryAuxData and Woodcock tracking data

### DIFF
--- a/include/AdePT/g4integration/geometry/AdePTGeometryBridge.hh
+++ b/include/AdePT/g4integration/geometry/AdePTGeometryBridge.hh
@@ -5,6 +5,7 @@
 #define ADEPT_GEOMETRY_BRIDGE_HH
 
 #include <AdePT/transport/geometry/GeometryAuxData.hh>
+#include <AdePT/transport/woodcock/WoodcockData.hh>
 #include <AdePT/g4integration/tracking_managers/G4HepEmTrackingManagerSpecialized.hh>
 
 #include <VecGeom/base/Config.h>

--- a/include/AdePT/transport/AsyncAdePTTransport.cuh
+++ b/include/AdePT/transport/AsyncAdePTTransport.cuh
@@ -11,6 +11,7 @@
 #include <AdePT/transport/state/GPUState.cuh>
 #include <AdePT/transport/random/G4HepEmRandomEngineDeviceImpl.hh>
 #include <AdePT/transport/geometry/GeometryAuxData.hh>
+#include <AdePT/transport/woodcock/WoodcockData.hh>
 #include <AdePT/transport/queues/TrackBuffer.hh>
 #include <AdePT/transport/containers/Atomic.h>
 #include <AdePT/transport/containers/MParray.h>

--- a/include/AdePT/transport/AsyncAdePTTransport.hh
+++ b/include/AdePT/transport/AsyncAdePTTransport.hh
@@ -14,6 +14,7 @@
 #include <AdePT/transport/geometry/GeometryAuxData.hh>
 #include <AdePT/transport/state/EventState.hh>
 #include <AdePT/transport/steps/GPUStep.hh>
+#include <AdePT/transport/woodcock/WoodcockData.hh>
 
 #include <VecGeom/base/Config.h>
 #include <VecGeom/management/CudaManager.h> // forward declares vecgeom::cxx::VPlacedVolume

--- a/include/AdePT/transport/geometry/GeometryAuxData.hh
+++ b/include/AdePT/transport/geometry/GeometryAuxData.hh
@@ -4,11 +4,6 @@
 #ifndef ADEPT_GEOMETRY_AUX_DATA_HH
 #define ADEPT_GEOMETRY_AUX_DATA_HH
 
-#include <VecGeom/navigation/NavigationState.h>
-
-#include <unordered_map>
-#include <vector>
-
 namespace adeptint {
 
 /// @brief Auxiliary logical volume data. This stores in the same structure the material-cuts couple index,
@@ -36,50 +31,6 @@ struct VolAuxArray {
     static VolAuxArray theAuxArray;
     return theAuxArray;
   }
-};
-
-/// @brief Root Volume data of a Woodcock tracking region: Navigation index + G4HepEm material cut couple index.
-struct WDTRoot {
-  vecgeom::NavigationState root; ///< NavState of the root placed volume
-  int hepemIMC;                  ///< G4HepEm mat-cut index for this root
-};
-
-/// @brief Compact Woodcock region header.
-struct WDTRegion {
-  int offset;    ///< first index in roots[]
-  int count;     ///< number of roots for this region
-  float ekinMin; ///< kinetic energy threshold
-};
-
-/// @brief Device view pointing to the uploaded Woodcock data.
-struct WDTDeviceView {
-  const WDTRoot *roots;     ///< [nRoots]
-  const WDTRegion *regions; ///< [nRegions] (only WDT-enabled regions)
-  const int *regionToWDT;   ///< [regionToWDTLen], regionId -> bucket (index into regions[]) or -1
-  int nRoots;
-  int nRegions;
-  unsigned short maxIter; ///< maximum number of Woodcock iterations
-};
-
-/// @brief Sparse host-side Woodcock collection built during geometry traversal.
-struct WDTHostRaw {
-  std::unordered_map<int, std::vector<int>> regionToRootIndices; ///< regionId -> list of indices into roots
-  std::vector<WDTRoot> roots;                                    ///< one entry per root placed volume
-  float ekinMin{0.f};                                            ///< global Woodcock minimum kinetic energy
-};
-
-/// @brief Compact, upload-ready representation of Woodcock data.
-struct WDTHostPacked {
-  std::vector<WDTRoot> roots;     ///< packed per-region contiguous
-  std::vector<WDTRegion> regions; ///< one per WDT region
-  std::vector<int> regionToWDT;   ///< dense by regionId (size = number of G4 regions)
-};
-
-/// @brief Owned device buffers to manage lifetime of Woodcock tracking data.
-struct WDTDeviceBuffers {
-  WDTRoot *d_roots     = nullptr;
-  WDTRegion *d_regions = nullptr;
-  int *d_map           = nullptr;
 };
 
 } // namespace adeptint

--- a/include/AdePT/transport/kernels/WoodcockHelper.cuh
+++ b/include/AdePT/transport/kernels/WoodcockHelper.cuh
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <AdePT/transport/geometry/GeometryAuxData.hh>
 #include <AdePT/transport/state/DeviceGlobals.cuh>
+#include <AdePT/transport/woodcock/WoodcockData.hh>
 
 namespace AsyncAdePT {
 

--- a/include/AdePT/transport/magneticfield/GeneralMagneticField.cuh
+++ b/include/AdePT/transport/magneticfield/GeneralMagneticField.cuh
@@ -8,6 +8,12 @@
 
 #include <VecGeom/base/Vector3D.h>
 
+#include <exception>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+
 #ifdef ADEPT_USE_EXT_BFIELD
 
 #include <covfie/core/backend/transformer/affine.hpp>

--- a/include/AdePT/transport/state/DeviceGlobals.cuh
+++ b/include/AdePT/transport/state/DeviceGlobals.cuh
@@ -8,6 +8,7 @@
 #include <AdePT/transport/magneticfield/GeneralMagneticField.cuh>
 #include <AdePT/transport/magneticfield/UniformMagneticField.cuh>
 #include <AdePT/transport/support/SystemOfUnits.h>
+#include <AdePT/transport/woodcock/WoodcockData.hh>
 
 #include <G4HepEmData.hh>
 #include <G4HepEmParameters.hh>

--- a/include/AdePT/transport/woodcock/WoodcockData.hh
+++ b/include/AdePT/transport/woodcock/WoodcockData.hh
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2026 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ADEPT_TRANSPORT_WOODCOCK_WOODCOCK_DATA_HH
+#define ADEPT_TRANSPORT_WOODCOCK_WOODCOCK_DATA_HH
+
+#include <VecGeom/navigation/NavigationState.h>
+
+#include <unordered_map>
+#include <vector>
+
+namespace adeptint {
+
+/// @brief Root Volume data of a Woodcock tracking region: Navigation index + G4HepEm material cut couple index.
+struct WDTRoot {
+  vecgeom::NavigationState root; ///< NavState of the root placed volume
+  int hepemIMC;                  ///< G4HepEm mat-cut index for this root
+};
+
+/// @brief Compact Woodcock region header.
+struct WDTRegion {
+  int offset;    ///< first index in roots[]
+  int count;     ///< number of roots for this region
+  float ekinMin; ///< kinetic energy threshold
+};
+
+/// @brief Device view pointing to the uploaded Woodcock data.
+struct WDTDeviceView {
+  const WDTRoot *roots;     ///< [nRoots]
+  const WDTRegion *regions; ///< [nRegions] (only WDT-enabled regions)
+  const int *regionToWDT;   ///< [regionToWDTLen], regionId -> bucket (index into regions[]) or -1
+  int nRoots;
+  int nRegions;
+  unsigned short maxIter; ///< maximum number of Woodcock iterations
+};
+
+/// @brief Sparse host-side Woodcock collection built during geometry traversal.
+struct WDTHostRaw {
+  std::unordered_map<int, std::vector<int>> regionToRootIndices; ///< regionId -> list of indices into roots
+  std::vector<WDTRoot> roots;                                    ///< one entry per root placed volume
+  float ekinMin{0.f};                                            ///< global Woodcock minimum kinetic energy
+};
+
+/// @brief Compact, upload-ready representation of Woodcock data.
+struct WDTHostPacked {
+  std::vector<WDTRoot> roots;     ///< packed per-region contiguous
+  std::vector<WDTRegion> regions; ///< one per WDT region
+  std::vector<int> regionToWDT;   ///< dense by regionId (size = number of G4 regions)
+};
+
+/// @brief Owned device buffers to manage lifetime of Woodcock tracking data.
+struct WDTDeviceBuffers {
+  WDTRoot *d_roots     = nullptr;
+  WDTRegion *d_regions = nullptr;
+  int *d_map           = nullptr;
+};
+
+} // namespace adeptint
+
+#endif


### PR DESCRIPTION
Following #609, this splits the GeometryAuxData and the Woodcock tracking data.
