### PR TITLE
[mini] Make SlotManager include explicit

### DIFF
--- a/include/AdePT/transport/AsyncAdePTTransport.cuh
+++ b/include/AdePT/transport/AsyncAdePTTransport.cuh
@@ -14,6 +14,7 @@
 #include <AdePT/transport/queues/TrackBuffer.hh>
 #include <AdePT/transport/containers/Atomic.h>
 #include <AdePT/transport/containers/MParray.h>
+#include <AdePT/transport/containers/SlotManager.cuh>
 #include <AdePT/transport/support/Global.h>
 #include <AdePT/transport/support/PhysicalConstants.h>
 #include <AdePT/transport/random/Ranluxpp.h>


### PR DESCRIPTION
In the `AsyncAdePTTransport.cuh`, the `SlotManager.cuh` was included implicitly via `GPUState.cuh`. As some functionality is used directly, it should be included explicitly. This was discovered when debugging a VecGeom bug fixed [here](https://gitlab.cern.ch/VecGeom/VecGeom/-/merge_requests/1383). The actual problem was in VecGeom but for good practices the include should be explicit.

