### PR TITLE
add debug smoke drift test to nightlies

### DIFF
--- a/.github/workflows/nightly-ci-el9.yml
+++ b/.github/workflows/nightly-ci-el9.yml
@@ -123,6 +123,9 @@ jobs:
             echo "- LCG setup: \`${LCG_SETUP:-missing}\`"
             echo "- Build type: \`${BUILD_TYPE:-missing}\`"
             echo "- Build root: \`${BUILD_ROOT:-/tmp/adept-nightly-ci}\`"
+            echo "- Release CI status: \`${RELEASE_CI_STATUS:-missing}\`"
+            echo "- Debug drift smoke build root: \`${DEBUG_DRIFT_SMOKE_BUILD_ROOT:-missing}\`"
+            echo "- Debug drift smoke status: \`${DEBUG_DRIFT_SMOKE_STATUS:-missing}\`"
             echo "- Nightly status: \`${NIGHTLY_STATUS:-missing}\`"
           } >> "${GITHUB_STEP_SUMMARY}"
 

--- a/test/regression/scripts/validation_drift_test.sh
+++ b/test/regression/scripts/validation_drift_test.sh
@@ -4,7 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # PR-vs-master physics drift check for one scenario.
-# Master executable is provided via environment:
+# A one-sided smoke run can be requested with:
+#   ADEPT_DRIFT_SMOKE_ONLY=1
+# Master executable is provided via environment for comparison mode:
 #   ADEPT_MASTER_EXECUTABLE
 
 set -eu -o pipefail
@@ -18,8 +20,22 @@ SCENARIO=$5
 COVFIE_BFIELD_FILE=${6:-}
 
 MASTER_EXECUTABLE=${ADEPT_MASTER_EXECUTABLE:-}
+DRIFT_SMOKE_ONLY=${ADEPT_DRIFT_SMOKE_ONLY:-0}
 
-if [ -z "${MASTER_EXECUTABLE}" ]; then
+case "${DRIFT_SMOKE_ONLY}" in
+  1|ON|On|on|TRUE|True|true|YES|Yes|yes)
+    DRIFT_SMOKE_ONLY=1
+    ;;
+  0|OFF|Off|off|FALSE|False|false|NO|No|no)
+    DRIFT_SMOKE_ONLY=0
+    ;;
+  *)
+    echo "Error: ADEPT_DRIFT_SMOKE_ONLY must be 0/1 or a boolean value, got '${DRIFT_SMOKE_ONLY}'."
+    exit 2
+    ;;
+esac
+
+if [ "${DRIFT_SMOKE_ONLY}" = "0" ] && [ -z "${MASTER_EXECUTABLE}" ]; then
   echo "Error: physics_drift '${SCENARIO}' requires ADEPT_MASTER_EXECUTABLE."
   echo "Set ADEPT_MASTER_EXECUTABLE to the integrationTest executable path of the master branch."
   echo "Example:"
@@ -27,7 +43,7 @@ if [ -z "${MASTER_EXECUTABLE}" ]; then
   exit 2
 fi
 
-if [ ! -x "${MASTER_EXECUTABLE}" ]; then
+if [ "${DRIFT_SMOKE_ONLY}" = "0" ] && [ ! -x "${MASTER_EXECUTABLE}" ]; then
   echo "Error: ADEPT_MASTER_EXECUTABLE is not an executable file: ${MASTER_EXECUTABLE}"
   exit 2
 fi
@@ -200,11 +216,17 @@ PR_OUTPUT="pr_${SCENARIO}"
 mkdir -p "${MASTER_SCENARIO_DIR}" "${PR_SCENARIO_DIR}"
 
 PR_SUPPORTS_ROOT="$(supports_truth_root "${PR_EXECUTABLE}")"
-MASTER_SUPPORTS_ROOT="$(supports_truth_root "${MASTER_EXECUTABLE}")"
+if [ "${DRIFT_SMOKE_ONLY}" = "1" ]; then
+  MASTER_SUPPORTS_ROOT="${PR_SUPPORTS_ROOT}"
+else
+  MASTER_SUPPORTS_ROOT="$(supports_truth_root "${MASTER_EXECUTABLE}")"
+fi
 
 if [ "${SCENARIO_REQUIRES_ATLAS_STEPPING_ACTION}" = "True" ]; then
   require_atlas_stepping_action "${PR_EXECUTABLE}" "PR"
-  require_atlas_stepping_action "${MASTER_EXECUTABLE}" "master"
+  if [ "${DRIFT_SMOKE_ONLY}" = "0" ]; then
+    require_atlas_stepping_action "${MASTER_EXECUTABLE}" "master"
+  fi
 fi
 
 if [ -n "${SCENARIO_COVFIE_BFIELD_FILE}" ]; then
@@ -213,7 +235,9 @@ if [ -n "${SCENARIO_COVFIE_BFIELD_FILE}" ]; then
     exit 2
   fi
   require_ext_bfield_build "${PR_EXECUTABLE}" "PR"
