### PR TITLE
Modernize include guards

### DIFF
--- a/examples/Example1/include/ActionInitialisation.hh
+++ b/examples/Example1/include/ActionInitialisation.hh
@@ -25,8 +25,7 @@
 // * acceptance of all terms of the Geant4 Software license.          *
 // ********************************************************************
 //
-#ifndef ACTIONINITIALISATION_HH
-#define ACTIONINITIALISATION_HH
+#pragma once
 
 #include "G4VUserActionInitialization.hh"
 #include "G4String.hh"
@@ -50,5 +49,3 @@ public:
   /// Create run action in the master thread to allow analysis merging.
   virtual void BuildForMaster() const final;
 };
-
-#endif /* ACTIONINITIALISATION_HH */

--- a/examples/Example1/include/DetectorConstruction.hh
+++ b/examples/Example1/include/DetectorConstruction.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 //
-#ifndef DETECTORCONSTRUCTION_H
-#define DETECTORCONSTRUCTION_H
+#pragma once
 
 #include "MagneticFields.hh"
 
@@ -63,5 +62,3 @@ private:
   G4GDMLParser fParser;
   bool fAllSensitive;
 };
-
-#endif /* DETECTORCONSTRUCTION_H */

--- a/examples/Example1/include/DetectorMessenger.hh
+++ b/examples/Example1/include/DetectorMessenger.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef DETECTORMESSENGER_H
-#define DETECTORMESSENGER_H
+#pragma once
 
 #include "G4UImessenger.hh"
 
@@ -46,5 +45,3 @@ private:
   G4UIcmdWith3VectorAndUnit *fFieldCmd  = nullptr;
   G4UIcmdWithAString *fFieldFileNameCmd = nullptr;
 };
-
-#endif

--- a/examples/Example1/include/EventAction.hh
+++ b/examples/Example1/include/EventAction.hh
@@ -25,8 +25,7 @@
 // * acceptance of all terms of the Geant4 Software license.          *
 // ********************************************************************
 //
-#ifndef EVENTACTION_HH
-#define EVENTACTION_HH
+#pragma once
 
 #include "G4UserEventAction.hh"
 #include "G4Types.hh"
@@ -63,5 +62,3 @@ private:
   /// Messenger for this
   EventActionMessenger *fMessenger{nullptr};
 };
-
-#endif /* EVENTACTION_HH */

--- a/examples/Example1/include/EventActionMessenger.hh
+++ b/examples/Example1/include/EventActionMessenger.hh
@@ -27,8 +27,7 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-#ifndef EVENTACTIONMESSENGER_HH
-#define EVENTACTIONMESSENGER_HH
+#pragma once
 
 #include "globals.hh"
 #include "G4UImessenger.hh"
@@ -54,5 +53,3 @@ private:
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
-
-#endif // EVENTACTIONMESSENGER_HH

--- a/examples/Example1/include/PrimaryGeneratorAction.hh
+++ b/examples/Example1/include/PrimaryGeneratorAction.hh
@@ -25,8 +25,7 @@
 // * acceptance of all terms of the Geant4 Software license.          *
 // ********************************************************************
 //
-#ifndef PRIMARYGENERATORACTION_HH
-#define PRIMARYGENERATORACTION_HH
+#pragma once
 
 #include "G4VUserPrimaryGeneratorAction.hh"
 #include "G4ParticleGun.hh"
@@ -54,5 +53,3 @@ private:
   /// Particle gun
   ParticleGun *fParticleGun;
 };
-
-#endif /* PRIMARYGENERATORACTION_HH */

--- a/examples/Example1/include/RunAction.hh
+++ b/examples/Example1/include/RunAction.hh
@@ -25,8 +25,7 @@
 // * acceptance of all terms of the Geant4 Software license.          *
 // ********************************************************************
 //
-#ifndef RUNACTION_HH
-#define RUNACTION_HH
+#pragma once
 
 #include "G4UserRunAction.hh"
 #include "G4String.hh"
@@ -66,5 +65,3 @@ private:
   static std::mutex fgRunTimerMutex;
   static bool fgRunTimerStarted;
 };
-
-#endif /* RUNACTION_HH */

--- a/examples/Example1/include/SensitiveDetector.hh
+++ b/examples/Example1/include/SensitiveDetector.hh
@@ -25,8 +25,7 @@
 // * acceptance of all terms of the Geant4 Software license.          *
 // ********************************************************************
 //
-#ifndef SENSITIVEDETECTOR_HH
-#define SENSITIVEDETECTOR_HH
+#pragma once
 
 #include "SimpleHit.hh"
 
@@ -72,5 +71,3 @@ private:
   /// Number of sensitive detectors
   std::size_t fNumSensitive{0};
 };
-
-#endif /* SENSITIVEDETECTOR_HH */

--- a/examples/Example1/include/SimpleHit.hh
+++ b/examples/Example1/include/SimpleHit.hh
@@ -25,8 +25,7 @@
 // * acceptance of all terms of the Geant4 Software license.          *
 // ********************************************************************
 //
-#ifndef SIMPLEHIT_HH
-#define SIMPLEHIT_HH
+#pragma once
 
 #include "G4VHit.hh"
 #include "G4THitsCollection.hh"
@@ -117,5 +116,3 @@ inline void SimpleHit::operator delete(void *aHit)
 {
   SimpleHitAllocator->FreeSingle((SimpleHit *)aHit);
 }
-
-#endif /* SIMPLEHIT_HH */

--- a/examples/Example1/include/SteppingAction.hh
+++ b/examples/Example1/include/SteppingAction.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2023 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef STEPPINGACTION_HH
-#define STEPPINGACTION_HH
+#pragma once
 
 #include "G4UserSteppingAction.hh"
 
@@ -13,5 +12,3 @@ public:
   ~SteppingAction() override;
   void UserSteppingAction(const G4Step *step) override;
 };
-
-#endif

--- a/examples/common/include/FTFP_BERT_AdePT.hh
+++ b/examples/common/include/FTFP_BERT_AdePT.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2023 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef FTFP_BERT_AdePT_h
-#define FTFP_BERT_AdePT_h 1
+#pragma once
 
 #include <CLHEP/Units/SystemOfUnits.h>
 
@@ -17,5 +16,3 @@ public:
   FTFP_BERT_AdePT(const FTFP_BERT_AdePT &)            = delete;
   FTFP_BERT_AdePT &operator=(const FTFP_BERT_AdePT &) = delete;
 };
-
-#endif

--- a/examples/common/include/FTFP_BERT_HepEm.hh
+++ b/examples/common/include/FTFP_BERT_HepEm.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef FTFP_BERT_HepEm_h
-#define FTFP_BERT_HepEm_h 1
+#pragma once
 
 #include <CLHEP/Units/SystemOfUnits.h>
 
@@ -17,5 +16,3 @@ public:
   FTFP_BERT_HepEm(const FTFP_BERT_HepEm &)            = delete;
   FTFP_BERT_HepEm &operator=(const FTFP_BERT_HepEm &) = delete;
 };
-
-#endif

--- a/examples/common/include/HepMC3G4AsciiReader.hh
+++ b/examples/common/include/HepMC3G4AsciiReader.hh
@@ -7,8 +7,7 @@
 //
 //
 
-#ifndef HEPMC3_G4_ASCII_READER_H
-#define HEPMC3_G4_ASCII_READER_H
+#pragma once
 
 #include "HepMC3G4Interface.hh"
 #include "HepMC3/Print.h"
@@ -100,5 +99,3 @@ inline G4int HepMC3G4AsciiReader::GetFirstEventNumber() const
 {
   return fFirstEventNumber;
 }
-
-#endif

--- a/examples/common/include/HepMC3G4AsciiReaderMessenger.hh
+++ b/examples/common/include/HepMC3G4AsciiReaderMessenger.hh
@@ -7,8 +7,7 @@
 //
 //
 
-#ifndef HEPMC3_G4_ASCII_READER_MESSENGER_H
-#define HEPMC3_G4_ASCII_READER_MESSENGER_H
+#pragma once
 
 #include "G4UImessenger.hh"
 
@@ -37,5 +36,3 @@ private:
   std::unique_ptr<G4UIcmdWithAnInteger> fFirstevent;
   std::unique_ptr<G4UIcmdWithAString> fOpen;
 };
-
-#endif

--- a/examples/common/include/HepMC3G4Interface.hh
+++ b/examples/common/include/HepMC3G4Interface.hh
@@ -7,8 +7,7 @@
 //
 //
 
