### PR TITLE
Make Woodcock tracking compiletime option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
 
 # Options
 option(ADEPT_USE_SURF "Enable surface model navigation on GPU" OFF)
+option(ADEPT_ENABLE_WDT "Enable Woodcock tracking" ON)
 option(ADEPT_MIXED_PRECISION "Use B-field integration and surface model in mixed precision" OFF)
 option(ADEPT_USE_SPLIT_KERNELS "Run split version of the transport kernels" OFF)
 option(ADEPT_USE_EXT_BFIELD "Use external B field from file via the covfie library" OFF)
@@ -336,12 +337,22 @@ if(ADEPT_USE_SURF)
       message(STATUS "${Green}Using the surface model in VecGeom in double precision${ColorReset}")
     endif()
     add_compile_definitions(ADEPT_USE_SURF)
+    if(ADEPT_ENABLE_WDT)
+      message(STATUS "${Magenta}Surface navigation currently disables Woodcock tracking${ColorReset}")
+      set(ADEPT_ENABLE_WDT OFF CACHE BOOL "Enable Woodcock tracking" FORCE)
+    endif()
   else()
     message(STATUS "${Magenta}No VecGeom surface support. Forcing ADEPT_USE_SURF to OFF${ColorReset}")
     set(ADEPT_USE_SURF OFF CACHE BOOL "Disable using the surface model" FORCE)
   endif()
 else()
   message(STATUS "${Green}Using the solid model in VecGeom${ColorReset}")
+endif()
+if(ADEPT_ENABLE_WDT)
+  message(STATUS "${Green}Woodcock tracking enabled${ColorReset}")
+  add_compile_definitions(ADEPT_ENABLE_WDT)
+else()
+  message(STATUS "${Magenta}Woodcock tracking disabled${ColorReset}")
 endif()
 
 # Find Geant4, optional for now
