### PR TITLE
record steps for tracks that are finished on CPU first

### DIFF
--- a/include/AdePT/transport/kernels/electrons.cuh
+++ b/include/AdePT/transport/kernels/electrons.cuh
@@ -125,6 +125,46 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     printErrors = !gTrackDebug.active || verbose;
 #endif
 
+    // Finish-on-CPU must happen before any interaction can create secondaries on the GPU.
+    // Otherwise, the deferred steps from the FinishOnCPU particles could be processed after
+    // their child steps, which would cause missing links in the HostTrackData
+    if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < allowFinishOffEvent[currentTrack.threadId] &&
+        InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
+      if (printErrors) {
+        printf("Thread %d Finishing e-/e+ of the %d last particles of event %d on CPU E=%f lvol=%d after %d steps.\n",
+               currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
+               currentTrack.eventId, eKin, lvolID, currentTrack.stepCounter);
+      }
+
+      slotManager.MarkSlotForFreeing(slot);
+
+      adept_step_recording::RecordGPUStep(currentTrack.trackId,     // Track ID
+                                          currentTrack.parentId,    // parent Track ID
+                                          kAdePTFinishOnCPUProcess, // step-defining process id
+                                          IsElectron ? ParticleType::Electron : ParticleType::Positron, // Particle type
+                                          0.,                                                           // Step length
+                                          0.,                                                           // Total Edep
+                                          currentTrack.weight,                                          // Track weight
+                                          navState,          // Pre-step point navstate
+                                          preStepPos,        // Pre-step point position
+                                          preStepDir,        // Pre-step point momentum direction
+                                          preStepEnergy,     // Pre-step point kinetic energy
+                                          navState,          // Post-step point navstate
+                                          pos,               // Post-step point position
+                                          dir,               // Post-step point momentum direction
+                                          eKin,              // Post-step point kinetic energy
+                                          globalTime,        // global time
+                                          localTime,         // local time
+                                          properTime,        // proper time
+                                          preStepGlobalTime, // global time at preStepPoint
+                                          currentTrack.eventId, currentTrack.threadId, // eventID and threadID
+                                          false,                                       // parent continues on CPU
+                                          currentTrack.stepCounter,                    // stepcounter
+                                          nullptr,                                     // pointer to secondary init data
+                                          0);                                          // number of secondaries
+      continue;
+    }
+
     auto survive = [&]() {
       currentTrack.eKin       = eKin;
       currentTrack.pos        = pos;
@@ -790,20 +830,6 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
         // call experiment-specific SteppingAction:
         SteppingActionT::ElectronAction(trackSurvives, eKin, energyDeposit, pos, globalTime, *postStepAuxData,
                                         &g4HepEmData, params);
-      }
-    }
-
-    // this one always needs to be last as it needs to be done only if the track survives
-    if (trackSurvives) {
-      if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < allowFinishOffEvent[currentTrack.threadId] &&
-          InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
-        if (printErrors)
-          printf("Thread %d Finishing e-/e+ of the %d last particles of event %d on CPU E=%f lvol=%d after %d steps.\n",
-                 currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
-                 currentTrack.eventId, eKin, lvolID, currentTrack.stepCounter);
-        trackSurvives     = false;
-        continuesOnCPU    = true;
-        returnedProcessId = kAdePTFinishOnCPUProcess;
       }
     }
 

--- a/include/AdePT/transport/kernels/electrons.cuh
+++ b/include/AdePT/transport/kernels/electrons.cuh
@@ -130,12 +130,6 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     // their child steps, which would cause missing links in the HostTrackData
     if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < allowFinishOffEvent[currentTrack.threadId] &&
         InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
-      if (printErrors) {
-        printf("Thread %d Finishing e-/e+ of the %d last particles of event %d on CPU E=%f lvol=%d after %d steps.\n",
-               currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
-               currentTrack.eventId, eKin, lvolID, currentTrack.stepCounter);
-      }
-
       slotManager.MarkSlotForFreeing(slot);
 
       adept_step_recording::RecordGPUStep(currentTrack.trackId,     // Track ID

--- a/include/AdePT/transport/kernels/electrons_split.cuh
+++ b/include/AdePT/transport/kernels/electrons_split.cuh
@@ -155,13 +155,6 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
         if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] <
                 allowFinishOffEvent[currentTrack.threadId] &&
             InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