-#ifndef HEPMC3_G4_INTERFACE_H
-#define HEPMC3_G4_INTERFACE_H
+#pragma once
 
 #include "G4VPrimaryGenerator.hh"
 
@@ -43,5 +42,3 @@ public:
   // GenerateHepMCEvent() will be converted to G4Event through HepMC2G4().
   virtual void GeneratePrimaryVertex(G4Event *anEvent);
 };
-
-#endif

--- a/examples/common/include/MagneticFields.hh
+++ b/examples/common/include/MagneticFields.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 //
-#ifndef MAGNETICFIELDS_H
-#define MAGNETICFIELDS_H
+#pragma once
 
 #include "G4MagneticField.hh"
 #include "G4ThreeVector.hh"
@@ -98,5 +97,3 @@ public:
 private:
   std::unique_ptr<IField> fField;
 };
-
-#endif // MAGNETICFIELDS_H

--- a/examples/common/include/ParticleGun.hh
+++ b/examples/common/include/ParticleGun.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2023 CERN
 // SPDX-License-Identifier: Apache-2.0
 //
-#ifndef PARTICLEGUN_HH
-#define PARTICLEGUN_HH
+#pragma once
 
 #include "G4ParticleGun.hh"
 #include "G4VPrimaryGenerator.hh"
@@ -59,5 +58,3 @@ private:
 
   std::unique_ptr<ParticleGunMessenger> fMessenger;
 };
-
-#endif /* PARTICLEGUN_HH */

--- a/examples/common/include/ParticleGunMessenger.hh
+++ b/examples/common/include/ParticleGunMessenger.hh
@@ -8,8 +8,7 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-#ifndef PARTICLEGUNMESSENGER_HH
-#define PARTICLEGUNMESSENGER_HH
+#pragma once
 
 #include "G4UImessenger.hh"
 #include "globals.hh"
@@ -49,5 +48,3 @@ private:
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
-
-#endif // PARTICLEGUNMESSENGER_HH

--- a/include/AdePT/core/AdePTConfiguration.hh
+++ b/include/AdePT/core/AdePTConfiguration.hh
@@ -1,9 +1,6 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_COMPAT_INCLUDE_ADEPT_CORE_ADEPTCONFIGURATION_HH
-#define ADEPT_COMPAT_INCLUDE_ADEPT_CORE_ADEPTCONFIGURATION_HH
+#pragma once
 
 #include <AdePT/g4integration/AdePTConfiguration.hh>
-
-#endif

--- a/include/AdePT/g4integration/AdePTConfiguration.hh
+++ b/include/AdePT/g4integration/AdePTConfiguration.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2024 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_CONFIGURATION_HH
-#define ADEPT_CONFIGURATION_HH
+#pragma once
 
 #include <cstdint>
 #include <memory>
@@ -110,5 +109,3 @@ private:
   std::string fCovfieBfieldFile{""};
   std::unique_ptr<AdePTConfigurationMessenger> fAdePTConfigurationMessenger;
 };
-
-#endif

--- a/include/AdePT/g4integration/AdePTTrackingManager.hh
+++ b/include/AdePT/g4integration/AdePTTrackingManager.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2023 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef AdePTTrackingManager_h
-#define AdePTTrackingManager_h 1
+#pragma once
 
 #include "G4VTrackingManager.hh"
 #include "G4RegionStore.hh"
@@ -100,5 +99,3 @@ private:
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
-
-#endif

--- a/include/AdePT/g4integration/G4EmStandardPhysics_AdePT.hh
+++ b/include/AdePT/g4integration/G4EmStandardPhysics_AdePT.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef G4EmStandardPhysics_AdePT_h
-#define G4EmStandardPhysics_AdePT_h 1
+#pragma once
 
 #include "G4EmStandardPhysics.hh"
 
@@ -22,5 +21,3 @@ private:
   AdePTTrackingManager *fTrackingManager{nullptr};
   AdePTConfiguration *fAdePTConfiguration{nullptr};
 };
-
-#endif

--- a/include/AdePT/g4integration/G4EmStandardPhysics_HepEm.hh
+++ b/include/AdePT/g4integration/G4EmStandardPhysics_HepEm.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef G4EmStandardPhysics_HepEm_h
-#define G4EmStandardPhysics_HepEm_h 1
+#pragma once
 
 #include "G4EmStandardPhysics.hh"
 
@@ -20,5 +19,3 @@ public:
 private:
   G4HepEmTrackingManager *fTrackingManager{nullptr};
 };
-
-#endif

--- a/include/AdePT/g4integration/config/AdePTConfigurationMessenger.hh
+++ b/include/AdePT/g4integration/config/AdePTConfigurationMessenger.hh
@@ -7,8 +7,7 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-#ifndef ADEPTCONFIGURATIONMESSENGER_HH
-#define ADEPTCONFIGURATIONMESSENGER_HH
+#pragma once
 
 #include "G4UImessenger.hh"
 #include "globals.hh"
@@ -66,5 +65,3 @@ private:
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
-
-#endif // ADEPTCONFIGURATIONMESSENGER_HH

--- a/include/AdePT/g4integration/geometry/AdePTGeometryBridge.hh
+++ b/include/AdePT/g4integration/geometry/AdePTGeometryBridge.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_GEOMETRY_BRIDGE_HH
-#define ADEPT_GEOMETRY_BRIDGE_HH
+#pragma once
 
 #include <AdePT/transport/geometry/GeometryAuxData.hh>
 #include <AdePT/transport/woodcock/WoodcockData.hh>
@@ -62,5 +61,3 @@ private:
   static std::vector<G4VPhysicalVolume const *> fGlobalVecGeomPvToG4Map;
   static std::vector<G4LogicalVolume const *> fGlobalVecGeomLvToG4Map;
 };
-
-#endif

--- a/include/AdePT/g4integration/returned_steps/AdePTGeant4Integration.hh
+++ b/include/AdePT/g4integration/returned_steps/AdePTGeant4Integration.hh
@@ -6,8 +6,7 @@
 ///   - G4Step reconstruction from GPU steps
 ///   - Processing of reconstructed steps using the Geant4 sensitive detector
 
-#ifndef ADEPTGEANT4_INTEGRATION_H
-#define ADEPTGEANT4_INTEGRATION_H
+#pragma once
 
 #include <AdePT/transport/steps/GPUStep.hh>
 #include <AdePT/g4integration/tracking_managers/G4HepEmTrackingManagerSpecialized.hh>
@@ -144,5 +143,3 @@ private:
   std::vector<GPUStep> fDeferredGPUSteps;
   std::vector<DeferredStep> fDeferredSteps;
 };
-
-#endif

--- a/include/AdePT/g4integration/returned_steps/HostTrackDataMapper.hh
+++ b/include/AdePT/g4integration/returned_steps/HostTrackDataMapper.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2025 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef HOSTTRACKDATAMAPPER_H
-#define HOSTTRACKDATAMAPPER_H
+#pragma once
 
 #include "G4VUserTrackInformation.hh"
 #include "G4VProcess.hh"
@@ -216,5 +215,3 @@ private:
   int currentGpuReturnG4ID = std::numeric_limits<int>::max();
   int currentEventID       = -1;
 };
-
-#endif

--- a/include/AdePT/g4integration/tracking_managers/AdePTThreadId.hh
+++ b/include/AdePT/g4integration/tracking_managers/AdePTThreadId.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_THREAD_ID_HH
-#define ADEPT_THREAD_ID_HH
+#pragma once
 
 #include "G4Threading.hh"
 
@@ -20,5 +19,3 @@ inline int GetThreadId()
 }
 
 } // namespace adept_integration
-
-#endif

--- a/include/AdePT/g4integration/tracking_managers/G4HepEmTrackingManagerSpecialized.hh
+++ b/include/AdePT/g4integration/tracking_managers/G4HepEmTrackingManagerSpecialized.hh
@@ -5,8 +5,7 @@
 ///   The derived class from G4HepEmTrackingManager must implement HandOverOneTrack and CheckEarlyTrackingExit to allow
 ///   for an early exit of the tracking loop in the G4HepEmTrackingManager
 
-#ifndef G4HepEmTrackingManagerSpecialized_h
-#define G4HepEmTrackingManagerSpecialized_h
+#pragma once
 
 #include "G4HepEmTrackingManager.hh"
 
