### PR TITLE
Run Woodcock kernels in parallel

### DIFF
--- a/include/AdePT/transport/AdePTTransport.cuh
+++ b/include/AdePT/transport/AdePTTransport.cuh
@@ -121,8 +121,8 @@ __global__ void InitParticleQueues(ParticleQueues queues, size_t CapacityTranspo
   adept::MParray::MakeInstanceAt(CapacityTransport, queues.nextActive);
 #ifdef ADEPT_USE_SPLIT_KERNELS
   adept::MParray::MakeInstanceAt(CapacityTransport, queues.propagation);
-  for (int i = 0; i < ParticleQueues::numInteractions; i++) {
-    adept::MParray::MakeInstanceAt(CapacityTransport, queues.interactionQueues[i]);
+  for (int i = 0; i < ParticleQueues::numSplitQueues; i++) {
+    adept::MParray::MakeInstanceAt(CapacityTransport, queues.splitQueues[i]);
   }
 #endif
 }
@@ -251,8 +251,8 @@ __global__ void FinishIteration(AllParticleQueues all, Stats *stats, TracksAndSl
       all.queues[i].initiallyActive->clear();
 #ifdef ADEPT_USE_SPLIT_KERNELS
       all.queues[i].propagation->clear();
-      for (int j = 0; j < ParticleQueues::numInteractions; j++) {
-        all.queues[i].interactionQueues[j]->clear();
+      for (int j = 0; j < ParticleQueues::numSplitQueues; j++) {
+        all.queues[i].splitQueues[j]->clear();
       }
 #endif
       stats->inFlight[i]       = all.queues[i].nextActive->size();
@@ -372,8 +372,8 @@ __global__ void ClearAllQueues(AllParticleQueues all)
     if (i == GPUQueueIndex::GammaWDT) return;
 #ifdef ADEPT_USE_SPLIT_KERNELS
     all.queues[i].propagation->clear();
-    for (int j = 0; j < ParticleQueues::numInteractions; j++) {
-      all.queues[i].interactionQueues[j]->clear();
+    for (int j = 0; j < ParticleQueues::numSplitQueues; j++) {
+      all.queues[i].splitQueues[j]->clear();
     }
 #endif
   }
@@ -643,18 +643,18 @@ std::unique_ptr<GPUstate, GPUstateDeleter> InitializeGPU(int trackCapacity, int 
 #ifdef ADEPT_USE_SPLIT_KERNELS
     gpuMalloc(gpuPtr, sizeOfQueueStorage);
     particleType.queues.propagation = static_cast<adept::MParray *>(gpuPtr);
-    for (int j = 0; j < ParticleQueues::numInteractions; j++) {
+    for (int j = 0; j < ParticleQueues::numSplitQueues; j++) {
       gpuMalloc(gpuPtr, sizeOfQueueStorage);
-      particleType.queues.interactionQueues[j] = static_cast<adept::MParray *>(gpuPtr);
+      particleType.queues.splitQueues[j] = static_cast<adept::MParray *>(gpuPtr);
     }
 #endif
     InitParticleQueues<<<1, 1>>>(particleType.queues, nSlot);
 
     ADEPT_DEVICE_API_CALL(StreamCreate(&particleType.stream));
     ADEPT_DEVICE_API_CALL(EventCreate(&particleType.event));
-    ADEPT_DEVICE_API_CALL(StreamCreate(&particleType.physicsStream));
+    ADEPT_DEVICE_API_CALL(StreamCreate(&particleType.auxiliaryStream));
     ADEPT_DEVICE_API_CALL(
-        EventCreateWithFlags(&particleType.physicsEvent, ADEPT_DEVICE_API_SYMBOL(EventDisableTiming)));
+        EventCreateWithFlags(&particleType.auxiliaryEvent, ADEPT_DEVICE_API_SYMBOL(EventDisableTiming)));
 #ifdef ADEPT_USE_SPLIT_KERNELS
     ADEPT_DEVICE_API_CALL(EventCreateWithFlags(&particleType.setupEvent, ADEPT_DEVICE_API_SYMBOL(EventDisableTiming)));
 #endif
@@ -862,17 +862,21 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
       };
       const AllParticleQueues allParticleQueues = {{electrons.queues, positrons.queues, gammas.queues, woodcockQueues}};
 #ifdef ADEPT_USE_SPLIT_KERNELS
-      const AllInteractionQueues allGammaInteractionQueues = {
-          {gammas.queues.interactionQueues[0], gammas.queues.interactionQueues[1], gammas.queues.interactionQueues[2],
-           gammas.queues.interactionQueues[ParticleQueues::gammaWoodcockSetupQueue],
-           gammas.queues.interactionQueues[4]}};
-      const AllInteractionQueues allElectronInteractionQueues = {{electrons.queues.interactionQueues[0],
-                                                                  electrons.queues.interactionQueues[1], nullptr,
-                                                                  nullptr, electrons.queues.interactionQueues[4]}};
-      const AllInteractionQueues allPositronInteractionQueues = {
-          {positrons.queues.interactionQueues[0], positrons.queues.interactionQueues[1],
-           positrons.queues.interactionQueues[2], positrons.queues.interactionQueues[3],
-           positrons.queues.interactionQueues[4]}};
+      const SplitQueues gammaSplitQueues    = {{gammas.queues.splitQueues[ParticleQueues::gammaConversionQueue],
+                                                gammas.queues.splitQueues[ParticleQueues::gammaComptonQueue],
+                                                gammas.queues.splitQueues[ParticleQueues::gammaPhotoelectricQueue],
+                                                gammas.queues.splitQueues[ParticleQueues::gammaWoodcockQueue],
+                                                gammas.queues.splitQueues[ParticleQueues::relocationQueue]}};
+      const SplitQueues electronSplitQueues = {
+          {electrons.queues.splitQueues[ParticleQueues::chargedIonizationQueue],
+           electrons.queues.splitQueues[ParticleQueues::chargedBremsstrahlungQueue], nullptr, nullptr,
+           electrons.queues.splitQueues[ParticleQueues::relocationQueue]}};
+      const SplitQueues positronSplitQueues = {
+          {positrons.queues.splitQueues[ParticleQueues::chargedIonizationQueue],
+           positrons.queues.splitQueues[ParticleQueues::chargedBremsstrahlungQueue],
+           positrons.queues.splitQueues[ParticleQueues::positronAnnihilationQueue],
+           positrons.queues.splitQueues[ParticleQueues::positronStoppedAnnihilationQueue],
+           positrons.queues.splitQueues[ParticleQueues::relocationQueue]}};
 #endif
       const TracksAndSlots tracksAndSlots = {electrons.tracks,
                                              positrons.tracks,
@@ -982,20 +986,20 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
         ElectronMSC<true><<<blocks, threads, 0, electrons.stream>>>(
             electrons.tracks, gpuState.hepEmBuffers_d.electronsHepEm, electrons.queues.propagation);
         ElectronSetupInteractions<true><<<blocks, threads, 0, electrons.stream>>>(
-            gpuState.hepEmBuffers_d.electronsHepEm, electrons.queues.propagation, particleManager,
-            allElectronInteractionQueues, returnAllSteps, returnLastStep);
+            gpuState.hepEmBuffers_d.electronsHepEm, electrons.queues.propagation, particleManager, electronSplitQueues,
+            returnAllSteps, returnLastStep);
         ADEPT_DEVICE_API_CALL(EventRecord(electrons.setupEvent, electrons.stream));
-        ADEPT_DEVICE_API_CALL(StreamWaitEvent(electrons.physicsStream, electrons.setupEvent, 0));
+        ADEPT_DEVICE_API_CALL(StreamWaitEvent(electrons.auxiliaryStream, electrons.setupEvent, 0));
         ElectronRelocation<true><<<blocks, threads, 0, electrons.stream>>>(
-            gpuState.hepEmBuffers_d.electronsHepEm, particleManager, electrons.queues.interactionQueues[4],
-            returnAllSteps, returnLastStep);
-        ElectronIonization<true><<<blocks, threads, 0, electrons.physicsStream>>>(
-            gpuState.hepEmBuffers_d.electronsHepEm, particleManager, electrons.queues.interactionQueues[0],
-            returnAllSteps, returnLastStep);
-        ElectronBremsstrahlung<true><<<blocks, threads, 0, electrons.physicsStream>>>(
-            gpuState.hepEmBuffers_d.electronsHepEm, particleManager, electrons.queues.interactionQueues[1],
-            returnAllSteps, returnLastStep);
-        ADEPT_DEVICE_API_CALL(EventRecord(electrons.physicsEvent, electrons.physicsStream));
+            gpuState.hepEmBuffers_d.electronsHepEm, particleManager,
+            electrons.queues.splitQueues[ParticleQueues::relocationQueue], returnAllSteps, returnLastStep);
+        ElectronIonization<true><<<blocks, threads, 0, electrons.auxiliaryStream>>>(
+            gpuState.hepEmBuffers_d.electronsHepEm, particleManager,
+            electrons.queues.splitQueues[ParticleQueues::chargedIonizationQueue], returnAllSteps, returnLastStep);
+        ElectronBremsstrahlung<true><<<blocks, threads, 0, electrons.auxiliaryStream>>>(
+            gpuState.hepEmBuffers_d.electronsHepEm, particleManager,
+            electrons.queues.splitQueues[ParticleQueues::chargedBremsstrahlungQueue], returnAllSteps, returnLastStep);
+        ADEPT_DEVICE_API_CALL(EventRecord(electrons.auxiliaryEvent, electrons.auxiliaryStream));
 #else
         TransportElectrons<SelectedSteppingAction>
             <<<blocks, threads, 0, electrons.stream>>>(particleManager, gpuState.stats_dev, steppingActionParams,
@@ -1004,7 +1008,7 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
         ADEPT_DEVICE_API_CALL(EventRecord(electrons.event, electrons.stream));
         ADEPT_DEVICE_API_CALL(StreamWaitEvent(gpuState.stream, electrons.event, 0));
 #ifdef ADEPT_USE_SPLIT_KERNELS
-        ADEPT_DEVICE_API_CALL(StreamWaitEvent(gpuState.stream, electrons.physicsEvent, 0));
+        ADEPT_DEVICE_API_CALL(StreamWaitEvent(gpuState.stream, electrons.auxiliaryEvent, 0));
 #endif
       }
 
@@ -1025,26 +1029,27 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
         ElectronMSC<false><<<blocks, threads, 0, positrons.stream>>>(
             positrons.tracks, gpuState.hepEmBuffers_d.positronsHepEm, positrons.queues.propagation);
         ElectronSetupInteractions<false><<<blocks, threads, 0, positrons.stream>>>(
-            gpuState.hepEmBuffers_d.positronsHepEm, positrons.queues.propagation, particleManager,
-            allPositronInteractionQueues, returnAllSteps, returnLastStep);
+            gpuState.hepEmBuffers_d.positronsHepEm, positrons.queues.propagation, particleManager, positronSplitQueues,
+            returnAllSteps, returnLastStep);
         ADEPT_DEVICE_API_CALL(EventRecord(positrons.setupEvent, positrons.stream));
-        ADEPT_DEVICE_API_CALL(StreamWaitEvent(positrons.physicsStream, positrons.setupEvent, 0));
+        ADEPT_DEVICE_API_CALL(StreamWaitEvent(positrons.auxiliaryStream, positrons.setupEvent, 0));
         ElectronRelocation<false><<<blocks, threads, 0, positrons.stream>>>(
-            gpuState.hepEmBuffers_d.positronsHepEm, particleManager, positrons.queues.interactionQueues[4],
-            returnAllSteps, returnLastStep);
-        ElectronIonization<false><<<blocks, threads, 0, positrons.physicsStream>>>(
-            gpuState.hepEmBuffers_d.positronsHepEm, particleManager, positrons.queues.interactionQueues[0],
-            returnAllSteps, returnLastStep);
-        ElectronBremsstrahlung<false><<<blocks, threads, 0, positrons.physicsStream>>>(
-            gpuState.hepEmBuffers_d.positronsHepEm, particleManager, positrons.queues.interactionQueues[1],
-            returnAllSteps, returnLastStep);
-        PositronAnnihilation<<<blocks, threads, 0, positrons.physicsStream>>>(
-            gpuState.hepEmBuffers_d.positronsHepEm, particleManager, positrons.queues.interactionQueues[2],
-            returnAllSteps, returnLastStep);
-        PositronStoppedAnnihilation<<<blocks, threads, 0, positrons.physicsStream>>>(
-            gpuState.hepEmBuffers_d.positronsHepEm, particleManager, positrons.queues.interactionQueues[3],
-            returnAllSteps, returnLastStep);
-        ADEPT_DEVICE_API_CALL(EventRecord(positrons.physicsEvent, positrons.physicsStream));
+            gpuState.hepEmBuffers_d.positronsHepEm, particleManager,
+            positrons.queues.splitQueues[ParticleQueues::relocationQueue], returnAllSteps, returnLastStep);
+        ElectronIonization<false><<<blocks, threads, 0, positrons.auxiliaryStream>>>(
+            gpuState.hepEmBuffers_d.positronsHepEm, particleManager,
+            positrons.queues.splitQueues[ParticleQueues::chargedIonizationQueue], returnAllSteps, returnLastStep);
+        ElectronBremsstrahlung<false><<<blocks, threads, 0, positrons.auxiliaryStream>>>(
+            gpuState.hepEmBuffers_d.positronsHepEm, particleManager,
+            positrons.queues.splitQueues[ParticleQueues::chargedBremsstrahlungQueue], returnAllSteps, returnLastStep);
+        PositronAnnihilation<<<blocks, threads, 0, positrons.auxiliaryStream>>>(
+            gpuState.hepEmBuffers_d.positronsHepEm, particleManager,
+            positrons.queues.splitQueues[ParticleQueues::positronAnnihilationQueue], returnAllSteps, returnLastStep);
+        PositronStoppedAnnihilation<<<blocks, threads, 0, positrons.auxiliaryStream>>>(
+            gpuState.hepEmBuffers_d.positronsHepEm, particleManager,
+            positrons.queues.splitQueues[ParticleQueues::positronStoppedAnnihilationQueue], returnAllSteps,
+            returnLastStep);
+        ADEPT_DEVICE_API_CALL(EventRecord(positrons.auxiliaryEvent, positrons.auxiliaryStream));
 #else
         TransportPositrons<SelectedSteppingAction>
             <<<blocks, threads, 0, positrons.stream>>>(particleManager, gpuState.stats_dev, steppingActionParams,
@@ -1054,7 +1059,7 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
         ADEPT_DEVICE_API_CALL(EventRecord(positrons.event, positrons.stream));
         ADEPT_DEVICE_API_CALL(StreamWaitEvent(gpuState.stream, positrons.event, 0));
 #ifdef ADEPT_USE_SPLIT_KERNELS
-        ADEPT_DEVICE_API_CALL(StreamWaitEvent(gpuState.stream, positrons.physicsEvent, 0));
+        ADEPT_DEVICE_API_CALL(StreamWaitEvent(gpuState.stream, positrons.auxiliaryEvent, 0));
 #endif
       }
 