@@ -600,6 +611,7 @@ endif()
 set(ADEPT_PUBLIC_CONFIG_DEFINITIONS
   ADEPT_STEPACTION_TYPE=${_ADEPT_STEPACTION_TYPE}
   $<$<BOOL:${ADEPT_USE_SURF}>:ADEPT_USE_SURF>
+  $<$<BOOL:${ADEPT_ENABLE_WDT}>:ADEPT_ENABLE_WDT>
   $<$<BOOL:${ADEPT_MIXED_PRECISION}>:ADEPT_MIXED_PRECISION>
   $<$<BOOL:${ADEPT_USE_SPLIT_KERNELS}>:ADEPT_USE_SPLIT_KERNELS>
   $<$<AND:$<BOOL:${ADEPT_DEBUG_SINGLE_THREAD}>,$<CONFIG:Debug>>:ADEPT_DEBUG_SINGLE_THREAD>

--- a/include/AdePT/transport/AdePTTransport.cuh
+++ b/include/AdePT/transport/AdePTTransport.cuh
@@ -1127,12 +1127,15 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
 
         const auto [threads, blocks] = computeThreadsAndBlocks(particlesInFlight[GPUQueueIndex::Gamma]);
 #ifdef ADEPT_USE_SPLIT_KERNELS
+#ifdef ADEPT_ENABLE_WDT
         const auto [wdtThreads, wdtBlocks] = computeThreadsAndBlocks(particlesInFlight[GPUQueueIndex::GammaWDT]);
+#endif
         const auto [interactionThreads, interactionBlocks] = computeThreadsAndBlocks(
             particlesInFlight[GPUQueueIndex::Gamma] + particlesInFlight[GPUQueueIndex::GammaWDT]);
         GammaHowFar<SelectedSteppingAction><<<blocks, threads, 0, gammas.stream>>>(
             gpuState.hepEmBuffers_d.gammasHepEm, particleManager, gammas.queues.propagation, gpuState.stats_dev,
             steppingActionParams, allowFinishOffEvent, returnAllSteps, returnLastStep);
+#ifdef ADEPT_ENABLE_WDT
         if (hasWDTRegions) {
           GammaWoodcock<SelectedSteppingAction><<<wdtBlocks, wdtThreads, 0, gammas.auxiliaryStream>>>(
               gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
@@ -1140,6 +1143,7 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
               allowFinishOffEvent, returnAllSteps, returnLastStep);
           ADEPT_DEVICE_API_CALL(EventRecord(gammas.auxiliaryEvent, gammas.auxiliaryStream));
         }
+#endif
         GammaPropagation<<<blocks, threads, 0, gammas.stream>>>(gammas.tracks, gpuState.hepEmBuffers_d.gammasHepEm,
                                                                 gammas.queues.propagation);
         if (hasWDTRegions) {
@@ -1172,6 +1176,7 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
             <<<blocks, threads, 0, gammas.stream>>>(particleManager, gpuState.stats_dev, steppingActionParams,
                                                     allowFinishOffEvent, returnAllSteps, returnLastStep);
 
+#ifdef ADEPT_ENABLE_WDT
         if (hasWDTRegions) {
           const auto [wdtThreads, wdtBlocks] = computeThreadsAndBlocks(particlesInFlight[GPUQueueIndex::GammaWDT]);
           TransportGammasWoodcock<SelectedSteppingAction><<<wdtBlocks, wdtThreads, 0, gammas.auxiliaryStream>>>(
@@ -1179,6 +1184,7 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
               returnLastStep);
           ADEPT_DEVICE_API_CALL(EventRecord(gammas.auxiliaryEvent, gammas.auxiliaryStream));
         }
+#endif
 #endif
 
         ADEPT_DEVICE_API_CALL(EventRecord(gammas.event, gammas.stream));

--- a/include/AdePT/transport/kernels/WoodcockHelper.cuh
+++ b/include/AdePT/transport/kernels/WoodcockHelper.cuh
@@ -12,6 +12,11 @@ namespace adept::transport {
 // kinetic energy
 __device__ __forceinline__ bool ShouldUseWDT(const vecgeom::NavigationState &state, double eKin)
 {
+#ifndef ADEPT_ENABLE_WDT
+  (void)state;
+  (void)eKin;
+  return false;
+#else
   // 1) region from current logical volume
   const int lvolId   = state.GetLogicalId();
   const auto &aux    = gVolAuxData[lvolId];
@@ -32,6 +37,7 @@ __device__ __forceinline__ bool ShouldUseWDT(const vecgeom::NavigationState &sta
   // Now it is 1) a GPU region 2) a Woodcock tracking region and 3) the track has enough energy:
   // mark for Woodcock tracking
   return true;
+#endif
 }
 
 } // namespace adept::transport

--- a/include/AdePT/transport/kernels/gammas.cuh
+++ b/include/AdePT/transport/kernels/gammas.cuh
@@ -4,7 +4,10 @@
 #pragma once
 
 #include <AdePT/transport/navigation/AdePTNavigator.h>
+#include <AdePT/transport/kernels/WoodcockHelper.cuh>
+#ifdef ADEPT_ENABLE_WDT
 #include <AdePT/transport/kernels/gammasWDT.cuh>
+#endif
 
 #include <AdePT/transport/support/PhysicalConstants.h>
 #include <AdePT/transport/tracks/TrackDebug.cuh>
@@ -19,6 +22,13 @@
 #include <G4HepEmGammaInteractionCompton.hh>
 #include <G4HepEmGammaInteractionConversion.hh>
 #include <G4HepEmGammaInteractionPhotoelectric.hh>
+#ifndef ADEPT_G4HEPEM_GAMMA_ICC_INCLUDED
+#define ADEPT_G4HEPEM_GAMMA_ICC_INCLUDED
+#include <G4HepEmGammaManager.icc>
+#include <G4HepEmGammaInteractionCompton.icc>
+#include <G4HepEmGammaInteractionConversion.icc>
+#include <G4HepEmGammaInteractionPhotoelectric.icc>
+#endif
 
 using VolAuxData      = adeptint::VolAuxData;
 using StepActionParam = adept::SteppingAction::Params;
@@ -235,19 +245,8 @@ __global__ void __launch_bounds__(256, 1)
 
         // next region is a GPU region
         if (regionId >= 0) {
-
-          const adeptint::WDTDeviceView &view = gWDTData;
-          const int wdtIdx                    = view.regionToWDT[regionId]; // index into view.regions (or -1)
-
-          // next region is a Woodcock tracking region
-          if (wdtIdx >= 0) {
-            const adeptint::WDTRegion reg = view.regions[wdtIdx];
-            // minimal energy for Woodcock tracking succeeded, do Woodcock tracking
-            if (eKin > reg.ekinMin) {
-              enterWDTRegion = true;
-            }
-          }
-          trackSurvives = true;
+          enterWDTRegion = ShouldUseWDT(nextState, eKin);
+          trackSurvives  = true;
         } else {
           // To be safe, just push a bit the track exiting the GPU region to make sure
           // Geant4 does not relocate it again inside the same region

--- a/include/AdePT/transport/kernels/gammasWDT.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT.cuh
@@ -19,10 +19,13 @@
 #include <G4HepEmGammaInteractionConversion.hh>
 #include <G4HepEmGammaInteractionPhotoelectric.hh>
 // Pull in implementation.
+#ifndef ADEPT_G4HEPEM_GAMMA_ICC_INCLUDED
+#define ADEPT_G4HEPEM_GAMMA_ICC_INCLUDED
 #include <G4HepEmGammaManager.icc>
 #include <G4HepEmGammaInteractionCompton.icc>
 #include <G4HepEmGammaInteractionConversion.icc>
 #include <G4HepEmGammaInteractionPhotoelectric.icc>
+#endif
 
 using VolAuxData      = adeptint::VolAuxData;
 using StepActionParam = adept::SteppingAction::Params;

--- a/include/AdePT/transport/kernels/gammasWDT_split.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT_split.cuh
@@ -19,10 +19,13 @@
 #include <G4HepEmGammaInteractionConversion.hh>
 #include <G4HepEmGammaInteractionPhotoelectric.hh>
 // Pull in implementation.
+#ifndef ADEPT_G4HEPEM_GAMMA_ICC_INCLUDED
+#define ADEPT_G4HEPEM_GAMMA_ICC_INCLUDED
 #include <G4HepEmGammaManager.icc>
 #include <G4HepEmGammaInteractionCompton.icc>
 #include <G4HepEmGammaInteractionConversion.icc>
 #include <G4HepEmGammaInteractionPhotoelectric.icc>
+#endif
 
 using StepActionParam = adept::SteppingAction::Params;
 using VolAuxData      = adeptint::VolAuxData;

--- a/include/AdePT/transport/kernels/gammas_split.cuh
+++ b/include/AdePT/transport/kernels/gammas_split.cuh
@@ -4,10 +4,13 @@
 #pragma once
 
 #include <AdePT/transport/navigation/AdePTNavigator.h>
+#include <AdePT/transport/kernels/WoodcockHelper.cuh>
 
 #include <AdePT/transport/support/PhysicalConstants.h>
 #include <AdePT/transport/kernels/AdePTSteppingActionSelector.cuh>
+#ifdef ADEPT_ENABLE_WDT
 #include <AdePT/transport/kernels/gammasWDT_split.cuh>
+#endif
 #include <AdePT/transport/queues/ParticleManager.cuh>
 #include <AdePT/transport/state/DeviceGlobals.cuh>
 #include <AdePT/transport/state/TransportStats.hh>
@@ -19,6 +22,13 @@
 #include <G4HepEmGammaInteractionCompton.hh>
 #include <G4HepEmGammaInteractionConversion.hh>
 #include <G4HepEmGammaInteractionPhotoelectric.hh>
+#ifndef ADEPT_G4HEPEM_GAMMA_ICC_INCLUDED
+#define ADEPT_G4HEPEM_GAMMA_ICC_INCLUDED
+#include <G4HepEmGammaManager.icc>
+#include <G4HepEmGammaInteractionCompton.icc>
+#include <G4HepEmGammaInteractionConversion.icc>
+#include <G4HepEmGammaInteractionPhotoelectric.icc>
+#endif
 
 using StepActionParam = adept::SteppingAction::Params;
 using VolAuxData      = adeptint::VolAuxData;
@@ -378,16 +388,7 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
         // Move to the next boundary after recording the transported step.
         currentTrack.navState = currentTrack.nextState;
 
-        // Check whether next region is a Woodcock tracking region
-        const adeptint::WDTDeviceView &view = gWDTData;
-        const int wdtIdx = view.regionToWDT[nextauxData.fGPUregionId]; // index into view.regions (or -1)
-        if (wdtIdx >= 0) {
-          const adeptint::WDTRegion reg = view.regions[wdtIdx];
-          // minimal energy for Woodcock tracking succeeded, do Woodcock tracking
-          if (currentTrack.eKin > reg.ekinMin) {
-            enterWDTRegion = true;
-          }
-        }
+        enterWDTRegion = ShouldUseWDT(currentTrack.nextState, currentTrack.eKin);
 
         theTrack->SetMCIndex(nextauxData.fMCIndex);
         survive();

--- a/src/transport/AdePTTransport.cc
+++ b/src/transport/AdePTTransport.cc
@@ -206,10 +206,20 @@ void AdePTTransport::Initialize(adeptint::VolAuxData *auxData, const adeptint::W
   volAuxArray.fAuxData    = auxData;
   adept::transport::InitVolAuxArray(volAuxArray);
 
+#ifdef ADEPT_ENABLE_WDT
   fHasWDTRegions = !wdtPacked.regions.empty();
+#else
+  fHasWDTRegions = false;
+  if (!wdtPacked.regions.empty()) {
+    std::cout << "=== AdePTTransport: Woodcock tracking is disabled in this build; ignoring "
+              << wdtPacked.regions.size() << " configured WDT region(s)\n";
+  }
+#endif
 
   adeptint::WDTDeviceBuffers wdtDev;
+#ifdef ADEPT_ENABLE_WDT
   adept::transport::detail::InitWDTOnDevice(wdtPacked, wdtDev, fMaxWDTIter);
+#endif
   fWDTDev = wdtDev;
 
   const auto toDeviceSlots = 4u * 8192u * fNThread;

--- a/test/run_ci_matrix.sh
+++ b/test/run_ci_matrix.sh
@@ -50,11 +50,12 @@ Runs AdePT in a local matrix similar to Jenkins:
   - mono (default monolithic kernels, external B-field support)
   - split (-DADEPT_USE_SPLIT_KERNELS=ON)
   - mixed (-DADEPT_MIXED_PRECISION=ON)
+  - surface (-DADEPT_USE_SURF=ON; WDT disabled by CMake)
 
 Options:
   --suite <drift|drift-smoke|ci>
                               Test suite to run (default: drift)
-  --configs <list>           Comma list: mono,split,mixed (default: mono,split)
+  --configs <list>           Comma list: mono,split,mixed,surface (default: mono,split)
   --build-type <type>        CMake build type (default: Release)
   --cuda-arch <arch|auto>    CUDA arch (default: auto)
   --jobs <N|auto>            Parallel build jobs (default: auto = nproc)
@@ -74,6 +75,7 @@ Options:
 Suite behavior:
   drift (default): builds PR + master for each config and runs physics_drift_* tests
   drift-smoke    : builds only this checkout and runs physics_drift_* once, without comparison
+                   (surface builds only and runs the B-field unit tests)
   ci              : runs Jenkins-like selection for each config (can take much longer)
 USAGE
 }
@@ -204,11 +206,14 @@ IFS=',' read -r -a CONFIGS <<< "${CONFIG_LIST}"
 [[ ${#CONFIGS[@]} -gt 0 ]] || die "No configs provided"
 
 for cfg in "${CONFIGS[@]}"; do
+  if [[ "${SUITE}" == "drift" && "${cfg}" == "surface" ]]; then
+    die "Surface is not part of the PR-vs-master drift suite; use --suite drift-smoke --configs surface."
+  fi
   case "${cfg}" in
-    mono|split|mixed)
+    mono|split|mixed|surface)
       ;;
     *)
-      die "Invalid config '${cfg}'. Allowed: mono, split, mixed"
+      die "Invalid config '${cfg}'. Allowed: mono, split, mixed, surface"
       ;;
   esac
 done
@@ -271,6 +276,7 @@ config_suffix() {
     mono) echo "MONOL" ;;
     split) echo "SPLIT_ON" ;;
     mixed) echo "MIXED_PRECISION" ;;
+    surface) echo "SURFACE" ;;
   esac
 }
 