@@ -46,5 +45,3 @@ private:
 
   // G4Region const * fPreviousRegion = nullptr;
 };
-
-#endif // G4HepEmTrackingManagerSpecialized_h

--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -1,9 +1,6 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_COMPAT_INCLUDE_ADEPT_INTEGRATION_ADEPTTRACKINGMANAGER_HH
-#define ADEPT_COMPAT_INCLUDE_ADEPT_INTEGRATION_ADEPTTRACKINGMANAGER_HH
+#pragma once
 
 #include <AdePT/g4integration/AdePTTrackingManager.hh>
-
-#endif

--- a/include/AdePT/integration/G4EmStandardPhysics_AdePT.hh
+++ b/include/AdePT/integration/G4EmStandardPhysics_AdePT.hh
@@ -1,9 +1,6 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_COMPAT_INCLUDE_ADEPT_INTEGRATION_G4EMSTANDARDPHYSICS_ADEPT_HH
-#define ADEPT_COMPAT_INCLUDE_ADEPT_INTEGRATION_G4EMSTANDARDPHYSICS_ADEPT_HH
+#pragma once
 
 #include <AdePT/g4integration/G4EmStandardPhysics_AdePT.hh>
-
-#endif

--- a/include/AdePT/integration/G4EmStandardPhysics_HepEm.hh
+++ b/include/AdePT/integration/G4EmStandardPhysics_HepEm.hh
@@ -1,9 +1,6 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_COMPAT_INCLUDE_ADEPT_INTEGRATION_G4EMSTANDARDPHYSICS_HEPEM_HH
-#define ADEPT_COMPAT_INCLUDE_ADEPT_INTEGRATION_G4EMSTANDARDPHYSICS_HEPEM_HH
+#pragma once
 
 #include <AdePT/g4integration/G4EmStandardPhysics_HepEm.hh>
-
-#endif

--- a/include/AdePT/transport/AsyncAdePTTransport.cuh
+++ b/include/AdePT/transport/AsyncAdePTTransport.cuh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ASYNC_ADEPT_TRANSPORT_CUH
-#define ASYNC_ADEPT_TRANSPORT_CUH
+#pragma once
 
 #include <AdePT/transport/support/Portability.hh>
 
@@ -1469,5 +1468,3 @@ TrackBuffer::TrackBuffer(unsigned int numToDevice) : fNumToDevice{numToDevice}
 }
 
 } // namespace AsyncAdePT
-
-#endif // ASYNC_ADEPT_TRANSPORT_CUH

--- a/include/AdePT/transport/AsyncAdePTTransport.hh
+++ b/include/AdePT/transport/AsyncAdePTTransport.hh
@@ -6,8 +6,7 @@
 /// - filling the buffer with tracks to be transported on the GPU
 /// - driving the GPU transport worker
 
-#ifndef ASYNC_ADEPT_TRANSPORT_HH
-#define ASYNC_ADEPT_TRANSPORT_HH
+#pragma once
 
 #include <AdePT/transport/g4hepem/AdePTG4HepEmState.hh>
 #include <AdePT/transport/config/AdePTTransportConfig.hh>
@@ -106,5 +105,3 @@ public:
 } // namespace AsyncAdePT
 
 #include "AsyncAdePTTransport.icc"
-
-#endif

--- a/include/AdePT/transport/config/AdePTTransportConfig.hh
+++ b/include/AdePT/transport/config/AdePTTransportConfig.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_TRANSPORT_CONFIG_HH
-#define ADEPT_TRANSPORT_CONFIG_HH
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -25,5 +24,3 @@ struct AdePTTransportConfig {
   double cpuCopyFraction{0.5};
   double stepBufferSafetyFactor{1.5};
 };
-
-#endif

--- a/include/AdePT/transport/containers/Atomic.h
+++ b/include/AdePT/transport/containers/Atomic.h
@@ -7,8 +7,7 @@
  * @author Andrei Gheata (andrei.gheata@cern.ch)
  */
 
-#ifndef ADEPT_ATOMIC_H_
-#define ADEPT_ATOMIC_H_
+#pragma once
 
 #include <AdePT/transport/support/Global.h>
 #include <cassert>
@@ -247,4 +246,3 @@ struct Atomic_t<Type, typename std::enable_if<!std::is_integral<Type>::value>::t
 };
 
 } // End namespace adept
-#endif // ADEPT_ATOMIC_H_

--- a/include/AdePT/transport/containers/BlockData.h
+++ b/include/AdePT/transport/containers/BlockData.h
@@ -7,8 +7,7 @@
  * @author Andrei Gheata (andrei.gheata@cern.ch)
  */
 
-#ifndef ADEPT_BLOCKDATA_H_
-#define ADEPT_BLOCKDATA_H_
+#pragma once
 
 #include <AdePT/transport/containers/Atomic.h>
 #include <AdePT/transport/containers/VariableSizeObj.h>
@@ -136,5 +135,3 @@ public:
 
 }; // End BlockData
 } // End namespace adept
-
-#endif // ADEPT_BLOCKDATA_H_

--- a/include/AdePT/transport/containers/MParray.h
+++ b/include/AdePT/transport/containers/MParray.h
@@ -7,13 +7,10 @@
  * @author Andrei Gheata (andrei.gheata@cern.ch)
  */
 
-#ifndef ADEPT_MPARRAY_H_
-#define ADEPT_MPARRAY_H_
+#pragma once
 
 #include <AdePT/transport/containers/MParrayT.h>
 
 namespace adept {
 using MParray = MParrayT<int>;
 } // End namespace adept
-
-#endif // ADEPT_MPARRAY_H_

--- a/include/AdePT/transport/containers/MParrayT.h
+++ b/include/AdePT/transport/containers/MParrayT.h
@@ -7,8 +7,7 @@
  * @author Andrei Gheata (andrei.gheata@cern.ch)
  */
 
-#ifndef ADEPT_MPARRAYT_H_
-#define ADEPT_MPARRAYT_H_
+#pragma once
 
 #include <AdePT/transport/containers/Atomic.h>
 #include <AdePT/transport/containers/VariableSizeObj.h>
@@ -113,5 +112,3 @@ public:
 
 }; // End class MParrayT
 } // End namespace adept
-
-#endif // ADEPT_MPARRAYT_H_

--- a/include/AdePT/transport/containers/SlotManager.cuh
+++ b/include/AdePT/transport/containers/SlotManager.cuh
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2023 CERN
 // SPDX-License-Identifier: Apache-2.0
-#ifndef SLOTMANAGER_CUH
-#define SLOTMANAGER_CUH
+#pragma once
 
 #include "AdePT/transport/support/Global.h"
 
@@ -200,5 +199,3 @@ __global__ void AssertConsistencyOfSlotManagers(SlotManager *mgrs, std::size_t N
   }
 }
 #endif
-
-#endif // SLOTMANAGER_CUH

--- a/include/AdePT/transport/containers/VariableSizeObj.h
+++ b/include/AdePT/transport/containers/VariableSizeObj.h
@@ -123,8 +123,7 @@
  * If omitting new_size above, the copy will have the same size as the source.
  */
 
-#ifndef COPCORE_VARIABLESIZEOBJ_H
-#define COPCORE_VARIABLESIZEOBJ_H
+#pragma once
 
 #include <AdePT/transport/support/Global.h>
 
@@ -313,5 +312,3 @@ private:
   }
 };
 } // namespace copcore
-
-#endif //  COPCORE_VARIABLESIZEOBJ_H

--- a/include/AdePT/transport/containers/VariableSizeObjAllocator.h
+++ b/include/AdePT/transport/containers/VariableSizeObjAllocator.h
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2020 CERN
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 /**
  * @file VariableSizeObjAllocator.h
  * @brief Backend-aware allocator for variable size objects

--- a/include/AdePT/transport/containers/mpmc_bounded_queue.h
+++ b/include/AdePT/transport/containers/mpmc_bounded_queue.h
@@ -8,8 +8,7 @@
  * based on http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue
  */
 
-#ifndef ADEPT_MPMC_BOUNDED_QUEUE
-#define ADEPT_MPMC_BOUNDED_QUEUE
+#pragma once
 
 #include <stdint.h>
 #include <cassert>
@@ -184,4 +183,3 @@ public:
 
 }; // End mpmc_bounded_queue
 } // End namespace adept
-#endif // ADEPT_MPMC_BOUNDED_QUEUE