@@ -1065,11 +1070,11 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
         ADEPT_DEVICE_API_CALL(StreamWaitEvent(gammas.stream, gpuState.fGPUStepTransferManager->getSwapDoneEvent(), 0));
 #ifdef ADEPT_USE_SPLIT_KERNELS
         ADEPT_DEVICE_API_CALL(
-            StreamWaitEvent(gammas.physicsStream, gpuState.fGPUStepTransferManager->getSwapDoneEvent(), 0));
+            StreamWaitEvent(gammas.auxiliaryStream, gpuState.fGPUStepTransferManager->getSwapDoneEvent(), 0));
 #else
         if (hasWDTRegions) {
           ADEPT_DEVICE_API_CALL(
-              StreamWaitEvent(gammas.physicsStream, gpuState.fGPUStepTransferManager->getSwapDoneEvent(), 0));
+              StreamWaitEvent(gammas.auxiliaryStream, gpuState.fGPUStepTransferManager->getSwapDoneEvent(), 0));
         }
 #endif
 
@@ -1078,45 +1083,45 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
         const auto [wdtThreads, wdtBlocks] = computeThreadsAndBlocks(particlesInFlight[GPUQueueIndex::GammaWDT]);
         const auto [interactionThreads, interactionBlocks] = computeThreadsAndBlocks(
             particlesInFlight[GPUQueueIndex::Gamma] + particlesInFlight[GPUQueueIndex::GammaWDT]);