-          if (printErrors) {
-            printf(
-                "Thread %d Finishing e-/e+ of the %d last particles of event %d on CPU E=%f lvol=%d after %d steps.\n",
-                currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
-                currentTrack.eventId, currentTrack.eKin, lvolID, currentTrack.stepCounter);
-          }
-
           slotManager.MarkSlotForFreeing(slot);
 
           adept_step_recording::RecordGPUStep(currentTrack.trackId,     // Track ID

--- a/include/AdePT/transport/kernels/gammas.cuh
+++ b/include/AdePT/transport/kernels/gammas.cuh
@@ -76,6 +76,46 @@ __global__ void __launch_bounds__(256, 1)
     }
 #endif
 
+    // Finish-on-CPU must happen before any interaction can create secondaries on the GPU.
+    // Otherwise, the deferred steps from the FinishOnCPU particles could be processed after
+    // their child steps, which would cause missing links in the HostTrackData
+    if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < allowFinishOffEvent[currentTrack.threadId] &&
+        InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
+      if (printErrors) {
+        printf("Thread %d Finishing gamma of the %d last particles of event %d on CPU E=%f lvol=%d after %d steps.\n",
+               currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
+               currentTrack.eventId, eKin, lvolID, currentTrack.stepCounter);
+      }
+
+      slotManager.MarkSlotForFreeing(slot);
+
+      adept_step_recording::RecordGPUStep(currentTrack.trackId,     // Track ID
+                                          currentTrack.parentId,    // parent Track ID
+                                          kAdePTFinishOnCPUProcess, // step-defining process id
+                                          ParticleType::Gamma,      // Particle type
+                                          0.,                       // Step length
+                                          0.,                       // Total Edep
+                                          currentTrack.weight,      // Track weight
+                                          navState,                 // Pre-step point navstate
+                                          preStepPos,               // Pre-step point position
+                                          preStepDir,               // Pre-step point momentum direction
+                                          preStepEnergy,            // Pre-step point kinetic energy
+                                          navState,                 // Post-step point navstate
+                                          pos,                      // Post-step point position
+                                          dir,                      // Post-step point momentum direction
+                                          eKin,                     // Post-step point kinetic energy
+                                          globalTime,               // global time
+                                          localTime,                // local time
+                                          properTime,               // proper time
+                                          preStepGlobalTime,        // global time at preStepPoint
+                                          currentTrack.eventId, currentTrack.threadId, // event and thread ID
+                                          false,                                       // parent continues on CPU
+                                          currentTrack.stepCounter,                    // stepcounter
+                                          nullptr,                                     // pointer to secondary init data
+                                          0);                                          // number of secondaries
+      continue;
+    }
+
     // Write local variables back into track and enqueue
     auto survive = [&]() {
       currentTrack.eKin       = eKin;
@@ -428,21 +468,6 @@ __global__ void __launch_bounds__(256, 1)
         // call experiment-specific SteppingAction:
         SteppingActionT::GammaAction(trackSurvives, eKin, edep, pos, globalTime, *postStepAuxData, &g4HepEmData,
                                      params);
-      }
-    }
-
-    // Finishing on CPU must be checked last. It changes only the returned step
-    // type and does not affect whether the track survives this iteration.
-    if (trackSurvives && !continuesOnCPU) {
-      if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < allowFinishOffEvent[currentTrack.threadId] &&
-          InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
-        printf("Thread %d Finishing gamma of the %d last particles of event %d on CPU E=%f lvol=%d after %d steps.\n",
-               currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
-               currentTrack.eventId, eKin, lvolID, currentTrack.stepCounter);
-
-        trackSurvives        = false;
-        continuesOnCPU       = true;
-        stepDefinedProcessId = kAdePTFinishOnCPUProcess;
       }
     }
 

--- a/include/AdePT/transport/kernels/gammas.cuh
+++ b/include/AdePT/transport/kernels/gammas.cuh
@@ -81,12 +81,6 @@ __global__ void __launch_bounds__(256, 1)
     // their child steps, which would cause missing links in the HostTrackData
     if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < allowFinishOffEvent[currentTrack.threadId] &&
         InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
