### PR TITLE
run debug drift workflow in full CI tests

### DIFF
--- a/.github/workflows/self-hosted-pr-ci.yml
+++ b/.github/workflows/self-hosted-pr-ci.yml
@@ -96,7 +96,7 @@ jobs:
           full_description="Self-hosted EL9 CI queued"
           validation_description="Waiting for drift result in EL9"
           if [ "${COMMAND}" = "/run-test-full" ]; then
-            full_description="Self-hosted EL9 CI with full validation queued"
+            full_description="Self-hosted EL9 CI with full validation and Debug drift queued"
             validation_description="Full validation requested in EL9"
           fi
 
@@ -174,6 +174,7 @@ jobs:
         continue-on-error: true
         env:
           ALWAYS_RUN_VALIDATION: ${{ needs.prepare.outputs.command == '/run-test-full' && '1' || '0' }}
+          RUN_DEBUG_DRIFT: ${{ needs.prepare.outputs.command == '/run-test-full' && '1' || '0' }}
         run: |
           set -eo pipefail
 
@@ -208,6 +209,7 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/work/AdePT" \
             -e HOME=/tmp/adeptci-home \
             -e ADEPT_PR_CI_ALWAYS_RUN_VALIDATION="${ALWAYS_RUN_VALIDATION}" \
+            -e ADEPT_PR_CI_RUN_DEBUG_DRIFT="${RUN_DEBUG_DRIFT}" \
             -e ADEPT_VALIDATION_DEFAULT_NUM_THREADS=32 \
             -e ADEPT_VALIDATION_DEFAULT_NUM_TRACKSLOTS=6 \
             -e ADEPT_VALIDATION_DEFAULT_NUM_HITSLOTS=30 \
@@ -239,6 +241,9 @@ jobs:
               if [[ "${ADEPT_PR_CI_ALWAYS_RUN_VALIDATION:-0}" == "1" ]]; then
                 pr_ci_args+=(--always-run-validation)
               fi
+              if [[ "${ADEPT_PR_CI_RUN_DEBUG_DRIFT:-0}" == "1" ]]; then
+                pr_ci_args+=(--run-debug-drift)
+              fi
               "${pr_ci_args[@]}"
             '
 
@@ -266,6 +271,13 @@ jobs:
             : "${VALIDATION_FORCED:=0}"
           fi
           : "${VALIDATION_STATUS:=1}"
+          if [ "${COMMAND}" = "/run-test-full" ]; then
+            : "${DEBUG_DRIFT_RAN:=1}"
+            : "${DEBUG_DRIFT_STATUS:=1}"
+          else
+            : "${DEBUG_DRIFT_RAN:=0}"
+            : "${DEBUG_DRIFT_STATUS:=0}"
+          fi
           : "${FULL_CI_STATUS:=1}"
 
           if [ "${UNIT_STATUS}" -ne 0 ]; then
@@ -293,7 +305,10 @@ jobs:
             validation_description="Validation tests failed"
           fi
 
-          if [ "${FULL_CI_STATUS}" -eq 0 ] && [ "${VALIDATION_RAN}" -eq 0 ]; then
+          if [ "${FULL_CI_STATUS}" -eq 0 ] && [ "${DEBUG_DRIFT_RAN}" -eq 1 ]; then
+            full_state="success"
+            full_description="Debug drift and validation passed"
+          elif [ "${FULL_CI_STATUS}" -eq 0 ] && [ "${VALIDATION_RAN}" -eq 0 ]; then
             full_state="success"
             full_description="Drift matched master; validation skipped"
           elif [ "${FULL_CI_STATUS}" -eq 0 ] && [ "${DRIFT_STATUS}" -eq 0 ]; then
@@ -305,6 +320,9 @@ jobs:
           elif [ "${UNIT_STATUS}" -ne 0 ]; then
             full_state="failure"
             full_description="Unit tests failed"
+          elif [ "${DEBUG_DRIFT_RAN}" -eq 1 ] && [ "${DEBUG_DRIFT_STATUS}" -ne 0 ]; then
+            full_state="failure"
+            full_description="Debug drift failed"
           elif [ "${VALIDATION_RAN}" -eq 1 ] && [ "${VALIDATION_STATUS}" -ne 0 ]; then
             full_state="failure"
             full_description="Validation tests failed"
@@ -354,6 +372,8 @@ jobs:
             echo "- User: \`$(whoami)\`"
             echo "- Workflow step outcome: \`${{ steps.run_ci.outcome }}\`"
             echo "- Drift status: \`${DRIFT_STATUS:-missing}\`"
+            echo "- Debug drift ran: \`${DEBUG_DRIFT_RAN:-missing}\`"
+            echo "- Debug drift status: \`${DEBUG_DRIFT_STATUS:-missing}\`"
             echo "- Unit status: \`${UNIT_STATUS:-missing}\`"
             echo "- Validation ran: \`${VALIDATION_RAN:-missing}\`"
             echo "- Validation forced: \`${VALIDATION_FORCED:-missing}\`"

--- a/test/run_pr_ci.sh
+++ b/test/run_pr_ci.sh
@@ -27,6 +27,7 @@ FETCH_MASTER=1
 FORCE_REBUILD=0
 REFRESH_MASTER=0
 RUN_VALIDATION_ALWAYS=0