--- a/include/AdePT/transport/g4hepem/AdePTG4HepEmState.hh
+++ b/include/AdePT/transport/g4hepem/AdePTG4HepEmState.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_G4_HEPEM_STATE_HH
-#define ADEPT_G4_HEPEM_STATE_HH
+#pragma once
 
 #include <memory>
 
@@ -76,5 +75,3 @@ private:
 };
 
 } // namespace AsyncAdePT
-
-#endif

--- a/include/AdePT/transport/geometry/GeometryAuxData.hh
+++ b/include/AdePT/transport/geometry/GeometryAuxData.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_GEOMETRY_AUX_DATA_HH
-#define ADEPT_GEOMETRY_AUX_DATA_HH
+#pragma once
 
 namespace adeptint {
 
@@ -34,5 +33,3 @@ struct VolAuxArray {
 };
 
 } // namespace adeptint
-
-#endif

--- a/include/AdePT/transport/kernels/electrons.cuh
+++ b/include/AdePT/transport/kernels/electrons.cuh
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <AdePT/transport/navigation/AdePTNavigator.h>
 
 // Classes for Runge-Kutta integration

--- a/include/AdePT/transport/kernels/electrons_split.cuh
+++ b/include/AdePT/transport/kernels/electrons_split.cuh
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <AdePT/transport/navigation/AdePTNavigator.h>
 
 // Classes for Runge-Kutta integration

--- a/include/AdePT/transport/kernels/gammas.cuh
+++ b/include/AdePT/transport/kernels/gammas.cuh
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <AdePT/transport/navigation/AdePTNavigator.h>
 #include <AdePT/transport/kernels/gammasWDT.cuh>
 

--- a/include/AdePT/transport/kernels/gammasWDT.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT.cuh
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <AdePT/transport/navigation/AdePTNavigator.h>
 
 #include <AdePT/transport/support/PhysicalConstants.h>

--- a/include/AdePT/transport/kernels/gammasWDT_split.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT_split.cuh
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <AdePT/transport/navigation/AdePTNavigator.h>
 
 #include <AdePT/transport/support/PhysicalConstants.h>

--- a/include/AdePT/transport/kernels/gammas_split.cuh
+++ b/include/AdePT/transport/kernels/gammas_split.cuh
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <AdePT/transport/navigation/AdePTNavigator.h>
 
 #include <AdePT/transport/support/PhysicalConstants.h>

--- a/include/AdePT/transport/magneticfield/CompareResponses.h
+++ b/include/AdePT/transport/magneticfield/CompareResponses.h
@@ -3,8 +3,7 @@
 
 // Author:   J. Apostolakis,  22 June 2022
 
-#ifndef CompareResponses_hh
-#define CompareResponses_hh 1
+#pragma once
 
 #include <VecGeom/base/Vector3D.h>
 
@@ -52,5 +51,3 @@ static __device__ __host__ void ReportSameMoveVector3D(int id, vecgeom::Vector3D
          (resultVec - originalVec).Mag(), originalVec[0], originalVec[1], originalVec[2], originalVec.Mag(),
          resultVec[0], resultVec[1], resultVec[2], resultVec.Mag());
 }
-
-#endif /* CompareResponses_hh */

--- a/include/AdePT/transport/magneticfield/ConstBzFieldStepper.h
+++ b/include/AdePT/transport/magneticfield/ConstBzFieldStepper.h
@@ -10,8 +10,7 @@
  *  Original Author: swenzel   ( S. Wenzel ) Apr 23, 2014
  */
 
-#ifndef CONSTBzFIELDSTEPPER_H_
-#define CONSTBzFIELDSTEPPER_H_
+#pragma once
 
 #include "VecGeom/base/Global.h"
 
@@ -112,5 +111,3 @@ inline __attribute__((always_inline)) void ConstBzFieldStepper::DoStep(
   dy = dx0 * sinphi + cosphi * dy0;
   dz = dz0;
 }
-
-#endif /* CONSTBzFIELDSTEPPER_H_ */

--- a/include/AdePT/transport/magneticfield/ConstFieldHelixStepper.h
+++ b/include/AdePT/transport/magneticfield/ConstFieldHelixStepper.h
@@ -9,8 +9,7 @@
  *      Author: J. Apostolakis
  */
 
-#ifndef CONSTFIELDHELIXSTEPPER_H_
-#define CONSTFIELDHELIXSTEPPER_H_
+#pragma once
 
 #include <VecGeom/base/Vector3D.h>
 // Needed for Vector3D
@@ -266,5 +265,3 @@ inline void ConstFieldHelixStepper::PrintStep(vecgeom::Vector3D<Real_t> const &s
 
 // } // namespace ADEPT_IMPL_NAMESPACE
 // } // namespace adept
-
-#endif /* CONSTFIELDHELIXSTEPPER_H_ */

--- a/include/AdePT/transport/magneticfield/DormandPrinceRK45.h
+++ b/include/AdePT/transport/magneticfield/DormandPrinceRK45.h
@@ -1,5 +1,8 @@
 // SPDX-FileCopyrightText: 2021 CERN
 // SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
 //
 // Author:  J. Apostolakis,  15 Nov 2021
 //

--- a/include/AdePT/transport/magneticfield/ErrorEstimatorRK.h
+++ b/include/AdePT/transport/magneticfield/ErrorEstimatorRK.h
@@ -7,8 +7,7 @@
 //  Created on: November 15, 2021
 //      Author: J. Apostolakis
 
-#ifndef ErrorEstimatorRK_h
-#define ErrorEstimatorRK_h
+#pragma once
 
 class ErrorEstimatorRK {
 public:
@@ -70,4 +69,3 @@ ErrorEstimatorRK::EstimateSquareError(const Real_t yEstError[], // [fNoComponent
 
   return vecCore::math::Max(errpos_sq, errmom_sq); // Maximum Square Error
 }
-#endif

--- a/include/AdePT/transport/magneticfield/GeneralMagneticField.cuh
+++ b/include/AdePT/transport/magneticfield/GeneralMagneticField.cuh
@@ -3,8 +3,7 @@
 //
 // Author:  S. Diederichs,   11 Nov 2024
 
-#ifndef GeneralMagneticField_H__
-#define GeneralMagneticField_H__
+#pragma once
 
 #include <VecGeom/base/Vector3D.h>
 
@@ -121,5 +120,3 @@ private:
   field_view_t *fFieldView = nullptr;      // Device-stored field view, needed to access the data
 #endif
 };
-
-#endif // GeneralMagneticField_H__

--- a/include/AdePT/transport/magneticfield/MagneticFieldEquation.h
+++ b/include/AdePT/transport/magneticfield/MagneticFieldEquation.h
@@ -7,8 +7,7 @@
 //  use in solving ODEs of motion using Runge-Kutta methods.
 //
 
-#ifndef MagneticFieldEquation_H_
-#define MagneticFieldEquation_H_
+#pragma once
 
 #include <AdePT/transport/support/PhysicalConstants.h>
 
@@ -264,5 +263,3 @@ inline __host__ __device__ void MagneticFieldEquation<MagField_t>::EvaluateDeriv
   // std::endl;
   EvaluateRhsGivenB<Real_t, int>(y, charge, BfieldVec, dy_ds);
 }
-
-#endif

--- a/include/AdePT/transport/magneticfield/PrintFieldVectors.h
+++ b/include/AdePT/transport/magneticfield/PrintFieldVectors.h
@@ -3,8 +3,7 @@
 //
 // Author:  J. Apostolakis,  19 Nov 2021
 //
-#ifndef PRINT_FIELD_VECTORS_H__
-#define PRINT_FIELD_VECTORS_H__
+#pragma once
 
 static constexpr int NvarPrint = 6;
 
@@ -155,5 +154,3 @@ static inline // __host__ __device__
 // { }
 
 }; // namespace PrintFieldVectors
-
-#endif

--- a/include/AdePT/transport/magneticfield/RkIntegrationDriver.h
+++ b/include/AdePT/transport/magneticfield/RkIntegrationDriver.h
@@ -7,8 +7,7 @@
  *      Author: J. Apostolakis
  */
 
-#ifndef RKINTEGRATION_DRIVER_H_
-#define RKINTEGRATION_DRIVER_H_
+#pragma once
 
 #include "ErrorEstimatorRK.h"
 
@@ -298,5 +297,3 @@ inline __host__ __device__ void RkIntegrationDriver<Stepper_t, Real_t, Int_t, Eq
     printf(" End> Pos= %9.6f %9.6f %9.6f  Mom= %9.6f %9.6f %9.6f\n", x, y, z, dx, dy, dz);
   }
 }
