### PR TITLE
set RNG state in constructor

### DIFF
--- a/include/AdePT/transport/tracks/Track.cuh
+++ b/include/AdePT/transport/tracks/Track.cuh
@@ -65,11 +65,10 @@ struct TrackBase {
                        float weight, double const position[3], double const direction[3],
                        const vecgeom::NavigationState &newNavState, unsigned int eventId, uint64_t trackId,
                        uint64_t parentId, short threadId, unsigned short stepCounter)
-      : eKin{eKin}, globalTime{globalTime}, trackId{trackId}, parentId{parentId}, navState{newNavState}, weight{weight},
-        localTime{localTime}, properTime{properTime}, eventId{eventId}, threadId{threadId}, stepCounter{stepCounter},
-        looperCounter{0}, zeroStepCounter{0}
+      : rngState{rngSeed}, eKin{eKin}, globalTime{globalTime}, trackId{trackId}, parentId{parentId},
+        navState{newNavState}, weight{weight}, localTime{localTime}, properTime{properTime}, eventId{eventId},
+        threadId{threadId}, stepCounter{stepCounter}, looperCounter{0}, zeroStepCounter{0}
   {
-    rngState.SetSeed(rngSeed);
     pos = {position[0], position[1], position[2]};
     dir = {direction[0], direction[1], direction[2]};
   }


### PR DESCRIPTION
This small PR fixes a double `SetSeed` call in Ranlux++, which is very expensive:

Before, the rngState was default constructed (using the default seed: ` RanluxppDouble(uint64_t seed = 314159265) { this->SetSeed(seed); }`, and then the `SetSeed` was called again. 

This is in fact the most compute heavy part of the `InitTracks` kernel, which takes in Athena ~5-8% of all GPU compute time.
With this fix, the time of the kernel is roughly halved (at least when it is called with a proper number of blocks).
