### PR TITLE
cleanup leftover of async naming

### DIFF
--- a/include/AdePT/transport/AdePTTransport.cuh
+++ b/include/AdePT/transport/AdePTTransport.cuh
@@ -29,9 +29,6 @@
 #include <AdePT/transport/kernels/WoodcockHelper.cuh>
 
 #include <AdePT/transport/tracks/TrackDebug.cuh>
-// deprecated kernels that split the gamma interactions:
-// #include <AdePT/transport/kernels/electrons_async.cuh>
-// #include <AdePT/transport/kernels/gammas_async.cuh>
 
 #include <AdePT/transport/navigation/BVHNavigator.h>
 

--- a/include/AdePT/transport/kernels/gammas.cuh
+++ b/include/AdePT/transport/kernels/gammas.cuh
@@ -24,7 +24,7 @@ using VolAuxData      = adeptint::VolAuxData;
 using StepActionParam = adept::SteppingAction::Params;
 
 namespace adept::transport {
-// Asynchronous TransportGammas Interface
+// TransportGammas Interface
 template <class SteppingActionT>
 __global__ void __launch_bounds__(256, 1)
     TransportGammas(ParticleManager particleManager, Stats *InFlightStats, const StepActionParam params,

--- a/include/AdePT/transport/kernels/gammasWDT.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT.cuh
@@ -28,7 +28,7 @@ using VolAuxData      = adeptint::VolAuxData;
 using StepActionParam = adept::SteppingAction::Params;
 
 namespace adept::transport {
-// Asynchronous TransportGammasWoodcock Interface
+// TransportGammasWoodcock Interface
 template <class SteppingActionT>
 __global__ void __launch_bounds__(256, 1)
     TransportGammasWoodcock(ParticleManager particleManager, Stats *InFlightStats, const StepActionParam params,

--- a/include/AdePT/transport/kernels/gammasWDT_split.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT_split.cuh
@@ -29,7 +29,7 @@ using VolAuxData      = adeptint::VolAuxData;
 
 namespace adept::transport {
 
-// Asynchronous TransportGammasWoodcock Interface
+// TransportGammasWoodcock Interface
 template <class SteppingActionT>
 __global__ void __launch_bounds__(256, 1)
     GammaWoodcock(G4HepEmGammaTrack *hepEMTracks, ParticleManager particleManager,

--- a/test/run_ci_matrix.sh
+++ b/test/run_ci_matrix.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Tracked local matrix runner for AdePT CI-like checks.
-# Default mode runs fast physics_drift tests for async/split/mixed.
+# Default mode runs fast physics_drift tests for mono/split/mixed.
 
 set -euo pipefail
 
@@ -18,7 +18,7 @@ DEFAULT_MASTER_REF="auto"
 
 BUILD_TYPE="Release"
 SUITE="drift"
-CONFIG_LIST="async,split,mixed"
+CONFIG_LIST="mono,split,mixed"
 BUILD_ROOT="${SCRIPT_DIR}/build"
 MASTER_REF="${DEFAULT_MASTER_REF}"
 FETCH_MASTER=1
@@ -47,14 +47,14 @@ usage() {
 Usage: $(basename "$0") [options]
 
 Runs AdePT in a local matrix similar to Jenkins:
-  - async (default flags, external B-field support)
+  - mono (default monolithic kernels, external B-field support)
   - split (-DADEPT_USE_SPLIT_KERNELS=ON)
   - mixed (-DADEPT_MIXED_PRECISION=ON)
 
 Options:
   --suite <drift|drift-smoke|ci>
                               Test suite to run (default: drift)
-  --configs <list>           Comma list: async,split,mixed (default: async,split,mixed)
+  --configs <list>           Comma list: mono,split,mixed (default: mono,split,mixed)
   --build-type <type>        CMake build type (default: Release)
   --cuda-arch <arch|auto>    CUDA arch (default: auto)
   --jobs <N|auto>            Parallel build jobs (default: auto = nproc)
@@ -205,10 +205,10 @@ IFS=',' read -r -a CONFIGS <<< "${CONFIG_LIST}"
 
 for cfg in "${CONFIGS[@]}"; do
   case "${cfg}" in
-    async|split|mixed)
+    mono|split|mixed)
       ;;
     *)
-      die "Invalid config '${cfg}'. Allowed: async, split, mixed"
+      die "Invalid config '${cfg}'. Allowed: mono, split, mixed"
       ;;
   esac
 done
@@ -268,7 +268,7 @@ COMMON_CMAKE_ARGS+=("${CMAKE_EXTRA_ARGS[@]}")
 
 config_suffix() {
   case "$1" in
-    async) echo "MONOL" ;;
+    mono) echo "MONOL" ;;
     split) echo "SPLIT_ON" ;;
     mixed) echo "MIXED_PRECISION" ;;
   esac
@@ -282,7 +282,7 @@ build_config() {
 
   local -a cfg_args=()
   case "${cfg}" in
-    async)
+    mono)
       ;;
     split)
       cfg_args+=("-DADEPT_USE_SPLIT_KERNELS=ON")