@@ -289,6 +295,9 @@ build_config() {
       ;;
     mixed)
       cfg_args+=("-DADEPT_MIXED_PRECISION=ON")
+      ;;
+    surface)
+      cfg_args+=("-DADEPT_USE_SURF=ON")
       ;;
     *)
       die "Internal error: unsupported config '${cfg}'"
@@ -421,6 +430,17 @@ run_drift_smoke_tests() {
   run_ctest --test-dir "${pr_build_dir}" --output-on-failure -R '^physics_drift_' -j1
 }
 
+run_bfield_unit_tests() {
+  local build_dir=$1
+
+  log "Building surface B-field unit target in ${build_dir}"
+  cmake --build "${build_dir}" --target test_bfield -j"${JOBS}"
+
+  log "Running surface B-field unit tests in ${build_dir}"
+  run_ctest --test-dir "${build_dir}" --output-on-failure \
+    -R '^(UniformMagneticField|MagneticFieldEquation|RkIntegrationDriver|FieldPropagatorRungeKutta)\.' -j1
+}
+
 run_ci_subset_tests() {
   local cfg=$1
   local build_dir=$2
@@ -437,6 +457,10 @@ run_ci_subset_tests() {
       ;;
     mixed)
       log "Skipping mixed CI subset tests (no mixed non-drift stage in current Jenkins pipeline)"
+      ;;
+    surface)
+      log "Running surface CI subset: B-field unit tests"
+      run_bfield_unit_tests "${build_dir}"
       ;;
     *)
       die "Internal error: unsupported config '${cfg}'"
