### PR TITLE
remove geometry-related pushes in AdePT, keep one for the GPU-CPU handoff

### DIFF
--- a/include/AdePT/transport/AdePTTransport.cuh
+++ b/include/AdePT/transport/AdePTTransport.cuh
@@ -193,7 +193,6 @@ __global__ void InitTracks(adeptint::TrackData *trackinfo, int ntracks, Particle
                            const vecgeom::VPlacedVolume *world, adept::MParrayT<QueueIndexPair> *toBeEnqueued,
                            uint64_t initialSeed)
 {
-  // constexpr double tolerance = 10. * vecgeom::kTolerance;
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < ntracks; i += blockDim.x * gridDim.x) {
     const auto &trackInfo = trackinfo[i];
 

--- a/include/AdePT/transport/kernels/electrons.cuh
+++ b/include/AdePT/transport/kernels/electrons.cuh
@@ -59,7 +59,6 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
                                                           AllowFinishOffEventArray allowFinishOffEvent,
                                                           const bool returnAllSteps, const bool returnLastStep)
 {
-  constexpr double kPushDistance    = 1000 * vecgeom::kTolerance;
   constexpr unsigned short maxSteps = 10'000;
   constexpr int Charge              = IsElectron ? -1 : 1;
   constexpr double restMass         = copcore::units::kElectronMassC2;
@@ -317,8 +316,8 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
       geometryStepLength = AdePTNavigator::ComputeStepAndNextVolume(pos, dir, geometricalStepLengthFromPhysics,
                                                                     navState, nextState, hitsurf_index);
 #else
-      geometryStepLength = AdePTNavigator::ComputeStepAndNextVolume(pos, dir, geometricalStepLengthFromPhysics,
-                                                                    navState, nextState, kPushDistance);
+      geometryStepLength =
+          AdePTNavigator::ComputeStepAndNextVolume(pos, dir, geometricalStepLengthFromPhysics, navState, nextState);
 #endif
       pos += geometryStepLength * dir;
     }
@@ -477,9 +476,6 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
           postStepAuxData = &nextauxData;
           // track has left GPU region
           if (nextauxData.fGPUregionId < 0) {
-            // To be safe, just push a bit the track exiting the GPU region to make sure
-            // Geant4 does not relocate it again inside the same region
-            pos += kPushDistance * dir;
 
 #if ADEPT_DEBUG_TRACK > 0
             if (verbose) printf("\n| track returned to Geant4\n");

--- a/include/AdePT/transport/kernels/electrons_split.cuh
+++ b/include/AdePT/transport/kernels/electrons_split.cuh
@@ -289,7 +289,6 @@ template <bool IsElectron>
 __global__ void ElectronPropagation(ChargedTrack *electronsOrPositrons, G4HepEmElectronTrack *hepEMTracks,
                                     const adept::MParray *propagationQueue)
 {
-  constexpr double kPushDistance           = 1000 * vecgeom::kTolerance;
   constexpr int Charge                     = IsElectron ? -1 : 1;
   constexpr double restMass                = copcore::units::kElectronMassC2;
   constexpr int Nvar                       = 6;
@@ -351,7 +350,7 @@ __global__ void ElectronPropagation(ChargedTrack *electronsOrPositrons, G4HepEmE
 #else
       geometryStepLength =
           AdePTNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, theTrack->GetGStepLength(),
-                                                   currentTrack.navState, currentTrack.nextState, kPushDistance);
+                                                   currentTrack.navState, currentTrack.nextState);
 #endif
       currentTrack.pos += geometryStepLength * currentTrack.dir;
     }
