### PR TITLE
move mixed precision drift test to drift smoke test

### DIFF
--- a/.github/workflows/nightly-ci-el9.yml
+++ b/.github/workflows/nightly-ci-el9.yml
@@ -126,6 +126,8 @@ jobs:
             echo "- Release CI status: \`${RELEASE_CI_STATUS:-missing}\`"
             echo "- Debug drift smoke build root: \`${DEBUG_DRIFT_SMOKE_BUILD_ROOT:-missing}\`"
             echo "- Debug drift smoke status: \`${DEBUG_DRIFT_SMOKE_STATUS:-missing}\`"
+            echo "- Mixed precision drift smoke build root: \`${MIXED_DRIFT_SMOKE_BUILD_ROOT:-missing}\`"
+            echo "- Mixed precision drift smoke status: \`${MIXED_DRIFT_SMOKE_STATUS:-missing}\`"
             echo "- Nightly status: \`${NIGHTLY_STATUS:-missing}\`"
           } >> "${GITHUB_STEP_SUMMARY}"
 

--- a/.github/workflows/self-hosted-pr-ci.yml
+++ b/.github/workflows/self-hosted-pr-ci.yml
@@ -96,7 +96,7 @@ jobs:
           full_description="Self-hosted EL9 CI queued"
           validation_description="Waiting for drift result in EL9"
           if [ "${COMMAND}" = "/run-test-full" ]; then
-            full_description="Self-hosted EL9 CI with full validation and Debug smoke queued"
+            full_description="Self-hosted EL9 CI with full validation and drift smoke queued"
             validation_description="Full validation requested in EL9"
           fi
 
@@ -174,7 +174,7 @@ jobs:
         continue-on-error: true
         env:
           ALWAYS_RUN_VALIDATION: ${{ needs.prepare.outputs.command == '/run-test-full' && '1' || '0' }}
-          RUN_DEBUG_DRIFT: ${{ needs.prepare.outputs.command == '/run-test-full' && '1' || '0' }}
+          RUN_DRIFT_SMOKE: ${{ needs.prepare.outputs.command == '/run-test-full' && '1' || '0' }}
         run: |
           set -eo pipefail
 
@@ -209,7 +209,7 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/work/AdePT" \
             -e HOME=/tmp/adeptci-home \
             -e ADEPT_PR_CI_ALWAYS_RUN_VALIDATION="${ALWAYS_RUN_VALIDATION}" \
-            -e ADEPT_PR_CI_RUN_DEBUG_DRIFT="${RUN_DEBUG_DRIFT}" \
+            -e ADEPT_PR_CI_RUN_DRIFT_SMOKE="${RUN_DRIFT_SMOKE}" \
             -e ADEPT_VALIDATION_DEFAULT_NUM_THREADS=32 \
             -e ADEPT_VALIDATION_DEFAULT_NUM_TRACKSLOTS=6 \
             -e ADEPT_VALIDATION_DEFAULT_NUM_HITSLOTS=30 \
@@ -241,8 +241,8 @@ jobs:
               if [[ "${ADEPT_PR_CI_ALWAYS_RUN_VALIDATION:-0}" == "1" ]]; then
                 pr_ci_args+=(--always-run-validation)
               fi
-              if [[ "${ADEPT_PR_CI_RUN_DEBUG_DRIFT:-0}" == "1" ]]; then
-                pr_ci_args+=(--run-debug-drift)
+              if [[ "${ADEPT_PR_CI_RUN_DRIFT_SMOKE:-0}" == "1" ]]; then
+                pr_ci_args+=(--run-drift-smoke)
               fi
               "${pr_ci_args[@]}"
             '
@@ -272,11 +272,11 @@ jobs:
           fi
           : "${VALIDATION_STATUS:=1}"
           if [ "${COMMAND}" = "/run-test-full" ]; then
-            : "${DEBUG_DRIFT_RAN:=1}"
-            : "${DEBUG_DRIFT_STATUS:=1}"
+            : "${DRIFT_SMOKE_RAN:=1}"
+            : "${DRIFT_SMOKE_STATUS:=1}"
           else
-            : "${DEBUG_DRIFT_RAN:=0}"
-            : "${DEBUG_DRIFT_STATUS:=0}"
+            : "${DRIFT_SMOKE_RAN:=0}"
+            : "${DRIFT_SMOKE_STATUS:=0}"
           fi
           : "${FULL_CI_STATUS:=1}"
 
@@ -305,9 +305,9 @@ jobs:
             validation_description="Validation tests failed"
           fi
 