-      if (printErrors) {
-        printf("Thread %d Finishing gamma of the %d last particles of event %d on CPU E=%f lvol=%d after %d steps.\n",
-               currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
-               currentTrack.eventId, eKin, lvolID, currentTrack.stepCounter);
-      }
-
       slotManager.MarkSlotForFreeing(slot);
 
       adept_step_recording::RecordGPUStep(currentTrack.trackId,     // Track ID

--- a/include/AdePT/transport/kernels/gammasWDT.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT.cuh
@@ -86,12 +86,6 @@ __global__ void __launch_bounds__(256, 1)
     if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < allowFinishOffEvent[currentTrack.threadId] &&
         InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
       const int handoffLvolID = currentTrack.navState.GetLogicalId();
-      if (printErrors) {
-        printf("Thread %d Finishing gamma of the %d last particles of event %d on CPU E=%f lvol=%d after %d steps.\n",
-               currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
-               currentTrack.eventId, eKin, handoffLvolID, currentTrack.stepCounter);
-      }
-
       slotManager.MarkSlotForFreeing(slot);
 
       adept_step_recording::RecordGPUStep(currentTrack.trackId,     // Track ID

--- a/include/AdePT/transport/kernels/gammasWDT.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT.cuh
@@ -85,7 +85,6 @@ __global__ void __launch_bounds__(256, 1)
     // their child steps, which would cause missing links in the HostTrackData
     if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < allowFinishOffEvent[currentTrack.threadId] &&
         InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
-      const int handoffLvolID = currentTrack.navState.GetLogicalId();
       slotManager.MarkSlotForFreeing(slot);
 
       adept_step_recording::RecordGPUStep(currentTrack.trackId,     // Track ID

--- a/include/AdePT/transport/kernels/gammasWDT.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT.cuh
@@ -80,6 +80,47 @@ __global__ void __launch_bounds__(256, 1)
     double localTime                   = currentTrack.localTime;
     double properTime                  = currentTrack.properTime;
 
+    // Finish-on-CPU must happen before any interaction can create secondaries on the GPU.
+    // Otherwise, the deferred steps from the FinishOnCPU particles could be processed after
+    // their child steps, which would cause missing links in the HostTrackData
+    if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < allowFinishOffEvent[currentTrack.threadId] &&
+        InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
+      const int handoffLvolID = currentTrack.navState.GetLogicalId();
+      if (printErrors) {
+        printf("Thread %d Finishing gamma of the %d last particles of event %d on CPU E=%f lvol=%d after %d steps.\n",
+               currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
+               currentTrack.eventId, eKin, handoffLvolID, currentTrack.stepCounter);
+      }
+
+      slotManager.MarkSlotForFreeing(slot);
+
+      adept_step_recording::RecordGPUStep(currentTrack.trackId,     // Track ID
+                                          currentTrack.parentId,    // parent Track ID
+                                          kAdePTFinishOnCPUProcess, // step-defining process id
+                                          ParticleType::Gamma,      // Particle type
+                                          0.,                       // Step length
+                                          0.,                       // Total Edep
+                                          currentTrack.weight,      // Track weight
+                                          currentTrack.navState,    // Pre-step point navstate
+                                          preStepPos,               // Pre-step point position
+                                          preStepDir,               // Pre-step point momentum direction
+                                          eKin,                     // Pre-step point kinetic energy
+                                          currentTrack.navState,    // Post-step point navstate
+                                          pos,                      // Post-step point position
+                                          dir,                      // Post-step point momentum direction
+                                          eKin,                     // Post-step point kinetic energy
+                                          globalTime,               // global time
+                                          localTime,                // local time
+                                          properTime,               // proper time
+                                          preStepGlobalTime,        // global time at preStepPoint
+                                          currentTrack.eventId, currentTrack.threadId, // event and thread ID
+                                          false,                                       // parent continues on CPU
+                                          currentTrack.stepCounter,                    // stepcounter
+                                          nullptr,                                     // pointer to secondary init data
+                                          0);                                          // number of secondaries
+      continue;
+    }
+
     //
     // survive: decide whether to continue woodcock tracking or not:
     // Write local variables back into track and enqueue to correct queue
@@ -619,21 +660,6 @@ __global__ void __launch_bounds__(256, 1)
       } else {
         // call experiment-specific SteppingAction:
         SteppingActionT::GammaAction(trackSurvives, eKin, edep, pos, globalTime, nextauxData, &g4HepEmData, params);
-      }
-    }
-
-    // Finishing on CPU must be checked last. It changes only the returned step
-    // type and does not affect whether the track survives this iteration.
-    if (trackSurvives && !continuesOnCPU) {
-      if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] < allowFinishOffEvent[currentTrack.threadId] &&
-          InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
-        printf("Thread %d Finishing gamma of the %d last particles of event %d on CPU E=%f lvol=%d after %d steps.\n",
-               currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
-               currentTrack.eventId, eKin, lvolID, currentTrack.stepCounter);
-
-        trackSurvives        = false;
-        continuesOnCPU       = true;
-        stepDefinedProcessId = kAdePTFinishOnCPUProcess;
       }
     }
 

