### PR TITLE
update G4VG to 1.0.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ project(AdePT
 )
 
 # Set versions of G4VG and covfie that are pulled in the CMake configuration
-set(ADEPT_G4VG_VERSION 1.0.6)
+set(ADEPT_G4VG_VERSION 1.0.7)
 set(ADEPT_G4VG_TAG v${ADEPT_G4VG_VERSION})
 set(ADEPT_COVFIE_TAG_VERSION 0.15.5)
 set(ADEPT_COVFIE_TAG v${ADEPT_COVFIE_TAG_VERSION})


### PR DESCRIPTION
This updates the G4VG to 1.0.7 which includes a fix on the tessellated solid. With this and the latest VecGeom version, tessellated solids work in AdePT.