### PR TITLE
Remove Async from AdePTTransport naming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,8 +491,8 @@ endif()
 #----------------------------------------------------------------------------#
 set(ADEPT_CORE_SRCS
   src/transport/g4hepem/AdePTG4HepEmState.cpp
-  src/transport/AsyncAdePTTransport.cc
-  src/transport/AsyncAdePTTransport.cu
+  src/transport/AdePTTransport.cc
+  src/transport/AdePTTransport.cu
   src/transport/steps/HostCircularBuffer.cpp
 )
 
@@ -521,7 +521,7 @@ cuda_rdc_add_library(Transport ${_adept_library_type}
 )
 
 if(ADEPT_USE_HIP)
-  set_source_files_properties(src/transport/AsyncAdePTTransport.cu PROPERTIES LANGUAGE HIP)
+  set_source_files_properties(src/transport/AdePTTransport.cu PROPERTIES LANGUAGE HIP)
   set_source_files_properties(src/g4integration/cuda/G4IntegrationRdcFacade.cu PROPERTIES LANGUAGE HIP)
 endif()
 

--- a/include/AdePT/g4integration/AdePTTrackingManager.hh
+++ b/include/AdePT/g4integration/AdePTTrackingManager.hh
@@ -7,7 +7,7 @@
 #include "G4RegionStore.hh"
 
 #include "globals.hh"
-#include <AdePT/transport/AsyncAdePTTransport.hh>
+#include <AdePT/transport/AdePTTransport.hh>
 #include "AdePT/transport/support/SystemOfUnits.h"
 #include <AdePT/g4integration/returned_steps/AdePTGeant4Integration.hh>
 #include <AdePT/g4integration/AdePTConfiguration.hh>