-  require_ext_bfield_build "${MASTER_EXECUTABLE}" "master"
+  if [ "${DRIFT_SMOKE_ONLY}" = "0" ]; then
+    require_ext_bfield_build "${MASTER_EXECUTABLE}" "master"
+  fi
 fi
 
 if [ "${PR_SUPPORTS_ROOT}" = "1" ] && [ "${MASTER_SUPPORTS_ROOT}" = "1" ]; then
@@ -234,6 +258,16 @@ generate_validation_macro "${PR_SOURCE_DIR}" "${SCENARIO_MACRO}" \
   "${SCENARIO_FIELD}" "${CALL_USER_STEPPING_ACTION}" "${CALL_USER_TRACKING_ACTION}" "${SCENARIO_COVFIE_BFIELD_FILE}"
 
 if [ "${CALL_USER_STEPPING_ACTION}" = "True" ]; then
+  if [ "${DRIFT_SMOKE_ONLY}" = "1" ]; then
+    "${PR_EXECUTABLE}" --allsensitive --accumulated_events --truth_root \
+                       -m "${SCENARIO_MACRO}" \
+                       --output_dir "${PR_SCENARIO_DIR}" \
+                       --output_file "${PR_OUTPUT}"
+
+    echo "Scenario '${SCENARIO}' smoke run completed."
+    exit 0
+  fi
+
   # ROOT truth mode: produce aggregated histogram files for PR and master and
   # compare them semantically, histogram by histogram.
   "${MASTER_EXECUTABLE}" --allsensitive --accumulated_events --truth_root \
@@ -250,6 +284,16 @@ if [ "${CALL_USER_STEPPING_ACTION}" = "True" ]; then
     --file1 "${MASTER_SCENARIO_DIR}/${MASTER_OUTPUT}.root" \
     --file2 "${PR_SCENARIO_DIR}/${PR_OUTPUT}.root"
 else
+  if [ "${DRIFT_SMOKE_ONLY}" = "1" ]; then
+    "${PR_EXECUTABLE}" --allsensitive --accumulated_events \
+                       -m "${SCENARIO_MACRO}" \
+                       --output_dir "${PR_SCENARIO_DIR}" \
+                       --output_file "${PR_OUTPUT}"
+
+    echo "Scenario '${SCENARIO}' smoke run completed."
+    exit 0
+  fi
+
   # FIXME: This legacy CSV fallback should be removed once the master/reference
   # executable also supports --truth_root. The drift gate should then require
   # ROOT truth support instead of silently keeping the old CSV-only mode alive.

--- a/test/run_ci_matrix.sh
+++ b/test/run_ci_matrix.sh
@@ -52,7 +52,8 @@ Runs AdePT in a local matrix similar to Jenkins:
   - mixed (-DADEPT_MIXED_PRECISION=ON)
 
 Options:
-  --suite <drift|ci>         Test suite to run (default: drift)
+  --suite <drift|drift-smoke|ci>
+                              Test suite to run (default: drift)
   --configs <list>           Comma list: async,split,mixed (default: async,split,mixed)
   --build-type <type>        CMake build type (default: Release)
   --cuda-arch <arch|auto>    CUDA arch (default: auto)
@@ -72,6 +73,7 @@ Options:
 
 Suite behavior:
   drift (default): builds PR + master for each config and runs physics_drift_* tests
+  drift-smoke    : builds only this checkout and runs physics_drift_* once, without comparison
   ci              : runs Jenkins-like selection for each config (can take much longer)
 USAGE
 }
@@ -186,10 +188,10 @@ if [[ "${JOBS}" != "auto" && ! "${JOBS}" =~ ^[1-9][0-9]*$ ]]; then
 fi
 
 case "${SUITE}" in
-  drift|ci)
+  drift|drift-smoke|ci)
     ;;
   *)
-    die "Invalid --suite '${SUITE}'. Allowed: drift, ci"
+    die "Invalid --suite '${SUITE}'. Allowed: drift, drift-smoke, ci"
     ;;
 esac
 
@@ -401,6 +403,24 @@ run_drift_tests() {
   run_ctest --test-dir "${pr_build_dir}" --output-on-failure -R '^physics_drift_' -j1
 }
 
