### PR TITLE
Include VecGeom CudaManager where used

### DIFF
--- a/include/AdePT/transport/AdePTTransport.cuh
+++ b/include/AdePT/transport/AdePTTransport.cuh
@@ -37,6 +37,7 @@
 using SelectedSteppingAction = adept::SteppingAction::Action;
 
 #include <VecGeom/base/Config.h>
+#include <VecGeom/management/CudaManager.h>
 #ifdef VECGEOM_ENABLE_CUDA
 #include <VecGeom/backend/cuda/Interface.h>
 #endif

--- a/test/unit/testField/testField.cu
+++ b/test/unit/testField/testField.cu
@@ -14,6 +14,7 @@
 
 #include <VecGeom/base/Config.h>
 #include <G4Timer.hh>
+#include <VecGeom/management/CudaManager.h>
 #include <VecGeom/management/GeoManager.h>
 #ifdef VECGEOM_ENABLE_CUDA
 #include <VecGeom/backend/cuda/Interface.h>


### PR DESCRIPTION
This MR adds direct `VecGeom/management/CudaManager.h` includes in CUDA translation units that use `vecgeom::cxx::CudaManager`.

This avoids relying on transitive VecGeom includes, which changed in recent VecGeom development branches.
This must have zero impact on physics, since it is just a header include.

---