@@ -426,7 +426,7 @@ run_ci_subset_tests() {
   local build_dir=$2
 
   case "${cfg}" in
-    async)
+    mono)
       log "Running monolithic CI subset: unit + validation"
       run_ctest --test-dir "${build_dir}" --output-on-failure -L unit -j1
       run_ctest --test-dir "${build_dir}" --output-on-failure -L validation -j1

--- a/test/run_nightly_ci.sh
+++ b/test/run_nightly_ci.sh
@@ -38,10 +38,10 @@ usage() {
 Usage: $(basename "$0") [options]
 
 Runs the nightly CI selection on the self-hosted runner:
-  1. build ${BUILD_TYPE} matrix for async/split/mixed
-  2. run unit tests on async
-  3. run validation tests on async and split
-  4. build Debug matrix for async/split/mixed and run one-sided physics_drift smoke tests
+  1. build ${BUILD_TYPE} matrix for mono/split/mixed
+  2. run unit tests on mono
+  3. run validation tests on mono and split
+  4. build Debug matrix for mono/split/mixed and run one-sided physics_drift smoke tests
 
 Options:
   --build-root <path>        Build root (default: ${DEFAULT_BUILD_ROOT})
@@ -140,7 +140,7 @@ mkdir -p "${BUILD_ROOT}"
 
 matrix_args=(
   --suite ci
-  --configs async,split,mixed
+  --configs mono,split,mixed
   --build-root "${BUILD_ROOT}"
   --build-type "${BUILD_TYPE}"
   --cuda-arch "${CUDA_ARCH}"
@@ -155,7 +155,7 @@ done
 DEBUG_DRIFT_SMOKE_BUILD_ROOT="${BUILD_ROOT}/debug-drift-smoke"
 debug_drift_smoke_args=(
   --suite drift-smoke
-  --configs async,split,mixed
+  --configs mono,split,mixed
   --build-root "${DEBUG_DRIFT_SMOKE_BUILD_ROOT}"
   --build-type Debug
   --cuda-arch "${CUDA_ARCH}"

--- a/test/run_pr_ci.sh
+++ b/test/run_pr_ci.sh
@@ -43,10 +43,10 @@ usage() {
 Usage: $(basename "$0") [options]
 
 Runs the AdePT PR CI flow on a self-hosted runner:
-  1. build PR and upstream master reference for async/split/mixed
+  1. build PR and upstream master reference for mono/split/mixed
   2. run physics drift comparisons
-  3. always run unit tests on async
-  4. run validation on async + split when drift differs from master, or when requested
+  3. always run unit tests on mono
+  4. run validation on mono + split when drift differs from master, or when requested
   5. optionally build and run the physics drift smoke matrix in Debug mode
 
 Options:
@@ -245,9 +245,9 @@ log "CUDA arch: ${CUDA_ARCH}"
 log "Build jobs: ${JOBS}"
 log "Always run validation: ${RUN_VALIDATION_ALWAYS}"
 log "Run Debug drift: ${RUN_DEBUG_DRIFT}"
-log "Running drift matrix for async/split/mixed"
+log "Running drift matrix for mono/split/mixed"
 
-for cfg in async split mixed; do
+for cfg in mono split mixed; do
   log "Drift phase for config: ${cfg}"
   if ! "${MATRIX_RUNNER}" "${matrix_common_args[@]}" --configs "${cfg}"; then
     DRIFT_STATUS=1
@@ -270,9 +270,9 @@ if [[ "${RUN_DEBUG_DRIFT}" -eq 1 ]]; then
     debug_matrix_common_args+=(--force-rebuild)
   fi
 
-  log "Running Debug drift smoke matrix for async/split/mixed"
+  log "Running Debug drift smoke matrix for mono/split/mixed"
   log "Debug drift build root: ${DEBUG_DRIFT_BUILD_ROOT}"
-  for cfg in async split mixed; do
+  for cfg in mono split mixed; do
     log "Debug drift smoke phase for config: ${cfg}"
     if ! "${MATRIX_RUNNER}" "${debug_matrix_common_args[@]}" --configs "${cfg}"; then
       DEBUG_DRIFT_STATUS=1
@@ -286,13 +286,13 @@ MONOL_BUILD_DIR="${BUILD_ROOT}/BUILD_MONOL"
 SPLIT_BUILD_DIR="${BUILD_ROOT}/BUILD_SPLIT_ON"
 MONOL_BUILD_READY=0
 
-log "Ensuring async build has all test targets"
+log "Ensuring mono build has all test targets"
 if build_all_targets "${MONOL_BUILD_DIR}"; then
   MONOL_BUILD_READY=1
-  log "Running async unit tests"
+  log "Running mono unit tests"
   run_and_capture UNIT_STATUS run_ctest --test-dir "${MONOL_BUILD_DIR}" --output-on-failure -L unit -j1
 else
-  log "Skipping async unit tests because the async build is unavailable"
+  log "Skipping mono unit tests because the mono build is unavailable"
   UNIT_STATUS=1
 fi
 
@@ -303,17 +303,17 @@ if [[ "${DRIFT_STATUS}" -ne 0 || "${RUN_VALIDATION_ALWAYS}" -eq 1 ]]; then
   validation_split_status=1
 
   if [[ "${DRIFT_STATUS}" -ne 0 ]]; then
-    log "Drift differs from master; running validation on async and split"
+    log "Drift differs from master; running validation on mono and split"
   else
-    log "Full validation requested; running validation on async and split"
+    log "Full validation requested; running validation on mono and split"
   fi
 
   if [[ "${MONOL_BUILD_READY}" -eq 1 && ( "${UNIT_STATUS}" -eq 0 || "${RUN_VALIDATION_ALWAYS}" -eq 1 ) ]]; then
     run_and_capture validation_monol_status run_ctest --test-dir "${MONOL_BUILD_DIR}" --output-on-failure -L validation -j1
   elif [[ "${MONOL_BUILD_READY}" -ne 1 ]]; then
-    log "Skipping async validation because the async build is unavailable"
+    log "Skipping mono validation because the mono build is unavailable"
   else
-    log "Skipping async validation because the unit stage failed"
+    log "Skipping mono validation because the unit stage failed"
   fi
 
   if build_all_targets "${SPLIT_BUILD_DIR}"; then


### PR DESCRIPTION
This PR follows #626 and cleans the remaining usage of the `async` naming in AdePT:

- Some commented-out includes of non-existing asynchronous kernels were deleted
- The CI modes were named `async | split | mixed`, although all of them where async. This is changed to `mono | split | mixed`. Note that mixed is also using the monolithic kernels but mixed precision.