-          if [ "${FULL_CI_STATUS}" -eq 0 ] && [ "${DEBUG_DRIFT_RAN}" -eq 1 ]; then
+          if [ "${FULL_CI_STATUS}" -eq 0 ] && [ "${DRIFT_SMOKE_RAN}" -eq 1 ]; then
             full_state="success"
-            full_description="Debug smoke and validation passed"
+            full_description="Drift smoke and validation passed"
           elif [ "${FULL_CI_STATUS}" -eq 0 ] && [ "${VALIDATION_RAN}" -eq 0 ]; then
             full_state="success"
             full_description="Drift matched master; validation skipped"
@@ -320,9 +320,9 @@ jobs:
           elif [ "${UNIT_STATUS}" -ne 0 ]; then
             full_state="failure"
             full_description="Unit tests failed"
-          elif [ "${DEBUG_DRIFT_RAN}" -eq 1 ] && [ "${DEBUG_DRIFT_STATUS}" -ne 0 ]; then
+          elif [ "${DRIFT_SMOKE_RAN}" -eq 1 ] && [ "${DRIFT_SMOKE_STATUS}" -ne 0 ]; then
             full_state="failure"
-            full_description="Debug smoke failed"
+            full_description="Drift smoke failed"
           elif [ "${VALIDATION_RAN}" -eq 1 ] && [ "${VALIDATION_STATUS}" -ne 0 ]; then
             full_state="failure"
             full_description="Validation tests failed"
@@ -372,8 +372,8 @@ jobs:
             echo "- User: \`$(whoami)\`"
             echo "- Workflow step outcome: \`${{ steps.run_ci.outcome }}\`"
             echo "- Drift status: \`${DRIFT_STATUS:-missing}\`"
-            echo "- Debug smoke ran: \`${DEBUG_DRIFT_RAN:-missing}\`"
-            echo "- Debug smoke status: \`${DEBUG_DRIFT_STATUS:-missing}\`"
+            echo "- Drift smoke ran: \`${DRIFT_SMOKE_RAN:-missing}\`"
+            echo "- Drift smoke status: \`${DRIFT_SMOKE_STATUS:-missing}\`"
             echo "- Unit status: \`${UNIT_STATUS:-missing}\`"
             echo "- Validation ran: \`${VALIDATION_RAN:-missing}\`"
             echo "- Validation forced: \`${VALIDATION_FORCED:-missing}\`"

--- a/test/run_ci_matrix.sh
+++ b/test/run_ci_matrix.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Tracked local matrix runner for AdePT CI-like checks.
-# Default mode runs fast physics_drift tests for mono/split/mixed.
+# Default mode runs fast physics_drift tests for mono/split.
 
 set -euo pipefail
 
@@ -18,7 +18,7 @@ DEFAULT_MASTER_REF="auto"
 
 BUILD_TYPE="Release"
 SUITE="drift"
-CONFIG_LIST="mono,split,mixed"
+CONFIG_LIST="mono,split"
 BUILD_ROOT="${SCRIPT_DIR}/build"
 MASTER_REF="${DEFAULT_MASTER_REF}"
 FETCH_MASTER=1
@@ -54,7 +54,7 @@ Runs AdePT in a local matrix similar to Jenkins:
 Options:
   --suite <drift|drift-smoke|ci>
                               Test suite to run (default: drift)
-  --configs <list>           Comma list: mono,split,mixed (default: mono,split,mixed)
+  --configs <list>           Comma list: mono,split,mixed (default: mono,split)
   --build-type <type>        CMake build type (default: Release)
   --cuda-arch <arch|auto>    CUDA arch (default: auto)
   --jobs <N|auto>            Parallel build jobs (default: auto = nproc)

--- a/test/run_nightly_ci.sh
+++ b/test/run_nightly_ci.sh
@@ -38,10 +38,10 @@ usage() {
 Usage: $(basename "$0") [options]
 
 Runs the nightly CI selection on the self-hosted runner:
-  1. build ${BUILD_TYPE} matrix for mono/split/mixed
+  1. build ${BUILD_TYPE} matrix for mono/split
   2. run unit tests on mono
   3. run validation tests on mono and split
-  4. build Debug matrix for mono/split/mixed and run one-sided physics_drift smoke tests
+  4. run one-sided physics_drift smoke tests for Debug mono/split and mixed precision
 
 Options:
   --build-root <path>        Build root (default: ${DEFAULT_BUILD_ROOT})
@@ -66,6 +66,8 @@ write_results() {
     printf 'RELEASE_CI_STATUS=%s\n' "${RELEASE_CI_STATUS}"
     printf 'DEBUG_DRIFT_SMOKE_BUILD_ROOT=%q\n' "${DEBUG_DRIFT_SMOKE_BUILD_ROOT}"
     printf 'DEBUG_DRIFT_SMOKE_STATUS=%s\n' "${DEBUG_DRIFT_SMOKE_STATUS}"
+    printf 'MIXED_DRIFT_SMOKE_BUILD_ROOT=%q\n' "${MIXED_DRIFT_SMOKE_BUILD_ROOT}"
+    printf 'MIXED_DRIFT_SMOKE_STATUS=%s\n' "${MIXED_DRIFT_SMOKE_STATUS}"
     printf 'NIGHTLY_STATUS=%s\n' "${NIGHTLY_STATUS}"
   } > "${RESULTS_FILE}"
 }