@@ -20,7 +20,7 @@
 
 class AdePTTrackingManager : public G4VTrackingManager {
 public:
-  using AdePTTransport = AsyncAdePT::AsyncAdePTTransport;
+  using AdePTTransport = adept::transport::AdePTTransport;
 
   explicit AdePTTrackingManager(AdePTConfiguration *config, int verbosity = 0);
   ~AdePTTrackingManager();
@@ -70,7 +70,7 @@ private:
   /// - packed WDT metadata
   ///
   /// Once that host-side preparation is complete, the worker creates the
-  /// shared `AsyncAdePTTransport`. The transport constructor then performs the
+  /// shared `AdePTTransport`. The transport constructor then performs the
   /// corresponding one-time device initialization and upload.
   void InitializeSharedAdePTTransport();
 

--- a/include/AdePT/transport/AdePTTransport.cuh
+++ b/include/AdePT/transport/AdePTTransport.cuh
@@ -36,7 +36,7 @@
 #include <AdePT/transport/navigation/BVHNavigator.h>
 
 #include <AdePT/transport/kernels/AdePTSteppingActionSelector.cuh>
-using SteppingAction = adept::SteppingAction::Action;
+using SelectedSteppingAction = adept::SteppingAction::Action;
 
 #include <VecGeom/base/Config.h>
 #ifdef VECGEOM_ENABLE_CUDA
@@ -67,7 +67,7 @@ using SteppingAction = adept::SteppingAction::Action;
 #include <cstdlib>
 #include <cstdint>
 
-using namespace AsyncAdePT;
+using namespace adept::transport;
 
 /// Communication with the step processing thread.
 struct StepProcessingContext {
@@ -289,7 +289,7 @@ __global__ void FinishIteration(AllParticleQueues all, Stats *stats, TracksAndSl
   } else if (blockIdx.x == 2) {
     if (threadIdx.x == 0) {
       // Note: stepBufferOccupancy gives the maximum occupancy of all threads combined
-      stats->stepBufferOccupancy = AsyncAdePT::gDeviceStepBuffer.GetMaxSlotCount();
+      stats->stepBufferOccupancy = adept::transport::gDeviceStepBuffer.GetMaxSlotCount();
     }
   }
 
@@ -386,7 +386,7 @@ __global__ void InitSlotManagers(SlotManager *mgr, std::size_t N)
 }
 
 // Free functions implementing the CUDA parts
-namespace async_adept_impl {
+namespace adept::transport::detail {
 
 /**
  * @brief Sets stack and heap size limits for the device. If 0, the default limit is kept
@@ -543,7 +543,7 @@ void FreeWDTOnDevice(adeptint::WDTDeviceBuffers &dev)
 
   // clear the constant view
   adeptint::WDTDeviceView zero{};
-  ADEPT_DEVICE_API_CALL(MemcpyToSymbol(AsyncAdePT::gWDTData, &zero, sizeof(zero)));
+  ADEPT_DEVICE_API_CALL(MemcpyToSymbol(adept::transport::gWDTData, &zero, sizeof(zero)));
 }
 
 /// Allocate memory on device, as well as streams and cuda events to synchronise kernels.
@@ -588,11 +588,11 @@ std::unique_ptr<GPUstate, GPUstateDeleter> InitializeGPU(int trackCapacity, int 
   if (!generalBfieldFile.empty()) {
     // Initialize magnetic field data from file
     if (!gpuState.magneticField.InitializeFromFile(generalBfieldFile)) {
-      throw std::runtime_error("AsyncAdePTTransport::InitializeGPU cannot initialize GeneralMagneticField on GPU");
+      throw std::runtime_error("AdePTTransport::InitializeGPU cannot initialize GeneralMagneticField on GPU");
     }
     // Copy the GeneralMagneticField instance to GPU and setup the global view pointer
-    if (!async_adept_impl::InitializeBField(gpuState.magneticField)) {
-      throw std::runtime_error("AsyncAdePTTransport::InitializeBField cannot initialize GeneralMagneticField on GPU");
+    if (!adept::transport::detail::InitializeBField(gpuState.magneticField)) {
+      throw std::runtime_error("AdePTTransport::InitializeBField cannot initialize GeneralMagneticField on GPU");
     }
   }
 #else
@@ -607,7 +607,7 @@ std::unique_ptr<GPUstate, GPUstateDeleter> InitializeGPU(int trackCapacity, int 
   auto field_value = Bfield->Evaluate(position);
   if (field_value.Mag2() > 0) {
     if (!InitializeBField(*Bfield))
-      throw std::runtime_error("AsyncAdePTTransport::InitializeBField cannot initialize UniformMagneticField on GPU");
+      throw std::runtime_error("AdePTTransport::InitializeBField cannot initialize UniformMagneticField on GPU");
   }
 #endif
 
@@ -960,7 +960,7 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
 
         const auto [threads, blocks] = computeThreadsAndBlocks(particlesInFlight[GPUQueueIndex::Electron]);
 #ifdef ADEPT_USE_SPLIT_KERNELS
-        ElectronHowFar<true, SteppingAction><<<blocks, threads, 0, electrons.stream>>>(
+        ElectronHowFar<true, SelectedSteppingAction><<<blocks, threads, 0, electrons.stream>>>(
             particleManager, gpuState.hepEmBuffers_d.electronsHepEm, electrons.queues.propagation, gpuState.stats_dev,
             steppingActionParams, allowFinishOffEvent, returnAllSteps, returnLastStep);
         ElectronPropagation<true><<<blocks, threads, 0, electrons.stream>>>(
@@ -980,7 +980,7 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
             gpuState.hepEmBuffers_d.electronsHepEm, particleManager, electrons.queues.interactionQueues[1],
             returnAllSteps, returnLastStep);
 #else
-        TransportElectrons<SteppingAction>
+        TransportElectrons<SelectedSteppingAction>
             <<<blocks, threads, 0, electrons.stream>>>(particleManager, gpuState.stats_dev, steppingActionParams,
                                                        allowFinishOffEvent, returnAllSteps, returnLastStep);
 #endif
@@ -997,7 +997,7 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
 
         const auto [threads, blocks] = computeThreadsAndBlocks(particlesInFlight[GPUQueueIndex::Positron]);
 #ifdef ADEPT_USE_SPLIT_KERNELS
-        ElectronHowFar<false, SteppingAction><<<blocks, threads, 0, positrons.stream>>>(
+        ElectronHowFar<false, SelectedSteppingAction><<<blocks, threads, 0, positrons.stream>>>(
             particleManager, gpuState.hepEmBuffers_d.positronsHepEm, positrons.queues.propagation, gpuState.stats_dev,
             steppingActionParams, allowFinishOffEvent, returnAllSteps, returnLastStep);
         ElectronPropagation<false><<<blocks, threads, 0, positrons.stream>>>(
@@ -1023,7 +1023,7 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
             gpuState.hepEmBuffers_d.positronsHepEm, particleManager, positrons.queues.interactionQueues[3],
             returnAllSteps, returnLastStep);
 #else
-        TransportPositrons<SteppingAction>
+        TransportPositrons<SelectedSteppingAction>
             <<<blocks, threads, 0, positrons.stream>>>(particleManager, gpuState.stats_dev, steppingActionParams,
                                                        allowFinishOffEvent, returnAllSteps, returnLastStep);
 #endif
@@ -1040,7 +1040,7 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
 
         const auto [threads, blocks] = computeThreadsAndBlocks(particlesInFlight[GPUQueueIndex::Gamma]);
 #ifdef ADEPT_USE_SPLIT_KERNELS
-        GammaHowFar<SteppingAction><<<blocks, threads, 0, gammas.stream>>>(
+        GammaHowFar<SelectedSteppingAction><<<blocks, threads, 0, gammas.stream>>>(
             gpuState.hepEmBuffers_d.gammasHepEm, particleManager, gammas.queues.propagation, gpuState.stats_dev,
             steppingActionParams, allowFinishOffEvent, returnAllSteps, returnLastStep);
         GammaPropagation<<<blocks, threads, 0, gammas.stream>>>(gammas.tracks, gpuState.hepEmBuffers_d.gammasHepEm,
@@ -1049,7 +1049,7 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
           // The GammaWoodcock kernel has to run after the HowFar and Propagation, GammaPropagation uses the propagation
           // queue and GammaWockcock can add slots the the propagationqueue, as it will be consumed in the
           // SetupInteractions kernel
-          GammaWoodcock<SteppingAction><<<blocks, threads, 0, gammas.stream>>>(
+          GammaWoodcock<SelectedSteppingAction><<<blocks, threads, 0, gammas.stream>>>(
               gpuState.hepEmBuffers_d.gammasHepEm, particleManager, gammas.queues.propagation, gpuState.stats_dev,
               steppingActionParams, allowFinishOffEvent, returnAllSteps, returnLastStep);
         }
@@ -1073,12 +1073,12 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
                                                                   gammas.queues.interactionQueues[2], returnAllSteps,
                                                                   returnLastStep);
 #else
-        TransportGammas<SteppingAction>
+        TransportGammas<SelectedSteppingAction>
             <<<blocks, threads, 0, gammas.stream>>>(particleManager, gpuState.stats_dev, steppingActionParams,
                                                     allowFinishOffEvent, returnAllSteps, returnLastStep);
 
         if (hasWDTRegions) {
-          TransportGammasWoodcock<SteppingAction>
+          TransportGammasWoodcock<SelectedSteppingAction>
               <<<blocks, threads, 0, gammas.stream>>>(particleManager, gpuState.stats_dev, steppingActionParams,
                                                       allowFinishOffEvent, returnAllSteps, returnLastStep);
         }
@@ -1389,14 +1389,14 @@ std::thread LaunchGPUWorker(int trackCapacity, int stepCapacity, int numThreads,
                      hasWDTRegions};
 }
 
-void FreeGPU(std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> &gpuState, std::thread &gpuWorker,
-             adeptint::WDTDeviceBuffers &wdtDev)
+void FreeGPU(std::unique_ptr<adept::transport::GPUstate, adept::transport::GPUstateDeleter> &gpuState,
+             std::thread &gpuWorker, adeptint::WDTDeviceBuffers &wdtDev)
 {
   gpuState->runTransport = false;
   gpuWorker.join();
 
   adeptint::VolAuxData *volAux = nullptr;
-  ADEPT_DEVICE_API_CALL(MemcpyFromSymbol(&volAux, AsyncAdePT::gVolAuxData, sizeof(adeptint::VolAuxData *)));
+  ADEPT_DEVICE_API_CALL(MemcpyFromSymbol(&volAux, adept::transport::gVolAuxData, sizeof(adeptint::VolAuxData *)));
   ADEPT_DEVICE_API_CALL(Free(volAux));
 
   // Free WDT device buffers and clear its constant view
@@ -1422,9 +1422,9 @@ void FreeGPU(std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> 
 template bool InitializeBField<GeneralMagneticField>(GeneralMagneticField &);
 template bool InitializeBField<UniformMagneticField>(UniformMagneticField &);
 
-} // namespace async_adept_impl
+} // namespace adept::transport::detail
 
-namespace AsyncAdePT {
+namespace adept::transport {
 __constant__ __device__ struct G4HepEmParameters g4HepEmPars;
 __constant__ __device__ struct G4HepEmData g4HepEmData;
 
@@ -1467,4 +1467,4 @@ TrackBuffer::TrackBuffer(unsigned int numToDevice) : fNumToDevice{numToDevice}
   toDeviceBuffer[1].nTrack    = 0;
 }
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/AdePTTransport.hh
+++ b/include/AdePT/transport/AdePTTransport.hh
@@ -25,12 +25,12 @@
 #include <thread>
 #include <unordered_map>
 #include <optional>
-namespace AsyncAdePT {
+namespace adept::transport {
 struct TrackBuffer;
 
 void InitVolAuxArray(adeptint::VolAuxArray &array);
 
-class AsyncAdePTTransport {
+class AdePTTransport {
 public:
   uint64_t fAdePTSeed = 1234567;
 
@@ -71,11 +71,11 @@ private:
   bool InitializePhysics();
 
 public:
-  AsyncAdePTTransport(const AdePTTransportConfig &configuration, std::unique_ptr<AdePTG4HepEmState> adeptG4HepEmState,
-                      adeptint::VolAuxData *auxData, const adeptint::WDTHostPacked &wdtPacked,
-                      const std::vector<float> &uniformFieldValues);
-  AsyncAdePTTransport(const AsyncAdePTTransport &other) = delete;
-  ~AsyncAdePTTransport();
+  AdePTTransport(const AdePTTransportConfig &configuration, std::unique_ptr<AdePTG4HepEmState> adeptG4HepEmState,
+                 adeptint::VolAuxData *auxData, const adeptint::WDTHostPacked &wdtPacked,
+                 const std::vector<float> &uniformFieldValues);
+  AdePTTransport(const AdePTTransport &other) = delete;
+  ~AdePTTransport();
 
   /// @brief Adds a track to the buffer
   void AddTrack(int pdg, uint64_t trackId, uint64_t parentId, double energy, double x, double y, double z, double dirx,
@@ -102,6 +102,6 @@ public:
   void MarkHostFlushed(int threadId);
 };
 
-} // namespace AsyncAdePT
+} // namespace adept::transport
 
-#include "AsyncAdePTTransport.icc"
+#include "AdePTTransport.icc"

--- a/include/AdePT/transport/AdePTTransport.icc
+++ b/include/AdePT/transport/AdePTTransport.icc
@@ -1,25 +1,26 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#include <AdePT/transport/AsyncAdePTTransport.hh>
+#include <AdePT/transport/AdePTTransport.hh>
 
 /// Forward declarations for the transport-owned step-batch accessors that remain
 /// header-visible because `HandleGPUStepBatchesWith(...)` is templated.
-namespace async_adept_impl {
-std::pair<GPUStep *, GPUStep *> GetGPUStepBatchFromBuffer(unsigned int, unsigned int, AsyncAdePT::GPUstate &, bool &);
-void CloseGPUStepBatch(unsigned int, AsyncAdePT::GPUstate &, GPUStep *, const bool);
-} // namespace async_adept_impl
+namespace adept::transport::detail {
+std::pair<GPUStep *, GPUStep *> GetGPUStepBatchFromBuffer(unsigned int, unsigned int, adept::transport::GPUstate &,
+                                                          bool &);
+void CloseGPUStepBatch(unsigned int, adept::transport::GPUstate &, GPUStep *, const bool);
+} // namespace adept::transport::detail
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 template <typename Callback>
-inline void AsyncAdePTTransport::HandleGPUStepBatchesWith(int threadId, int eventId, Callback &&callback)
+inline void AdePTTransport::HandleGPUStepBatchesWith(int threadId, int eventId, Callback &&callback)
 {
   std::pair<GPUStep *, GPUStep *> range;
   bool dataOnBuffer;
 
-  while ((range = async_adept_impl::GetGPUStepBatchFromBuffer(threadId, eventId, *fGPUstate, dataOnBuffer)).first !=
-         nullptr) {
+  while ((range = adept::transport::detail::GetGPUStepBatchFromBuffer(threadId, eventId, *fGPUstate, dataOnBuffer))
+             .first != nullptr) {
     // Transport still owns the step-batch lifetime here. The callback only gets
     // a temporary `std::span` view while the batch is valid.
     struct CloseGPUStepBatch {
@@ -27,7 +28,7 @@ inline void AsyncAdePTTransport::HandleGPUStepBatchesWith(int threadId, int even
       GPUstate &gpuState;
       GPUStep *begin;
       bool dataOnBuffer;
-      ~CloseGPUStepBatch() { async_adept_impl::CloseGPUStepBatch(threadId, gpuState, begin, dataOnBuffer); }
+      ~CloseGPUStepBatch() { adept::transport::detail::CloseGPUStepBatch(threadId, gpuState, begin, dataOnBuffer); }
     } closeBatch{threadId, *fGPUstate, range.first, dataOnBuffer};
 
     // The callback runs the Geant4-side step reconstruction for this batch.
@@ -37,4 +38,4 @@ inline void AsyncAdePTTransport::HandleGPUStepBatchesWith(int threadId, int even
   }
 }
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/g4hepem/AdePTG4HepEmState.hh
+++ b/include/AdePT/transport/g4hepem/AdePTG4HepEmState.hh
@@ -9,7 +9,7 @@ struct G4HepEmConfig;
 struct G4HepEmData;
 struct G4HepEmParameters;
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 /// @brief Owns the prepared host-side G4HepEm inputs used by transport.
 /// @details
@@ -74,4 +74,4 @@ private:
   std::unique_ptr<G4HepEmParameters, ParametersDeleter> fParameters;
 };
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/kernels/WoodcockHelper.cuh
+++ b/include/AdePT/transport/kernels/WoodcockHelper.cuh
@@ -6,7 +6,7 @@
 #include <AdePT/transport/state/DeviceGlobals.cuh>
 #include <AdePT/transport/woodcock/WoodcockData.hh>
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 // Helper function to decide whether a gamma should be processed via Woodcock tracking based on navigation state and
 // kinetic energy
@@ -34,4 +34,4 @@ __device__ __forceinline__ bool ShouldUseWDT(const vecgeom::NavigationState &sta
   return true;
 }
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/kernels/electrons.cuh
+++ b/include/AdePT/transport/kernels/electrons.cuh
@@ -48,7 +48,7 @@ __device__ double GetVelocity(double eKin)
   return copcore::units::kCLight * beta;
 }
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 // Compute the physics and geometry step limit, transport the electrons while
 // applying the continuous effects and maybe a discrete process that could
@@ -865,4 +865,4 @@ __global__ void TransportPositrons(ParticleManager particleManager, Stats *InFli
                                                             returnAllSteps, returnLastStep);
 }
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/kernels/electrons_split.cuh
+++ b/include/AdePT/transport/kernels/electrons_split.cuh
@@ -47,7 +47,7 @@ __device__ double GetVelocity(double eKin)
   return copcore::units::kCLight * beta;
 }
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 template <bool IsElectron, class SteppingActionT>
 __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronTrack *hepEMTracks,
@@ -82,7 +82,7 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
     // the MCC vector is indexed by the logical volume id
     const int lvolID = currentTrack.navState.GetLogicalId();
 
-    VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID];
+    VolAuxData const &auxData = adept::transport::gVolAuxData[lvolID];
 
     currentTrack.preStepEKin       = currentTrack.eKin;
     currentTrack.preStepGlobalTime = currentTrack.globalTime;
@@ -479,7 +479,7 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
     // the MCC vector is indexed by the logical volume id
     const int lvolID = currentTrack.navState.GetLogicalId();
 
-    VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID];
+    VolAuxData const &auxData = adept::transport::gVolAuxData[lvolID];
 
     bool trackSurvives = true;
 
@@ -625,7 +625,7 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
     // the MCC vector is indexed by the logical volume id
     const int lvolID = currentTrack.navState.GetLogicalId();
 
-    VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID];
+    VolAuxData const &auxData = adept::transport::gVolAuxData[lvolID];
 
     auto survive = [&]() { electronsOrPositrons.EnqueueNext(slot); };
 
@@ -669,7 +669,7 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
     bool isLastStep     = !trackSurvives;
     if (cross_boundary) {
       const int nextlvolID          = currentTrack.nextState.GetLogicalId();
-      VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];
+      VolAuxData const &nextauxData = adept::transport::gVolAuxData[nextlvolID];
       returnsToCPU                  = nextauxData.fGPUregionId < 0;
       if (returnsToCPU) {
         // Push the handoff point a little into the CPU region so Geant4 does
@@ -710,7 +710,7 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
     if (cross_boundary) {
       // Check if the next volume belongs to the GPU region and push it to the appropriate queue
       const int nextlvolID          = currentTrack.nextState.GetLogicalId();
-      VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];
+      VolAuxData const &nextauxData = adept::transport::gVolAuxData[nextlvolID];
       if (!returnsToCPU) {
         // Move to the next boundary now that the step is recorded.
         currentTrack.navState = currentTrack.nextState;
@@ -786,7 +786,7 @@ __global__ void ElectronIonization(G4HepEmElectronTrack *hepEMTracks, ParticleMa
     // the MCC vector is indexed by the logical volume id
     const int lvolID = currentTrack.navState.GetLogicalId();
 
-    VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID];
+    VolAuxData const &auxData = adept::transport::gVolAuxData[lvolID];
     bool trackSurvives        = false;
 
     auto survive = [&]() {
@@ -913,7 +913,7 @@ __global__ void ElectronBremsstrahlung(G4HepEmElectronTrack *hepEMTracks, Partic
     // the MCC vector is indexed by the logical volume id
     const int lvolID = currentTrack.navState.GetLogicalId();
 
-    VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID];
+    VolAuxData const &auxData = adept::transport::gVolAuxData[lvolID];
     bool trackSurvives        = false;
 
     auto survive = [&]() {
@@ -1052,7 +1052,7 @@ __global__ void PositronAnnihilation(G4HepEmElectronTrack *hepEMTracks, Particle
     // the MCC vector is indexed by the logical volume id
     const int lvolID = currentTrack.navState.GetLogicalId();
 
-    VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID];
+    VolAuxData const &auxData = adept::transport::gVolAuxData[lvolID];
 
     // Retrieve HepEM track
     G4HepEmElectronTrack &elTrack = hepEMTracks[slot];
@@ -1191,7 +1191,7 @@ __global__ void PositronStoppedAnnihilation(G4HepEmElectronTrack *hepEMTracks, P
     // the MCC vector is indexed by the logical volume id
     const int lvolID = currentTrack.navState.GetLogicalId();
 
-    VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID];
+    VolAuxData const &auxData = adept::transport::gVolAuxData[lvolID];
 
     // Retrieve HepEM track
     G4HepEmElectronTrack &elTrack = hepEMTracks[slot];
@@ -1251,4 +1251,4 @@ __global__ void PositronStoppedAnnihilation(G4HepEmElectronTrack *hepEMTracks, P
   }
 }
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/kernels/gammas.cuh
+++ b/include/AdePT/transport/kernels/gammas.cuh
@@ -23,7 +23,7 @@
 using VolAuxData      = adeptint::VolAuxData;
 using StepActionParam = adept::SteppingAction::Params;
 
-namespace AsyncAdePT {
+namespace adept::transport {
 // Asynchronous TransportGammas Interface
 template <class SteppingActionT>
 __global__ void __launch_bounds__(256, 1)
@@ -492,4 +492,4 @@ __global__ void __launch_bounds__(256, 1)
   } // end for loop over tracks
 }
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/kernels/gammasWDT.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT.cuh
@@ -27,7 +27,7 @@
 using VolAuxData      = adeptint::VolAuxData;
 using StepActionParam = adept::SteppingAction::Params;
 
-namespace AsyncAdePT {
+namespace adept::transport {
 // Asynchronous TransportGammasWoodcock Interface
 template <class SteppingActionT>
 __global__ void __launch_bounds__(256, 1)
@@ -688,4 +688,4 @@ __global__ void __launch_bounds__(256, 1)
   } // end for loop over tracks
 }
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/kernels/gammasWDT_split.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT_split.cuh
@@ -27,7 +27,7 @@
 using StepActionParam = adept::SteppingAction::Params;
 using VolAuxData      = adeptint::VolAuxData;
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 // Asynchronous TransportGammasWoodcock Interface
 template <class SteppingActionT>
@@ -553,4 +553,4 @@ __global__ void __launch_bounds__(256, 1)
   } // end for loop over tracks
 }
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/kernels/gammas_split.cuh
+++ b/include/AdePT/transport/kernels/gammas_split.cuh
@@ -23,7 +23,7 @@
 using StepActionParam = adept::SteppingAction::Params;
 using VolAuxData      = adeptint::VolAuxData;
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 template <class SteppingActionT>
 __global__ void GammaHowFar(G4HepEmGammaTrack *hepEMTracks, ParticleManager particleManager,
@@ -41,7 +41,7 @@ __global__ void GammaHowFar(G4HepEmGammaTrack *hepEMTracks, ParticleManager part
     NeutralTrack &currentTrack = particleManager.gammas.TrackAt(slot);
 
     int lvolID                = currentTrack.navState.GetLogicalId();
-    VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID];
+    VolAuxData const &auxData = adept::transport::gVolAuxData[lvolID];
 
     currentTrack.preStepEKin       = currentTrack.eKin;
     currentTrack.preStepGlobalTime = currentTrack.globalTime;
@@ -340,7 +340,7 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
 #endif
 
       const int nextlvolID          = currentTrack.nextState.GetLogicalId();
-      VolAuxData const &nextauxData = AsyncAdePT::gVolAuxData[nextlvolID];
+      VolAuxData const &nextauxData = adept::transport::gVolAuxData[nextlvolID];
       returnsToCPU                  = nextauxData.fGPUregionId < 0;
 
       short stepProcessId = kAdePTTransportationProcess;
@@ -444,7 +444,7 @@ __global__ void GammaConversion(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
     NeutralTrack &currentTrack = particleManager.gammas.TrackAt(slot);
 
     int lvolID                = currentTrack.navState.GetLogicalId();
-    VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID];
+    VolAuxData const &auxData = adept::transport::gVolAuxData[lvolID];
 
     // Write local variables back into track and enqueue
     auto survive = [&]() {
@@ -574,7 +574,7 @@ __global__ void GammaCompton(G4HepEmGammaTrack *hepEMTracks, ParticleManager par
     NeutralTrack &currentTrack = particleManager.gammas.TrackAt(slot);
 
     int lvolID                = currentTrack.navState.GetLogicalId();
-    VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID];
+    VolAuxData const &auxData = adept::transport::gVolAuxData[lvolID];
     bool trackSurvives        = false;
 
     // Write local variables back into track and enqueue
@@ -703,7 +703,7 @@ __global__ void GammaPhotoelectric(G4HepEmGammaTrack *hepEMTracks, ParticleManag
     NeutralTrack &currentTrack = particleManager.gammas.TrackAt(slot);
 
     int lvolID                = currentTrack.navState.GetLogicalId();
-    VolAuxData const &auxData = AsyncAdePT::gVolAuxData[lvolID];
+    VolAuxData const &auxData = adept::transport::gVolAuxData[lvolID];
 
     G4HepEmGammaTrack &gammaTrack = hepEMTracks[slot];
     G4HepEmTrack *theTrack        = gammaTrack.GetTrack();
@@ -795,4 +795,4 @@ __global__ void GammaPhotoelectric(G4HepEmGammaTrack *hepEMTracks, ParticleManag
   }
 }
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/queues/ParticleManager.cuh
+++ b/include/AdePT/transport/queues/ParticleManager.cuh
@@ -9,7 +9,7 @@
 
 #include <utility>
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 // A bundle of pointers to generate particles of an implicit type.
 template <typename TrackT>
@@ -71,4 +71,4 @@ struct ParticleManager {
   SpeciesParticleManager<NeutralTrack> gammasWDT;
 };
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/queues/ParticleQueues.cuh
+++ b/include/AdePT/transport/queues/ParticleQueues.cuh
@@ -8,7 +8,7 @@
 
 #include <utility>
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 // A bundle of queues per particle type:
 //  * Two for active particles, one for the current iteration and the second for the next.
@@ -98,4 +98,4 @@ struct QueueIndexPair {
   short queue;
 };
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/queues/TrackBuffer.hh
+++ b/include/AdePT/transport/queues/TrackBuffer.hh
@@ -14,7 +14,7 @@
 #include <shared_mutex>
 #include <thread>
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 /// @brief Buffer holding input tracks to be transported on GPU.
 struct TrackBuffer {
@@ -77,4 +77,4 @@ struct TrackBuffer {
   }
 };
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/state/DeviceGlobals.cuh
+++ b/include/AdePT/transport/state/DeviceGlobals.cuh
@@ -12,7 +12,7 @@
 #include <G4HepEmData.hh>
 #include <G4HepEmParameters.hh>
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 // Constant data structures from G4HepEm accessed by the kernels.
 extern __constant__ __device__ struct G4HepEmParameters g4HepEmPars;
@@ -31,4 +31,4 @@ extern __constant__ __device__ GeneralMagneticField *gMagneticField;
 extern __constant__ __device__ UniformMagneticField *gMagneticField;
 #endif
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/state/EventState.hh
+++ b/include/AdePT/transport/state/EventState.hh
@@ -3,7 +3,7 @@
 
 #pragma once
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 struct GPUstate;
 
@@ -29,4 +29,4 @@ enum class EventState : unsigned char {
   DeviceFlushed
 };
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/state/GPUState.cuh
+++ b/include/AdePT/transport/state/GPUState.cuh
@@ -24,7 +24,7 @@
 #include <memory>
 #include <vector>
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 /// @brief Holds all GPU resources needed to manage in-flight tracks of one particle species:
 ///        track buffer, slot manager, interaction queues, CUDA stream and event.
@@ -127,4 +127,4 @@ struct GPUstate {
   }
 };
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/state/TransportStats.hh
+++ b/include/AdePT/transport/state/TransportStats.hh
@@ -6,7 +6,7 @@
 #include <AdePT/transport/queues/ParticleQueues.cuh>
 #include <AdePT/transport/state/EventState.hh>
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 // A data structure to transfer statistics after each iteration.
 struct Stats {
@@ -40,4 +40,4 @@ struct AllowFinishOffEventArray {
   __host__ __device__ unsigned short operator[](int idx) const { return flags[idx]; }
 };
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/steps/DeviceStepBuffer.cuh
+++ b/include/AdePT/transport/steps/DeviceStepBuffer.cuh
@@ -15,7 +15,7 @@ struct CompareGPUSteps {
   __device__ bool operator()(const GPUStep &lhs, const GPUStep &rhs) const { return lhs.threadId < rhs.threadId; }
 };
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 /// Struct holding GPU steps to be used both on host and device.
 struct DeviceStepBufferView {
@@ -51,4 +51,4 @@ struct DeviceStepBufferView {
 
 __device__ DeviceStepBufferView gDeviceStepBuffer;
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/steps/GPUStepRecording.cuh
+++ b/include/AdePT/transport/steps/GPUStepRecording.cuh
@@ -30,11 +30,11 @@ __device__ void RecordGPUStep(uint64_t aTrackID, uint64_t aParentID, short stepL
   }
 
   // allocate step slots: one for the parent and then one for each secondary
-  auto slotStartIndex = AsyncAdePT::gDeviceStepBuffer.ReserveStepSlots(threadID, 1u + nSecondaries);
+  auto slotStartIndex = adept::transport::gDeviceStepBuffer.ReserveStepSlots(threadID, 1u + nSecondaries);
 
   // The ProcessGPUSteps on the Host expects the step of the parent track first, and then all secondaries
   // that were generated in that step.
-  GPUStep &parentStep = AsyncAdePT::gDeviceStepBuffer.GetSlot(threadID, slotStartIndex);
+  GPUStep &parentStep = adept::transport::gDeviceStepBuffer.GetSlot(threadID, slotStartIndex);
   // Fill the required data for the parent step
   FillGPUStep(parentStep, aTrackID, aParentID, stepLimProcessId, aParticleType, aStepLength, aTotalEnergyDeposit,
               aTrackWeight, aPreState, aPrePosition, aPreMomentumDirection, aPreEKin, aPostState, aPostPosition,
@@ -44,7 +44,7 @@ __device__ void RecordGPUStep(uint64_t aTrackID, uint64_t aParentID, short stepL
   // Fill the steps for the secondaries
   for (unsigned int i = 0; i < nSecondaries; ++i) {
     // The index is the startIndex + 1 (for the parent) + i for the current secondary
-    GPUStep &secondaryStep = AsyncAdePT::gDeviceStepBuffer.GetSlot(threadID, slotStartIndex + 1u + i);
+    GPUStep &secondaryStep = adept::transport::gDeviceStepBuffer.GetSlot(threadID, slotStartIndex + 1u + i);
     FillGPUStep(secondaryStep, secondaryData[i].trackId, aTrackID, secondaryData[i].creatorProcessId,
                 secondaryData[i].particleType,
                 /*steplength*/ 0., /*energydeposit*/ 0., aTrackWeight, aPostState, aPostPosition, secondaryData[i].dir,

--- a/include/AdePT/transport/steps/GPUStepTransferManager.cuh
+++ b/include/AdePT/transport/steps/GPUStepTransferManager.cuh
@@ -31,7 +31,7 @@
 #define BOLD_RED "\033[1;31m"
 #define BOLD_BLUE "\033[1;34m"
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 struct BufferHandle {
   std::array<DeviceStepBufferView, 2> stepBufferViews;
@@ -494,4 +494,4 @@ public:
   }
 };
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/steps/HostCircularBuffer.hh
+++ b/include/AdePT/transport/steps/HostCircularBuffer.hh
@@ -8,7 +8,7 @@
 #include <string>
 #include <vector>
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 /// @brief Tracks occupied ranges in the pinned host buffer used for returned GPU steps.
 /// @details
@@ -58,4 +58,4 @@ private:
   mutable std::mutex bufferManagerMutex;
 };
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/support/ResourceManagement.cuh
+++ b/include/AdePT/transport/support/ResourceManagement.cuh
@@ -8,7 +8,7 @@
 #include <AdePT/transport/support/ResourceManagement.hh>
 #include "AdePT/transport/support/Global.h"
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 void freeCuda(void *ptr)
 {
@@ -42,4 +42,4 @@ struct CudaDeleter<ADEPT_DEVICE_API_SYMBOL(Event_t)> {
 };
 #endif
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/include/AdePT/transport/support/ResourceManagement.hh
+++ b/include/AdePT/transport/support/ResourceManagement.hh
@@ -5,7 +5,7 @@
 
 #include <memory>
 
-namespace AsyncAdePT {
+namespace adept::transport {
 void freeCuda(void *ptr);
 void freeCudaHost(void *ptr);
 void freeCudaStream(void *stream);
@@ -23,4 +23,4 @@ struct CudaHostDeleter {
 template <typename T = void, typename Deleter = CudaDeleter<T>>
 using unique_ptr_cuda = std::unique_ptr<T, Deleter>;
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/src/g4integration/tracking_managers/AdePTTrackingManager.cc
+++ b/src/g4integration/tracking_managers/AdePTTrackingManager.cc
@@ -73,7 +73,7 @@ bool ReturnFirstAndLastStep(const AdePTConfiguration &configuration)
 }
 
 std::shared_ptr<AdePTTransport> GetSharedAdePTTransport(
-    const AdePTTransportConfig &transportConfig, std::unique_ptr<AsyncAdePT::AdePTG4HepEmState> adeptG4HepEmState,
+    const AdePTTransportConfig &transportConfig, std::unique_ptr<adept::transport::AdePTG4HepEmState> adeptG4HepEmState,
     adeptint::VolAuxData *auxData, const adeptint::WDTHostPacked &wdtPacked,
     const std::vector<float> &uniformFieldValues)
 {
@@ -149,7 +149,7 @@ void AdePTTrackingManager::InitializeSharedAdePTTransport()
   // shared transport. The transport constructor then performs the one-time
   // device-side initialization from these prepared inputs.
   const auto uniformFieldValues = fGeant4Integration.GetUniformField();
-  auto adeptG4HepEmState        = std::make_unique<AsyncAdePT::AdePTG4HepEmState>(fHepEmTrackingManager->GetConfig());
+  auto adeptG4HepEmState = std::make_unique<adept::transport::AdePTG4HepEmState>(fHepEmTrackingManager->GetConfig());
 
   // Check VecGeom geometry matches Geant4 before deriving any geometry metadata for transport.
   AdePTGeometryBridge::CheckGeometry(adeptG4HepEmState->GetData());

--- a/src/transport/AdePTTransport.cc
+++ b/src/transport/AdePTTransport.cc
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#include <AdePT/transport/AsyncAdePTTransport.hh>
+#include <AdePT/transport/AdePTTransport.hh>
 #include <AdePT/transport/queues/TrackBuffer.hh>
 
 #include <VecGeom/management/BVHManager.h>
@@ -18,27 +18,27 @@
 #include <iostream>
 #include <stdexcept>
 
-namespace async_adept_impl {
+namespace adept::transport::detail {
 void setDeviceLimits(int stackLimit = 0, int heapLimit = 0);
 void CopySurfaceModelToGPU();
 void InitWDTOnDevice(const adeptint::WDTHostPacked &, adeptint::WDTDeviceBuffers &, unsigned short);
 void UploadG4HepEmToGPU(G4HepEmData *hepEmData, G4HepEmParameters *hepEmParameters);
-std::thread LaunchGPUWorker(int, int, int, AsyncAdePT::TrackBuffer &, AsyncAdePT::GPUstate &,
-                            std::vector<std::atomic<AsyncAdePT::EventState>> &, std::condition_variable &, int, int,
-                            bool, bool, unsigned short, const double, bool);
-std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> InitializeGPU(
-    int trackCapacity, int stepCapacity, int numThreads, AsyncAdePT::TrackBuffer &trackBuffer, double CPUCapacityFactor,
-    double CPUCopyFraction, std::string &generalBfieldFile, const std::vector<float> &uniformBfieldValues);
-void FreeGPU(std::unique_ptr<AsyncAdePT::GPUstate, AsyncAdePT::GPUstateDeleter> &, std::thread &,
+std::thread LaunchGPUWorker(int, int, int, adept::transport::TrackBuffer &, adept::transport::GPUstate &,
+                            std::vector<std::atomic<adept::transport::EventState>> &, std::condition_variable &, int,
+                            int, bool, bool, unsigned short, const double, bool);
+std::unique_ptr<adept::transport::GPUstate, adept::transport::GPUstateDeleter> InitializeGPU(
+    int trackCapacity, int stepCapacity, int numThreads, adept::transport::TrackBuffer &trackBuffer,
+    double CPUCapacityFactor, double CPUCopyFraction, std::string &generalBfieldFile,
+    const std::vector<float> &uniformBfieldValues);
+void FreeGPU(std::unique_ptr<adept::transport::GPUstate, adept::transport::GPUstateDeleter> &, std::thread &,
              adeptint::WDTDeviceBuffers &);
-} // namespace async_adept_impl
+} // namespace adept::transport::detail
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
-AsyncAdePTTransport::AsyncAdePTTransport(const AdePTTransportConfig &configuration,
-                                         std::unique_ptr<AdePTG4HepEmState> adeptG4HepEmState,
-                                         adeptint::VolAuxData *auxData, const adeptint::WDTHostPacked &wdtPacked,
-                                         const std::vector<float> &uniformFieldValues)
+AdePTTransport::AdePTTransport(const AdePTTransportConfig &configuration,
+                               std::unique_ptr<AdePTG4HepEmState> adeptG4HepEmState, adeptint::VolAuxData *auxData,
+                               const adeptint::WDTHostPacked &wdtPacked, const std::vector<float> &uniformFieldValues)
     : fAdePTSeed{configuration.adeptSeed}, fNThread{configuration.numThreads},
       fTrackCapacity{configuration.trackCapacity}, fStepCapacity{configuration.stepCapacity},
       fDebugLevel{configuration.debugLevel}, fCUDAStackLimit{configuration.cudaStackLimit},
@@ -49,7 +49,7 @@ AsyncAdePTTransport::AsyncAdePTTransport(const AdePTTransportConfig &configurati
       fCPUCopyFraction{configuration.cpuCopyFraction}, fStepBufferSafetyFactor{configuration.stepBufferSafetyFactor}
 {
   if (fNThread > kMaxThreads)
-    throw std::invalid_argument("AsyncAdePTTransport limited to " + std::to_string(kMaxThreads) + " threads");
+    throw std::invalid_argument("AdePTTransport limited to " + std::to_string(kMaxThreads) + " threads");
 
   for (auto &eventState : fEventStates) {
     std::atomic_init(&eventState, EventState::DeviceFlushed);
@@ -58,15 +58,15 @@ AsyncAdePTTransport::AsyncAdePTTransport(const AdePTTransportConfig &configurati
   Initialize(auxData, wdtPacked, uniformFieldValues);
 }
 
-AsyncAdePTTransport::~AsyncAdePTTransport()
+AdePTTransport::~AdePTTransport()
 {
-  async_adept_impl::FreeGPU(std::ref(fGPUstate), fGPUWorker, fWDTDev);
+  adept::transport::detail::FreeGPU(std::ref(fGPUstate), fGPUWorker, fWDTDev);
 }
 
-void AsyncAdePTTransport::AddTrack(int pdg, uint64_t trackId, uint64_t parentId, double energy, double x, double y,
-                                   double z, double dirx, double diry, double dirz, double globalTime, double localTime,
-                                   double properTime, float weight, unsigned short stepCounter, int threadId,
-                                   unsigned int eventId, vecgeom::NavigationState &&state)
+void AdePTTransport::AddTrack(int pdg, uint64_t trackId, uint64_t parentId, double energy, double x, double y, double z,
+                              double dirx, double diry, double dirz, double globalTime, double localTime,
+                              double properTime, float weight, unsigned short stepCounter, int threadId,
+                              unsigned int eventId, vecgeom::NavigationState &&state)
 {
   if (pdg != 11 && pdg != -11 && pdg != 22) {
     std::cerr << __FILE__ << ":" << __LINE__ << ": Only supporting EM tracks. Got pdgID=" << pdg << "\n";
@@ -91,10 +91,10 @@ void AsyncAdePTTransport::AddTrack(int pdg, uint64_t trackId, uint64_t parentId,
   fEventStates[threadId].store(EventState::NewTracksFromG4, std::memory_order_release);
 }
 
-bool AsyncAdePTTransport::InitializeGeometry(const vecgeom::cxx::VPlacedVolume *world)
+bool AdePTTransport::InitializeGeometry(const vecgeom::cxx::VPlacedVolume *world)
 {
   auto &cudaManager = vecgeom::cxx::CudaManager::Instance();
-  async_adept_impl::setDeviceLimits(fCUDAStackLimit, fCUDAHeapLimit);
+  adept::transport::detail::setDeviceLimits(fCUDAStackLimit, fCUDAHeapLimit);
 
   bool success = true;
 #ifdef ADEPT_USE_SURF
@@ -111,7 +111,7 @@ bool AsyncAdePTTransport::InitializeGeometry(const vecgeom::cxx::VPlacedVolume *
   auto elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - start);
   std::cout << "== Conversion to surface model done in " << elapsed.count() << " [s]\n";
   cudaManager.SynchronizeNavigationTable();
-  async_adept_impl::CopySurfaceModelToGPU();
+  adept::transport::detail::CopySurfaceModelToGPU();
 #else
   cudaManager.LoadGeometry(world);
   auto world_dev = cudaManager.Synchronize();
@@ -121,43 +121,42 @@ bool AsyncAdePTTransport::InitializeGeometry(const vecgeom::cxx::VPlacedVolume *
   return success;
 }
 
-bool AsyncAdePTTransport::InitializePhysics()
+bool AdePTTransport::InitializePhysics()
 {
   if (!fAdePTG4HepEmState) {
-    throw std::runtime_error("AsyncAdePTTransport::InitializePhysics: Missing AdePT-owned G4HepEm state.");
+    throw std::runtime_error("AdePTTransport::InitializePhysics: Missing AdePT-owned G4HepEm state.");
   }
 
-  async_adept_impl::UploadG4HepEmToGPU(fAdePTG4HepEmState->GetData(), fAdePTG4HepEmState->GetParameters());
+  adept::transport::detail::UploadG4HepEmToGPU(fAdePTG4HepEmState->GetData(), fAdePTG4HepEmState->GetParameters());
   return true;
 }
 
-void AsyncAdePTTransport::Initialize(adeptint::VolAuxData *auxData, const adeptint::WDTHostPacked &wdtPacked,
-                                     const std::vector<float> &uniformFieldValues)
+void AdePTTransport::Initialize(adeptint::VolAuxData *auxData, const adeptint::WDTHostPacked &wdtPacked,
+                                const std::vector<float> &uniformFieldValues)
 {
   if (vecgeom::GeoManager::Instance().GetRegisteredVolumesCount() == 0)
-    throw std::runtime_error("AsyncAdePTTransport::Initialize: Number of geometry volumes is zero.");
+    throw std::runtime_error("AdePTTransport::Initialize: Number of geometry volumes is zero.");
 
-  std::cout << "=== AsyncAdePTTransport: initializing geometry and physics\n";
+  std::cout << "=== AdePTTransport: initializing geometry and physics\n";
   if (!vecgeom::GeoManager::Instance().IsClosed())
-    throw std::runtime_error("AsyncAdePTTransport::Initialize: VecGeom geometry not closed.");
+    throw std::runtime_error("AdePTTransport::Initialize: VecGeom geometry not closed.");
 
   const vecgeom::cxx::VPlacedVolume *world = vecgeom::GeoManager::Instance().GetWorld();
   if (!InitializeGeometry(world))
-    throw std::runtime_error("AsyncAdePTTransport::Initialize: Cannot initialize geometry on GPU");
+    throw std::runtime_error("AdePTTransport::Initialize: Cannot initialize geometry on GPU");
 
-  if (!InitializePhysics())
-    throw std::runtime_error("AsyncAdePTTransport::Initialize cannot initialize physics on GPU");
+  if (!InitializePhysics()) throw std::runtime_error("AdePTTransport::Initialize cannot initialize physics on GPU");
 
   const auto numVolumes   = vecgeom::GeoManager::Instance().GetRegisteredVolumesCount();
   auto &volAuxArray       = adeptint::VolAuxArray::GetInstance();
   volAuxArray.fNumVolumes = numVolumes;
   volAuxArray.fAuxData    = auxData;
-  AsyncAdePT::InitVolAuxArray(volAuxArray);
+  adept::transport::InitVolAuxArray(volAuxArray);
 
   fHasWDTRegions = !wdtPacked.regions.empty();
 
   adeptint::WDTDeviceBuffers wdtDev;
-  async_adept_impl::InitWDTOnDevice(wdtPacked, wdtDev, fMaxWDTIter);
+  adept::transport::detail::InitWDTOnDevice(wdtPacked, wdtDev, fMaxWDTIter);
   fWDTDev = wdtDev;
 
   std::cout << "\nAllocating " << 4 * 8192 * fNThread << " To-device buffer slots\n";
@@ -165,40 +164,41 @@ void AsyncAdePTTransport::Initialize(adeptint::VolAuxData *auxData, const adepti
 
   assert(fBuffer != nullptr);
 
-  fGPUstate  = async_adept_impl::InitializeGPU(fTrackCapacity, fStepCapacity, fNThread, *fBuffer, fCPUCapacityFactor,
-                                               fCPUCopyFraction, fBfieldFile, uniformFieldValues);
-  fGPUWorker = async_adept_impl::LaunchGPUWorker(fTrackCapacity, fStepCapacity, fNThread, *fBuffer, *fGPUstate,
-                                                 fEventStates, fCV_G4Workers, fAdePTSeed, fDebugLevel, fReturnAllSteps,
-                                                 fReturnFirstAndLastStep, fLastNParticlesOnCPU, fStepBufferSafetyFactor,
-                                                 fHasWDTRegions);
+  fGPUstate =
+      adept::transport::detail::InitializeGPU(fTrackCapacity, fStepCapacity, fNThread, *fBuffer, fCPUCapacityFactor,
+                                              fCPUCopyFraction, fBfieldFile, uniformFieldValues);
+  fGPUWorker = adept::transport::detail::LaunchGPUWorker(fTrackCapacity, fStepCapacity, fNThread, *fBuffer, *fGPUstate,
+                                                         fEventStates, fCV_G4Workers, fAdePTSeed, fDebugLevel,
+                                                         fReturnAllSteps, fReturnFirstAndLastStep, fLastNParticlesOnCPU,
+                                                         fStepBufferSafetyFactor, fHasWDTRegions);
 }
 
-void AsyncAdePTTransport::InitBVH()
+void AdePTTransport::InitBVH()
 {
   vecgeom::cxx::BVHManager::Init();
   vecgeom::cxx::BVHManager::DeviceInit();
 }
 
-void AsyncAdePTTransport::RequestFlush(int threadId)
+void AdePTTransport::RequestFlush(int threadId)
 {
   fEventStates[threadId].store(EventState::G4RequestsFlush, std::memory_order_release);
 }
 
-void AsyncAdePTTransport::WaitForFlushProgress()
+void AdePTTransport::WaitForFlushProgress()
 {
   std::unique_lock lock{fMutex_G4Workers};
   using namespace std::chrono_literals;
   fCV_G4Workers.wait_for(lock, 1ms);
 }
 
-bool AsyncAdePTTransport::AreReturnedStepsFlushed(int threadId) const
+bool AdePTTransport::AreReturnedStepsFlushed(int threadId) const
 {
   return fEventStates[threadId].load(std::memory_order_acquire) >= EventState::StepsFlushed;
 }
 
-void AsyncAdePTTransport::MarkHostFlushed(int threadId)
+void AdePTTransport::MarkHostFlushed(int threadId)
 {
   fEventStates[threadId].store(EventState::DeviceFlushed, std::memory_order_release);
 }
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/src/transport/AdePTTransport.cu
+++ b/src/transport/AdePTTransport.cu
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2023 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#include <AdePT/transport/AsyncAdePTTransport.cuh>
+#include <AdePT/transport/AdePTTransport.cuh>
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 void GPUstateDeleter::operator()(GPUstate *ptr)
 {
   delete ptr;
 }
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/src/transport/g4hepem/AdePTG4HepEmState.cpp
+++ b/src/transport/g4hepem/AdePTG4HepEmState.cpp
@@ -15,7 +15,7 @@
 #include <algorithm>
 #include <stdexcept>
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 /// @brief Release the tables owned by `G4HepEmData` and then delete the outer object.
 /// @details
@@ -97,4 +97,4 @@ AdePTG4HepEmState::AdePTG4HepEmState(G4HepEmConfig *hepEmConfig)
 
 AdePTG4HepEmState::~AdePTG4HepEmState() = default;
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/src/transport/steps/HostCircularBuffer.cpp
+++ b/src/transport/steps/HostCircularBuffer.cpp
@@ -13,7 +13,7 @@
 #define RESET "\033[0m"
 #define BOLD_RED "\033[1;31m"
 
-namespace AsyncAdePT {
+namespace adept::transport {
 
 HostCircularBuffer::HostCircularBuffer(std::size_t capacity)
     : fCapacity(capacity), fWriteOffset(0), fFreeContiguousSpace(capacity)
@@ -148,4 +148,4 @@ void HostCircularBuffer::printSegments(const std::string &msg) const
   std::cout << std::endl;
 }
 
-} // namespace AsyncAdePT
+} // namespace adept::transport

--- a/test/unit/test_hostCircularBuffer.cpp
+++ b/test/unit/test_hostCircularBuffer.cpp
@@ -27,7 +27,7 @@ static bool near(double lhs, double rhs)
 
 static int test_empty_buffer_allows_exact_fit()
 {
-  AsyncAdePT::HostCircularBuffer buffer(8);
+  adept::transport::HostCircularBuffer buffer(8);
 
   CHECK(buffer.GetWriteOffset() == 0);
   CHECK(buffer.GetFreeContiguousSlots(8) == 8);
@@ -39,7 +39,7 @@ static int test_empty_buffer_allows_exact_fit()
 
 static int test_segment_add_remove_and_full_buffer()
 {
-  AsyncAdePT::HostCircularBuffer buffer(10);
+  adept::transport::HostCircularBuffer buffer(10);
 
   CHECK(buffer.GetFreeContiguousSlots(10) == 10);
   CHECK(buffer.AddSegment(0, 10));
@@ -56,7 +56,7 @@ static int test_segment_add_remove_and_full_buffer()
 
 static int test_fill_fraction_preserves_existing_pending_transfer_semantics()
 {
-  AsyncAdePT::HostCircularBuffer buffer(10);
+  adept::transport::HostCircularBuffer buffer(10);
 
   CHECK(buffer.GetFreeContiguousSlots(4) == 10);
   CHECK(buffer.AddSegment(0, 4));
@@ -71,7 +71,7 @@ static int test_fill_fraction_preserves_existing_pending_transfer_semantics()
 
 static int test_wraparound_after_front_segment_is_removed()
 {
-  AsyncAdePT::HostCircularBuffer buffer(10);
+  adept::transport::HostCircularBuffer buffer(10);
 
   CHECK(buffer.GetFreeContiguousSlots(6) == 10);
   CHECK(buffer.AddSegment(0, 6));
@@ -90,7 +90,7 @@ static int test_wraparound_after_front_segment_is_removed()
 
 static int test_tail_space_is_reused_after_tail_segment_is_removed()
 {
-  AsyncAdePT::HostCircularBuffer buffer(12);
+  adept::transport::HostCircularBuffer buffer(12);
 
   CHECK(buffer.GetFreeContiguousSlots(4) == 12);
   CHECK(buffer.AddSegment(0, 4));
@@ -108,7 +108,7 @@ static int test_tail_space_is_reused_after_tail_segment_is_removed()
 
 static int test_middle_hole_is_not_reused_from_end_write_position()
 {
-  AsyncAdePT::HostCircularBuffer buffer(12);
+  adept::transport::HostCircularBuffer buffer(12);
 
   CHECK(buffer.GetFreeContiguousSlots(4) == 12);
   CHECK(buffer.AddSegment(0, 4));
@@ -126,7 +126,7 @@ static int test_middle_hole_is_not_reused_from_end_write_position()
 
 static int test_fragmentation_can_block_larger_transfers()
 {
-  AsyncAdePT::HostCircularBuffer buffer(12);
+  adept::transport::HostCircularBuffer buffer(12);
 
   CHECK(buffer.GetFreeContiguousSlots(4) == 12);
   CHECK(buffer.AddSegment(0, 4));
@@ -146,7 +146,7 @@ static int test_fragmentation_can_block_larger_transfers()
 
 static int test_concurrent_allocation_and_release()
 {
-  AsyncAdePT::HostCircularBuffer buffer(64);
+  adept::transport::HostCircularBuffer buffer(64);
 
   constexpr int nSegments = 10000;
   constexpr int nWorkers  = 4;


### PR DESCRIPTION
As there is no synchronous AdePT backend anymore, all the AsyncAdePT namings were redundant, as described in #609.

This PR cleans the names by removing all the `Async` from the file names. The `AsyncAdePT` namespace was replaced by `adept::transport` and the `async_adept_impl` was replaced by `adept::transport::detail`