@@ -476,7 +500,12 @@ for cfg in "${CONFIGS[@]}"; do
     build_config "master" "${MASTER_WORKTREE_DIR}" "${master_build_dir}" "${cfg}"
     run_drift_tests "${pr_build_dir}" "${master_build_dir}"
   elif [[ "${SUITE}" == "drift-smoke" ]]; then
-    run_drift_smoke_tests "${pr_build_dir}"
+    if [[ "${cfg}" == "surface" ]]; then
+      log "Surface config is compile-only plus B-field unit tests; skipping physics_drift smoke"
+      run_bfield_unit_tests "${pr_build_dir}"
+    else
+      run_drift_smoke_tests "${pr_build_dir}"
+    fi
   else
     run_ci_subset_tests "${cfg}" "${pr_build_dir}"
   fi

--- a/test/run_nightly_ci.sh
+++ b/test/run_nightly_ci.sh
@@ -41,7 +41,7 @@ Runs the nightly CI selection on the self-hosted runner:
   1. build ${BUILD_TYPE} matrix for mono/split
   2. run unit tests on mono
   3. run validation tests on mono and split
-  4. run one-sided physics_drift smoke tests for Debug mono/split and mixed precision
+  4. run one-sided physics_drift smoke tests for Debug mono/split and mixed precision, plus surface compile/B-field checks
 
 Options:
   --build-root <path>        Build root (default: ${DEFAULT_BUILD_ROOT})