@@ -140,7 +142,7 @@ mkdir -p "${BUILD_ROOT}"
 
 matrix_args=(
   --suite ci
-  --configs mono,split,mixed
+  --configs mono,split
   --build-root "${BUILD_ROOT}"
   --build-type "${BUILD_TYPE}"
   --cuda-arch "${CUDA_ARCH}"
@@ -155,7 +157,7 @@ done
 DEBUG_DRIFT_SMOKE_BUILD_ROOT="${BUILD_ROOT}/debug-drift-smoke"
 debug_drift_smoke_args=(
   --suite drift-smoke
-  --configs mono,split,mixed
+  --configs mono,split
   --build-root "${DEBUG_DRIFT_SMOKE_BUILD_ROOT}"
   --build-type Debug
   --cuda-arch "${CUDA_ARCH}"
@@ -167,12 +169,28 @@ for arg in "${CMAKE_EXTRA_ARGS[@]}"; do
   debug_drift_smoke_args+=(--cmake-extra "${arg}")
 done
 
+MIXED_DRIFT_SMOKE_BUILD_ROOT="${BUILD_ROOT}/mixed-drift-smoke"
+mixed_drift_smoke_args=(
+  --suite drift-smoke
+  --configs mixed
+  --build-root "${MIXED_DRIFT_SMOKE_BUILD_ROOT}"
+  --build-type "${BUILD_TYPE}"
+  --cuda-arch "${CUDA_ARCH}"
+  --jobs "${JOBS}"
+  --ctest-timeout-sec "${CTEST_TIMEOUT_SEC}"
+)
+
+for arg in "${CMAKE_EXTRA_ARGS[@]}"; do
+  mixed_drift_smoke_args+=(--cmake-extra "${arg}")
+done
+
 log "Using LCG setup: ${LCG_SETUP}"
 log "Build type: ${BUILD_TYPE}"
 log "Build root: ${BUILD_ROOT}"
 log "CUDA arch: ${CUDA_ARCH}"
 log "Build jobs: ${JOBS}"
 log "Debug drift smoke build root: ${DEBUG_DRIFT_SMOKE_BUILD_ROOT}"
+log "Mixed precision drift smoke build root: ${MIXED_DRIFT_SMOKE_BUILD_ROOT}"
 log "Running Jenkins-like nightly CI selection"
 
 # Increase self-hosted nightly validation concurrency and buffer capacity unless explicitly overridden.
@@ -195,6 +213,7 @@ export ADEPT_VALIDATION_WDT_CPU_CAPACITY_FACTOR
 
 RELEASE_CI_STATUS=1
 DEBUG_DRIFT_SMOKE_STATUS=1
+MIXED_DRIFT_SMOKE_STATUS=1
 NIGHTLY_STATUS=1
 if "${MATRIX_RUNNER}" "${matrix_args[@]}"; then
   RELEASE_CI_STATUS=0
@@ -205,7 +224,14 @@ if "${MATRIX_RUNNER}" "${debug_drift_smoke_args[@]}"; then
   DEBUG_DRIFT_SMOKE_STATUS=0
 fi
 
-if [[ "${RELEASE_CI_STATUS}" -eq 0 && "${DEBUG_DRIFT_SMOKE_STATUS}" -eq 0 ]]; then
+log "Running mixed precision physics_drift smoke suite"
+if "${MATRIX_RUNNER}" "${mixed_drift_smoke_args[@]}"; then
+  MIXED_DRIFT_SMOKE_STATUS=0
+fi
+
+if [[ "${RELEASE_CI_STATUS}" -eq 0 &&
+      "${DEBUG_DRIFT_SMOKE_STATUS}" -eq 0 &&
+      "${MIXED_DRIFT_SMOKE_STATUS}" -eq 0 ]]; then
   NIGHTLY_STATUS=0
 fi
 
@@ -213,6 +239,7 @@ write_results
 
 log "Release CI status: ${RELEASE_CI_STATUS}"
 log "Debug drift smoke status: ${DEBUG_DRIFT_SMOKE_STATUS}"
+log "Mixed precision drift smoke status: ${MIXED_DRIFT_SMOKE_STATUS}"
 log "Nightly status: ${NIGHTLY_STATUS}"
 
 exit "${NIGHTLY_STATUS}"

--- a/test/run_pr_ci.sh
+++ b/test/run_pr_ci.sh
@@ -27,7 +27,7 @@ FETCH_MASTER=1
 FORCE_REBUILD=0
 REFRESH_MASTER=0
 RUN_VALIDATION_ALWAYS=0
-RUN_DEBUG_DRIFT=0
+RUN_DRIFT_SMOKE=0
 
 log() {
   printf '[pr-ci] %s\n' "$*"
@@ -43,11 +43,11 @@ usage() {
 Usage: $(basename "$0") [options]
 
 Runs the AdePT PR CI flow on a self-hosted runner:
-  1. build PR and upstream master reference for mono/split/mixed
+  1. build PR and upstream master reference for mono/split
   2. run physics drift comparisons
   3. always run unit tests on mono
   4. run validation on mono + split when drift differs from master, or when requested
-  5. optionally build and run the physics drift smoke matrix in Debug mode
+  5. optionally build and run one-sided physics drift smoke checks for Debug and mixed precision
 
 Options:
   --build-root <path>        Build/cache root (default: ${DEFAULT_BUILD_ROOT})
@@ -61,7 +61,8 @@ Options:
   --force-rebuild            Force clean rebuilds in the matrix runner
   --refresh-master           Refresh cached master worktree/builds
   --always-run-validation    Run validation even when drift matches master
-  --run-debug-drift          Also build and run the drift smoke matrix with CMAKE_BUILD_TYPE=Debug
+  --run-drift-smoke          Also build and run Debug and mixed precision drift smoke checks
+  --run-debug-drift          Compatibility alias for --run-drift-smoke
   -h, --help                 Show this help
 EOF
 }
@@ -118,8 +119,8 @@ write_results() {
     printf 'BUILD_ROOT=%q\n' "${BUILD_ROOT}"
     printf 'MASTER_REF=%q\n' "${MASTER_REF}"
     printf 'DRIFT_STATUS=%s\n' "${DRIFT_STATUS}"
-    printf 'DEBUG_DRIFT_RAN=%s\n' "${DEBUG_DRIFT_RAN}"
-    printf 'DEBUG_DRIFT_STATUS=%s\n' "${DEBUG_DRIFT_STATUS}"
+    printf 'DRIFT_SMOKE_RAN=%s\n' "${DRIFT_SMOKE_RAN}"
+    printf 'DRIFT_SMOKE_STATUS=%s\n' "${DRIFT_SMOKE_STATUS}"
     printf 'UNIT_STATUS=%s\n' "${UNIT_STATUS}"
     printf 'VALIDATION_RAN=%s\n' "${VALIDATION_RAN}"
     printf 'VALIDATION_FORCED=%s\n' "${RUN_VALIDATION_ALWAYS}"
@@ -181,8 +182,8 @@ while [[ $# -gt 0 ]]; do
       RUN_VALIDATION_ALWAYS=1
       shift
       ;;
-    --run-debug-drift)
-      RUN_DEBUG_DRIFT=1
+    --run-drift-smoke|--run-debug-drift)
+      RUN_DRIFT_SMOKE=1
       shift
       ;;
     -h|--help)
@@ -212,8 +213,8 @@ normalize_lcg_cuda_env || die "Failed to normalize CUDA environment from LCG set
 mkdir -p "${BUILD_ROOT}"
 
 DRIFT_STATUS=0
-DEBUG_DRIFT_RAN=0
-DEBUG_DRIFT_STATUS=0
+DRIFT_SMOKE_RAN=0
+DRIFT_SMOKE_STATUS=0
 UNIT_STATUS=1
 VALIDATION_RAN=0
 VALIDATION_STATUS=0
@@ -244,18 +245,18 @@ log "Master reference: ${MASTER_REF}"
 log "CUDA arch: ${CUDA_ARCH}"
 log "Build jobs: ${JOBS}"
 log "Always run validation: ${RUN_VALIDATION_ALWAYS}"
-log "Run Debug drift: ${RUN_DEBUG_DRIFT}"
-log "Running drift matrix for mono/split/mixed"
+log "Run drift smoke: ${RUN_DRIFT_SMOKE}"
+log "Running drift matrix for mono/split"
 
-for cfg in mono split mixed; do
+for cfg in mono split; do
   log "Drift phase for config: ${cfg}"
   if ! "${MATRIX_RUNNER}" "${matrix_common_args[@]}" --configs "${cfg}"; then
     DRIFT_STATUS=1
   fi
 done
 
-if [[ "${RUN_DEBUG_DRIFT}" -eq 1 ]]; then
-  DEBUG_DRIFT_RAN=1
+if [[ "${RUN_DRIFT_SMOKE}" -eq 1 ]]; then
+  DRIFT_SMOKE_RAN=1
   DEBUG_DRIFT_BUILD_ROOT="${BUILD_ROOT}/debug-drift"
   debug_matrix_common_args=(
     --suite drift-smoke
@@ -270,16 +271,36 @@ if [[ "${RUN_DEBUG_DRIFT}" -eq 1 ]]; then
     debug_matrix_common_args+=(--force-rebuild)
   fi
 
-  log "Running Debug drift smoke matrix for mono/split/mixed"
+  log "Running Debug drift smoke matrix for mono/split"
   log "Debug drift build root: ${DEBUG_DRIFT_BUILD_ROOT}"
-  for cfg in mono split mixed; do
+  for cfg in mono split; do
     log "Debug drift smoke phase for config: ${cfg}"
     if ! "${MATRIX_RUNNER}" "${debug_matrix_common_args[@]}" --configs "${cfg}"; then
-      DEBUG_DRIFT_STATUS=1
+      DRIFT_SMOKE_STATUS=1
     fi
   done
+
+  MIXED_DRIFT_SMOKE_BUILD_ROOT="${BUILD_ROOT}/mixed-drift-smoke"
+  mixed_matrix_common_args=(
+    --suite drift-smoke
+    --configs mixed
+    --build-root "${MIXED_DRIFT_SMOKE_BUILD_ROOT}"
+    --cuda-arch "${CUDA_ARCH}"
+    --jobs "${JOBS}"
+    --ctest-timeout-sec "${CTEST_TIMEOUT_SEC}"
+  )
+
+  if [[ "${FORCE_REBUILD}" -eq 1 ]]; then
+    mixed_matrix_common_args+=(--force-rebuild)
+  fi
+
+  log "Running mixed precision drift smoke"
+  log "Mixed precision drift smoke build root: ${MIXED_DRIFT_SMOKE_BUILD_ROOT}"
+  if ! "${MATRIX_RUNNER}" "${mixed_matrix_common_args[@]}"; then
+    DRIFT_SMOKE_STATUS=1
+  fi
 else
-  log "Debug drift matrix skipped"
+  log "Drift smoke checks skipped"
 fi
 
 MONOL_BUILD_DIR="${BUILD_ROOT}/BUILD_MONOL"
@@ -335,7 +356,7 @@ fi
 
 if [[ "${UNIT_STATUS}" -eq 0 &&
       ( "${VALIDATION_RAN}" -eq 0 || "${VALIDATION_STATUS}" -eq 0 ) &&
-      "${DEBUG_DRIFT_STATUS}" -eq 0 ]]; then
+      "${DRIFT_SMOKE_STATUS}" -eq 0 ]]; then
   FULL_CI_STATUS=0
 else
   FULL_CI_STATUS=1
@@ -344,8 +365,8 @@ fi
 write_results
 
 log "Drift status: ${DRIFT_STATUS}"
-log "Debug drift ran: ${DEBUG_DRIFT_RAN}"
-log "Debug drift status: ${DEBUG_DRIFT_STATUS}"
+log "Drift smoke ran: ${DRIFT_SMOKE_RAN}"
+log "Drift smoke status: ${DRIFT_SMOKE_STATUS}"
 log "Unit status: ${UNIT_STATUS}"
 log "Validation ran: ${VALIDATION_RAN}"
 log "Validation forced: ${RUN_VALIDATION_ALWAYS}"


### PR DESCRIPTION
Previously, the drift tests included mono/split/mixed.

The mixed precision build was purely to see that the mixed precision compiles and runs. As mixed precision at this stage is used nowhere in production, this PR moves it from the standard drift build to the drift smoke test, which now consists of the debug build+run and the mixed precision build+run. It will be run in the nightlies and with /run-test-full. 

This will reduce the CI time by 1/3 for the normal `/run-test` workflow, allowing to add more drift tests.