--- a/include/AdePT/transport/kernels/gammasWDT_split.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT_split.cuh
@@ -129,13 +129,6 @@ __global__ void __launch_bounds__(256, 1)
         if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] <
                 allowFinishOffEvent[currentTrack.threadId] &&
             InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
-          if (printErrors) {
-            printf(
-                "Thread %d Finishing gamma of the %d last particles of event %d on CPU E=%f lvol=%d after %d steps.\n",
-                currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
-                currentTrack.eventId, currentTrack.eKin, lvolID, currentTrack.stepCounter);
-          }
-
           slotManager.MarkSlotForFreeing(slot);
 
           adept_step_recording::RecordGPUStep(currentTrack.trackId,           // Track ID

--- a/include/AdePT/transport/kernels/gammas_split.cuh
+++ b/include/AdePT/transport/kernels/gammas_split.cuh
@@ -101,13 +101,6 @@ __global__ void GammaHowFar(G4HepEmGammaTrack *hepEMTracks, ParticleManager part
         if (InFlightStats->perEventInFlightPrevious[currentTrack.threadId] <
                 allowFinishOffEvent[currentTrack.threadId] &&
             InFlightStats->perEventInFlightPrevious[currentTrack.threadId] != 0) {
-          if (printErrors) {
-            printf(
-                "Thread %d Finishing gamma of the %d last particles of event %d on CPU E=%f lvol=%d after %d steps.\n",
-                currentTrack.threadId, InFlightStats->perEventInFlightPrevious[currentTrack.threadId],
-                currentTrack.eventId, currentTrack.eKin, lvolID, currentTrack.stepCounter);
-          }
-
           slotManager.MarkSlotForFreeing(slot);
 
           adept_step_recording::RecordGPUStep(currentTrack.trackId,           // Track ID

--- a/src/g4integration/tracking_managers/AdePTTrackingManager.cc
+++ b/src/g4integration/tracking_managers/AdePTTrackingManager.cc
@@ -493,9 +493,12 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
     fHepEmTrackingManager->SetFinishEventOnCPU(threadId, -1);
   }
 
-  // first particle to be finished on CPU detected, let's finish the full event on CPU
+  // First particle to be finished on CPU detected, so finish the full event on CPU.
   if (fHepEmTrackingManager->GetFinishEventOnCPU(threadId) < 0 && aTrack->GetTrackStatus() == fStopButAlive) {
     fHepEmTrackingManager->SetFinishEventOnCPU(threadId, eventID);
+    if (fAdePTConfiguration->GetVerbosity() >= 2) {
+      std::cout << "AdePTTrackingManager: particles are finished on CPU for event " << eventID << std::endl;
+    }
   }
 
   // If this is the first step, set touchable and next touchable via SetInitialStep


### PR DESCRIPTION
This fixes a crash observed in CMSSW with the FinishOnCPU option.
The bug is the following in the monolithic kernels:

As the FinishOnCPU is evaluated in the SteppingAction at the end of the kernel (as opposed the beginning in the split kernels), a step flagged with FinishOnCPU may have generated a secondary. Then, as returned tracks are deferred to the end for reproducibility, the step where the secondary is generated, and hence, where its HostTrackData is created, is processed very late. Until then, the secondary that was generated on the GPU in the last step, may have done another step itself. When this step is processed, the HostTrackData is still missing (the step to generate it, is in the DeferredQueue), leading to the crash.

The correct fix is to check for FinishOnCPU in the beginning of the kernel, such that a deferred step cannot have a secondary attached.

Furthermore, the per kernel printouts of finishing particles on CPU are removed, now a single printout on CPU per event is written, guarded by the AdePT verbosity.