@@ -68,6 +68,8 @@ write_results() {
     printf 'DEBUG_DRIFT_SMOKE_STATUS=%s\n' "${DEBUG_DRIFT_SMOKE_STATUS}"
     printf 'MIXED_DRIFT_SMOKE_BUILD_ROOT=%q\n' "${MIXED_DRIFT_SMOKE_BUILD_ROOT}"
     printf 'MIXED_DRIFT_SMOKE_STATUS=%s\n' "${MIXED_DRIFT_SMOKE_STATUS}"
+    printf 'SURFACE_BUILD_ROOT=%q\n' "${SURFACE_BUILD_ROOT}"
+    printf 'SURFACE_STATUS=%s\n' "${SURFACE_STATUS}"
     printf 'NIGHTLY_STATUS=%s\n' "${NIGHTLY_STATUS}"
   } > "${RESULTS_FILE}"
 }
@@ -184,6 +186,21 @@ for arg in "${CMAKE_EXTRA_ARGS[@]}"; do
   mixed_drift_smoke_args+=(--cmake-extra "${arg}")
 done
 
+SURFACE_BUILD_ROOT="${BUILD_ROOT}/surface-compile"
+surface_args=(
+  --suite drift-smoke
+  --configs surface
+  --build-root "${SURFACE_BUILD_ROOT}"
+  --build-type "${BUILD_TYPE}"
+  --cuda-arch "${CUDA_ARCH}"
+  --jobs "${JOBS}"
+  --ctest-timeout-sec "${CTEST_TIMEOUT_SEC}"
+)
+
+for arg in "${CMAKE_EXTRA_ARGS[@]}"; do
+  surface_args+=(--cmake-extra "${arg}")
+done
+
 log "Using LCG setup: ${LCG_SETUP}"
 log "Build type: ${BUILD_TYPE}"
 log "Build root: ${BUILD_ROOT}"