@@ -607,8 +606,7 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
                                    adept::MParray *relocatingQueue, const bool returnAllSteps,
                                    const bool returnLastStep)
 {
-  constexpr double kPushDistance = 1000 * vecgeom::kTolerance;
-  auto &electronsOrPositrons     = (IsElectron ? particleManager.electrons : particleManager.positrons);
+  auto &electronsOrPositrons = (IsElectron ? particleManager.electrons : particleManager.positrons);
 
   SlotManager &slotManager = *electronsOrPositrons.fSlotManager;
   int activeSize           = relocatingQueue->size();
@@ -665,9 +663,6 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
       VolAuxData const &nextauxData = adept::transport::gVolAuxData[nextlvolID];
       returnsToCPU                  = nextauxData.fGPUregionId < 0;
       if (returnsToCPU) {
-        // Push the handoff point a little into the CPU region so Geant4 does
-        // not relocate the track back into the same GPU region.
-        currentTrack.pos += kPushDistance * currentTrack.dir;
         stepProcessId = kAdePTOutOfGPURegionProcess;
         isLastStep    = false;
       }

--- a/include/AdePT/transport/kernels/gammas.cuh
+++ b/include/AdePT/transport/kernels/gammas.cuh
@@ -40,7 +40,6 @@ __global__ void __launch_bounds__(256, 1)
     TransportGammas(ParticleManager particleManager, Stats *InFlightStats, const StepActionParam params,
                     AllowFinishOffEventArray allowFinishOffEvent, const bool returnAllSteps, const bool returnLastStep)
 {
-  constexpr double kPushDistance    = 1000 * vecgeom::kTolerance;
   constexpr unsigned short maxSteps = 10'000;
   auto &slotManager                 = *particleManager.gammas.fSlotManager;
   const int activeSize              = particleManager.gammas.ActiveSize();
@@ -171,8 +170,8 @@ __global__ void __launch_bounds__(256, 1)
     geometryStepLength = AdePTNavigator::ComputeStepAndNextVolume(pos, dir, geometricalStepLengthFromPhysics, navState,
                                                                   nextState, hitsurf_index);
 #else
-    geometryStepLength = AdePTNavigator::ComputeStepAndNextVolume(pos, dir, geometricalStepLengthFromPhysics, navState,
-                                                                  nextState, kPushDistance);
+    geometryStepLength =
+        AdePTNavigator::ComputeStepAndNextVolume(pos, dir, geometricalStepLengthFromPhysics, navState, nextState);
 #endif
     if (geometryStepLength < kPushStuck && geometryStepLength < geometricalStepLengthFromPhysics) {
       currentTrack.zeroStepCounter++;
@@ -248,9 +247,6 @@ __global__ void __launch_bounds__(256, 1)
           enterWDTRegion = ShouldUseWDT(nextState, eKin);
           trackSurvives  = true;
         } else {
-          // To be safe, just push a bit the track exiting the GPU region to make sure
-          // Geant4 does not relocate it again inside the same region
-          pos += kPushDistance * dir;
 
 #if ADEPT_DEBUG_TRACK > 0
           if (verbose) printf("\n| track returned to Geant4\n");

--- a/include/AdePT/transport/kernels/gammasWDT.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT.cuh
@@ -43,7 +43,6 @@ __global__ void __launch_bounds__(256, 1)
   // G4HepEmTrackingManager.cc. Here, it is adopted and adjusted to AdePT's GPU track structures and using VecGeom
   // instead of G4 navigation
 
-  constexpr double kPushDistance    = 1000 * vecgeom::kTolerance;
   constexpr unsigned short maxSteps = 10'000;
   auto &slotManager                 = *particleManager.gammasWDT.fSlotManager;
   const int activeSize              = particleManager.gammasWDT.ActiveSize();
@@ -446,9 +445,6 @@ __global__ void __launch_bounds__(256, 1)
           // particle is still alive
           trackSurvives = true;
         } else {
-          // To be safe, just push a bit the track exiting the GPU region to make sure
-          // Geant4 does not relocate it again inside the same region
-          pos += kPushDistance * dir;
 
 #if ADEPT_DEBUG_TRACK > 0
           if (verbose) printf("\n| track returned to Geant4\n");

--- a/include/AdePT/transport/kernels/gammasWDT_split.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT_split.cuh
@@ -44,7 +44,6 @@ __global__ void __launch_bounds__(256, 1)
   // G4HepEmTrackingManager.cc. Here, it is adopted and adjusted to AdePT's GPU track structures and using VecGeom
   // instead of G4 navigation
 
-  constexpr double kPushDistance           = 1000 * vecgeom::kTolerance;
   constexpr unsigned short kStepsStuckKill = 25;
   constexpr unsigned short maxSteps        = 10'000;
   auto &slotManager                        = *particleManager.gammasWDT.fSlotManager;
@@ -494,9 +493,6 @@ __global__ void __launch_bounds__(256, 1)
           }
 #endif
         } else {
-          // To be safe, just push a bit the track exiting the GPU region to make sure
-          // Geant4 does not relocate it again inside the same region
-          currentTrack.pos += kPushDistance * currentTrack.dir;
 
 #if ADEPT_DEBUG_TRACK > 0
           if (verbose) printf("\n| track returned to Geant4\n");

--- a/include/AdePT/transport/kernels/gammas_split.cuh
+++ b/include/AdePT/transport/kernels/gammas_split.cuh
@@ -186,7 +186,6 @@ __global__ void GammaHowFar(G4HepEmGammaTrack *hepEMTracks, ParticleManager part
 
 __global__ void GammaPropagation(NeutralTrack *gammas, G4HepEmGammaTrack *hepEMTracks, const adept::MParray *active)
 {
-  constexpr double kPushDistance           = 1000 * vecgeom::kTolerance;
   constexpr double kPushStuck              = 100 * vecgeom::kTolerance;
   constexpr unsigned short kStepsStuckPush = 5;
 
@@ -207,9 +206,8 @@ __global__ void GammaPropagation(NeutralTrack *gammas, G4HepEmGammaTrack *hepEMT
         AdePTNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, theTrack->GetGStepLength(),
                                                  currentTrack.navState, currentTrack.nextState, currentTrack.hitsurfID);
 #else
-    auto geometryStepLength =
-        AdePTNavigator::ComputeStepAndNextVolume(currentTrack.pos, currentTrack.dir, theTrack->GetGStepLength(),
-                                                 currentTrack.navState, currentTrack.nextState, kPushDistance);
+    auto geometryStepLength = AdePTNavigator::ComputeStepAndNextVolume(
+        currentTrack.pos, currentTrack.dir, theTrack->GetGStepLength(), currentTrack.navState, currentTrack.nextState);
 #endif
     //  printf("pvol=%d  step=%g  onboundary=%d  pos={%g, %g, %g}  dir={%g, %g, %g}\n", navState.TopId(),
     //  geometryStepLength,
@@ -308,9 +306,8 @@ __global__ void GammaSetupInteractions(G4HepEmGammaTrack *hepEMTracks, const ade
 __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager particleManager,
                                 adept::MParray *relocatingQueue, const bool returnAllSteps, const bool returnLastStep)
 {
-  constexpr double kPushDistance = 1000 * vecgeom::kTolerance;
-  auto &slotManager              = *particleManager.gammas.fSlotManager;
-  int activeSize                 = relocatingQueue->size();
+  auto &slotManager = *particleManager.gammas.fSlotManager;
+  int activeSize    = relocatingQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot             = (*relocatingQueue)[i];
     NeutralTrack &currentTrack = particleManager.gammas.TrackAt(slot);
@@ -351,9 +348,6 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
 
       short stepProcessId = kAdePTTransportationProcess;
       if (returnsToCPU) {
-        // Push the handoff point a little into the CPU region so Geant4 does
-        // not relocate the track back into the same GPU region.
-        currentTrack.pos += kPushDistance * currentTrack.dir;
         stepProcessId = kAdePTOutOfGPURegionProcess;
       }
 

--- a/include/AdePT/transport/magneticfield/fieldPropagatorConstBz.h
+++ b/include/AdePT/transport/magneticfield/fieldPropagatorConstBz.h
@@ -63,7 +63,6 @@ __host__ __device__ double fieldPropagatorConstBz::ComputeStepAndNextVolume(
     vecgeom::NavigationState &next_state, long &hitsurf_index, bool &propagated, const double safetyIn,
     const int max_iterations)
 {
-  const double kPush = 0;
 
   double momentumMag = sqrt(kinE * (kinE + 2 * mass));
 
@@ -118,10 +117,10 @@ __host__ __device__ double fieldPropagatorConstBz::ComputeStepAndNextVolume(
         safety       = newSafety;
       } else {
 #ifdef ADEPT_USE_SURF
-        move = Navigator::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state,
-                                                   hitsurf_index, kPush);
+        move =
+            Navigator::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state, hitsurf_index);
 #else
-        move = Navigator::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state, kPush);
+        move = Navigator::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state);
 #endif
       }
     }
@@ -140,8 +139,8 @@ __host__ __device__ double fieldPropagatorConstBz::ComputeStepAndNextVolume(
       // We want to try the maximum step in the next iteration.
       maxNextSafeMove   = safeLength;
       continueIteration = true;
-    } else if (move <= kPush + Navigator::kBoundaryPush && stepDone == 0) {
-      // FIXME: Even for zero steps, the Navigator will return kPush + possibly
+    } else if (move <= Navigator::kBoundaryPush && stepDone == 0) {
+      // FIXME: Even for zero steps, the Navigator will return possibly
       // Navigator::kBoundaryPush instead of a real 0.
       move        = 0;
       lastWasZero = true;

--- a/include/AdePT/transport/magneticfield/fieldPropagatorRungeKutta.h
+++ b/include/AdePT/transport/magneticfield/fieldPropagatorRungeKutta.h
@@ -57,8 +57,6 @@ public:
 protected:
   static constexpr unsigned int fMaxTrials = 100;
   static constexpr unsigned int Nvar       = 6; // For position (3) and momentum (3) -- invariant
-  static constexpr Real_t kPush            = 0.;
-  static constexpr Real_t kDistCheckPush   = kPush + Navigator::kBoundaryPush;
   // Cannot change the energy (or momentum magnitude) -- currently usable only for pure magnetic fields
 };
 
@@ -106,11 +104,10 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
       false; // This could be a per-region flag ... - better depend on template parameter?
   if (inZeroFieldRegion) {
 #ifdef ADEPT_USE_SURF
-    stepDone = Navigator_t::ComputeStepAndNextVolume(position, direction, remains, current_state, next_state,
-                                                     hitsurf_index, kDistCheckPush);
-#else
     stepDone =
-        Navigator_t::ComputeStepAndNextVolume(position, direction, remains, current_state, next_state, kDistCheckPush);
+        Navigator_t::ComputeStepAndNextVolume(position, direction, remains, current_state, next_state, hitsurf_index);
+#else
+    stepDone = Navigator_t::ComputeStepAndNextVolume(position, direction, remains, current_state, next_state);
 #endif
     position += stepDone * direction;
     return stepDone;
@@ -221,16 +218,15 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
 #if ADEPT_DEBUG_TRACK > 0
         if (verbose)
           printf("\n| +++  ComputeStepAndNextVolume pos {%.17f, %.17f, %.17f} chordDir {%.17f, %.17f, %.17f} "
-                 "chordLen %g push %g\n",
-                 position[0], position[1], position[2], chordDir[0], chordDir[1], chordDir[2], chordLen, kPush);
+                 "chordLen %g\n",
+                 position[0], position[1], position[2], chordDir[0], chordDir[1], chordDir[2], chordLen);
 #endif
 
 #ifdef ADEPT_USE_SURF
         move = Navigator_t::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state,
-                                                     hitsurf_index, kDistCheckPush);
+                                                     hitsurf_index);
 #else
