### PR TITLE
fix bug for returning FinishOnCPU steps

### DIFF
--- a/src/g4integration/tracking_managers/AdePTTrackingManager.cc
+++ b/src/g4integration/tracking_managers/AdePTTrackingManager.cc
@@ -111,8 +111,10 @@ bool CanReturnTrackDirectly(const GPUStep &step, unsigned int blockSize, bool ca
   if (step.fStepLimProcessId != kAdePTOutOfGPURegionProcess && step.fStepLimProcessId != kAdePTFinishOnCPUProcess) {
     return false;
   }
-  assert(blockSize == 1);
-  assert(step.fTotalEnergyDeposit == 0.);
+  // kAdePTFinishOnCPUProcess is set after a real interaction can happen. Thus,
+  // an extra guard is needed to check for steps that have to call the SD code
+  if (blockSize != 1) return false;
+  if (step.fTotalEnergyDeposit != 0.) return false;
   return true;
 }
 


### PR DESCRIPTION
This PR fixes a bug reported by @codex review in #540:

For the FinishOnCPU option, the step defining process is set after the real interaction. That means, steps that return with FinishOnCPU may have energy deposition or secondaries attached. In that case, the step replay must not be skipped.