### PR TITLE
use drift-smoke test for debug run

### DIFF
--- a/.github/workflows/self-hosted-pr-ci.yml
+++ b/.github/workflows/self-hosted-pr-ci.yml
@@ -96,7 +96,7 @@ jobs:
           full_description="Self-hosted EL9 CI queued"
           validation_description="Waiting for drift result in EL9"
           if [ "${COMMAND}" = "/run-test-full" ]; then
-            full_description="Self-hosted EL9 CI with full validation and Debug drift queued"
+            full_description="Self-hosted EL9 CI with full validation and Debug smoke queued"
             validation_description="Full validation requested in EL9"
           fi
 
@@ -307,7 +307,7 @@ jobs:
 
           if [ "${FULL_CI_STATUS}" -eq 0 ] && [ "${DEBUG_DRIFT_RAN}" -eq 1 ]; then
             full_state="success"
-            full_description="Debug drift and validation passed"
+            full_description="Debug smoke and validation passed"
           elif [ "${FULL_CI_STATUS}" -eq 0 ] && [ "${VALIDATION_RAN}" -eq 0 ]; then
             full_state="success"
             full_description="Drift matched master; validation skipped"
@@ -322,7 +322,7 @@ jobs:
             full_description="Unit tests failed"
           elif [ "${DEBUG_DRIFT_RAN}" -eq 1 ] && [ "${DEBUG_DRIFT_STATUS}" -ne 0 ]; then
             full_state="failure"
-            full_description="Debug drift failed"
+            full_description="Debug smoke failed"
           elif [ "${VALIDATION_RAN}" -eq 1 ] && [ "${VALIDATION_STATUS}" -ne 0 ]; then
             full_state="failure"
             full_description="Validation tests failed"
@@ -372,8 +372,8 @@ jobs:
             echo "- User: \`$(whoami)\`"
             echo "- Workflow step outcome: \`${{ steps.run_ci.outcome }}\`"
             echo "- Drift status: \`${DRIFT_STATUS:-missing}\`"
-            echo "- Debug drift ran: \`${DEBUG_DRIFT_RAN:-missing}\`"
-            echo "- Debug drift status: \`${DEBUG_DRIFT_STATUS:-missing}\`"
+            echo "- Debug smoke ran: \`${DEBUG_DRIFT_RAN:-missing}\`"
+            echo "- Debug smoke status: \`${DEBUG_DRIFT_STATUS:-missing}\`"
             echo "- Unit status: \`${UNIT_STATUS:-missing}\`"
             echo "- Validation ran: \`${VALIDATION_RAN:-missing}\`"
             echo "- Validation forced: \`${VALIDATION_FORCED:-missing}\`"

--- a/test/run_pr_ci.sh
+++ b/test/run_pr_ci.sh
@@ -47,7 +47,7 @@ Runs the AdePT PR CI flow on a self-hosted runner:
   2. run physics drift comparisons
   3. always run unit tests on async
   4. run validation on async + split when drift differs from master, or when requested
-  5. optionally build and run the physics drift matrix in Debug mode
+  5. optionally build and run the physics drift smoke matrix in Debug mode
 
 Options:
   --build-root <path>        Build/cache root (default: ${DEFAULT_BUILD_ROOT})
@@ -61,7 +61,7 @@ Options:
   --force-rebuild            Force clean rebuilds in the matrix runner
   --refresh-master           Refresh cached master worktree/builds
   --always-run-validation    Run validation even when drift matches master
-  --run-debug-drift          Also build and run the drift matrix with CMAKE_BUILD_TYPE=Debug
+  --run-debug-drift          Also build and run the drift smoke matrix with CMAKE_BUILD_TYPE=Debug
   -h, --help                 Show this help
 EOF
 }
@@ -258,29 +258,22 @@ if [[ "${RUN_DEBUG_DRIFT}" -eq 1 ]]; then
   DEBUG_DRIFT_RAN=1
   DEBUG_DRIFT_BUILD_ROOT="${BUILD_ROOT}/debug-drift"
   debug_matrix_common_args=(
-    --suite drift
+    --suite drift-smoke
     --build-root "${DEBUG_DRIFT_BUILD_ROOT}"
     --build-type Debug
-    --master-ref "${MASTER_REF}"
     --cuda-arch "${CUDA_ARCH}"
     --jobs "${JOBS}"
     --ctest-timeout-sec "${CTEST_TIMEOUT_SEC}"
   )
 
-  if [[ "${FETCH_MASTER}" -eq 0 ]]; then
-    debug_matrix_common_args+=(--no-fetch-master)
-  fi
   if [[ "${FORCE_REBUILD}" -eq 1 ]]; then
     debug_matrix_common_args+=(--force-rebuild)
   fi
-  if [[ "${REFRESH_MASTER}" -eq 1 ]]; then
-    debug_matrix_common_args+=(--refresh-master)
-  fi
 
-  log "Running Debug drift matrix for async/split/mixed"
+  log "Running Debug drift smoke matrix for async/split/mixed"
   log "Debug drift build root: ${DEBUG_DRIFT_BUILD_ROOT}"
   for cfg in async split mixed; do
-    log "Debug drift phase for config: ${cfg}"
+    log "Debug drift smoke phase for config: ${cfg}"
     if ! "${MATRIX_RUNNER}" "${debug_matrix_common_args[@]}" --configs "${cfg}"; then
       DEBUG_DRIFT_STATUS=1
     fi


### PR DESCRIPTION
This PR fixes a small bug from #620:
The debug drift test should run a smoke test only. It should not build master + PR branch in debug mode and compare, but simply build once the PR in debug mode and make it run.

As the categories were mixed up, this caused the CI failure in  #624: while the normal drift test failed, as a histogram was changed, this was flagged as the debug drift test failing, causing the full CI to fail.
