### PR TITLE
add nsys profiling hooks and documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ option(ADEPT_MIXED_PRECISION "Use B-field integration and surface model in mixed
 option(ADEPT_USE_SPLIT_KERNELS "Run split version of the transport kernels" OFF)
 option(ADEPT_USE_EXT_BFIELD "Use external B field from file via the covfie library" OFF)
 option(ADEPT_DEBUG_SINGLE_THREAD "Run transport kernels in single thread mode" OFF)
+option(ADEPT_ENABLE_NSYS_PROFILING "Compile CUDA profiler API hooks for transport-loop nsys captures" OFF)
 set(ADEPT_DEBUG_TRACK 0 CACHE STRING "Debug tracking level (0=off, >0=on with levels)")
 option(ADEPT_ENFORCE_STRICT_FLAGS "Enforce strict compiler flags, as also used in CMSSW" OFF)
 option(ADEPT_ENABLE_POWER_METER "Compile the code for consumption measurement" OFF)
@@ -86,6 +87,13 @@ if(ADEPT_COMPUTE_BACKEND STREQUAL CUDA)
   set(ADEPT_USE_CUDA TRUE)
 elseif(ADEPT_COMPUTE_BACKEND STREQUAL HIP)
   set(ADEPT_USE_HIP TRUE)
+endif()
+
+if(ADEPT_ENABLE_NSYS_PROFILING AND NOT ADEPT_USE_CUDA)
+  message(FATAL_ERROR
+    "ADEPT_ENABLE_NSYS_PROFILING requires ADEPT_COMPUTE_BACKEND=CUDA because "
+    "it uses the CUDA profiler API used by nsys capture ranges."
+  )
 endif()
 
 if(ADEPT_USE_CUDA)
@@ -278,6 +286,10 @@ endif()
 if (ADEPT_USE_SPLIT_KERNELS)
   add_compile_definitions(ADEPT_USE_SPLIT_KERNELS)
   message(STATUS "${Green}AdePT will run with split kernels${ColorReset}")
+endif()
+if (ADEPT_ENABLE_NSYS_PROFILING)
+  add_compile_definitions(ADEPT_ENABLE_NSYS_PROFILING)
+  message(STATUS "${Green}AdePT will compile nsys CUDA profiler hooks${ColorReset}")
 endif()
 # Debugging in single-thread mode
 if (ADEPT_DEBUG_SINGLE_THREAD)
@@ -568,6 +580,7 @@ set(ADEPT_PUBLIC_CONFIG_DEFINITIONS
   $<$<BOOL:${ADEPT_USE_SPLIT_KERNELS}>:ADEPT_USE_SPLIT_KERNELS>
   $<$<AND:$<BOOL:${ADEPT_DEBUG_SINGLE_THREAD}>,$<CONFIG:Debug>>:ADEPT_DEBUG_SINGLE_THREAD>
   $<$<BOOL:${ADEPT_USE_EXT_BFIELD}>:ADEPT_USE_EXT_BFIELD>
+  $<$<BOOL:${ADEPT_ENABLE_NSYS_PROFILING}>:ADEPT_ENABLE_NSYS_PROFILING>
   $<$<BOOL:${ADEPT_ENABLE_POWER_METER}>:ADEPT_ENABLE_POWER_METER>
   $<$<BOOL:${ADEPT_DEBUG_TRACK}>:ADEPT_DEBUG_TRACK=${ADEPT_DEBUG_TRACK}>
 )

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The table below shows the available CMake options for AdePT that may be used to 
 |ADEPT_DEBUG_SINGLE_THREAD|OFF| Run transport kernels in single thread mode |
 |ADEPT_DEBUG_TRACK|0| Debug tracking level (0=off, >0=on with levels) |
 |ADEPT_ENFORCE_STRICT_FLAGS|0| Use strict compiler flags, as also used in CMSSW. Many warnings are promoted to errors using this flag. |
+|ADEPT_ENABLE_NSYS_PROFILING|OFF| Compile CUDA profiler API hooks for transport-loop `nsys` captures. Requires `ADEPT_COMPUTE_BACKEND=CUDA`. |
 |ADEPT_STEPPINGACTION|NONE| SteppingAction mode: `NONE`, `CMS`, `LHCb`, or `ATLAS`. |
 
 To build, run:
@@ -156,6 +157,13 @@ $ cd adept-build
 $ ./BuildProducts/bin/example1 -m <macro_file>   ### for more option, use -h
 ```
 In the build folder, several example `<macro_file>` are generated, such as `example1.mac` or `example1_ttbar.mac`.
+
+### Profiling
+
+AdePT can be profiled with Nsight Systems (`nsys`) and Nsight Compute (`ncu`).
+For transport-only `nsys` capture hooks, configure with
+`ADEPT_ENABLE_NSYS_PROFILING=ON`. The full workflow is documented in
+[Profiling AdePT](docs/user/profiling.md).
 
 ## Including AdePT in other CMake projects
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,7 @@ user/gpu_tracking
 user/integration-g4
 user/runtime-parameters
 user/examples
+user/profiling
 ```
 
 ```{toctree}

--- a/docs/installation/build-from-source.md
+++ b/docs/installation/build-from-source.md
@@ -40,6 +40,7 @@ cmake --build ./adept-build -- -j6
 | `ADEPT_BUILD_TESTING` | `OFF` | Build unit and regression tests |
 | `ADEPT_BUILD_EXAMPLES` | `OFF` | Build examples |
 | `ADEPT_ENABLE_POWER_METER` | `OFF` | Compile the code for consumption measurement |
+| `ADEPT_ENABLE_NSYS_PROFILING` | `OFF` | Compile CUDA profiler API hooks for transport-loop `nsys` captures. Requires `ADEPT_COMPUTE_BACKEND=CUDA`. |
 | `ADEPT_STEPPINGACTION` | `NONE` | SteppingAction mode: `NONE`, `CMS`, `LHCb`, or `ATLAS`. |
 | `ADEPT_USE_BUILTIN_G4VG` | `ON` | Fetch and build G4VG as part of AdePT (used when Geant4 integration is enabled) |
 

--- a/docs/user/profiling.md
+++ b/docs/user/profiling.md
@@ -1,0 +1,88 @@
+<!--
+SPDX-FileCopyrightText: 2026 CERN
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# Profiling AdePT
+
+AdePT can be profiled with the NVIDIA tools Nsight Systems (`nsys`) and
+Nsight Compute (`ncu`). Note that high level counters are available in the
+output when running with `/adept/verbose 4`.
+
+## Nsight Systems
+
+`nsys` is the right tool to inspect whole-application timing, CUDA stream
+overlap, kernel launch rates, and which particle type is dominating.
+
+As profiling full production workflows can be difficult,
+AdePT provides optional CUDA profiler API hooks so `nsys` can skip GPU geometry
+initialization and capture only a transport-loop window. Enable them at build
+time with:
+
+```console
+cmake -S . -B ./adept-build \
+  -DADEPT_COMPUTE_BACKEND=CUDA \
+  -DADEPT_ENABLE_NSYS_PROFILING=ON \
+  <otherargs>
+```
+
+`ADEPT_ENABLE_NSYS_PROFILING` requires the CUDA backend. CMake fails during
+configuration if it is requested with a non-CUDA backend.
+
+At runtime, enable the transport capture hook with:
+
+```console
+export ADEPT_NSYS_CAPTURE_TRANSPORT=1
+```
+
+Optional runtime controls:
+
+| Variable | Default | Meaning |
+| --- | :---: | --- |
+| `ADEPT_NSYS_CAPTURE_START_AFTER_ITERATIONS` | `0` | Start capture before this transport-loop iteration. |
+| `ADEPT_NSYS_CAPTURE_STOP_AFTER_ITERATIONS` | `0` | Stop capture before this transport-loop iteration. `0` means stop during transport teardown. |
+
+The iteration range is half-open: `[start, stop)`. For example,
+`START_AFTER_ITERATIONS=50` and `STOP_AFTER_ITERATIONS=150` captures transport
+iterations 50 through 149. Invalid or negative values are ignored and treated as
+the default `0`.
+
+Run `nsys` with the CUDA profiler API capture range:
+
+```console
+nsys profile --capture-range=cudaProfilerApi --capture-range-end=stop \
+  --trace=cuda,nvtx --sample=none --cpuctxsw=none \
+  --stats=true --force-overwrite=true \
+  --output adept_transport_profile \
+  <application command>
+```
+
+Open the report with:
+
+```console
+nsys-ui adept_transport_profile.nsys-rep
+```
+
+## Nsight Compute
+
+`ncu` is the tool for detailed kernel analysis: register count, achieved
+occupancy, memory coalescing, cache behavior, stall reasons, and source-level
+metrics. Use kernel-name filters plus launch skipping/counting to select
+representative transport kernels:
+
+```console
+ncu --target-processes all \
+  --kernel-name-base demangled \
+  --kernel-name 'regex:.*Electron(HowFar|Propagation|MSC|Relocation).*' \
+  --launch-skip <n> \
+  --launch-count <m> \
+  --set detailed \
+  --force-overwrite \
+  --export ncu_electron_geometry \
+  <application command>
+```
+
+Choose `--launch-skip` from an `nsys` profile so the selected launches are in
+the dominant transport region rather than startup or tail iterations. For
+source-level attribution, use a build configuration that emits CUDA line
+information, such as `RelWithDebInfo`.

--- a/include/AdePT/transport/AdePTTransport.cuh
+++ b/include/AdePT/transport/AdePTTransport.cuh
@@ -18,6 +18,7 @@
 #include <AdePT/transport/support/Global.h>
 #include <AdePT/transport/support/PhysicalConstants.h>
 #include <AdePT/transport/random/Ranluxpp.h>
+#include <AdePT/transport/support/ScopedTransportProfiler.hh>
 
 #ifdef ADEPT_USE_SPLIT_KERNELS
 #include <AdePT/transport/kernels/electrons_split.cuh>
@@ -777,6 +778,9 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
   std::thread stepProcessingThread{&StepProcessingLoop,   (StepProcessingContext *)stepProcessing.get(),
                                    std::ref(gpuState),    std::ref(eventStates),
                                    std::ref(cvG4Workers), std::ref(debugLevel)};
+#ifdef ADEPT_ENABLE_NSYS_PROFILING
+  ScopedTransportProfiler profiler;
+#endif
 
   auto computeThreadsAndBlocks = [](unsigned int nParticles) -> std::pair<unsigned int, unsigned int> {
     constexpr int TransportThreads = 32;
@@ -833,6 +837,9 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
     for (unsigned int iteration = 0; inFlight > 0 || gpuState.injectState != InjectState::Idle ||
                                      std::any_of(eventStates.begin(), eventStates.end(), needTransport);
          ++iteration) {
+#ifdef ADEPT_ENABLE_NSYS_PROFILING
+      profiler.BeginIteration(iteration);
+#endif
 
       // Swap the queues for the next iteration.
       electrons.queues.SwapActive();
@@ -1367,6 +1374,10 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
 
     if (debugLevel > 2) std::cout << "End transport loop.\n";
   }
+
+#ifdef ADEPT_ENABLE_NSYS_PROFILING
+  profiler.Stop();
+#endif
 
   stepProcessing->keepRunning = false;
   stepProcessing->cv.notify_one();

--- a/include/AdePT/transport/support/ScopedTransportProfiler.hh
+++ b/include/AdePT/transport/support/ScopedTransportProfiler.hh
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2026 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#if defined(ADEPT_ENABLE_NSYS_PROFILING) || defined(__DOXYGEN__)
+
+#include <cerrno>
+#include <cstdlib>
+#include <limits>
+
+namespace adept::transport::detail {
+
+bool StartTransportProfilerCapture();
+void StopTransportProfilerCapture();
+
+inline bool GetBoolEnvVar(const char *name)
+{
+  const char *value = std::getenv(name);
+  if (value == nullptr || value[0] == '\0') return false;
+  return !(value[0] == '0' && value[1] == '\0');
+}
+
+inline unsigned int GetUnsignedEnvVar(const char *name, unsigned int defaultValue = 0)
+{
+  const char *value = std::getenv(name);
+  if (value == nullptr || value[0] == '\0' || value[0] < '0' || value[0] > '9') return defaultValue;
+  char *end         = nullptr;
+  errno             = 0;
+  const auto parsed = std::strtoul(value, &end, 10);
+  if (errno != 0 || end == value || *end != '\0' || parsed > std::numeric_limits<unsigned int>::max()) {
+    return defaultValue;
+  }
+  return static_cast<unsigned int>(parsed);
+}
+
+/**
+ * @brief Scoped controller for optional CUDA profiler API capture in the transport loop.
+ *
+ * ScopedTransportProfiler reads the AdePT profiling environment variables once at
+ * construction and starts/stops the CUDA profiler API capture as transport-loop
+ * iterations advance. It is intended for `nsys --capture-range=cudaProfilerApi`
+ * runs where initialization kernels should be skipped and only a representative
+ * transport window should be captured.
+ *
+ * Runtime control is provided by `ADEPT_NSYS_CAPTURE_TRANSPORT`,
+ * `ADEPT_NSYS_CAPTURE_START_AFTER_ITERATIONS`, and
+ * `ADEPT_NSYS_CAPTURE_STOP_AFTER_ITERATIONS`. The iteration window is half-open:
+ * `[start, stop)`.
+ *
+ * The object only stops a capture if it successfully started that capture
+ * itself. AdePT currently has a single active transport loop; if multiple
+ * transport loops are introduced, the shared capture state in the implementation
+ * must be made thread-safe.
+ */
+class ScopedTransportProfiler {
+public:
+  /**
+   * @brief Read the profiling environment and initialize the scoped controller.
+   */
+  ScopedTransportProfiler()
+      : fRequested(GetBoolEnvVar("ADEPT_NSYS_CAPTURE_TRANSPORT")),
+        fStartIteration(GetUnsignedEnvVar("ADEPT_NSYS_CAPTURE_START_AFTER_ITERATIONS")),
+        fStopIteration(GetUnsignedEnvVar("ADEPT_NSYS_CAPTURE_STOP_AFTER_ITERATIONS"))
+  {
+  }
+
+  /**
+   * @brief Stop an active capture during stack unwinding or normal teardown.
+   */
+  ~ScopedTransportProfiler() { Stop(); }
+
+  ScopedTransportProfiler(const ScopedTransportProfiler &)            = delete;
+  ScopedTransportProfiler &operator=(const ScopedTransportProfiler &) = delete;
+
+  /**
+   * @brief Update the capture state before launching work for a transport iteration.
+   *
+   * @param iteration Zero-based transport-loop iteration. Capture starts before
+   * this iteration when it is equal to the configured start value, and stops
+   * before this iteration when it reaches the configured stop value.
+   */
+  void BeginIteration(unsigned int iteration)
+  {
+    // The configured range is half-open: [start, stop). The stop check runs
+    // before launching the first non-captured iteration.
+    if (fStopIteration > 0 && iteration >= fStopIteration) {
+      if (fActive) Stop();
+      fStopped = true;
+    }
+    if (fRequested && !fActive && !fStopped && iteration == fStartIteration) {
+      fActive = StartTransportProfilerCapture();
+    }
+  }
+
+  /**
+   * @brief Stop the CUDA profiler capture if this object started it.
+   */
+  void Stop()
+  {
+    if (!fActive) return;
+    StopTransportProfilerCapture();
+    fActive = false;
+  }
+
+private:
+  bool fRequested{false};
+  bool fActive{false};
+  bool fStopped{false};
+  unsigned int fStartIteration{0};
+  unsigned int fStopIteration{0};
+};
+
+} // namespace adept::transport::detail
+
+#endif

--- a/src/transport/AdePTTransport.cc
+++ b/src/transport/AdePTTransport.cc
@@ -9,6 +9,10 @@
 #ifdef ADEPT_USE_SURF
 #include <VecGeom/surfaces/BrepHelper.h>
 #endif
+#ifdef ADEPT_ENABLE_NSYS_PROFILING
+#include <cuda_profiler_api.h>
+#include <cuda_runtime_api.h>
+#endif
 
 #include <G4HepEmData.hh>
 #include <G4HepEmParameters.hh>
@@ -32,6 +36,37 @@ std::unique_ptr<adept::transport::GPUstate, adept::transport::GPUstateDeleter> I
     const std::vector<float> &uniformBfieldValues);
 void FreeGPU(std::unique_ptr<adept::transport::GPUstate, adept::transport::GPUstateDeleter> &, std::thread &,
              adeptint::WDTDeviceBuffers &);
+
+#ifdef ADEPT_ENABLE_NSYS_PROFILING
+// AdePT owns one active transport loop at a time, so profiler capture state is
+// intentionally process-global and unsynchronized. If multiple concurrent
+// transport loops are introduced, protect this state with an atomic or mutex.
+static bool gTransportProfilerStarted = false;
+
+bool StartTransportProfilerCapture()
+{
+  if (gTransportProfilerStarted) return false;
+  const auto result = cudaProfilerStart();
+  if (result != cudaSuccess) {
+    std::cerr << "AdePTTransport: cudaProfilerStart failed: " << cudaGetErrorString(result)
+              << "; disabling transport profiler capture" << std::endl;
+    return false;
+  }
+  gTransportProfilerStarted = true;
+  std::cout << "AdePT: CUDA profiler capture started" << std::endl;
+  return true;
+}
+
+void StopTransportProfilerCapture()
+{
+  if (!gTransportProfilerStarted) return;
+  const auto result = cudaProfilerStop();
+  if (result != cudaSuccess) {
+    std::cerr << "AdePTTransport: cudaProfilerStop failed: " << cudaGetErrorString(result) << std::endl;
+  }
+  gTransportProfilerStarted = false;
+}
+#endif
 } // namespace adept::transport::detail
 
 namespace adept::transport {

--- a/src/transport/AdePTTransport.cc
+++ b/src/transport/AdePTTransport.cc
@@ -60,6 +60,11 @@ bool StartTransportProfilerCapture()
 void StopTransportProfilerCapture()
 {
   if (!gTransportProfilerStarted) return;
+  const auto syncResult = cudaDeviceSynchronize();
+  if (syncResult != cudaSuccess) {
+    std::cerr << "AdePTTransport: cudaDeviceSynchronize before cudaProfilerStop failed: "
+              << cudaGetErrorString(syncResult) << std::endl;
+  }
   const auto result = cudaProfilerStop();
   if (result != cudaSuccess) {
     std::cerr << "AdePTTransport: cudaProfilerStop failed: " << cudaGetErrorString(result) << std::endl;


### PR DESCRIPTION
This PR adds optional CUDA profiler API hooks for profiling the transport loop with Nsight Systems, plus documentation for nsys and ncu workflows.

As the large production work flows can be difficult to profile, nsys hooks are introduced to only profile the transport loop and avoid geometry startup.

To enable it, compile with `-DADEPT_ENABLE_NSYS_PROFILING=ON` and run with `ADEPT_NSYS_CAPTURE_TRANSPORT`.
The variables `ADEPT_NSYS_CAPTURE_START_AFTER_ITERATIONS` and `ADEPT_NSYS_CAPTURE_STOP_AFTER_ITERATIONS` can be used to scope the profiling as otherwise the profiler can crash with too large events and >100k iterations.

The full behaviour is documented in the RTD documentation. Tested both in Athena and Gauss.