### PR TITLE
Relax exported covfie package requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,10 @@ project(AdePT
 # Set versions of G4VG and covfie that are pulled in the CMake configuration
 set(ADEPT_G4VG_VERSION 1.0.6)
 set(ADEPT_G4VG_TAG v${ADEPT_G4VG_VERSION})
-set(ADEPT_COVFIE_VERSION 0.15.5)
-set(ADEPT_COVFIE_TAG v${ADEPT_COVFIE_VERSION})
+set(ADEPT_COVFIE_TAG_VERSION 0.15.5)
+set(ADEPT_COVFIE_TAG v${ADEPT_COVFIE_TAG_VERSION})
+# covfie tag v0.15.5 still exports CMake package version 0.15.3.
+set(ADEPT_COVFIE_PACKAGE_VERSION 0.15.3)
 
 #----------------------------------------------------------------------------#
 # CMake and Build Settings
@@ -408,7 +410,7 @@ if(ADEPT_USE_EXT_BFIELD)
   message(STATUS "Compiling with external magnetic field support via covfie")
   add_compile_definitions(ADEPT_USE_EXT_BFIELD)
 
-  find_package(covfie ${ADEPT_COVFIE_VERSION} QUIET)
+  find_package(covfie ${ADEPT_COVFIE_PACKAGE_VERSION} QUIET)
   if (covfie_FOUND)
     get_target_property(COVFIE_INCLUDE_DIR covfie::core INTERFACE_INCLUDE_DIRECTORIES)
     message(STATUS "covfie found at: ${COVFIE_INCLUDE_DIR}")

--- a/cmake/AdePTConfig.cmake.in
+++ b/cmake/AdePTConfig.cmake.in
@@ -34,7 +34,7 @@ endif()
 find_dependency(G4VG @ADEPT_G4VG_VERSION@ REQUIRED)
 
 if(@ADEPT_USE_EXT_BFIELD@)
-  find_dependency(covfie @ADEPT_COVFIE_VERSION@ REQUIRED)
+  find_dependency(covfie @ADEPT_COVFIE_PACKAGE_VERSION@ REQUIRED)
 endif()
 
 if(@ADEPT_ENABLE_POWER_METER@)


### PR DESCRIPTION
covfie v0.15.5 still exports via CMake v0.15.3. Therefore, requiring 15.5 can cause issues, which were observed when building LHCb, which failed with 

```
CMake Error at /cvmfs/lhcb.cern.ch/lib/var/lib/LbEnv/3588/stable/linux-64/share/cmake-3.30/Modules/CMakeFindDependencyMacro.cmake:76 (find_package):
  Could not find a configuration file for package "covfie" that is compatible
  with requested version "0.15.5".

  The following configuration files were considered but not accepted:

    /home/ndiederi/software/LHCb_06.05/stack/AdePT/InstallArea/x86_64_v3-el9-gcc13+cuda12_4-opt+g/share/covfie/cmake/covfieConfig.cmake, version: 0.15.3

Call Stack (most recent call first):
  /home/ndiederi/software/LHCb_06.05/stack/AdePT/InstallArea/x86_64_v3-el9-gcc13+cuda12_4-opt+g/lib/cmake/AdePT/AdePTConfig.cmake:61 (find_dependency)
  cmake/GaussinoDependencies.cmake:82 (find_package)
  CMakeLists.txt:50 (include)

```

despite pulling covfie v0.15.5.

See https://github.com/acts-project/covfie/issues/99