### PR TITLE
remove redundant path for track lineage info

### DIFF
--- a/test/regression/IntegrationTest/include/TrackLineageInfo.hh
+++ b/test/regression/IntegrationTest/include/TrackLineageInfo.hh
@@ -12,7 +12,7 @@
  * - the primary ancestor track ID
  * - the shower generation
  *
- * The initial-recorded flag avoids double counting secondaries: they are first
+ * Lineage is assigned once. The initial-recorded flag avoids double counting secondaries: they are first
  * seen in the parent stepping callback and then enter their own tracking
  * callback afterwards.
  */
@@ -29,18 +29,12 @@ public:
 
   int GetPrimaryTrackID() const { return fPrimaryTrackID; }
   unsigned int GetGeneration() const { return fGeneration; }
-  /// Update the lineage in place when the parent step propagates it downstream.
-  void SetLineage(int primaryTrackID, unsigned int generation)
-  {
-    fPrimaryTrackID = primaryTrackID;
-    fGeneration     = generation;
-  }
 
   bool HasRecordedInitial() const { return fInitialRecorded; }
   void MarkRecordedInitial() { fInitialRecorded = true; }
 
 private:
-  int fPrimaryTrackID;
-  unsigned int fGeneration;
+  const int fPrimaryTrackID;
+  const unsigned int fGeneration;
   bool fInitialRecorded{false};
 };

--- a/test/regression/IntegrationTest/src/SteppingAction.cc
+++ b/test/regression/IntegrationTest/src/SteppingAction.cc
@@ -9,6 +9,8 @@
 #include "G4RunManager.hh"
 #include "G4Step.hh"
 
+#include <stdexcept>
+
 namespace {
 
 /// Helper to access the mutable regression run object from Geant4 callbacks.
@@ -48,13 +50,14 @@ void SteppingAction::UserSteppingAction(const G4Step *theStep)
 
       for (auto *secondary : *secondaries) {
         if (secondary == nullptr) continue;
-        auto *secondaryInfo = static_cast<TrackLineageInfo *>(secondary->GetUserInformation());
-        if (secondaryInfo == nullptr) {
-          secondaryInfo = new TrackLineageInfo(primaryTrackID, generation);
-          secondary->SetUserInformation(secondaryInfo);
+        if (secondary->GetUserInformation() != nullptr) {
+          throw std::runtime_error("Secondary track already has user information attached before stepping action");
         }
 
-        if (truthHistogrammer != nullptr && secondaryInfo != nullptr && !secondaryInfo->HasRecordedInitial()) {
+        auto *secondaryInfo = new TrackLineageInfo(primaryTrackID, generation);
+        secondary->SetUserInformation(secondaryInfo);
+
+        if (truthHistogrammer != nullptr && !secondaryInfo->HasRecordedInitial()) {
           // The initial snapshot is recorded when the secondary first becomes
           // fully linked to its parent lineage. Mark it so later callbacks do
           // not duplicate the same track in the truth histograms.

--- a/test/regression/IntegrationTest/src/SteppingAction.cc
+++ b/test/regression/IntegrationTest/src/SteppingAction.cc
@@ -52,10 +52,6 @@ void SteppingAction::UserSteppingAction(const G4Step *theStep)
         if (secondaryInfo == nullptr) {
           secondaryInfo = new TrackLineageInfo(primaryTrackID, generation);
           secondary->SetUserInformation(secondaryInfo);
-        } else {
-          // Keep the lineage payload in sync if the same secondary is observed
-          // again while the parent step is still being processed.
-          secondaryInfo->SetLineage(primaryTrackID, generation);
         }
 
         if (truthHistogrammer != nullptr && secondaryInfo != nullptr && !secondaryInfo->HasRecordedInitial()) {


### PR DESCRIPTION
This PR cleans up a redundant path:
The lineage info is assigned once, in the step of the primary that creates the secondaries. There should be no track info attached at this point, therefore an error is thrown in case it is already attached.

Found by @WitekPokorski 