-        move = Navigator_t::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state,
-                                                     kDistCheckPush);
+        move = Navigator_t::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state);
 #endif
       }
     }
@@ -253,20 +249,19 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
 
       maxNextSafeMove   = vecCore::Max(arcAdvanced, Real_t(safety)); // Reset it, once a step succeeds!!
       continueIteration = true;
-    } else if (stepDone == 0 && move <= kDistCheckPush) {
+    } else if (stepDone == 0 && move <= Navigator_t::kBoundaryPush) {
       // Cope with a track at a boundary that wants to bend back into the previous
       // volume in the first step (by reducing the attempted distance.)
 
       // Deal with back-scattered tracks that need to be relocated. Check distance along initial direction.
 #ifdef ADEPT_USE_SURF
-      move = Navigator_t::ComputeStepAndNextVolume(position, direction, remains, current_state, next_state,
-                                                   hitsurf_index, kDistCheckPush);
+      move =
+          Navigator_t::ComputeStepAndNextVolume(position, direction, remains, current_state, next_state, hitsurf_index);
 #else
-      move = Navigator_t::ComputeStepAndNextVolume(position, direction, remains, current_state, next_state,
-                                                   kDistCheckPush);
+      move = Navigator_t::ComputeStepAndNextVolume(position, direction, remains, current_state, next_state);
 #endif
 
-      if (move <= kDistCheckPush) {
+      if (move <= Navigator_t::kBoundaryPush) {
 #if ADEPT_DEBUG_TRACK > 0
         if (verbose) {
           printf("| BACK-SCATTERING or WRONG RELOCATION detected hitting ");

--- a/src/g4integration/returned_steps/AdePTGeant4Integration.cpp
+++ b/src/g4integration/returned_steps/AdePTGeant4Integration.cpp
@@ -161,6 +161,8 @@ void Deleter::operator()(StepReconstructionObjects *ptr)
 
 namespace {
 
+constexpr double kG4HandoffPush = 100. * vecgeom::kTolerance;
+
 G4ParticleDefinition *GetParticleDefinition(ParticleType particleType)
 {
   switch (particleType) {
@@ -283,14 +285,21 @@ G4Track *AdePTGeant4Integration::MakeTrackForCPUStacking(const G4Track &track, G
 G4Track *AdePTGeant4Integration::MakeReturnedTrackFromStep(GPUStep const &parentStep, const HostTrackData &hostTData,
                                                            bool setStopButAlive) const
 {
-  constexpr double tolerance = 10. * vecgeom::kTolerance;
-
   G4ThreeVector direction(parentStep.fPostStepPoint.fMomentumDirection.x(),
                           parentStep.fPostStepPoint.fMomentumDirection.y(),
                           parentStep.fPostStepPoint.fMomentumDirection.z());
   G4ThreeVector position(parentStep.fPostStepPoint.fPosition.x(), parentStep.fPostStepPoint.fPosition.y(),
                          parentStep.fPostStepPoint.fPosition.z());
-  position += tolerance * direction;
+  // VecGeom has decided that the track left the GPU region and is now in the CPU region. The coordinate can
+  // still be exactly on the shared boundary, though. Geant4 did not make that boundary crossing itself, so its
+  // navigator has no last-exited-daughter state to stop the next geometry step from immediately finding the GPU
+  // daughter again. If that happens, AdePT offloads the track back to the GPU without any real progress and the track
+  // can bounce. This tiny handoff-only push moves the point just far enough along the outgoing direction for CPU
+  // tracking to resume on the CPU side of the boundary.
+  if (parentStep.fStepLimProcessId == kAdePTOutOfGPURegionProcess &&
+      parentStep.fPostStepPoint.fNavigationState.IsOnBoundary()) {
+    position += kG4HandoffPush * direction;
+  }
 
   auto *dynamic = new G4DynamicParticle(GetParticleDefinition(parentStep.fParticleType), direction,
                                         parentStep.fPostStepPoint.fEKin);

--- a/src/g4integration/returned_steps/AdePTGeant4Integration.cpp
+++ b/src/g4integration/returned_steps/AdePTGeant4Integration.cpp
@@ -350,9 +350,7 @@ G4Track *AdePTGeant4Integration::ConstructSecondaryTrackInPlace(GPUStep const *s
 void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUStep> gpuSteps, bool const callUserSteppingAction,
                                             bool const callUserTrackingAction)
 {
-  // FIXME: to be removed, as it is not needed with the direct VecGeom to G4 NavState.
-  // needed here only temporarily to match exactly the behavior of returning nuclear interaction steps as tracks
-  constexpr double tolerance = 10. * vecgeom::kTolerance;
+
   if (!fStepReconstructionObjects) {
     fStepReconstructionObjects.reset(new AdePTGeant4Integration_detail::StepReconstructionObjects());
   }
@@ -509,12 +507,11 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUStep> gpuSteps, b
     if (nuclearProcess != nullptr) {
       returnParentTrackToG4 = isLeptonNuclearStep;
 
-      const G4ThreeVector direction(parentStep.fPostStepPoint.fMomentumDirection.x(),
+      G4ThreeVector const position(parentStep.fPostStepPoint.fPosition.x(), parentStep.fPostStepPoint.fPosition.y(),
+                                   parentStep.fPostStepPoint.fPosition.z());
+      G4ThreeVector const direction(parentStep.fPostStepPoint.fMomentumDirection.x(),
                                     parentStep.fPostStepPoint.fMomentumDirection.y(),
                                     parentStep.fPostStepPoint.fMomentumDirection.z());
-      G4ThreeVector position(parentStep.fPostStepPoint.fPosition.x(), parentStep.fPostStepPoint.fPosition.y(),
-                             parentStep.fPostStepPoint.fPosition.z());
-      position += tolerance * direction;
 
       auto *dynamic = new G4DynamicParticle(fStepReconstructionObjects->fG4Step->GetTrack()->GetParticleDefinition(),
                                             direction, parentStep.fPostStepPoint.fEKin);

--- a/test/unit/test_bfield.cpp
+++ b/test/unit/test_bfield.cpp
@@ -186,7 +186,7 @@ struct ThrowingNavigator {
   }
 
   static double ComputeStepAndNextVolume(const vecgeom::Vector3D<double> &, const vecgeom::Vector3D<double> &, double,
-                                         const vecgeom::NavigationState &, vecgeom::NavigationState &, double)
+                                         const vecgeom::NavigationState &, vecgeom::NavigationState &)
   {
     ++stepCalls;
     ADD_FAILURE() << "navigation should not be called";
@@ -196,10 +196,10 @@ struct ThrowingNavigator {
   static double ComputeStepAndNextVolume(const vecgeom::Vector3D<double> &position,
                                          const vecgeom::Vector3D<double> &direction, double step,
                                          const vecgeom::NavigationState &currentState,
-                                         vecgeom::NavigationState &nextState, long &hitSurfaceIndex, double push)
+                                         vecgeom::NavigationState &nextState, long &hitSurfaceIndex)
   {
     hitSurfaceIndex = -1;
-    return ComputeStepAndNextVolume(position, direction, step, currentState, nextState, push);
+    return ComputeStepAndNextVolume(position, direction, step, currentState, nextState);
   }
 };
 
@@ -219,7 +219,7 @@ struct BoundaryNavigator {
 
   static double ComputeStepAndNextVolume(const vecgeom::Vector3D<double> &, const vecgeom::Vector3D<double> &,
                                          double step, const vecgeom::NavigationState &,
-                                         vecgeom::NavigationState &nextState, double)
+                                         vecgeom::NavigationState &nextState)
   {
     ++stepCalls;
     nextState.SetBoundaryState(true);
@@ -229,10 +229,10 @@ struct BoundaryNavigator {
   static double ComputeStepAndNextVolume(const vecgeom::Vector3D<double> &position,
                                          const vecgeom::Vector3D<double> &direction, double step,
                                          const vecgeom::NavigationState &currentState,
-                                         vecgeom::NavigationState &nextState, long &hitSurfaceIndex, double push)
+                                         vecgeom::NavigationState &nextState, long &hitSurfaceIndex)
   {
     hitSurfaceIndex = 0;
-    return ComputeStepAndNextVolume(position, direction, step, currentState, nextState, push);
+    return ComputeStepAndNextVolume(position, direction, step, currentState, nextState);
   }
 };
 


### PR DESCRIPTION
This PR resolves #543. 

In AdePT, previously some pushes were used to 
a) help VecGeom avoiding stuck tracks
b) when handing tracks from GPU in VecGeom back to G4 on CPU, to avoid that particles get located in a GPU region by G4, leading to a infinite loop of particles bouncing between GPU and CPU.

For a) in fact it is harmful, because the push provided via the interface: https://gitlab.cern.ch/VecGeom/VecGeom/-/blob/master/VecGeom/navigation/BVHNavigator.h?ref_type=heads#L572
is always applied and not only when the particle is on boundary. This could lead to an error, because if the push was leading to a step of 0, (because the track was close to boundary), then the position was not updated by the push, despite it was the push that led to the step of 0 (see [here](https://gitlab.cern.ch/VecGeom/VecGeom/-/blob/master/VecGeom/navigation/BVHNavigator.h?ref_type=heads#L599-L602)). This was a problem, as then for larger pushes (AdePT was using `1000 *kTolerance`), the particle could still be outside of the next volume, despite being relocated to that one.

b) in fact, the track is still located within G4 when it is initialized in G4HepEm [here](https://github.com/mnovak42/g4hepem/blob/master/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc#L276). UPDATE:
Therefore, these pushes are unfortunately necessary:
As it was found, there are some rare, but occurring cases, where a track is located in G4 (correctly), but then it does a 0 step and hits the GPU volume again, as when the `G4Navigator` is freshly initialized, it does not have a LastExitedVolume state set, leading to the bouncing between G4 on CPU and VecGeom on GPU. Without being able to set the LastExitedVolume in the `G4Navigator` a push is needed when handing off a track from GPU to CPU. Here, we push by `100 * kTolerance`. 

Due to the actual changes in b), this needs thorough testing in Athena, CMSSW, and Gauss, before this PR should be merged:
Tested in:

- [x] Athena
- [x] CMSSW
- [x] Gauss