-
-#endif /* RKINTEGRATION_DRIVER_H_ */

--- a/include/AdePT/transport/magneticfield/UniformMagneticField.cuh
+++ b/include/AdePT/transport/magneticfield/UniformMagneticField.cuh
@@ -3,8 +3,7 @@
 //
 // Author:  J. Apostolakis,   16 Nov 2021
 
-#ifndef UniformMagneticField_H__
-#define UniformMagneticField_H__
+#pragma once
 
 // #include <VecCore/Math.h>
 #include <VecGeom/base/Vector3D.h>
@@ -65,5 +64,3 @@ public:
 private:
   vecgeom::Vector3D<float> fFieldComponents;
 };
-
-#endif

--- a/include/AdePT/transport/magneticfield/fieldConstants.h
+++ b/include/AdePT/transport/magneticfield/fieldConstants.h
@@ -3,8 +3,7 @@
 
 // Author:   J. Apostolakis,  29 Nov 2021
 
-#ifndef FIELD_CONSTANTS_H__
-#define FIELD_CONSTANTS_H__
+#pragma once
 
 namespace fieldConstants {
 
@@ -20,5 +19,3 @@ static constexpr float deltaChord = 0.25 * copcore::units::millimeter;
 // deltaChord in G4, so we keep the same name
 
 }; // namespace fieldConstants
-
-#endif

--- a/include/AdePT/transport/magneticfield/fieldPropagatorConstBany.h
+++ b/include/AdePT/transport/magneticfield/fieldPropagatorConstBany.h
@@ -3,8 +3,7 @@
 
 // Author: J. Apostolakis  Nov/Dec 2020
 
-#ifndef FIELD_PROPAGATOR_CONST_BANY_H
-#define FIELD_PROPAGATOR_CONST_BANY_H
+#pragma once
 
 #include <VecGeom/base/Vector3D.h>
 
@@ -42,5 +41,3 @@ inline __host__ __device__ void fieldPropagatorConstBany::stepInField(ConstField
     position = position + step * direction;
   }
 }
-
-#endif

--- a/include/AdePT/transport/magneticfield/fieldPropagatorRungeKutta.h
+++ b/include/AdePT/transport/magneticfield/fieldPropagatorRungeKutta.h
@@ -3,8 +3,7 @@
 
 // Author: J. Apostolakis  15 Nov 2021
 
-#ifndef FIELD_PROPAGATOR_RUNGEKUTTA_H
-#define FIELD_PROPAGATOR_RUNGEKUTTA_H
+#pragma once
 
 #include <VecGeom/base/Vector3D.h>
 
@@ -347,5 +346,3 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
 
   return stepDone;
 }
-
-#endif

--- a/include/AdePT/transport/navigation/AdePTNavigator.h
+++ b/include/AdePT/transport/navigation/AdePTNavigator.h
@@ -6,8 +6,7 @@
  * @brief Top switch for different navigators
  */
 
-#ifndef ADEPT_NAVIGATOR_H_
-#define ADEPT_NAVIGATOR_H_
+#pragma once
 
 #include <AdePT/transport/navigation/BVHNavigator.h>
 #ifdef ADEPT_USE_SURF
@@ -25,4 +24,3 @@ using AdePTNavigator = SurfNavigator<double>;
 using AdePTNavigator = BVHNavigator;
 #endif
 // } // End namespace COPCORE_IMPL
-#endif // ADEPT_NAVIGATOR_H_

--- a/include/AdePT/transport/navigation/BVHNavigator.h
+++ b/include/AdePT/transport/navigation/BVHNavigator.h
@@ -6,8 +6,7 @@
  * @brief Navigation methods for geometry.
  */
 
-#ifndef RT_NAVIGATOR_H_
-#define RT_NAVIGATOR_H_
+#pragma once
 
 #include <VecGeom/base/Global.h>
 #include <VecGeom/navigation/BVHNavigator.h>
@@ -17,4 +16,3 @@
 using BVHNavigator = vecgeom::BVHNavigator;
 
 // } // End namespace COPCORE_IMPL
-#endif // RT_LOOP_NAVIGATOR_H_

--- a/include/AdePT/transport/navigation/LoopNavigator.h
+++ b/include/AdePT/transport/navigation/LoopNavigator.h
@@ -6,8 +6,7 @@
  * @brief Navigation methods for geometry.
  */
 
-#ifndef RT_LOOP_NAVIGATOR_H_
-#define RT_LOOP_NAVIGATOR_H_
+#pragma once
 
 #include <VecGeom/base/Global.h>
 #include <VecGeom/navigation/LoopNavigator.h>
@@ -17,4 +16,3 @@ inline namespace COPCORE_IMPL {
 using LoopNavigator = vecgeom::LoopNavigator;
 
 } // End namespace COPCORE_IMPL
-#endif // RT_LOOP_NAVIGATOR_H_

--- a/include/AdePT/transport/navigation/SurfNavigator.h
+++ b/include/AdePT/transport/navigation/SurfNavigator.h
@@ -6,8 +6,7 @@
  * @brief Navigation methods using the surface model.
  */
 
-#ifndef RT_SURF_NAVIGATOR_H_
-#define RT_SURF_NAVIGATOR_H_
+#pragma once
 
 #include <AdePT/transport/support/Global.h>
 
@@ -105,4 +104,3 @@ public:
 };
 
 // } // End namespace COPCORE_IMPL
-#endif // RT_SURF_NAVIGATOR_H_

--- a/include/AdePT/transport/queues/ParticleManager.cuh
+++ b/include/AdePT/transport/queues/ParticleManager.cuh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_TRANSPORT_QUEUES_PARTICLE_MANAGER_CUH
-#define ADEPT_TRANSPORT_QUEUES_PARTICLE_MANAGER_CUH
+#pragma once
 
 #include <AdePT/transport/containers/SlotManager.cuh>
 #include <AdePT/transport/queues/ParticleQueues.cuh>
@@ -73,5 +72,3 @@ struct ParticleManager {
 };
 
 } // namespace AsyncAdePT
-
-#endif

--- a/include/AdePT/transport/queues/ParticleQueues.cuh
+++ b/include/AdePT/transport/queues/ParticleQueues.cuh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_TRANSPORT_QUEUES_PARTICLE_QUEUES_CUH
-#define ADEPT_TRANSPORT_QUEUES_PARTICLE_QUEUES_CUH
+#pragma once
 
 #include <AdePT/transport/containers/MParray.h>
 #include <AdePT/transport/tracks/ParticleTypes.hh>
@@ -100,5 +99,3 @@ struct QueueIndexPair {
 };
 
 } // namespace AsyncAdePT
-
-#endif

--- a/include/AdePT/transport/queues/TrackBuffer.hh
+++ b/include/AdePT/transport/queues/TrackBuffer.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_TRACK_BUFFER_HH
-#define ADEPT_TRACK_BUFFER_HH
+#pragma once
 
 #include <AdePT/transport/support/ResourceManagement.hh>
 #include <AdePT/transport/tracks/TrackData.h>
@@ -79,5 +78,3 @@ struct TrackBuffer {
 };
 
 } // namespace AsyncAdePT
-
-#endif

--- a/include/AdePT/transport/random/G4HepEmRandomEngineDeviceImpl.hh
+++ b/include/AdePT/transport/random/G4HepEmRandomEngineDeviceImpl.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_G4HEPEM_RANDOM_ENGINE_DEVICE_IMPL_HH
-#define ADEPT_G4HEPEM_RANDOM_ENGINE_DEVICE_IMPL_HH
+#pragma once
 
 #include <AdePT/transport/random/Ranluxpp.h>
 
@@ -22,6 +21,4 @@ inline __device__ void G4HepEmRandomEngine::flatArray(const int size, double *ve
     vect[i] = ((RanluxppDouble *)fObject)->Rndm();
   }
 }
-#endif
-
 #endif

--- a/include/AdePT/transport/random/Ranluxpp.h
+++ b/include/AdePT/transport/random/Ranluxpp.h
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2020 CERN
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef COPCORE_RANLUXPP_H_
-#define COPCORE_RANLUXPP_H_
+#pragma once
 
 #include <AdePT/transport/support/Global.h>
 
@@ -188,5 +187,3 @@ public:
     return newRNG;
   }
 };
-
-#endif