-        // particlesInFlight entries are launch-size hints. Queue sizes read in the kernels are authoritative,
-        // so do not use the hints to decide whether WDT work exists.
+        // These counts only size the launches; the kernels read the queue sizes they consume.
+        // Keep WDT launch decisions tied to the configured WDT regions, not to the previous iteration's count.
         GammaHowFar<SelectedSteppingAction><<<blocks, threads, 0, gammas.stream>>>(
             gpuState.hepEmBuffers_d.gammasHepEm, particleManager, gammas.queues.propagation, gpuState.stats_dev,
             steppingActionParams, allowFinishOffEvent, returnAllSteps, returnLastStep);
         if (hasWDTRegions) {
-          GammaWoodcock<SelectedSteppingAction><<<wdtBlocks, wdtThreads, 0, gammas.physicsStream>>>(
+          GammaWoodcock<SelectedSteppingAction><<<wdtBlocks, wdtThreads, 0, gammas.auxiliaryStream>>>(
               gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
-              allGammaInteractionQueues.queues[ParticleQueues::gammaWoodcockSetupQueue], gpuState.stats_dev,
-              steppingActionParams, allowFinishOffEvent, returnAllSteps, returnLastStep);
-          ADEPT_DEVICE_API_CALL(EventRecord(gammas.physicsEvent, gammas.physicsStream));
+              gammaSplitQueues.queues[ParticleQueues::gammaWoodcockQueue], gpuState.stats_dev, steppingActionParams,
+              allowFinishOffEvent, returnAllSteps, returnLastStep);
+          ADEPT_DEVICE_API_CALL(EventRecord(gammas.auxiliaryEvent, gammas.auxiliaryStream));
         }
         GammaPropagation<<<blocks, threads, 0, gammas.stream>>>(gammas.tracks, gpuState.hepEmBuffers_d.gammasHepEm,
                                                                 gammas.queues.propagation);
         if (hasWDTRegions) {
-          ADEPT_DEVICE_API_CALL(StreamWaitEvent(gammas.stream, gammas.physicsEvent, 0));
+          ADEPT_DEVICE_API_CALL(StreamWaitEvent(gammas.stream, gammas.auxiliaryEvent, 0));
         }
         GammaSetupInteractions<<<interactionBlocks, interactionThreads, 0, gammas.stream>>>(
-            gpuState.hepEmBuffers_d.gammasHepEm, gammas.queues.propagation, particleManager, allGammaInteractionQueues,
+            gpuState.hepEmBuffers_d.gammasHepEm, gammas.queues.propagation, particleManager, gammaSplitQueues,
             returnAllSteps, returnLastStep);
         ADEPT_DEVICE_API_CALL(EventRecord(gammas.setupEvent, gammas.stream));
-        ADEPT_DEVICE_API_CALL(StreamWaitEvent(gammas.physicsStream, gammas.setupEvent, 0));
-        GammaRelocation<<<blocks, threads, 0, gammas.stream>>>(gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
-                                                               gammas.queues.interactionQueues[4], returnAllSteps,
-                                                               returnLastStep);
+        ADEPT_DEVICE_API_CALL(StreamWaitEvent(gammas.auxiliaryStream, gammas.setupEvent, 0));
+        GammaRelocation<<<blocks, threads, 0, gammas.stream>>>(
+            gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
+            gammas.queues.splitQueues[ParticleQueues::relocationQueue], returnAllSteps, returnLastStep);
         // Copying the number of interacting tracks back to host and using this information to adjust
         // the launch parameters of the interactions kernel is complicated and expensive due to a
         // required additional kernel launch and copy. Instead, launch the kernels with the same
         // parameters, the unneeded threads immediately return and become free again.
-        GammaConversion<<<interactionBlocks, interactionThreads, 0, gammas.physicsStream>>>(
-            gpuState.hepEmBuffers_d.gammasHepEm, particleManager, gammas.queues.interactionQueues[0], returnAllSteps,
-            returnLastStep);
-        GammaCompton<<<interactionBlocks, interactionThreads, 0, gammas.physicsStream>>>(
-            gpuState.hepEmBuffers_d.gammasHepEm, particleManager, gammas.queues.interactionQueues[1], returnAllSteps,
-            returnLastStep);
-        GammaPhotoelectric<<<interactionBlocks, interactionThreads, 0, gammas.physicsStream>>>(
-            gpuState.hepEmBuffers_d.gammasHepEm, particleManager, gammas.queues.interactionQueues[2], returnAllSteps,
-            returnLastStep);
-        ADEPT_DEVICE_API_CALL(EventRecord(gammas.physicsEvent, gammas.physicsStream));
+        GammaConversion<<<interactionBlocks, interactionThreads, 0, gammas.auxiliaryStream>>>(
+            gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
+            gammas.queues.splitQueues[ParticleQueues::gammaConversionQueue], returnAllSteps, returnLastStep);
+        GammaCompton<<<interactionBlocks, interactionThreads, 0, gammas.auxiliaryStream>>>(
+            gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
+            gammas.queues.splitQueues[ParticleQueues::gammaComptonQueue], returnAllSteps, returnLastStep);
+        GammaPhotoelectric<<<interactionBlocks, interactionThreads, 0, gammas.auxiliaryStream>>>(
+            gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
+            gammas.queues.splitQueues[ParticleQueues::gammaPhotoelectricQueue], returnAllSteps, returnLastStep);
+        ADEPT_DEVICE_API_CALL(EventRecord(gammas.auxiliaryEvent, gammas.auxiliaryStream));
 #else
         TransportGammas<SelectedSteppingAction>
             <<<blocks, threads, 0, gammas.stream>>>(particleManager, gpuState.stats_dev, steppingActionParams,
@@ -1124,20 +1129,20 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
 
         if (hasWDTRegions) {
           const auto [wdtThreads, wdtBlocks] = computeThreadsAndBlocks(particlesInFlight[GPUQueueIndex::GammaWDT]);
-          TransportGammasWoodcock<SelectedSteppingAction><<<wdtBlocks, wdtThreads, 0, gammas.physicsStream>>>(
+          TransportGammasWoodcock<SelectedSteppingAction><<<wdtBlocks, wdtThreads, 0, gammas.auxiliaryStream>>>(
               particleManager, gpuState.stats_dev, steppingActionParams, allowFinishOffEvent, returnAllSteps,
               returnLastStep);
-          ADEPT_DEVICE_API_CALL(EventRecord(gammas.physicsEvent, gammas.physicsStream));
+          ADEPT_DEVICE_API_CALL(EventRecord(gammas.auxiliaryEvent, gammas.auxiliaryStream));
         }
 #endif
 
         ADEPT_DEVICE_API_CALL(EventRecord(gammas.event, gammas.stream));
         ADEPT_DEVICE_API_CALL(StreamWaitEvent(gpuState.stream, gammas.event, 0));
 #ifdef ADEPT_USE_SPLIT_KERNELS
-        ADEPT_DEVICE_API_CALL(StreamWaitEvent(gpuState.stream, gammas.physicsEvent, 0));
+        ADEPT_DEVICE_API_CALL(StreamWaitEvent(gpuState.stream, gammas.auxiliaryEvent, 0));
 #else
         if (hasWDTRegions) {
-          ADEPT_DEVICE_API_CALL(StreamWaitEvent(gpuState.stream, gammas.physicsEvent, 0));
+          ADEPT_DEVICE_API_CALL(StreamWaitEvent(gpuState.stream, gammas.auxiliaryEvent, 0));
         }
 #endif
       }
@@ -1210,12 +1215,12 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
         ADEPT_DEVICE_API_CALL(StreamWaitEvent(stream, cudaEvent));
       }
 #ifdef ADEPT_USE_SPLIT_KERNELS
-      for (auto stream : {electrons.physicsStream, positrons.physicsStream, gammas.physicsStream}) {
+      for (auto stream : {electrons.auxiliaryStream, positrons.auxiliaryStream, gammas.auxiliaryStream}) {
         ADEPT_DEVICE_API_CALL(StreamWaitEvent(stream, cudaEvent));
       }
 #else
       if (hasWDTRegions) {
-        ADEPT_DEVICE_API_CALL(StreamWaitEvent(gammas.physicsStream, cudaEvent));
+        ADEPT_DEVICE_API_CALL(StreamWaitEvent(gammas.auxiliaryStream, cudaEvent));
       }
 #endif
       // ------------------------------------------

--- a/include/AdePT/transport/AdePTTransport.cuh
+++ b/include/AdePT/transport/AdePTTransport.cuh
@@ -862,21 +862,21 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
       };
       const AllParticleQueues allParticleQueues = {{electrons.queues, positrons.queues, gammas.queues, woodcockQueues}};
 #ifdef ADEPT_USE_SPLIT_KERNELS
