### PR TITLE
fix warning in debug mode

### DIFF
--- a/src/g4integration/returned_steps/AdePTGeant4Integration.cpp
+++ b/src/g4integration/returned_steps/AdePTGeant4Integration.cpp
@@ -353,7 +353,7 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUStep> gpuSteps, b
   // first step in the span is the parent step
   const GPUStep &parentStep = gpuSteps[0];
 
-  assert(gpuSteps.size() == 1 + parentStep.fNumSecondaries);
+  assert(gpuSteps.size() == static_cast<decltype(gpuSteps.size())>(1 + parentStep.fNumSecondaries));
 
   // Reconstruct G4NavigationHistory and G4Step, then call the SD code for the returned step
   vecgeom::NavigationState const &preNavState = parentStep.fPreStepPoint.fNavigationState;


### PR DESCRIPTION
This PR fixes a small warning in debug mode:

```
AdePT/src/g4integration/returned_steps/AdePTGeant4Integration.cpp: In member function 'void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUStep>, bool, bool)':
/work/AdePT/src/g4integration/returned_steps/AdePTGeant4Integration.cpp:356:26: warning: comparison of integer expressions of different signedness: 'std::span<const GPUStep>::size_type' {aka 'long unsigned int'} and 'int' [-Wsign-compare]
  356 |   assert(gpuSteps.size() == 1 + parentStep.fNumSecondaries);
      |          ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```