--- a/include/AdePT/transport/random/ranluxpp/helpers.h
+++ b/include/AdePT/transport/random/ranluxpp/helpers.h
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2020 CERN
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef COPCORE_RANLUXPP_HELPERS_H_
-#define COPCORE_RANLUXPP_HELPERS_H_
+#pragma once
 
 #include <cstdint>
 
@@ -144,5 +143,3 @@ __host__ __device__ static inline int64_t compute_r(const uint64_t *upper, uint6
   }
   return c + (c == 0 && greater_m);
 }
-
-#endif

--- a/include/AdePT/transport/random/ranluxpp/mulmod.h
+++ b/include/AdePT/transport/random/ranluxpp/mulmod.h
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2020 CERN
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef COPCORE_RANLUXPP_MULMOD_H_
-#define COPCORE_RANLUXPP_MULMOD_H_
+#pragma once
 
 #include "helpers.h"
 
@@ -248,6 +247,4 @@ __host__ __device__ static void powermod(const uint64_t *base, uint64_t *res, ui
 // end disabling of -Wpedantic
 #if defined(__GNUC__) && !defined(__CUDA_ARCH__)
 #pragma GCC diagnostic pop
-#endif
-
 #endif

--- a/include/AdePT/transport/random/ranluxpp/ranlux_lcg.h
+++ b/include/AdePT/transport/random/ranluxpp/ranlux_lcg.h
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2021 CERN
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
-#ifndef COPCORE_RANLUXPP_RANLUX_LCG_H_
-#define COPCORE_RANLUXPP_RANLUX_LCG_H_
+#pragma once
 
 #include "helpers.h"
 
@@ -81,5 +80,3 @@ __host__ __device__ static void to_ranlux(const uint64_t *lcg, uint64_t *ranlux,
 
   c_out = carry;
 }
-
-#endif

--- a/include/AdePT/transport/state/DeviceGlobals.cuh
+++ b/include/AdePT/transport/state/DeviceGlobals.cuh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_TRANSPORT_STATE_DEVICE_GLOBALS_CUH
-#define ADEPT_TRANSPORT_STATE_DEVICE_GLOBALS_CUH
+#pragma once
 
 #include <AdePT/transport/geometry/GeometryAuxData.hh>
 #include <AdePT/transport/magneticfield/GeneralMagneticField.cuh>
@@ -33,5 +32,3 @@ extern __constant__ __device__ UniformMagneticField *gMagneticField;
 #endif
 
 } // namespace AsyncAdePT
-
-#endif

--- a/include/AdePT/transport/state/EventState.hh
+++ b/include/AdePT/transport/state/EventState.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2024 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_TRANSPORT_STATE_EVENT_STATE_HH
-#define ADEPT_TRANSPORT_STATE_EVENT_STATE_HH
+#pragma once
 
 namespace AsyncAdePT {
 
@@ -31,5 +30,3 @@ enum class EventState : unsigned char {
 };
 
 } // namespace AsyncAdePT
-
-#endif

--- a/include/AdePT/transport/state/GPUState.cuh
+++ b/include/AdePT/transport/state/GPUState.cuh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_TRANSPORT_STATE_GPU_STATE_CUH
-#define ADEPT_TRANSPORT_STATE_GPU_STATE_CUH
+#pragma once
 
 #include <AdePT/transport/containers/MParrayT.h>
 #include <AdePT/transport/containers/SlotManager.cuh>
@@ -129,5 +128,3 @@ struct GPUstate {
 };
 
 } // namespace AsyncAdePT
-
-#endif

--- a/include/AdePT/transport/state/TransportStats.hh
+++ b/include/AdePT/transport/state/TransportStats.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_TRANSPORT_STATE_TRANSPORT_STATS_HH
-#define ADEPT_TRANSPORT_STATE_TRANSPORT_STATS_HH
+#pragma once
 
 #include <AdePT/transport/queues/ParticleQueues.cuh>
 #include <AdePT/transport/state/EventState.hh>
@@ -42,5 +41,3 @@ struct AllowFinishOffEventArray {
 };
 
 } // namespace AsyncAdePT
-
-#endif

--- a/include/AdePT/transport/steps/DeviceStepBuffer.cuh
+++ b/include/AdePT/transport/steps/DeviceStepBuffer.cuh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_DEVICE_STEP_BUFFER_CUH
-#define ADEPT_DEVICE_STEP_BUFFER_CUH
+#pragma once
 
 #include <AdePT/transport/steps/GPUStep.hh>
 #include <AdePT/transport/support/Global.h>
@@ -53,5 +52,3 @@ struct DeviceStepBufferView {
 __device__ DeviceStepBufferView gDeviceStepBuffer;
 
 } // namespace AsyncAdePT
-
-#endif

--- a/include/AdePT/transport/steps/GPUStep.hh
+++ b/include/AdePT/transport/steps/GPUStep.hh
@@ -3,8 +3,7 @@
 
 // This file contains the step data returned from GPU transport to the host.
 
-#ifndef ADEPT_GPU_STEP_HH
-#define ADEPT_GPU_STEP_HH
+#pragma once
 
 #include <AdePT/transport/tracks/ParticleTypes.hh>
 #include "VecGeom/navigation/NavigationState.h"
@@ -146,5 +145,3 @@ __device__ __forceinline__ void FillGPUStep(
   Copy3DVector(aPostMomentumDirection, aGPUStep.fPostStepPoint.fMomentumDirection);
   aGPUStep.fPostStepPoint.fEKin = aPostEKin;
 };
-
-#endif

--- a/include/AdePT/transport/steps/GPUStepRecording.cuh
+++ b/include/AdePT/transport/steps/GPUStepRecording.cuh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_GPU_STEP_RECORDING_CUH
-#define ADEPT_GPU_STEP_RECORDING_CUH
+#pragma once
 
 #include <AdePT/transport/steps/DeviceStepBuffer.cuh>
 #include <AdePT/transport/steps/GPUStep.hh>
@@ -57,5 +56,3 @@ __device__ void RecordGPUStep(uint64_t aTrackID, uint64_t aParentID, short stepL
 }
 
 } // namespace adept_step_recording
-
-#endif

--- a/include/AdePT/transport/steps/GPUStepTransferManager.cuh
+++ b/include/AdePT/transport/steps/GPUStepTransferManager.cuh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_GPU_STEP_TRANSFER_MANAGER_CUH
-#define ADEPT_GPU_STEP_TRANSFER_MANAGER_CUH
+#pragma once
 
 #include <AdePT/transport/support/ResourceManagement.cuh>
 #include <AdePT/transport/steps/DeviceStepBuffer.cuh>
@@ -496,5 +495,3 @@ public:
 };
 
 } // namespace AsyncAdePT
-
-#endif

--- a/include/AdePT/transport/steps/HostCircularBuffer.hh
+++ b/include/AdePT/transport/steps/HostCircularBuffer.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_HOST_CIRCULAR_BUFFER_HH
-#define ADEPT_HOST_CIRCULAR_BUFFER_HH
+#pragma once
 
 #include <cstddef>
 #include <mutex>
@@ -60,5 +59,3 @@ private:
 };
 
 } // namespace AsyncAdePT
-
-#endif

--- a/include/AdePT/transport/support/AdePTPrecision.hh
+++ b/include/AdePT/transport/support/AdePTPrecision.hh
@@ -1,13 +1,10 @@
 // SPDX-FileCopyrightText: 2025 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_PRECISION_HH
-#define ADEPT_PRECISION_HH
+#pragma once
 
 #ifdef ADEPT_MIXED_PRECISION
 using rk_integration_t = float;
 #else
 using rk_integration_t = double;
-#endif
-
 #endif

--- a/include/AdePT/transport/support/ArgParser.h
+++ b/include/AdePT/transport/support/ArgParser.h
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2020 CERN
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <AdePT/transport/support/Global.h>
 #include <algorithm>
 #include <iostream>

--- a/include/AdePT/transport/support/Global.h
+++ b/include/AdePT/transport/support/Global.h
@@ -6,8 +6,7 @@
  * @brief CopCore global macros and types
  */
 
-#ifndef COPCORE_GLOBAL_H_
-#define COPCORE_GLOBAL_H_
+#pragma once
 
 #include <cstdio>
 #include <type_traits>
@@ -127,5 +126,3 @@ const char *BackendName(Backend const &backend)
 #else
 #define COPCORE_CALLABLE_IN_NAMESPACE_DECLARE(HVAR, NAMESPACE, FUNC) auto HVAR = NAMESPACE::FUNC;
 #endif