-      const SplitQueues gammaSplitQueues    = {{gammas.queues.splitQueues[ParticleQueues::gammaConversionQueue],
-                                                gammas.queues.splitQueues[ParticleQueues::gammaComptonQueue],
-                                                gammas.queues.splitQueues[ParticleQueues::gammaPhotoelectricQueue],
-                                                gammas.queues.splitQueues[ParticleQueues::gammaWoodcockQueue],
-                                                gammas.queues.splitQueues[ParticleQueues::relocationQueue]}};
-      const SplitQueues electronSplitQueues = {
-          {electrons.queues.splitQueues[ParticleQueues::chargedIonizationQueue],
-           electrons.queues.splitQueues[ParticleQueues::chargedBremsstrahlungQueue], nullptr, nullptr,
-           electrons.queues.splitQueues[ParticleQueues::relocationQueue]}};
+      const SplitQueues gammaSplitQueues    = {{gammas.queues.splitQueues[ParticleQueues::gammaConversion],
+                                                gammas.queues.splitQueues[ParticleQueues::gammaCompton],
+                                                gammas.queues.splitQueues[ParticleQueues::gammaPhotoelectric],
+                                                gammas.queues.splitQueues[ParticleQueues::gammaWoodcock],
+                                                gammas.queues.splitQueues[ParticleQueues::relocation]}};
+      const SplitQueues electronSplitQueues = {{electrons.queues.splitQueues[ParticleQueues::chargedIonization],
+                                                electrons.queues.splitQueues[ParticleQueues::chargedBremsstrahlung],
+                                                nullptr, nullptr,
+                                                electrons.queues.splitQueues[ParticleQueues::relocation]}};
       const SplitQueues positronSplitQueues = {
-          {positrons.queues.splitQueues[ParticleQueues::chargedIonizationQueue],
-           positrons.queues.splitQueues[ParticleQueues::chargedBremsstrahlungQueue],
-           positrons.queues.splitQueues[ParticleQueues::positronAnnihilationQueue],
-           positrons.queues.splitQueues[ParticleQueues::positronStoppedAnnihilationQueue],
-           positrons.queues.splitQueues[ParticleQueues::relocationQueue]}};
+          {positrons.queues.splitQueues[ParticleQueues::chargedIonization],
+           positrons.queues.splitQueues[ParticleQueues::chargedBremsstrahlung],
+           positrons.queues.splitQueues[ParticleQueues::positronAnnihilation],
+           positrons.queues.splitQueues[ParticleQueues::positronStoppedAnnihilation],
+           positrons.queues.splitQueues[ParticleQueues::relocation]}};
 #endif
       const TracksAndSlots tracksAndSlots = {electrons.tracks,
                                              positrons.tracks,
@@ -992,13 +992,13 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
         ADEPT_DEVICE_API_CALL(StreamWaitEvent(electrons.auxiliaryStream, electrons.setupEvent, 0));
         ElectronRelocation<true><<<blocks, threads, 0, electrons.stream>>>(
             gpuState.hepEmBuffers_d.electronsHepEm, particleManager,
-            electrons.queues.splitQueues[ParticleQueues::relocationQueue], returnAllSteps, returnLastStep);
+            electrons.queues.splitQueues[ParticleQueues::relocation], returnAllSteps, returnLastStep);
         ElectronIonization<true><<<blocks, threads, 0, electrons.auxiliaryStream>>>(
             gpuState.hepEmBuffers_d.electronsHepEm, particleManager,
-            electrons.queues.splitQueues[ParticleQueues::chargedIonizationQueue], returnAllSteps, returnLastStep);
+            electrons.queues.splitQueues[ParticleQueues::chargedIonization], returnAllSteps, returnLastStep);
         ElectronBremsstrahlung<true><<<blocks, threads, 0, electrons.auxiliaryStream>>>(
             gpuState.hepEmBuffers_d.electronsHepEm, particleManager,
-            electrons.queues.splitQueues[ParticleQueues::chargedBremsstrahlungQueue], returnAllSteps, returnLastStep);
+            electrons.queues.splitQueues[ParticleQueues::chargedBremsstrahlung], returnAllSteps, returnLastStep);
         ADEPT_DEVICE_API_CALL(EventRecord(electrons.auxiliaryEvent, electrons.auxiliaryStream));
 #else
         TransportElectrons<SelectedSteppingAction>
@@ -1035,20 +1035,19 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
         ADEPT_DEVICE_API_CALL(StreamWaitEvent(positrons.auxiliaryStream, positrons.setupEvent, 0));
         ElectronRelocation<false><<<blocks, threads, 0, positrons.stream>>>(
             gpuState.hepEmBuffers_d.positronsHepEm, particleManager,
-            positrons.queues.splitQueues[ParticleQueues::relocationQueue], returnAllSteps, returnLastStep);
+            positrons.queues.splitQueues[ParticleQueues::relocation], returnAllSteps, returnLastStep);
         ElectronIonization<false><<<blocks, threads, 0, positrons.auxiliaryStream>>>(
             gpuState.hepEmBuffers_d.positronsHepEm, particleManager,
-            positrons.queues.splitQueues[ParticleQueues::chargedIonizationQueue], returnAllSteps, returnLastStep);
+            positrons.queues.splitQueues[ParticleQueues::chargedIonization], returnAllSteps, returnLastStep);
         ElectronBremsstrahlung<false><<<blocks, threads, 0, positrons.auxiliaryStream>>>(
             gpuState.hepEmBuffers_d.positronsHepEm, particleManager,
-            positrons.queues.splitQueues[ParticleQueues::chargedBremsstrahlungQueue], returnAllSteps, returnLastStep);
+            positrons.queues.splitQueues[ParticleQueues::chargedBremsstrahlung], returnAllSteps, returnLastStep);
         PositronAnnihilation<<<blocks, threads, 0, positrons.auxiliaryStream>>>(
             gpuState.hepEmBuffers_d.positronsHepEm, particleManager,
-            positrons.queues.splitQueues[ParticleQueues::positronAnnihilationQueue], returnAllSteps, returnLastStep);
+            positrons.queues.splitQueues[ParticleQueues::positronAnnihilation], returnAllSteps, returnLastStep);
         PositronStoppedAnnihilation<<<blocks, threads, 0, positrons.auxiliaryStream>>>(
             gpuState.hepEmBuffers_d.positronsHepEm, particleManager,
-            positrons.queues.splitQueues[ParticleQueues::positronStoppedAnnihilationQueue], returnAllSteps,
-            returnLastStep);
+            positrons.queues.splitQueues[ParticleQueues::positronStoppedAnnihilation], returnAllSteps, returnLastStep);
         ADEPT_DEVICE_API_CALL(EventRecord(positrons.auxiliaryEvent, positrons.auxiliaryStream));
 #else
         TransportPositrons<SelectedSteppingAction>
@@ -1083,15 +1082,13 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
         const auto [wdtThreads, wdtBlocks] = computeThreadsAndBlocks(particlesInFlight[GPUQueueIndex::GammaWDT]);
         const auto [interactionThreads, interactionBlocks] = computeThreadsAndBlocks(
             particlesInFlight[GPUQueueIndex::Gamma] + particlesInFlight[GPUQueueIndex::GammaWDT]);
-        // These counts only size the launches; the kernels read the queue sizes they consume.
-        // Keep WDT launch decisions tied to the configured WDT regions, not to the previous iteration's count.
         GammaHowFar<SelectedSteppingAction><<<blocks, threads, 0, gammas.stream>>>(
             gpuState.hepEmBuffers_d.gammasHepEm, particleManager, gammas.queues.propagation, gpuState.stats_dev,
             steppingActionParams, allowFinishOffEvent, returnAllSteps, returnLastStep);
         if (hasWDTRegions) {
           GammaWoodcock<SelectedSteppingAction><<<wdtBlocks, wdtThreads, 0, gammas.auxiliaryStream>>>(
               gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
-              gammaSplitQueues.queues[ParticleQueues::gammaWoodcockQueue], gpuState.stats_dev, steppingActionParams,
+              gammaSplitQueues.queues[ParticleQueues::gammaWoodcock], gpuState.stats_dev, steppingActionParams,
               allowFinishOffEvent, returnAllSteps, returnLastStep);
           ADEPT_DEVICE_API_CALL(EventRecord(gammas.auxiliaryEvent, gammas.auxiliaryStream));
         }
@@ -1105,22 +1102,22 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
             returnAllSteps, returnLastStep);
         ADEPT_DEVICE_API_CALL(EventRecord(gammas.setupEvent, gammas.stream));
         ADEPT_DEVICE_API_CALL(StreamWaitEvent(gammas.auxiliaryStream, gammas.setupEvent, 0));
-        GammaRelocation<<<blocks, threads, 0, gammas.stream>>>(
-            gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
-            gammas.queues.splitQueues[ParticleQueues::relocationQueue], returnAllSteps, returnLastStep);
+        GammaRelocation<<<blocks, threads, 0, gammas.stream>>>(gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
+                                                               gammas.queues.splitQueues[ParticleQueues::relocation],
+                                                               returnAllSteps, returnLastStep);
         // Copying the number of interacting tracks back to host and using this information to adjust
         // the launch parameters of the interactions kernel is complicated and expensive due to a
         // required additional kernel launch and copy. Instead, launch the kernels with the same
         // parameters, the unneeded threads immediately return and become free again.
         GammaConversion<<<interactionBlocks, interactionThreads, 0, gammas.auxiliaryStream>>>(
             gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
-            gammas.queues.splitQueues[ParticleQueues::gammaConversionQueue], returnAllSteps, returnLastStep);
+            gammas.queues.splitQueues[ParticleQueues::gammaConversion], returnAllSteps, returnLastStep);
         GammaCompton<<<interactionBlocks, interactionThreads, 0, gammas.auxiliaryStream>>>(
             gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
-            gammas.queues.splitQueues[ParticleQueues::gammaComptonQueue], returnAllSteps, returnLastStep);
+            gammas.queues.splitQueues[ParticleQueues::gammaCompton], returnAllSteps, returnLastStep);
         GammaPhotoelectric<<<interactionBlocks, interactionThreads, 0, gammas.auxiliaryStream>>>(
             gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
-            gammas.queues.splitQueues[ParticleQueues::gammaPhotoelectricQueue], returnAllSteps, returnLastStep);
+            gammas.queues.splitQueues[ParticleQueues::gammaPhotoelectric], returnAllSteps, returnLastStep);
         ADEPT_DEVICE_API_CALL(EventRecord(gammas.auxiliaryEvent, gammas.auxiliaryStream));
 #else
         TransportGammas<SelectedSteppingAction>