+run_drift_smoke_tests() {
+  local pr_build_dir=$1
+
+  local pr_exec="${pr_build_dir}/BuildProducts/bin/integrationTest"
+
+  [[ -x "${pr_exec}" ]] || die "Executable not found: ${pr_exec}"
+
+  local drift_count
+  drift_count=$(run_ctest --test-dir "${pr_build_dir}" -N -R '^physics_drift_' | awk '/Total Tests:/ {print $3}')
+  if [[ -z "${drift_count}" || "${drift_count}" == "0" ]]; then
+    die "No physics_drift tests were found in ${pr_build_dir}"
+  fi
+
+  log "Running physics_drift smoke tests in ${pr_build_dir}"
+  ADEPT_DRIFT_SMOKE_ONLY=1 \
+  run_ctest --test-dir "${pr_build_dir}" --output-on-failure -R '^physics_drift_' -j1
+}
+
 run_ci_subset_tests() {
   local cfg=$1
   local build_dir=$2
@@ -455,6 +475,8 @@ for cfg in "${CONFIGS[@]}"; do
     master_build_dir="${BUILD_ROOT}/BUILD_MASTER_REFERENCE_${suffix}"
     build_config "master" "${MASTER_WORKTREE_DIR}" "${master_build_dir}" "${cfg}"
     run_drift_tests "${pr_build_dir}" "${master_build_dir}"
+  elif [[ "${SUITE}" == "drift-smoke" ]]; then
+    run_drift_smoke_tests "${pr_build_dir}"
   else
     run_ci_subset_tests "${cfg}" "${pr_build_dir}"
   fi

--- a/test/run_nightly_ci.sh
+++ b/test/run_nightly_ci.sh
@@ -38,9 +38,10 @@ usage() {
 Usage: $(basename "$0") [options]
 
 Runs the nightly CI selection on the self-hosted runner:
-  1. build Release matrix for async/split/mixed
+  1. build ${BUILD_TYPE} matrix for async/split/mixed
   2. run unit tests on async
   3. run validation tests on async and split
+  4. build Debug matrix for async/split/mixed and run one-sided physics_drift smoke tests
 
 Options:
   --build-root <path>        Build root (default: ${DEFAULT_BUILD_ROOT})
@@ -62,6 +63,9 @@ write_results() {
     printf 'LCG_SETUP=%q\n' "${LCG_SETUP}"
     printf 'BUILD_ROOT=%q\n' "${BUILD_ROOT}"
     printf 'BUILD_TYPE=%q\n' "${BUILD_TYPE}"
+    printf 'RELEASE_CI_STATUS=%s\n' "${RELEASE_CI_STATUS}"
+    printf 'DEBUG_DRIFT_SMOKE_BUILD_ROOT=%q\n' "${DEBUG_DRIFT_SMOKE_BUILD_ROOT}"
+    printf 'DEBUG_DRIFT_SMOKE_STATUS=%s\n' "${DEBUG_DRIFT_SMOKE_STATUS}"
     printf 'NIGHTLY_STATUS=%s\n' "${NIGHTLY_STATUS}"
   } > "${RESULTS_FILE}"
 }
@@ -148,11 +152,27 @@ for arg in "${CMAKE_EXTRA_ARGS[@]}"; do
   matrix_args+=(--cmake-extra "${arg}")
 done
 
+DEBUG_DRIFT_SMOKE_BUILD_ROOT="${BUILD_ROOT}/debug-drift-smoke"
+debug_drift_smoke_args=(
+  --suite drift-smoke
+  --configs async,split,mixed
+  --build-root "${DEBUG_DRIFT_SMOKE_BUILD_ROOT}"
+  --build-type Debug
+  --cuda-arch "${CUDA_ARCH}"
+  --jobs "${JOBS}"
+  --ctest-timeout-sec "${CTEST_TIMEOUT_SEC}"
+)
+
+for arg in "${CMAKE_EXTRA_ARGS[@]}"; do
+  debug_drift_smoke_args+=(--cmake-extra "${arg}")
+done
+
 log "Using LCG setup: ${LCG_SETUP}"
 log "Build type: ${BUILD_TYPE}"
 log "Build root: ${BUILD_ROOT}"
 log "CUDA arch: ${CUDA_ARCH}"
 log "Build jobs: ${JOBS}"
+log "Debug drift smoke build root: ${DEBUG_DRIFT_SMOKE_BUILD_ROOT}"
 log "Running Jenkins-like nightly CI selection"
 
 # Increase self-hosted nightly validation concurrency and buffer capacity unless explicitly overridden.
@@ -173,13 +193,26 @@ export ADEPT_VALIDATION_WDT_NUM_TRACKSLOTS
 export ADEPT_VALIDATION_WDT_NUM_HITSLOTS
 export ADEPT_VALIDATION_WDT_CPU_CAPACITY_FACTOR
 
+RELEASE_CI_STATUS=1
+DEBUG_DRIFT_SMOKE_STATUS=1
 NIGHTLY_STATUS=1
 if "${MATRIX_RUNNER}" "${matrix_args[@]}"; then
+  RELEASE_CI_STATUS=0
+fi
+
+log "Running Debug physics_drift smoke suite"
+if "${MATRIX_RUNNER}" "${debug_drift_smoke_args[@]}"; then
+  DEBUG_DRIFT_SMOKE_STATUS=0
+fi
+
+if [[ "${RELEASE_CI_STATUS}" -eq 0 && "${DEBUG_DRIFT_SMOKE_STATUS}" -eq 0 ]]; then
   NIGHTLY_STATUS=0
 fi
 
 write_results
 
+log "Release CI status: ${RELEASE_CI_STATUS}"
+log "Debug drift smoke status: ${DEBUG_DRIFT_SMOKE_STATUS}"
 log "Nightly status: ${NIGHTLY_STATUS}"
 
 exit "${NIGHTLY_STATUS}"


### PR DESCRIPTION
Previously, the nightlies were not running any debug mode runs.

Now, the drift tests are enabled in debug mode, as they are quite fast. As a 'drift' of master vs master does not make sense, it runs only one run and does not do a comparison. (This saves half of the builds and half of the run time).