-
-#endif // COPCORE_GLOBAL_H_

--- a/include/AdePT/transport/support/Macros.h
+++ b/include/AdePT/transport/support/Macros.h
@@ -37,8 +37,7 @@
  * expands to `inline __attribute__((always_inline))` on host compilers.
  */
 
-#ifndef COPCORE_MACROS_H_
-#define COPCORE_MACROS_H_
+#pragma once
 
 // Macros for separating CUDA compiler from others
 #ifdef __CUDACC__
@@ -76,5 +75,3 @@
 #define DISABLE_PEDANTIC_WARNINGS
 #define ENABLE_PEDANTIC_WARNINGS
 #endif
-
-#endif // COPCORE_MACROS_H_

--- a/include/AdePT/transport/support/PhysicalConstants.h
+++ b/include/AdePT/transport/support/PhysicalConstants.h
@@ -27,8 +27,7 @@
  *
  */
 
-#ifndef COPCORE_PHYSICALCONSTANTS_H
-#define COPCORE_PHYSICALCONSTANTS_H
+#pragma once
 
 #include <AdePT/transport/support/SystemOfUnits.h>
 
@@ -115,5 +114,3 @@ static constexpr double kUniverseMeanDensity = 1.e-25 * g / cm3;
 
 } // namespace units
 } // namespace copcore
-
-#endif // COPCORE_PHYSICALCONSTANTS_H

--- a/include/AdePT/transport/support/Portability.hh
+++ b/include/AdePT/transport/support/Portability.hh
@@ -16,8 +16,7 @@
 
 // Portability macros used to switch between cuda/hip
 
-#ifndef PORTABILITY_HH
-#define PORTABILITY_HH
+#pragma once
 
 #ifndef __CUDA_ARCH__
 #include <stdexcept>
@@ -376,5 +375,3 @@ inline ADEPT_ATT_HOST_DEVICE char const *operator<<(StreamlikeIdentity const &, 
 } // namespace detail
 
 } // namespace portability
-
-#endif

--- a/include/AdePT/transport/support/ResourceManagement.cuh
+++ b/include/AdePT/transport/support/ResourceManagement.cuh
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2023 CERN
 // SPDX-License-Identifier: Apache-2.0
-#ifndef RESOURCE_MANAGEMENT_CUH
-#define RESOURCE_MANAGEMENT_CUH
+#pragma once
 
 #include <AdePT/transport/support/Portability.hh>
 
@@ -44,5 +43,3 @@ struct CudaDeleter<ADEPT_DEVICE_API_SYMBOL(Event_t)> {
 #endif
 
 } // namespace AsyncAdePT
-
-#endif // RESOURCE_MANAGEMENT_CUH

--- a/include/AdePT/transport/support/ResourceManagement.hh
+++ b/include/AdePT/transport/support/ResourceManagement.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2023 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef RESOURCE_MANAGEMENT_HH
-#define RESOURCE_MANAGEMENT_HH
+#pragma once
 
 #include <memory>
 
@@ -25,5 +24,3 @@ template <typename T = void, typename Deleter = CudaDeleter<T>>
 using unique_ptr_cuda = std::unique_ptr<T, Deleter>;
 
 } // namespace AsyncAdePT
-
-#endif // RESOURCE_MANAGEMENT_HH

--- a/include/AdePT/transport/support/SystemOfUnits.h
+++ b/include/AdePT/transport/support/SystemOfUnits.h
@@ -33,8 +33,7 @@
  *
  */
 
-#ifndef COPCORE_SYSTEMOFUNITS_H
-#define COPCORE_SYSTEMOFUNITS_H
+#pragma once
 
 namespace copcore {
 namespace units {
@@ -305,5 +304,3 @@ static constexpr double perMillion  = 0.000001;
 
 } // namespace units
 } // namespace copcore
-
-#endif // COPCORE_SYSTEMOFUNITS_H

--- a/include/AdePT/transport/tracks/ParticleTypes.hh
+++ b/include/AdePT/transport/tracks/ParticleTypes.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2025 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_PARTICLE_TYPES_HH
-#define ADEPT_PARTICLE_TYPES_HH
+#pragma once
 
 /// @brief Strongly-typed enum for the three EM particle species tracked by AdePT.
 ///
@@ -23,5 +22,3 @@ enum class ParticleType : char {
   Positron = 1,
   Gamma    = 2,
 };
-
-#endif // ADEPT_PARTICLE_TYPES_HH

--- a/include/AdePT/transport/tracks/Track.cuh
+++ b/include/AdePT/transport/tracks/Track.cuh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_TRACK_CUH
-#define ADEPT_TRACK_CUH
+#pragma once
 
 #include <AdePT/transport/tracks/TrackData.h>
 #include <AdePT/transport/support/SystemOfUnits.h>
@@ -184,5 +183,3 @@ struct ChargedTrack : TrackBase {
     navState.Print();
   }
 };
-
-#endif

--- a/include/AdePT/transport/tracks/TrackData.h
+++ b/include/AdePT/transport/tracks/TrackData.h
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2023 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_TRACKDATA_H
-#define ADEPT_TRACKDATA_H
+#pragma once
 
 #include <AdePT/transport/containers/MParray.h>
 
@@ -43,4 +42,3 @@ struct TrackData {
 } // namespace adeptint
 
 using MParrayTracks = adept::MParrayT<adeptint::TrackData>;
-#endif

--- a/include/AdePT/transport/tracks/TrackDebug.cuh
+++ b/include/AdePT/transport/tracks/TrackDebug.cuh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_TRACK_DEBUG_CUH
-#define ADEPT_TRACK_DEBUG_CUH
+#pragma once
 
 // Track debug information
 struct TrackDebug {
@@ -14,5 +13,3 @@ struct TrackDebug {
 };
 
 __device__ TrackDebug gTrackDebug;
-
-#endif

--- a/include/AdePT/transport/woodcock/WoodcockData.hh
+++ b/include/AdePT/transport/woodcock/WoodcockData.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_TRANSPORT_WOODCOCK_WOODCOCK_DATA_HH
-#define ADEPT_TRANSPORT_WOODCOCK_WOODCOCK_DATA_HH
+#pragma once
 
 #include <VecGeom/navigation/NavigationState.h>
 
@@ -56,5 +55,3 @@ struct WDTDeviceBuffers {
 };
 
 } // namespace adeptint
-
-#endif

--- a/test/common/ConstantCovfieField.hh
+++ b/test/common/ConstantCovfieField.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef ADEPT_TEST_COMMON_CONSTANTCOVFIEFIELD_HH
-#define ADEPT_TEST_COMMON_CONSTANTCOVFIEFIELD_HH
+#pragma once
 
 #include <array>
 #include <ostream>
@@ -68,5 +67,3 @@ inline void WriteConstantCovfieField(std::ostream &output, const std::array<floa
 }
 
 } // namespace adept_test
-
-#endif

--- a/test/regression/IntegrationTest/include/ActionInitialisation.hh
+++ b/test/regression/IntegrationTest/include/ActionInitialisation.hh
@@ -25,8 +25,7 @@
 // * acceptance of all terms of the Geant4 Software license.          *
 // ********************************************************************
 //
-#ifndef ACTIONINITIALISATION_HH
-#define ACTIONINITIALISATION_HH
+#pragma once
 
 #include "G4VUserActionInitialization.hh"
 #include "G4String.hh"
@@ -54,5 +53,3 @@ private:
   bool fDoAccumulatedEvents;
   bool fWriteTruthROOT;
 };
-
-#endif /* ACTIONINITIALISATION_HH */

--- a/test/regression/IntegrationTest/include/DetectorConstruction.hh
+++ b/test/regression/IntegrationTest/include/DetectorConstruction.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 //
-#ifndef DETECTORCONSTRUCTION_H
-#define DETECTORCONSTRUCTION_H
+#pragma once
 
 #include "MagneticFields.hh"
 
@@ -63,5 +62,3 @@ private:
   G4GDMLParser fParser;
   bool fAllSensitive;
 };
-
-#endif /* DETECTORCONSTRUCTION_H */

--- a/test/regression/IntegrationTest/include/DetectorMessenger.hh
+++ b/test/regression/IntegrationTest/include/DetectorMessenger.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef DETECTORMESSENGER_H
-#define DETECTORMESSENGER_H
+#pragma once
 
 #include "G4UImessenger.hh"
 