@@ -191,6 +208,7 @@ log "CUDA arch: ${CUDA_ARCH}"
 log "Build jobs: ${JOBS}"
 log "Debug drift smoke build root: ${DEBUG_DRIFT_SMOKE_BUILD_ROOT}"
 log "Mixed precision drift smoke build root: ${MIXED_DRIFT_SMOKE_BUILD_ROOT}"
+log "Surface navigation compile build root: ${SURFACE_BUILD_ROOT}"
 log "Running Jenkins-like nightly CI selection"
 
 # Increase self-hosted nightly validation concurrency and buffer capacity unless explicitly overridden.
@@ -214,6 +232,7 @@ export ADEPT_VALIDATION_WDT_CPU_CAPACITY_FACTOR
 RELEASE_CI_STATUS=1
 DEBUG_DRIFT_SMOKE_STATUS=1
 MIXED_DRIFT_SMOKE_STATUS=1
+SURFACE_STATUS=1
 NIGHTLY_STATUS=1
 if "${MATRIX_RUNNER}" "${matrix_args[@]}"; then
   RELEASE_CI_STATUS=0
@@ -229,9 +248,15 @@ if "${MATRIX_RUNNER}" "${mixed_drift_smoke_args[@]}"; then
   MIXED_DRIFT_SMOKE_STATUS=0
 fi
 