--- a/include/AdePT/transport/AdePTTransport.cuh
+++ b/include/AdePT/transport/AdePTTransport.cuh
@@ -258,10 +258,13 @@ __global__ void FinishIteration(AllParticleQueues all, Stats *stats, TracksAndSl
       stats->inFlight[i]       = all.queues[i].nextActive->size();
       stats->queueFillLevel[i] = float(all.queues[i].nextActive->size()) / all.queues[i].nextActive->max_size();
     }
+    // Thread 0 folds WDT gammas into the gamma total below; wait until the per-species counts are written.
+    __syncthreads();
     if (threadIdx.x == 0) {
       // reset Woodcock tracking gamma queue and add to gammas
       all.queues[GPUQueueIndex::GammaWDT].initiallyActive->clear();
-      stats->inFlight[GPUQueueIndex::Gamma] += all.queues[GPUQueueIndex::GammaWDT].nextActive->size();
+      stats->wdtGammasInFlight = all.queues[GPUQueueIndex::GammaWDT].nextActive->size();
+      stats->inFlight[GPUQueueIndex::Gamma] += stats->wdtGammasInFlight;
       stats->queueFillLevel[GPUQueueIndex::GammaWDT] = float(all.queues[GPUQueueIndex::GammaWDT].nextActive->size()) /
                                                        all.queues[GPUQueueIndex::GammaWDT].nextActive->max_size();
     }
@@ -649,11 +652,11 @@ std::unique_ptr<GPUstate, GPUstateDeleter> InitializeGPU(int trackCapacity, int 
 
     ADEPT_DEVICE_API_CALL(StreamCreate(&particleType.stream));
     ADEPT_DEVICE_API_CALL(EventCreate(&particleType.event));
-#ifdef ADEPT_USE_SPLIT_KERNELS
     ADEPT_DEVICE_API_CALL(StreamCreate(&particleType.physicsStream));
-    ADEPT_DEVICE_API_CALL(EventCreateWithFlags(&particleType.setupEvent, ADEPT_DEVICE_API_SYMBOL(EventDisableTiming)));
     ADEPT_DEVICE_API_CALL(
         EventCreateWithFlags(&particleType.physicsEvent, ADEPT_DEVICE_API_SYMBOL(EventDisableTiming)));
+#ifdef ADEPT_USE_SPLIT_KERNELS
+    ADEPT_DEVICE_API_CALL(EventCreateWithFlags(&particleType.setupEvent, ADEPT_DEVICE_API_SYMBOL(EventDisableTiming)));
 #endif
 
     // Allocate the array where the tracks are stored
@@ -809,8 +812,8 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
     InitSlotManagers<<<80, 256, 0, gpuState.stream>>>(gpuState.slotManager_dev, gpuState.nSlotManager_dev);
     ADEPT_DEVICE_API_CALL(MemsetAsync(gpuState.stats_dev, 0, sizeof(Stats), gpuState.stream));
 
-    int inFlight                                              = 0;
-    unsigned int particlesInFlight[GPUQueueIndex::NumSpecies] = {1, 1, 1};
+    int inFlight                                                     = 0;
+    unsigned int particlesInFlight[GPUQueueIndex::NumParticleQueues] = {1, 1, 1, 1};
 
     auto needTransport = [](std::atomic<EventState> const &state) {
       return state.load(std::memory_order_acquire) < EventState::StepsFlushed;
@@ -861,7 +864,8 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
 #ifdef ADEPT_USE_SPLIT_KERNELS
       const AllInteractionQueues allGammaInteractionQueues = {
           {gammas.queues.interactionQueues[0], gammas.queues.interactionQueues[1], gammas.queues.interactionQueues[2],
-           nullptr, gammas.queues.interactionQueues[4]}};
+           gammas.queues.interactionQueues[ParticleQueues::gammaWoodcockSetupQueue],
+           gammas.queues.interactionQueues[4]}};
       const AllInteractionQueues allElectronInteractionQueues = {{electrons.queues.interactionQueues[0],
                                                                   electrons.queues.interactionQueues[1], nullptr,
                                                                   nullptr, electrons.queues.interactionQueues[4]}};
@@ -1059,23 +1063,39 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
 
         // wait for swapping of step buffers
         ADEPT_DEVICE_API_CALL(StreamWaitEvent(gammas.stream, gpuState.fGPUStepTransferManager->getSwapDoneEvent(), 0));
+#ifdef ADEPT_USE_SPLIT_KERNELS
+        ADEPT_DEVICE_API_CALL(
+            StreamWaitEvent(gammas.physicsStream, gpuState.fGPUStepTransferManager->getSwapDoneEvent(), 0));
+#else
+        if (hasWDTRegions) {
+          ADEPT_DEVICE_API_CALL(
+              StreamWaitEvent(gammas.physicsStream, gpuState.fGPUStepTransferManager->getSwapDoneEvent(), 0));
+        }
+#endif
 
         const auto [threads, blocks] = computeThreadsAndBlocks(particlesInFlight[GPUQueueIndex::Gamma]);
 #ifdef ADEPT_USE_SPLIT_KERNELS
+        const auto [wdtThreads, wdtBlocks] = computeThreadsAndBlocks(particlesInFlight[GPUQueueIndex::GammaWDT]);
+        const auto [interactionThreads, interactionBlocks] = computeThreadsAndBlocks(
+            particlesInFlight[GPUQueueIndex::Gamma] + particlesInFlight[GPUQueueIndex::GammaWDT]);
+        // particlesInFlight entries are launch-size hints. Queue sizes read in the kernels are authoritative,
+        // so do not use the hints to decide whether WDT work exists.
         GammaHowFar<SelectedSteppingAction><<<blocks, threads, 0, gammas.stream>>>(
             gpuState.hepEmBuffers_d.gammasHepEm, particleManager, gammas.queues.propagation, gpuState.stats_dev,
             steppingActionParams, allowFinishOffEvent, returnAllSteps, returnLastStep);
+        if (hasWDTRegions) {
+          GammaWoodcock<SelectedSteppingAction><<<wdtBlocks, wdtThreads, 0, gammas.physicsStream>>>(
+              gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
+              allGammaInteractionQueues.queues[ParticleQueues::gammaWoodcockSetupQueue], gpuState.stats_dev,
+              steppingActionParams, allowFinishOffEvent, returnAllSteps, returnLastStep);
+          ADEPT_DEVICE_API_CALL(EventRecord(gammas.physicsEvent, gammas.physicsStream));
+        }
         GammaPropagation<<<blocks, threads, 0, gammas.stream>>>(gammas.tracks, gpuState.hepEmBuffers_d.gammasHepEm,
                                                                 gammas.queues.propagation);
         if (hasWDTRegions) {
-          // The GammaWoodcock kernel has to run after the HowFar and Propagation, GammaPropagation uses the propagation
-          // queue and GammaWockcock can add slots the the propagationqueue, as it will be consumed in the
-          // SetupInteractions kernel
-          GammaWoodcock<SelectedSteppingAction><<<blocks, threads, 0, gammas.stream>>>(
-              gpuState.hepEmBuffers_d.gammasHepEm, particleManager, gammas.queues.propagation, gpuState.stats_dev,
-              steppingActionParams, allowFinishOffEvent, returnAllSteps, returnLastStep);
+          ADEPT_DEVICE_API_CALL(StreamWaitEvent(gammas.stream, gammas.physicsEvent, 0));
         }