@@ -46,5 +45,3 @@ private:
   G4UIcmdWith3VectorAndUnit *fFieldCmd  = nullptr;
   G4UIcmdWithAString *fFieldFileNameCmd = nullptr;
 };
-
-#endif

--- a/test/regression/IntegrationTest/include/EventAction.hh
+++ b/test/regression/IntegrationTest/include/EventAction.hh
@@ -25,8 +25,7 @@
 // * acceptance of all terms of the Geant4 Software license.          *
 // ********************************************************************
 //
-#ifndef EVENTACTION_HH
-#define EVENTACTION_HH
+#pragma once
 
 #include "G4UserEventAction.hh"
 #include "G4Types.hh"
@@ -71,5 +70,3 @@ private:
   EventActionMessenger *fMessenger{nullptr};
   RunAction *fRunAction{nullptr};
 };
-
-#endif /* EVENTACTION_HH */

--- a/test/regression/IntegrationTest/include/EventActionMessenger.hh
+++ b/test/regression/IntegrationTest/include/EventActionMessenger.hh
@@ -27,8 +27,7 @@
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-#ifndef EVENTACTIONMESSENGER_HH
-#define EVENTACTIONMESSENGER_HH
+#pragma once
 
 #include "globals.hh"
 #include "G4UImessenger.hh"
@@ -54,5 +53,3 @@ private:
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
-
-#endif // EVENTACTIONMESSENGER_HH

--- a/test/regression/IntegrationTest/include/PrimaryGeneratorAction.hh
+++ b/test/regression/IntegrationTest/include/PrimaryGeneratorAction.hh
@@ -25,8 +25,7 @@
 // * acceptance of all terms of the Geant4 Software license.          *
 // ********************************************************************
 //
-#ifndef PRIMARYGENERATORACTION_HH
-#define PRIMARYGENERATORACTION_HH
+#pragma once
 
 #include "G4VUserPrimaryGeneratorAction.hh"
 #include "G4ParticleGun.hh"
@@ -54,5 +53,3 @@ private:
   /// Particle gun
   ParticleGun *fParticleGun;
 };
-
-#endif /* PRIMARYGENERATORACTION_HH */

--- a/test/regression/IntegrationTest/include/Run.hh
+++ b/test/regression/IntegrationTest/include/Run.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2023 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef RUN_HH
-#define RUN_HH
+#pragma once
 
 #include "G4Run.hh"
 
@@ -47,5 +46,3 @@ private:
   std::unique_ptr<TruthHistogrammer> fTruthHistogrammer;
   RunAction *fRunAction;
 };
-
-#endif

--- a/test/regression/IntegrationTest/include/RunAction.hh
+++ b/test/regression/IntegrationTest/include/RunAction.hh
@@ -25,8 +25,7 @@
 // * acceptance of all terms of the Geant4 Software license.          *
 // ********************************************************************
 //
-#ifndef RUNACTION_HH
-#define RUNACTION_HH
+#pragma once
 
 #include "G4UserRunAction.hh"
 #include "G4String.hh"
@@ -77,5 +76,3 @@ private:
   static bool fgRunTimerStarted;
   Run *fRun;
 };
-
-#endif /* RUNACTION_HH */

--- a/test/regression/IntegrationTest/include/SensitiveDetector.hh
+++ b/test/regression/IntegrationTest/include/SensitiveDetector.hh
@@ -25,8 +25,7 @@
 // * acceptance of all terms of the Geant4 Software license.          *
 // ********************************************************************
 //
-#ifndef SENSITIVEDETECTOR_HH
-#define SENSITIVEDETECTOR_HH
+#pragma once
 
 #include <unordered_map>
 #include <set>
@@ -74,5 +73,3 @@ private:
   /// Number of sensitive detectors
   std::size_t fNumSensitive{0};
 };
-
-#endif /* SENSITIVEDETECTOR_HH */

--- a/test/regression/IntegrationTest/include/SimpleHit.hh
+++ b/test/regression/IntegrationTest/include/SimpleHit.hh
@@ -25,8 +25,7 @@
 // * acceptance of all terms of the Geant4 Software license.          *
 // ********************************************************************
 //
-#ifndef SIMPLEHIT_HH
-#define SIMPLEHIT_HH
+#pragma once
 
 #include "G4VHit.hh"
 #include "G4THitsCollection.hh"
@@ -121,5 +120,3 @@ inline void SimpleHit::operator delete(void *aHit)
 {
   SimpleHitAllocator->FreeSingle((SimpleHit *)aHit);
 }
-
-#endif /* SIMPLEHIT_HH */

--- a/test/regression/IntegrationTest/include/SteppingAction.hh
+++ b/test/regression/IntegrationTest/include/SteppingAction.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2023 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef STEPPINGACTION_HH
-#define STEPPINGACTION_HH
+#pragma once
 
 #include "G4UserSteppingAction.hh"
 
@@ -20,5 +19,3 @@ public:
   ~SteppingAction() override;
   void UserSteppingAction(const G4Step *step) override;
 };
-
-#endif

--- a/test/regression/IntegrationTest/include/TestManager.h
+++ b/test/regression/IntegrationTest/include/TestManager.h
@@ -6,8 +6,7 @@
  * @brief Benchmarking utilities: Timers, accumulators and formatted output.
  */
 
-#ifndef TEST_H
-#define TEST_H
+#pragma once
 
 // The clock to use for measurements
 #define CLOCK std::chrono::system_clock
@@ -222,5 +221,3 @@ public:
 
 #endif
 */
-
-#endif

--- a/test/regression/IntegrationTest/include/TrackLineageInfo.hh
+++ b/test/regression/IntegrationTest/include/TrackLineageInfo.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef TRACKLINEAGEINFO_HH
-#define TRACKLINEAGEINFO_HH
+#pragma once
 
 #include "G4VUserTrackInformation.hh"
 
@@ -45,5 +44,3 @@ private:
   unsigned int fGeneration;
   bool fInitialRecorded{false};
 };
-
-#endif

--- a/test/regression/IntegrationTest/include/TrackingAction.hh
+++ b/test/regression/IntegrationTest/include/TrackingAction.hh
@@ -3,8 +3,7 @@
 
 /// \brief Definition of the TrackingAction class
 
-#ifndef TRACKINGACTION_HH
-#define TRACKINGACTION_HH
+#pragma once
 
 #include "G4UserTrackingAction.hh"
 
@@ -25,5 +24,3 @@ public:
   void PreUserTrackingAction(const G4Track *) override;
   void PostUserTrackingAction(const G4Track *) override;
 };
-
-#endif // TRACKINGACTION_HH

--- a/test/regression/IntegrationTest/include/TruthHistogrammer.hh
+++ b/test/regression/IntegrationTest/include/TruthHistogrammer.hh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef TRUTHHISTOGRAMMER_HH
-#define TRUTHHISTOGRAMMER_HH
+#pragma once
 
 #include <cstdint>
 #include <map>
@@ -73,5 +72,3 @@ private:
   /// Store one exact floating-point observation by value and count its population.
   void IncrementValue(const std::string &histogramName, double value, std::uint64_t count = 1);
 };
-
-#endif

--- a/test/unit/testField/testField.cuh
+++ b/test/unit/testField/testField.cuh
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2021 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef testField_CUH
-#define testField_CUH
+#pragma once
 
 #include "testField.h"
 
@@ -165,5 +164,3 @@ extern float BzFieldValue_host; //   = 1.0 * copcore::units::tesla;
 extern /*__device__*/ float *BzFieldValue_dev;
 
 __global__ void SetBzFieldPtr(float *pBzFieldValue_dev);
-
-#endif

--- a/test/unit/testField/testField.h
+++ b/test/unit/testField/testField.h
@@ -1,8 +1,7 @@
 // SPDX-FileCopyrightText: 2021 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef testField_H
-#define testField_H
+#pragma once
 
 struct G4HepEmState;
 
@@ -30,5 +29,3 @@ struct ScoringPerVolume {
 void testField(int numParticles, double energy, int batch, const int *MCCindex, ScoringPerVolume *scoringPerVolume,
                GlobalScoring *globalScoring, int numVolumes, int numPlaced, G4HepEmState *state,
                bool rotatingParticleGun);
-
-#endif


### PR DESCRIPTION
This PR cleans the include guards and modernizes them:

Instead of using `#ifndef FILENAME_HH` it uses `#pragma once`

It is a pure mechanical cleanup.