+RUN_DEBUG_DRIFT=0
 
 log() {
   printf '[pr-ci] %s\n' "$*"
@@ -46,6 +47,7 @@ Runs the AdePT PR CI flow on a self-hosted runner:
   2. run physics drift comparisons
   3. always run unit tests on async
   4. run validation on async + split when drift differs from master, or when requested
+  5. optionally build and run the physics drift matrix in Debug mode
 
 Options:
   --build-root <path>        Build/cache root (default: ${DEFAULT_BUILD_ROOT})
@@ -59,6 +61,7 @@ Options:
   --force-rebuild            Force clean rebuilds in the matrix runner
   --refresh-master           Refresh cached master worktree/builds
   --always-run-validation    Run validation even when drift matches master
+  --run-debug-drift          Also build and run the drift matrix with CMAKE_BUILD_TYPE=Debug
   -h, --help                 Show this help
 EOF
 }
@@ -115,6 +118,8 @@ write_results() {
     printf 'BUILD_ROOT=%q\n' "${BUILD_ROOT}"
     printf 'MASTER_REF=%q\n' "${MASTER_REF}"
     printf 'DRIFT_STATUS=%s\n' "${DRIFT_STATUS}"
+    printf 'DEBUG_DRIFT_RAN=%s\n' "${DEBUG_DRIFT_RAN}"
+    printf 'DEBUG_DRIFT_STATUS=%s\n' "${DEBUG_DRIFT_STATUS}"
     printf 'UNIT_STATUS=%s\n' "${UNIT_STATUS}"
     printf 'VALIDATION_RAN=%s\n' "${VALIDATION_RAN}"
     printf 'VALIDATION_FORCED=%s\n' "${RUN_VALIDATION_ALWAYS}"
@@ -176,6 +181,10 @@ while [[ $# -gt 0 ]]; do
       RUN_VALIDATION_ALWAYS=1
       shift
       ;;
+    --run-debug-drift)
+      RUN_DEBUG_DRIFT=1
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -203,6 +212,8 @@ normalize_lcg_cuda_env || die "Failed to normalize CUDA environment from LCG set
 mkdir -p "${BUILD_ROOT}"
 
 DRIFT_STATUS=0
+DEBUG_DRIFT_RAN=0
+DEBUG_DRIFT_STATUS=0
 UNIT_STATUS=1
 VALIDATION_RAN=0
 VALIDATION_STATUS=0
@@ -233,6 +244,7 @@ log "Master reference: ${MASTER_REF}"
 log "CUDA arch: ${CUDA_ARCH}"
 log "Build jobs: ${JOBS}"
 log "Always run validation: ${RUN_VALIDATION_ALWAYS}"
+log "Run Debug drift: ${RUN_DEBUG_DRIFT}"
 log "Running drift matrix for async/split/mixed"
 
 for cfg in async split mixed; do
@@ -241,6 +253,41 @@ for cfg in async split mixed; do
     DRIFT_STATUS=1
   fi
 done
+
+if [[ "${RUN_DEBUG_DRIFT}" -eq 1 ]]; then
+  DEBUG_DRIFT_RAN=1
+  DEBUG_DRIFT_BUILD_ROOT="${BUILD_ROOT}/debug-drift"
+  debug_matrix_common_args=(
+    --suite drift
+    --build-root "${DEBUG_DRIFT_BUILD_ROOT}"
+    --build-type Debug
+    --master-ref "${MASTER_REF}"
+    --cuda-arch "${CUDA_ARCH}"
+    --jobs "${JOBS}"
+    --ctest-timeout-sec "${CTEST_TIMEOUT_SEC}"
+  )
+
+  if [[ "${FETCH_MASTER}" -eq 0 ]]; then
+    debug_matrix_common_args+=(--no-fetch-master)
+  fi
+  if [[ "${FORCE_REBUILD}" -eq 1 ]]; then
+    debug_matrix_common_args+=(--force-rebuild)
+  fi
+  if [[ "${REFRESH_MASTER}" -eq 1 ]]; then
+    debug_matrix_common_args+=(--refresh-master)
+  fi
+
+  log "Running Debug drift matrix for async/split/mixed"
+  log "Debug drift build root: ${DEBUG_DRIFT_BUILD_ROOT}"
+  for cfg in async split mixed; do
+    log "Debug drift phase for config: ${cfg}"
+    if ! "${MATRIX_RUNNER}" "${debug_matrix_common_args[@]}" --configs "${cfg}"; then
+      DEBUG_DRIFT_STATUS=1
+    fi
+  done
+else
+  log "Debug drift matrix skipped"
+fi
 
 MONOL_BUILD_DIR="${BUILD_ROOT}/BUILD_MONOL"
 SPLIT_BUILD_DIR="${BUILD_ROOT}/BUILD_SPLIT_ON"
@@ -293,7 +340,9 @@ else
   VALIDATION_STATUS=0
 fi
 
-if [[ "${UNIT_STATUS}" -eq 0 && ( "${VALIDATION_RAN}" -eq 0 || "${VALIDATION_STATUS}" -eq 0 ) ]]; then
+if [[ "${UNIT_STATUS}" -eq 0 &&
+      ( "${VALIDATION_RAN}" -eq 0 || "${VALIDATION_STATUS}" -eq 0 ) &&
+      "${DEBUG_DRIFT_STATUS}" -eq 0 ]]; then
   FULL_CI_STATUS=0
 else
   FULL_CI_STATUS=1
@@ -302,6 +351,8 @@ fi
 write_results
 
 log "Drift status: ${DRIFT_STATUS}"
+log "Debug drift ran: ${DEBUG_DRIFT_RAN}"
+log "Debug drift status: ${DEBUG_DRIFT_STATUS}"
 log "Unit status: ${UNIT_STATUS}"
 log "Validation ran: ${VALIDATION_RAN}"
 log "Validation forced: ${RUN_VALIDATION_ALWAYS}"


### PR DESCRIPTION
This PR extends the `/run-test-full` workflow. In the full test, now additionally a debug build is compiled and runs the drift test suite.