-        GammaSetupInteractions<<<blocks, threads, 0, gammas.stream>>>(
+        GammaSetupInteractions<<<interactionBlocks, interactionThreads, 0, gammas.stream>>>(
             gpuState.hepEmBuffers_d.gammasHepEm, gammas.queues.propagation, particleManager, allGammaInteractionQueues,
             returnAllSteps, returnLastStep);
         ADEPT_DEVICE_API_CALL(EventRecord(gammas.setupEvent, gammas.stream));
@@ -1087,13 +1107,13 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
         // the launch parameters of the interactions kernel is complicated and expensive due to a
         // required additional kernel launch and copy. Instead, launch the kernels with the same
         // parameters, the unneeded threads immediately return and become free again.
-        GammaConversion<<<blocks, threads, 0, gammas.physicsStream>>>(
+        GammaConversion<<<interactionBlocks, interactionThreads, 0, gammas.physicsStream>>>(
             gpuState.hepEmBuffers_d.gammasHepEm, particleManager, gammas.queues.interactionQueues[0], returnAllSteps,
             returnLastStep);
-        GammaCompton<<<blocks, threads, 0, gammas.physicsStream>>>(gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
-                                                                   gammas.queues.interactionQueues[1], returnAllSteps,
-                                                                   returnLastStep);
-        GammaPhotoelectric<<<blocks, threads, 0, gammas.physicsStream>>>(
+        GammaCompton<<<interactionBlocks, interactionThreads, 0, gammas.physicsStream>>>(
+            gpuState.hepEmBuffers_d.gammasHepEm, particleManager, gammas.queues.interactionQueues[1], returnAllSteps,
+            returnLastStep);
+        GammaPhotoelectric<<<interactionBlocks, interactionThreads, 0, gammas.physicsStream>>>(
             gpuState.hepEmBuffers_d.gammasHepEm, particleManager, gammas.queues.interactionQueues[2], returnAllSteps,
             returnLastStep);
         ADEPT_DEVICE_API_CALL(EventRecord(gammas.physicsEvent, gammas.physicsStream));
@@ -1103,9 +1123,11 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
                                                     allowFinishOffEvent, returnAllSteps, returnLastStep);
 
         if (hasWDTRegions) {
-          TransportGammasWoodcock<SelectedSteppingAction>
-              <<<blocks, threads, 0, gammas.stream>>>(particleManager, gpuState.stats_dev, steppingActionParams,
-                                                      allowFinishOffEvent, returnAllSteps, returnLastStep);
+          const auto [wdtThreads, wdtBlocks] = computeThreadsAndBlocks(particlesInFlight[GPUQueueIndex::GammaWDT]);
+          TransportGammasWoodcock<SelectedSteppingAction><<<wdtBlocks, wdtThreads, 0, gammas.physicsStream>>>(
+              particleManager, gpuState.stats_dev, steppingActionParams, allowFinishOffEvent, returnAllSteps,
+              returnLastStep);
+          ADEPT_DEVICE_API_CALL(EventRecord(gammas.physicsEvent, gammas.physicsStream));
         }
 #endif
 
@@ -1113,6 +1135,10 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
         ADEPT_DEVICE_API_CALL(StreamWaitEvent(gpuState.stream, gammas.event, 0));
 #ifdef ADEPT_USE_SPLIT_KERNELS
         ADEPT_DEVICE_API_CALL(StreamWaitEvent(gpuState.stream, gammas.physicsEvent, 0));
+#else
+        if (hasWDTRegions) {
+          ADEPT_DEVICE_API_CALL(StreamWaitEvent(gpuState.stream, gammas.physicsEvent, 0));
+        }
 #endif
       }
 
@@ -1187,6 +1213,10 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
       for (auto stream : {electrons.physicsStream, positrons.physicsStream, gammas.physicsStream}) {
         ADEPT_DEVICE_API_CALL(StreamWaitEvent(stream, cudaEvent));
       }
+#else
+      if (hasWDTRegions) {
+        ADEPT_DEVICE_API_CALL(StreamWaitEvent(gammas.physicsStream, cudaEvent));
+      }
 #endif
       // ------------------------------------------
       // *** Take decisions for next iterations ***
@@ -1208,6 +1238,12 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
         for (int i = 0; i < GPUQueueIndex::NumSpecies; i++) {
           inFlight += gpuState.stats->inFlight[i];
           particlesInFlight[i] = gpuState.stats->inFlight[i];
+        }
+        particlesInFlight[GPUQueueIndex::GammaWDT] = gpuState.stats->wdtGammasInFlight;
+        if (particlesInFlight[GPUQueueIndex::Gamma] > particlesInFlight[GPUQueueIndex::GammaWDT]) {
+          particlesInFlight[GPUQueueIndex::Gamma] -= particlesInFlight[GPUQueueIndex::GammaWDT];
+        } else {
+          particlesInFlight[GPUQueueIndex::Gamma] = 0;
         }
 
         for (unsigned short threadId = 0; threadId < numThreads; ++threadId) {
@@ -1314,9 +1350,9 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
         std::cerr << inFlight << " in flight ";
         std::cerr << "(" << gpuState.stats->inFlight[GPUQueueIndex::Electron] << " "
                   << gpuState.stats->inFlight[GPUQueueIndex::Positron] << " "
-                  << gpuState.stats->inFlight[GPUQueueIndex::Gamma] << "),\tqueues:(" << std::setprecision(3)
-                  << gpuState.stats->queueFillLevel[GPUQueueIndex::Electron] << " "
-                  << gpuState.stats->queueFillLevel[GPUQueueIndex::Positron] << " "
+                  << gpuState.stats->inFlight[GPUQueueIndex::Gamma] << " " << gpuState.stats->wdtGammasInFlight
+                  << "),\tqueues:(" << std::setprecision(3) << gpuState.stats->queueFillLevel[GPUQueueIndex::Electron]
+                  << " " << gpuState.stats->queueFillLevel[GPUQueueIndex::Positron] << " "
                   << gpuState.stats->queueFillLevel[GPUQueueIndex::Gamma] << " "
                   << gpuState.stats->queueFillLevel[GPUQueueIndex::GammaWDT] << ")";
         std::cerr << "\t slots [e-, e+, gamma]: [" << gpuState.stats->slotFillLevel[0] << ", "

--- a/include/AdePT/transport/kernels/electrons_split.cuh
+++ b/include/AdePT/transport/kernels/electrons_split.cuh
@@ -466,7 +466,7 @@ __global__ void ElectronMSC(ChargedTrack *electrons, G4HepEmElectronTrack *hepEM
  */
 template <bool IsElectron>
 __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, const adept::MParray *propagationQueue,
-                                          ParticleManager particleManager, AllInteractionQueues interactionQueues,
+                                          ParticleManager particleManager, SplitQueues splitQueues,
                                           const bool returnAllSteps, const bool returnLastStep)
 {
   auto &electronsOrPositrons = (IsElectron ? particleManager.electrons : particleManager.positrons);
@@ -496,7 +496,7 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
     // Set Non-stopped, on-boundary tracks for relocation
     if (currentTrack.nextState.IsOnBoundary() && !currentTrack.stopped) {
       // Add particle to relocation queue
-      interactionQueues.queues[4]->push_back(slot);
+      splitQueues.queues[ParticleQueues::relocationQueue]->push_back(slot);
       continue;
     }
 
@@ -549,10 +549,10 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
         // (Will be resampled in the next iteration.)
         theTrack->SetNumIALeft(-1.0, winnerProcessIndex);
         // Enqueue the particles
-        interactionQueues.queues[winnerProcessIndex]->push_back(slot);
+        splitQueues.queues[winnerProcessIndex]->push_back(slot);
       } else {
         // Stopped positron
-        interactionQueues.queues[3]->push_back(slot);
+        splitQueues.queues[ParticleQueues::positronStoppedAnnihilationQueue]->push_back(slot);
       }
 
     } else {

--- a/include/AdePT/transport/kernels/electrons_split.cuh
+++ b/include/AdePT/transport/kernels/electrons_split.cuh
@@ -496,7 +496,7 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
     // Set Non-stopped, on-boundary tracks for relocation
     if (currentTrack.nextState.IsOnBoundary() && !currentTrack.stopped) {
       // Add particle to relocation queue
-      splitQueues.queues[ParticleQueues::relocationQueue]->push_back(slot);
+      splitQueues.queues[ParticleQueues::relocation]->push_back(slot);
       continue;
     }
 
@@ -552,7 +552,7 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
         splitQueues.queues[winnerProcessIndex]->push_back(slot);
       } else {
         // Stopped positron
-        splitQueues.queues[ParticleQueues::positronStoppedAnnihilationQueue]->push_back(slot);
+        splitQueues.queues[ParticleQueues::positronStoppedAnnihilation]->push_back(slot);
       }
 
     } else {

--- a/include/AdePT/transport/kernels/gammas_split.cuh
+++ b/include/AdePT/transport/kernels/gammas_split.cuh
@@ -241,7 +241,7 @@ __global__ void GammaSetupInteractions(G4HepEmGammaTrack *hepEMTracks, const ade
                                        const bool returnAllSteps, const bool returnLastStep)
 {
   auto &slotManager   = *particleManager.gammas.fSlotManager;
-  auto *wdtSetupQueue = splitQueues.queues[ParticleQueues::gammaWoodcockQueue];
+  auto *wdtSetupQueue = splitQueues.queues[ParticleQueues::gammaWoodcock];
   int normalSize      = propagationQueue->size();
   int wdtSize         = wdtSetupQueue->size();
   int activeSize      = normalSize + wdtSize;
@@ -255,7 +255,7 @@ __global__ void GammaSetupInteractions(G4HepEmGammaTrack *hepEMTracks, const ade
     G4HepEmTrack *theTrack        = gammaTrack.GetTrack();
 
     if (currentTrack.nextState.IsOnBoundary()) {
-      splitQueues.queues[ParticleQueues::relocationQueue]->push_back(slot);
+      splitQueues.queues[ParticleQueues::relocation]->push_back(slot);
       continue;
     } else {
       // NOTE: This may be moved to the next kernel

--- a/include/AdePT/transport/kernels/gammas_split.cuh
+++ b/include/AdePT/transport/kernels/gammas_split.cuh
@@ -237,11 +237,11 @@ __global__ void GammaPropagation(NeutralTrack *gammas, G4HepEmGammaTrack *hepEMT
 }
 
 __global__ void GammaSetupInteractions(G4HepEmGammaTrack *hepEMTracks, const adept::MParray *propagationQueue,
-                                       ParticleManager particleManager, AllInteractionQueues interactionQueues,
+                                       ParticleManager particleManager, SplitQueues splitQueues,
                                        const bool returnAllSteps, const bool returnLastStep)
 {
   auto &slotManager   = *particleManager.gammas.fSlotManager;
-  auto *wdtSetupQueue = interactionQueues.queues[ParticleQueues::gammaWoodcockSetupQueue];
+  auto *wdtSetupQueue = splitQueues.queues[ParticleQueues::gammaWoodcockQueue];
   int normalSize      = propagationQueue->size();
   int wdtSize         = wdtSetupQueue->size();
   int activeSize      = normalSize + wdtSize;
@@ -255,7 +255,7 @@ __global__ void GammaSetupInteractions(G4HepEmGammaTrack *hepEMTracks, const ade
     G4HepEmTrack *theTrack        = gammaTrack.GetTrack();
 
     if (currentTrack.nextState.IsOnBoundary()) {
-      interactionQueues.queues[4]->push_back(slot);
+      splitQueues.queues[ParticleQueues::relocationQueue]->push_back(slot);
       continue;
     } else {
       // NOTE: This may be moved to the next kernel
@@ -266,7 +266,7 @@ __global__ void GammaSetupInteractions(G4HepEmGammaTrack *hepEMTracks, const ade
       theTrack->SetNumIALeft(-1.0, 0);
 
       if (theTrack->GetWinnerProcessIndex() < 3) {
-        interactionQueues.queues[theTrack->GetWinnerProcessIndex()]->push_back(slot);
+        splitQueues.queues[theTrack->GetWinnerProcessIndex()]->push_back(slot);
       } else {
         // Gamma nuclear is handled on the host from the returned step only.
         slotManager.MarkSlotForFreeing(slot);

--- a/include/AdePT/transport/kernels/gammas_split.cuh
+++ b/include/AdePT/transport/kernels/gammas_split.cuh
@@ -240,10 +240,13 @@ __global__ void GammaSetupInteractions(G4HepEmGammaTrack *hepEMTracks, const ade
                                        ParticleManager particleManager, AllInteractionQueues interactionQueues,
                                        const bool returnAllSteps, const bool returnLastStep)
 {
-  auto &slotManager = *particleManager.gammas.fSlotManager;
-  int activeSize    = propagationQueue->size();
+  auto &slotManager   = *particleManager.gammas.fSlotManager;
+  auto *wdtSetupQueue = interactionQueues.queues[ParticleQueues::gammaWoodcockSetupQueue];
+  int normalSize      = propagationQueue->size();
+  int wdtSize         = wdtSetupQueue->size();
+  int activeSize      = normalSize + wdtSize;
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
-    const int slot             = (*propagationQueue)[i];
+    const int slot             = i < normalSize ? (*propagationQueue)[i] : (*wdtSetupQueue)[i - normalSize];
     NeutralTrack &currentTrack = particleManager.gammas.TrackAt(slot);
 
     int lvolID = currentTrack.navState.GetLogicalId();

--- a/include/AdePT/transport/queues/ParticleQueues.cuh
+++ b/include/AdePT/transport/queues/ParticleQueues.cuh
@@ -18,7 +18,7 @@ Gamma interactions:
 0 - Conversion
 1 - Compton
 2 - Photoelectric
-3 - Unused
+3 - Woodcock setup queue for split kernels
 4 - Relocation
 
 Electron interactions:
@@ -42,7 +42,8 @@ It is not straightforward to allocate just the needed queues per particle type b
 ParticleQueues needs to be passed by copy to the kernels, which means that we can't do
 dynamic allocations
 */
-  static constexpr char numInteractions = 5;
+  static constexpr char numInteractions         = 5;
+  static constexpr char gammaWoodcockSetupQueue = 3;
   adept::MParray *nextActive;
   adept::MParray *initiallyActive;
 #ifdef ADEPT_USE_SPLIT_KERNELS

--- a/include/AdePT/transport/queues/ParticleQueues.cuh
+++ b/include/AdePT/transport/queues/ParticleQueues.cuh
@@ -17,15 +17,15 @@ struct ParticleQueues {
   // depends on the particle type and is named below.
   static constexpr char numSplitQueues = 5;
 
-  static constexpr char gammaConversionQueue             = 0;
-  static constexpr char gammaComptonQueue                = 1;
-  static constexpr char gammaPhotoelectricQueue          = 2;
-  static constexpr char gammaWoodcockQueue               = 3;
-  static constexpr char chargedIonizationQueue           = 0;
-  static constexpr char chargedBremsstrahlungQueue       = 1;
-  static constexpr char positronAnnihilationQueue        = 2;
-  static constexpr char positronStoppedAnnihilationQueue = 3;
-  static constexpr char relocationQueue                  = 4;
+  static constexpr char gammaConversion             = 0;
+  static constexpr char gammaCompton                = 1;
+  static constexpr char gammaPhotoelectric          = 2;
+  static constexpr char gammaWoodcock               = 3;
+  static constexpr char chargedIonization           = 0;
+  static constexpr char chargedBremsstrahlung       = 1;
+  static constexpr char positronAnnihilation        = 2;
+  static constexpr char positronStoppedAnnihilation = 3;
+  static constexpr char relocation                  = 4;
 
   adept::MParray *nextActive;
   adept::MParray *initiallyActive;

--- a/include/AdePT/transport/queues/ParticleQueues.cuh
+++ b/include/AdePT/transport/queues/ParticleQueues.cuh
@@ -15,17 +15,29 @@ namespace adept::transport {
 struct ParticleQueues {
   // Extra queues used only by the split-kernel transport path. The slot meaning
   // depends on the particle type and is named below.
+
+  //   In-flight and stopped annihilation use different codes but may be merged to save space
+  // in unused queues or if launching one kernel is faster than two smaller ones
+
+  // It is not straightforward to allocate just the needed queues per particle type because
+  // ParticleQueues needs to be passed by copy to the kernels, which means that we can't do
+  // dynamic allocations
+
   static constexpr char numSplitQueues = 5;
 
-  static constexpr char gammaConversion             = 0;
-  static constexpr char gammaCompton                = 1;
-  static constexpr char gammaPhotoelectric          = 2;
-  static constexpr char gammaWoodcock               = 3;
-  static constexpr char chargedIonization           = 0;
-  static constexpr char chargedBremsstrahlung       = 1;
+  // gamma queues:
+  static constexpr char gammaConversion    = 0;
+  static constexpr char gammaCompton       = 1;
+  static constexpr char gammaPhotoelectric = 2;
+  static constexpr char gammaWoodcock      = 3;
+  // electron + positron queues:
+  static constexpr char chargedIonization     = 0;
+  static constexpr char chargedBremsstrahlung = 1;
+  // positron only queues:
   static constexpr char positronAnnihilation        = 2;
   static constexpr char positronStoppedAnnihilation = 3;
-  static constexpr char relocation                  = 4;
+  // common to all queues:
+  static constexpr char relocation = 4;
 
   adept::MParray *nextActive;
   adept::MParray *initiallyActive;

--- a/include/AdePT/transport/queues/ParticleQueues.cuh
+++ b/include/AdePT/transport/queues/ParticleQueues.cuh
@@ -13,42 +13,25 @@ namespace adept::transport {
 // A bundle of queues per particle type:
 //  * Two for active particles, one for the current iteration and the second for the next.
 struct ParticleQueues {
-  /*
-Gamma interactions:
-0 - Conversion
-1 - Compton
-2 - Photoelectric
-3 - Woodcock setup queue for split kernels
-4 - Relocation
+  // Extra queues used only by the split-kernel transport path. The slot meaning
+  // depends on the particle type and is named below.
+  static constexpr char numSplitQueues = 5;
 
-Electron interactions:
-0 - Ionization
-1 - Bremsstrahlung
-2 - Unused
-3 - Unused
-4 - Relocation
+  static constexpr char gammaConversionQueue             = 0;
+  static constexpr char gammaComptonQueue                = 1;
+  static constexpr char gammaPhotoelectricQueue          = 2;
+  static constexpr char gammaWoodcockQueue               = 3;
+  static constexpr char chargedIonizationQueue           = 0;
+  static constexpr char chargedBremsstrahlungQueue       = 1;
+  static constexpr char positronAnnihilationQueue        = 2;
+  static constexpr char positronStoppedAnnihilationQueue = 3;
+  static constexpr char relocationQueue                  = 4;
 
-Positron interactions:
-0 - Ionization
-1 - Bremsstrahlung
-2 - In flight annihilation
-3 - Stopped annihilation
-4 - Relocation
-
-In-flight and stopped annihilation use different codes but may be merged to save space
-in unused queues or if launching one kernel is faster than two smaller ones
-
-It is not straightforward to allocate just the needed queues per particle type because
-ParticleQueues needs to be passed by copy to the kernels, which means that we can't do
-dynamic allocations
-*/
-  static constexpr char numInteractions         = 5;
-  static constexpr char gammaWoodcockSetupQueue = 3;
   adept::MParray *nextActive;
   adept::MParray *initiallyActive;
 #ifdef ADEPT_USE_SPLIT_KERNELS
   adept::MParray *propagation;
-  adept::MParray *interactionQueues[numInteractions];
+  adept::MParray *splitQueues[numSplitQueues];
 #endif
 
   void SwapActive() { std::swap(initiallyActive, nextActive); }
@@ -88,9 +71,9 @@ struct AllParticleQueues {
 };
 
 #ifdef ADEPT_USE_SPLIT_KERNELS
-// A bundle of queues per interaction type
-struct AllInteractionQueues {
-  adept::MParray *queues[ParticleQueues::numInteractions];
+// A bundle of the extra queues used by split kernels for one particle type.
+struct SplitQueues {
+  adept::MParray *queues[ParticleQueues::numSplitQueues];
 };
 #endif
 

--- a/include/AdePT/transport/state/GPUState.cuh
+++ b/include/AdePT/transport/state/GPUState.cuh
@@ -35,8 +35,8 @@ struct SpeciesState {
   ParticleQueues queues{};
   ADEPT_DEVICE_API_SYMBOL(Stream_t) stream {};
   ADEPT_DEVICE_API_SYMBOL(Event_t) event {};
-  ADEPT_DEVICE_API_SYMBOL(Stream_t) physicsStream {}; ///< Auxiliary stream for species-local physics kernels.
-  ADEPT_DEVICE_API_SYMBOL(Event_t) physicsEvent {};   ///< Completion event for work on the physics stream.
+  ADEPT_DEVICE_API_SYMBOL(Stream_t) auxiliaryStream {}; ///< Extra per-species stream for split/WDT kernels.
+  ADEPT_DEVICE_API_SYMBOL(Event_t) auxiliaryEvent {};   ///< Completion event for work on the auxiliary stream.
 #ifdef ADEPT_USE_SPLIT_KERNELS
   ADEPT_DEVICE_API_SYMBOL(Event_t) setupEvent {};
 #endif
@@ -117,8 +117,8 @@ struct GPUstate {
       auto destroySpeciesSync = [](auto &particleType) {
         if (particleType.stream) ADEPT_DEVICE_API_CALL(StreamDestroy(particleType.stream));
         if (particleType.event) ADEPT_DEVICE_API_CALL(EventDestroy(particleType.event));
-        if (particleType.physicsStream) ADEPT_DEVICE_API_CALL(StreamDestroy(particleType.physicsStream));
-        if (particleType.physicsEvent) ADEPT_DEVICE_API_CALL(EventDestroy(particleType.physicsEvent));
+        if (particleType.auxiliaryStream) ADEPT_DEVICE_API_CALL(StreamDestroy(particleType.auxiliaryStream));
+        if (particleType.auxiliaryEvent) ADEPT_DEVICE_API_CALL(EventDestroy(particleType.auxiliaryEvent));
 #ifdef ADEPT_USE_SPLIT_KERNELS
         if (particleType.setupEvent) ADEPT_DEVICE_API_CALL(EventDestroy(particleType.setupEvent));
 #endif

--- a/include/AdePT/transport/state/GPUState.cuh
+++ b/include/AdePT/transport/state/GPUState.cuh
@@ -35,10 +35,10 @@ struct SpeciesState {
   ParticleQueues queues{};
   ADEPT_DEVICE_API_SYMBOL(Stream_t) stream {};
   ADEPT_DEVICE_API_SYMBOL(Event_t) event {};
+  ADEPT_DEVICE_API_SYMBOL(Stream_t) physicsStream {}; ///< Auxiliary stream for species-local physics kernels.
+  ADEPT_DEVICE_API_SYMBOL(Event_t) physicsEvent {};   ///< Completion event for work on the physics stream.
 #ifdef ADEPT_USE_SPLIT_KERNELS
-  ADEPT_DEVICE_API_SYMBOL(Stream_t) physicsStream {};
   ADEPT_DEVICE_API_SYMBOL(Event_t) setupEvent {};
-  ADEPT_DEVICE_API_SYMBOL(Event_t) physicsEvent {};
 #endif
 };
 
@@ -117,10 +117,10 @@ struct GPUstate {
       auto destroySpeciesSync = [](auto &particleType) {
         if (particleType.stream) ADEPT_DEVICE_API_CALL(StreamDestroy(particleType.stream));
         if (particleType.event) ADEPT_DEVICE_API_CALL(EventDestroy(particleType.event));
-#ifdef ADEPT_USE_SPLIT_KERNELS
         if (particleType.physicsStream) ADEPT_DEVICE_API_CALL(StreamDestroy(particleType.physicsStream));
-        if (particleType.setupEvent) ADEPT_DEVICE_API_CALL(EventDestroy(particleType.setupEvent));
         if (particleType.physicsEvent) ADEPT_DEVICE_API_CALL(EventDestroy(particleType.physicsEvent));
+#ifdef ADEPT_USE_SPLIT_KERNELS
+        if (particleType.setupEvent) ADEPT_DEVICE_API_CALL(EventDestroy(particleType.setupEvent));
 #endif
       };
       destroySpeciesSync(electrons);

--- a/include/AdePT/transport/state/TransportStats.hh
+++ b/include/AdePT/transport/state/TransportStats.hh
@@ -10,7 +10,10 @@ namespace adept::transport {
 
 // A data structure to transfer statistics after each iteration.
 struct Stats {
+  // The gamma entry includes WDT gammas for transport-loop control.
   int inFlight[GPUQueueIndex::NumSpecies];
+  // WDT-only launch-size hint. Device queue sizes remain authoritative.
+  int wdtGammasInFlight;
   float queueFillLevel[GPUQueueIndex::NumParticleQueues];
   float slotFillLevel[GPUQueueIndex::NumSpecies];
   unsigned int perEventInFlight[kMaxThreads];         // Updated asynchronously

--- a/include/AdePT/transport/state/TransportStats.hh
+++ b/include/AdePT/transport/state/TransportStats.hh
@@ -10,9 +10,10 @@ namespace adept::transport {
 
 // A data structure to transfer statistics after each iteration.
 struct Stats {
-  // The gamma entry includes WDT gammas for transport-loop control.
+  // Gamma total used by transport-loop control; includes normal and WDT gamma queues.
   int inFlight[GPUQueueIndex::NumSpecies];
-  // WDT-only launch-size hint. Device queue sizes remain authoritative.
+  // WDT contribution to the gamma total, kept so normal and WDT gamma kernels can be launched with different grid
+  // sizes.
   int wdtGammasInFlight;
   float queueFillLevel[GPUQueueIndex::NumParticleQueues];
   float slotFillLevel[GPUQueueIndex::NumSpecies];


### PR DESCRIPTION
This PR runs the WDT kernels in parallel to the normal gamma kernels, both for the split kernels and the monolithic kernels.

For this, the `physicsStream` from #635 is used to also cover the WDT kernels. As the name was not appropriate anymore, it was changed to `auxilaryStream`.
Additionally, the queues were renamed:
The split-kernel extra queues are now named:

- ParticleQueues::splitQueues
- SplitQueues
- ParticleQueues::numSplitQueues

Queue slots now have explicit names:

- gammaConversion
- gammaCompton
- gammaPhotoelectric
- gammaWoodcock
- chargedIonization
- chargedBremsstrahlung
- positronAnnihilation
- positronStoppedAnnihilation
- relocation

Furthermore, now the WDT kernels are launched with the correct size, and so are the other gamma kernels.

This PR accelerates LHCb by ~10% for the split kernels, for ATLAS it does not matter, as the WDT kernels run in parallel to the bottlenecking electron kernels.

