### PR TITLE
set nSteps correctly when tracks from GPU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,20 @@ block()
       return 0;
     }
     ]] AdePT_HAS_G4VTRACKINGMANAGER)
+
+  # Check whether G4Track can increment the current step number by nSteps
+  check_cxx_source_compiles([[
+    #include "G4Track.hh"
+
+    int main() {
+      auto increment = static_cast<void (G4Track::*)(G4int)>(&G4Track::IncrementCurrentStepNumber);
+      (void)increment;
+      return 0;
+    }
+    ]] ADEPT_HAS_G4TRACK_NSTEP_INCREMENT)
+  if(ADEPT_HAS_G4TRACK_NSTEP_INCREMENT)
+    add_compile_definitions(ADEPT_HAS_G4TRACK_NSTEP_INCREMENT)
+  endif()
 endblock()
 
 # Find HepMC3, used by integration examples to load realistic events

--- a/include/AdePT/g4integration/returned_steps/AdePTGeant4Integration.hh
+++ b/include/AdePT/g4integration/returned_steps/AdePTGeant4Integration.hh
@@ -119,7 +119,7 @@ private:
   /// replay track to continue on the CPU, and the visible reconstructed track
   /// cannot be handed to the stack manager because it is reused integration
   /// storage.
-  G4Track *MakeTrackForCPUStacking(const G4Track &track) const;
+  G4Track *MakeTrackForCPUStacking(const G4Track &track, G4int nSteps) const;
 
   /// @brief Recreate a track to from a returned parent step to be continued on CPU.
   /// @details

--- a/src/g4integration/returned_steps/AdePTGeant4Integration.cpp
+++ b/src/g4integration/returned_steps/AdePTGeant4Integration.cpp
@@ -176,6 +176,18 @@ G4ParticleDefinition *GetParticleDefinition(ParticleType particleType)
   }
 }
 
+void IncrementCurrentStepNumber(G4Track &track, G4int nSteps)
+{
+  if (nSteps < 1) nSteps = 1;
+#ifdef ADEPT_HAS_G4TRACK_NSTEP_INCREMENT
+  track.IncrementCurrentStepNumber(nSteps);
+#else
+  for (G4int i = 0; i < nSteps; ++i) {
+    track.IncrementCurrentStepNumber();
+  }
+#endif
+}
+
 void MergeNuclearReplayIntoVisibleStep(const G4Track &scratchTrack, const G4Step &scratchStep, G4Step &visibleStep,
                                        bool isLeptonNuclearStep)
 {
@@ -238,14 +250,14 @@ void AdePTGeant4Integration::ReturnDeferredTrack(std::span<const GPUStep> gpuSte
   fHostTrackDataMapper->retireToCPU(parentStep.fTrackID);
 }
 
-G4Track *AdePTGeant4Integration::MakeTrackForCPUStacking(const G4Track &track) const
+G4Track *AdePTGeant4Integration::MakeTrackForCPUStacking(const G4Track &track, G4int nSteps) const
 {
   auto *dynamic =
       new G4DynamicParticle(track.GetParticleDefinition(), track.GetMomentumDirection(), track.GetKineticEnergy());
   dynamic->SetPrimaryParticle(track.GetDynamicParticle()->GetPrimaryParticle());
 
   auto *clone = new G4Track(dynamic, track.GetGlobalTime(), track.GetPosition());
-  clone->IncrementCurrentStepNumber();
+  IncrementCurrentStepNumber(*clone, nSteps);
   clone->SetTrackID(track.GetTrackID());
   clone->SetParentID(track.GetParentID());
   clone->SetLocalTime(track.GetLocalTime());
@@ -285,7 +297,7 @@ G4Track *AdePTGeant4Integration::MakeReturnedTrackFromStep(GPUStep const &parent
   dynamic->SetPrimaryParticle(hostTData.primary);
 
   auto *track = new G4Track(dynamic, parentStep.fGlobalTime, position);
-  track->IncrementCurrentStepNumber();
+  IncrementCurrentStepNumber(*track, static_cast<G4int>(parentStep.fStepCounter));
   track->SetTrackID(hostTData.g4id);
   track->SetParentID(hostTData.g4parentid);
   track->SetLocalTime(parentStep.fLocalTime);
@@ -508,7 +520,7 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUStep> gpuSteps, b
                                             direction, parentStep.fPostStepPoint.fEKin);
 
       auto *nuclearReactionTrack = new G4Track(dynamic, parentStep.fGlobalTime, position);
-      nuclearReactionTrack->IncrementCurrentStepNumber();
+      IncrementCurrentStepNumber(*nuclearReactionTrack, static_cast<G4int>(parentStep.fStepCounter));
       nuclearReactionTrack->SetLocalTime(parentStep.fLocalTime);
       nuclearReactionTrack->SetProperTime(parentStep.fProperTime);
       nuclearReactionTrack->SetWeight(parentStep.fTrackWeight);
@@ -580,7 +592,8 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUStep> gpuSteps, b
       // Fallback only for the case without an attached Geant4 nuclear process:
       // there is then no temporary nuclear-replay track that can be continued
       // on the CPU, so we create a separate heap-owned track for the stack.
-      returnedParentTrack   = MakeTrackForCPUStacking(*fStepReconstructionObjects->fG4Step->GetTrack());
+      returnedParentTrack   = MakeTrackForCPUStacking(*fStepReconstructionObjects->fG4Step->GetTrack(),
+                                                      static_cast<G4int>(parentStep.fStepCounter));
       returnParentTrackToG4 = true;
     }
   } else if (isOutOfGPURegionStep || isFinishOnCPUStep) {


### PR DESCRIPTION
This PR fixes the step number of the G4Track when a track is returned from the GPU to the CPU.

It enables to either increment the StepNumber in a bulk (available in this MR in G4: https://gitlab.cern.ch/geant4/geant4-dev/-/merge_requests/5768) or falls back to a simple for loop.

When testing, the compiler actually optimizes away the simple for loop in release builds, so that no performance penalty is there, even for the older fall-back. 

Note that this is an important fix, because in case particles get stuck in a loop between CPU to GPU, before, the stepNumber was always reset to one when returned from GPU. This way, an infinite loop can occur, which is otherwise prevented, when particles are getting killed after N number of steps. With the fix, these infinite loops should not be possible anymore, as particles should get killed eventually, when their step number gets too high.