### PR TITLE
fix handling of delta rejection

### DIFF
--- a/include/AdePT/transport/kernels/electrons.cuh
+++ b/include/AdePT/transport/kernels/electrons.cuh
@@ -499,7 +499,9 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
 #if ADEPT_DEBUG_TRACK > 0
         if (verbose) printf("| delta interaction\n");
 #endif
-        trackSurvives = true;
+        winnerProcessIndex = kAdePTTransportationProcess;
+        returnedProcessId  = kAdePTTransportationProcess;
+        trackSurvives      = true;
       } else {
         // Perform the discrete interaction, make sure the branched RNG state is
         // ready to be used.

--- a/include/AdePT/transport/kernels/electrons_split.cuh
+++ b/include/AdePT/transport/kernels/electrons_split.cuh
@@ -511,7 +511,7 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
         ++currentTrack.looperCounter;
 
         // mark winner process to be transport, although this is not strictly true
-        winnerProcessIndex = 10;
+        winnerProcessIndex = kAdePTTransportationProcess;
 
         reached_interaction = false;
       } else if (winnerProcessIndex < 0) {
@@ -523,6 +523,7 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
         // Reset number of interaction left for the winner discrete process.
         // (Will be resampled in the next iteration.)
         theTrack->SetNumIALeft(-1.0, winnerProcessIndex);
+        winnerProcessIndex = kAdePTTransportationProcess;
       }
     } else {
       // Stopped positrons annihilate, stopped electrons score and die


### PR DESCRIPTION
When a electron/positron hits a discrete interaction, the interaction can be rejected due to the continues energy loss and the resulting smaller cross section.

Previously, the step limiting process was kept the same. However, this led to a bug for lepton nuclear interactions:

If lepton nuclear rolled, and the interaction was rejected, the step was anyway sent back to the CPU and the nuclear interaction was performed. Luckily, this was spotted due to a crash with the hostTrackData mapper:

A track rolled lepton nuclear. Despite being rejected, the step was transferred and deferred on the CPU. The GPU now continued to track the lepton and then it eventually finished. The finishing of the track deleted the hostTrackData. Now, when finally the deferred lepton-nuclear step was handled, the hostTrackData was already deleted, leading to a crash. 

This is fixed by resetting the step defined process when the interaction was rejected to avoid the trigger of the lepton nuclear interaction on the CPU.


Note on the CI test: As expected, the physics drift tests fail, as the step limiting process is changed for delta interactions, therefore exactly that histogram fails:
```
ROOT histogram comparison found mismatches: 1 failing checks across 42 common histograms.
- Histogram 'step_defining_process_counts' differs at bin 2 ('Transportation'): file1=364492.0 file2=366650.0

    Start 21: physics_drift_regions
2/5 Test #21: physics_drift_regions ............***Failed   17.39 sec
```