+log "Running surface navigation compile and B-field unit tests"
+if "${MATRIX_RUNNER}" "${surface_args[@]}"; then
+  SURFACE_STATUS=0
+fi
+
 if [[ "${RELEASE_CI_STATUS}" -eq 0 &&
       "${DEBUG_DRIFT_SMOKE_STATUS}" -eq 0 &&
-      "${MIXED_DRIFT_SMOKE_STATUS}" -eq 0 ]]; then
+      "${MIXED_DRIFT_SMOKE_STATUS}" -eq 0 &&
+      "${SURFACE_STATUS}" -eq 0 ]]; then
   NIGHTLY_STATUS=0
 fi
 
@@ -240,6 +265,7 @@ write_results
 log "Release CI status: ${RELEASE_CI_STATUS}"
 log "Debug drift smoke status: ${DEBUG_DRIFT_SMOKE_STATUS}"
 log "Mixed precision drift smoke status: ${MIXED_DRIFT_SMOKE_STATUS}"
+log "Surface navigation compile/B-field status: ${SURFACE_STATUS}"
 log "Nightly status: ${NIGHTLY_STATUS}"
 
 exit "${NIGHTLY_STATUS}"

--- a/test/run_pr_ci.sh
+++ b/test/run_pr_ci.sh
@@ -47,7 +47,7 @@ Runs the AdePT PR CI flow on a self-hosted runner:
   2. run physics drift comparisons
   3. always run unit tests on mono
   4. run validation on mono + split when drift differs from master, or when requested
-  5. optionally build and run one-sided physics drift smoke checks for Debug and mixed precision
+  5. optionally build/run Debug and mixed precision drift smoke checks, plus surface compile/B-field checks
 
 Options:
   --build-root <path>        Build/cache root (default: ${DEFAULT_BUILD_ROOT})
@@ -61,7 +61,7 @@ Options:
   --force-rebuild            Force clean rebuilds in the matrix runner
   --refresh-master           Refresh cached master worktree/builds
   --always-run-validation    Run validation even when drift matches master
-  --run-drift-smoke          Also build and run Debug and mixed precision drift smoke checks
+  --run-drift-smoke          Also build/run Debug and mixed precision drift smoke, plus surface compile/B-field checks
   --run-debug-drift          Compatibility alias for --run-drift-smoke
   -h, --help                 Show this help
 EOF
@@ -297,6 +297,26 @@ if [[ "${RUN_DRIFT_SMOKE}" -eq 1 ]]; then
   log "Running mixed precision drift smoke"
   log "Mixed precision drift smoke build root: ${MIXED_DRIFT_SMOKE_BUILD_ROOT}"
   if ! "${MATRIX_RUNNER}" "${mixed_matrix_common_args[@]}"; then
+    DRIFT_SMOKE_STATUS=1
+  fi
+
+  SURFACE_BUILD_ROOT="${BUILD_ROOT}/surface-compile"
+  surface_matrix_common_args=(
+    --suite drift-smoke
+    --configs surface
+    --build-root "${SURFACE_BUILD_ROOT}"
+    --cuda-arch "${CUDA_ARCH}"
+    --jobs "${JOBS}"
+    --ctest-timeout-sec "${CTEST_TIMEOUT_SEC}"
+  )
+
+  if [[ "${FORCE_REBUILD}" -eq 1 ]]; then
+    surface_matrix_common_args+=(--force-rebuild)
+  fi
+
+  log "Running surface navigation compile and B-field unit tests"
+  log "Surface navigation compile build root: ${SURFACE_BUILD_ROOT}"
+  if ! "${MATRIX_RUNNER}" "${surface_matrix_common_args[@]}"; then
     DRIFT_SMOKE_STATUS=1
   fi
 else


### PR DESCRIPTION
This PR makes the Woodcock tracking a compile time option (default on), as it currently is not compatible with the VecGeom surface model, which does not support certain required features in the navigator.

A little bit of cleanup is done by further using the `enterWDTRegion = ShouldUseWDT(nextState, eKin);` in the kernels.

Additionally, the surface model is compiled in the CI (at least for `/run-test-full` and the nightlies), and the bfield test is run.