### PR TITLE
improve handling of safety in B field propagation

### DIFF
--- a/include/AdePT/transport/magneticfield/fieldPropagatorConstBz.h
+++ b/include/AdePT/transport/magneticfield/fieldPropagatorConstBz.h
@@ -30,7 +30,7 @@ public:
                                                       Vector3D &position, Vector3D &direction,
                                                       vecgeom::NavigationState const &current_state,
                                                       vecgeom::NavigationState &new_state, long &hitsurf_index,
-                                                      bool &propagated, const double safety = 0.0,
+                                                      bool &propagated, const double safetyIn = 0.0,
                                                       const int max_iteration = 100);
 
 private:
@@ -78,7 +78,8 @@ __host__ __device__ double fieldPropagatorConstBz::ComputeStepAndNextVolume(
 
   bool continueIteration = false;
 
-  double safety         = safetyIn;
+  // Cache the safety value together with the point where it was computed.
+  double safetyAtOrigin = safetyIn;
   Vector3D safetyOrigin = position;
   // Prepare next_state in case we skip navigation inside the safety sphere.
   current_state.CopyTo(&next_state);
@@ -93,6 +94,9 @@ __host__ __device__ double fieldPropagatorConstBz::ComputeStepAndNextVolume(
     Vector3D endPosition  = position;
     Vector3D endDirection = direction;
     double safeMove       = min(remains, maxNextSafeMove);
+    // Reduce the cached safety to the current chord start before testing the
+    // proposed chord. The position is updated only after the chord is accepted.
+    double safetyAtChordStart = safetyAtOrigin - (position - safetyOrigin).Length();
 
     helixBz.DoStep<Vector3D, double, int>(position, direction, charge, momentumMag, safeMove, endPosition,
                                           endDirection);
@@ -101,28 +105,24 @@ __host__ __device__ double fieldPropagatorConstBz::ComputeStepAndNextVolume(
     double chordLen   = chordVec.Length();
     Vector3D chordDir = (1 / chordLen) * chordVec;
 
-    double currentSafety = safety - (position - safetyOrigin).Length();
+    if (safetyAtChordStart <= chordLen && stepDone > 0) {
+      // The reduced cached safety is not enough for this chord, so refresh the
+      // cache at the current chord start before falling back to navigation.
+      safetyOrigin       = position;
+      safetyAtOrigin     = Navigator::ComputeSafety(position, current_state, remains);
+      safetyAtChordStart = safetyAtOrigin;
+    }
+
     double move;
-    if (currentSafety > chordLen) {
+    if (safetyAtChordStart > chordLen) {
       move = chordLen;
     } else {
-      double newSafety = 0;
-      if (stepDone > 0) {
-        // Use maximum accuracy only if safety is smaller than physicalStepLength
-        newSafety = Navigator::ComputeSafety(position, current_state, remains);
-      }
-      if (newSafety > chordLen) {
-        move         = chordLen;
-        safetyOrigin = position;
-        safety       = newSafety;
-      } else {
 #ifdef ADEPT_USE_SURF
-        move =
-            Navigator::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state, hitsurf_index);
+      move =
+          Navigator::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state, hitsurf_index);
 #else
-        move = Navigator::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state);
+      move = Navigator::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state);
 #endif
-      }
     }
 
     static constexpr double ReduceFactor = 0.1;

--- a/include/AdePT/transport/magneticfield/fieldPropagatorRungeKutta.h
+++ b/include/AdePT/transport/magneticfield/fieldPropagatorRungeKutta.h
@@ -133,8 +133,8 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
   // bool lastWasZero             = false; // Debug only ?  JA 2022.09.05
   const Real_t inv_momentumMag = 1.0 / momentumMag;
 
-  // Cache safety origin and value at the start point
-  double safety                          = safetyIn;
+  // Cache the safety value together with the point where it was computed.
+  double safetyAtOrigin                  = safetyIn;
   vecgeom::Vector3D<double> safetyOrigin = position;
   // Prepare next_state in case we skip navigation inside the safety sphere.
   current_state.CopyTo(&next_state);
@@ -143,7 +143,7 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
   if (verbose) {
     printf("| fieldPropagatorRK start pos {%.19f, %.19f, %.19f} dir {%.19f, %.19f, %.19f} physicsStep %g safety %g "
            "safeLength %g",
-           position[0], position[1], position[2], direction[0], direction[1], direction[2], physicsStep, safety,
+           position[0], position[1], position[2], direction[0], direction[1], direction[2], physicsStep, safetyAtOrigin,
            safeLength);
     current_state.Print();
   }
@@ -158,6 +158,10 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
     // Position and momentum at the end of the current arc
     vecgeom::Vector3D<double> endPosition    = position;
     vecgeom::Vector3D<double> endMomentumVec = momentumVec;
+
+    // Reduce the cached safety to the current chord start before testing the
+    // proposed chord. The position is updated only after the chord is accepted.
+    Real_t safetyAtChordStart = safetyAtOrigin - (position - safetyOrigin).Length();
 
     // Note: safeArc is not limited by geometry, so after pushing we need to validate that we have not crossed
     const Real_t safeArc = vecCore::Min(remains, maxNextSafeMove);
@@ -182,53 +186,46 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
     // Normalize direction, which is NOT after calling Advance
     endDirection.Normalize();
 
-    // Subtract from the existing safety after the move
-    Real_t currentSafety = safety - (endPosition - safetyOrigin).Length();
 #if ADEPT_DEBUG_TRACK > 0
     if (verbose) {
       if (chordIters > 0)
         printf("| field_point: pos {%.19f, %.19f, %.19f} dir {%.19f, %.19f, %.19f}\n", position[0], position[1],
                position[2], direction[0], direction[1], direction[2]);
       printf("| Advance #%d: safeArc %g | chordLen %g | reducedSafety %g ", chordIters, safeArc, chordLen,
-             currentSafety);
+             safetyAtChordStart);
     }
 #endif
+    if (safetyAtChordStart <= chordLen && stepDone > 0) {
+      // The reduced cached safety is not enough for this chord, so refresh the
+      // cache at the current chord start before falling back to navigation.
+      safetyOrigin       = position;
+      safetyAtOrigin     = Navigator_t::ComputeSafety(position, current_state, remains);
+      safetyAtChordStart = safetyAtOrigin;
+#if ADEPT_DEBUG_TRACK > 0
+      if (verbose) printf("| refreshedSafety %g  ", safetyAtChordStart);
+#endif
+    }
+
     double move;
-    if (currentSafety > chordLen) {
-      // The move is still safe
+    if (safetyAtChordStart > chordLen) {
+      // The move is safe
       move = chordLen;
     } else {
-      // Safety is violated by the move, set it to 0 and recompute it if not the first step
-      double newSafety = 0;
-      if (stepDone > 0) {
-        // Use maximum accuracy only if safety is smaller than the step remainder
-        newSafety = Navigator_t::ComputeSafety(position, current_state, remains);
+      // The move is not safe.
+      // We need to check if the arc actually crosses any boundary along the chord and within chordLen
 #if ADEPT_DEBUG_TRACK > 0
-        if (verbose) printf("| newSafety %g  ", newSafety);
-#endif
-      }
-      if (newSafety > chordLen) {
-        // The recomputed safety was actually larger than the chord -> safe step
-        move = chordLen;
-        // update safety with the computed one BEFORE the arc advance
-        safetyOrigin = position;
-        safety       = newSafety;
-      } else {
-        // We need to check if the arc actually crosses any boundary along the chord and within chordLen
-#if ADEPT_DEBUG_TRACK > 0
-        if (verbose)
-          printf("\n| +++  ComputeStepAndNextVolume pos {%.17f, %.17f, %.17f} chordDir {%.17f, %.17f, %.17f} "
-                 "chordLen %g\n",
-                 position[0], position[1], position[2], chordDir[0], chordDir[1], chordDir[2], chordLen);
+      if (verbose)
+        printf("\n| +++  ComputeStepAndNextVolume pos {%.17f, %.17f, %.17f} chordDir {%.17f, %.17f, %.17f} "
+               "chordLen %g\n",
+               position[0], position[1], position[2], chordDir[0], chordDir[1], chordDir[2], chordLen);
 #endif
 
 #ifdef ADEPT_USE_SURF
-        move = Navigator_t::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state,
-                                                     hitsurf_index);
+      move =
+          Navigator_t::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state, hitsurf_index);
 #else
-        move = Navigator_t::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state);
+      move = Navigator_t::ComputeStepAndNextVolume(position, chordDir, chordLen, current_state, next_state);
 #endif
-      }
     }
 
     // lastWasZero &= chordIters < ReduceIters;
@@ -247,7 +244,7 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
       if (verbose) printf("| full chord advance %g ", arcAdvanced);
 #endif
 
-      maxNextSafeMove   = vecCore::Max(arcAdvanced, Real_t(safety)); // Reset it, once a step succeeds!!
+      maxNextSafeMove   = vecCore::Max(arcAdvanced, Real_t(safetyAtOrigin)); // Reset it, once a step succeeds!!
       continueIteration = true;
     } else if (stepDone == 0 && move <= Navigator_t::kBoundaryPush) {
       // Cope with a track at a boundary that wants to bend back into the previous

--- a/test/unit/test_bfield.cpp
+++ b/test/unit/test_bfield.cpp
@@ -355,6 +355,9 @@ std::array<RkCase, 5> UniformFieldCases()
 // Field storage and equation tests. These are cheap invariants for the lowest
 // layers of the magnetic-field stack.
 
+// UniformMagneticField should be a position-independent field lookup. This
+// catches accidental dependence on the position type or lossy return conversion
+// when callers use either float or double coordinates.
 TEST(UniformMagneticField, EvaluatesStoredFloatFieldForFloatAndDoublePositions)
 {
   const vecgeom::Vector3D<float> storedField{1.25f, -2.5f, 0.75f};
@@ -371,6 +374,8 @@ TEST(UniformMagneticField, EvaluatesStoredFloatFieldForFloatAndDoublePositions)
   EXPECT_DOUBLE_EQ(doubleValue[2], double(storedField[2]));
 }
 
+// The equation of motion must use the unit momentum direction for dx/ds and
+// produce a Lorentz kick perpendicular to both momentum and magnetic field.
 TEST(MagneticFieldEquation, DerivativeDirectionIsUnitAndForceIsPerpendicular)
 {
   using Equation = MagneticFieldEquation<UniformMagneticField>;
@@ -397,6 +402,8 @@ TEST(MagneticFieldEquation, DerivativeDirectionIsUnitAndForceIsPerpendicular)
   EXPECT_NEAR(bField.Dot(force), 0.0, 1.0e-12 * bField.Length() * force.Length());
 }
 
+// Flipping the charge should only flip dp/ds. The spatial derivative is the
+// track direction and must not depend on the charge sign.
 TEST(MagneticFieldEquation, ChargeSignOnlyFlipsMomentumDerivative)
 {
   using Equation = MagneticFieldEquation<UniformMagneticField>;
@@ -415,6 +422,8 @@ TEST(MagneticFieldEquation, ChargeSignOnlyFlipsMomentumDerivative)
   }
 }
 
+// With B = 0 the momentum derivative must vanish exactly. This guards against
+// stale field values or cross-product sign mistakes leaking into zero-field mode.
 TEST(MagneticFieldEquation, ZeroFieldKeepsMomentumConstant)
 {
   using Equation = MagneticFieldEquation<UniformMagneticField>;
@@ -433,6 +442,8 @@ TEST(MagneticFieldEquation, ZeroFieldKeepsMomentumConstant)
 // substep progress accounting; the later ones exercise the real stepper against
 // simple physics expectations in both precisions.
 
+// A rejected substep must not alter progress already owned by the caller. This
+// protects the retry path where the driver rejects before accepting new distance.
 TEST(RkIntegrationDriver, RejectedStepKeepsCumulativeProgress)
 {
   using Driver = RkIntegrationDriver<RejectingStepper, double, int, LinearEquation, DummyField>;
@@ -450,6 +461,8 @@ TEST(RkIntegrationDriver, RejectedStepKeepsCumulativeProgress)
   EXPECT_DOUBLE_EQ(progress, 7.5);
 }
 
+// If the trial budget runs out after some accepted progress, Advance must report
+// only that accepted distance instead of pretending the requested step completed.
 TEST(RkIntegrationDriver, ReportsAcceptedProgressWhenTrialBudgetIsExhausted)
 {
   using Driver = RkIntegrationDriver<OneRejectedSubstepStepper, double, int, LinearEquation, DummyField>;
@@ -468,6 +481,8 @@ TEST(RkIntegrationDriver, ReportsAcceptedProgressWhenTrialBudgetIsExhausted)
   EXPECT_NEAR(position[2], 0.0, 1.0e-12);
 }
 
+// A rejected substep in the middle of the integration should not make the next
+// accepted trial overshoot the requested path length.
 TEST(RkIntegrationDriver, AdvanceDoesNotOvershootAfterRejectedSubstep)
 {
   using Driver = RkIntegrationDriver<OneRejectedSubstepStepper, double, int, LinearEquation, DummyField>;
@@ -512,16 +527,22 @@ void CheckZeroFieldStraightLine()
   ExpectVectorNear(momentum.Unit(), startDirection, std::is_same_v<Real_t, float> ? 2.0e-7 : 1.0e-14);
 }
 
+// Double-precision RK integration should collapse to straight-line transport
+// when the magnetic field is zero.
 TEST(RkIntegrationDriver, ZeroFieldIsStraightLineInDoublePrecision)
 {
   CheckZeroFieldStraightLine<double>();
 }
 
+// Float-precision RK integration should obey the same zero-field straight-line
+// contract, within the looser float tolerance.
 TEST(RkIntegrationDriver, ZeroFieldIsStraightLineInFloatPrecision)
 {
   CheckZeroFieldStraightLine<float>();
 }
 
+// In a constant field the double-precision RK result should match the analytic
+// helix. This catches unit, charge-sign, and field-orientation regressions.
 TEST(RkIntegrationDriver, UniformFieldMatchesHelixInDoublePrecision)
 {
   for (const auto &testCase : UniformFieldCases()) {
@@ -531,6 +552,8 @@ TEST(RkIntegrationDriver, UniformFieldMatchesHelixInDoublePrecision)
   }
 }
 
+// The same helix comparison is run for the float RK path, where the tolerance
+// reflects the float field storage and integration arithmetic.
 TEST(RkIntegrationDriver, UniformFieldMatchesHelixInFloatPrecision)
 {
   for (const auto &testCase : UniformFieldCases()) {
@@ -543,6 +566,8 @@ TEST(RkIntegrationDriver, UniformFieldMatchesHelixInFloatPrecision)
 // and focus on the surrounding propagation logic: failed RK advance, safety
 // shortcut, and navigator-limited chord acceptance.
 
+// If the RK driver makes no accepted progress, the propagator must stop before
+// normalizing a zero-length chord or asking geometry to navigate a bogus step.
 TEST(FieldPropagatorRungeKutta, FailedAdvanceStopsBeforeZeroChordNormalization)
 {
   using Propagator = fieldPropagatorRungeKutta<DummyField, FailingPropagatorDriver, double, ThrowingNavigator>;
@@ -568,6 +593,8 @@ TEST(FieldPropagatorRungeKutta, FailedAdvanceStopsBeforeZeroChordNormalization)
   ExpectVectorNear(direction, vecgeom::Vector3D<double>{1.0, 0.0, 0.0}, 0.0);
 }
 
+// The RK driver may return partial accepted progress after exhausting its trial
+// budget. The propagator must bookkeep that accepted arc length and continue.
 TEST(FieldPropagatorRungeKutta, UsesAcceptedArcLengthWhenDriverReportsIncomplete)
 {
   using Propagator =
@@ -596,6 +623,8 @@ TEST(FieldPropagatorRungeKutta, UsesAcceptedArcLengthWhenDriverReportsIncomplete
   ExpectVectorNear(direction, vecgeom::Vector3D<double>{1.0, 0.0, 0.0}, 0.0);
 }
 
+// A large cached geometric safety should allow the whole chord to be accepted
+// without calling VecGeom navigation. This protects the fast safety shortcut.
 TEST(FieldPropagatorRungeKutta, UsesSafetyToAcceptFullChordWithoutNavigation)
 {
   using Propagator = fieldPropagatorRungeKutta<DummyField, StraightLinePropagatorDriver, double, ThrowingNavigator>;
@@ -621,6 +650,35 @@ TEST(FieldPropagatorRungeKutta, UsesSafetyToAcceptFullChordWithoutNavigation)
   ExpectVectorNear(direction, vecgeom::Vector3D<double>{1.0, 0.0, 0.0}, 0.0);
 }
 
+// The cached safety has to be reduced to the current chord start, not to the
+// proposed endpoint. Otherwise a safe chord can be rejected and sent to geometry.
+TEST(FieldPropagatorRungeKutta, UsesCurrentSafetyBeforeTestingCandidateChord)
+{
+  using Propagator = fieldPropagatorRungeKutta<DummyField, StraightLinePropagatorDriver, double, ThrowingNavigator>;
+
+  ThrowingNavigator::Reset();
+  vecgeom::Vector3D<double> position{1.0, 2.0, 3.0};
+  vecgeom::Vector3D<double> direction{1.0, 0.0, 0.0};
+  vecgeom::NavigationState currentState;
+  vecgeom::NavigationState nextState;
+  long hitSurfaceIndex = -1;
+  bool propagated      = false;
+  bool zeroFirstStep   = false;
+  int itersDone        = 0;
+
+  const double moved = Propagator::ComputeStepAndNextVolume(DummyField{}, 10.0, 1.0, 1, 5.0, 5.0, position, direction,
+                                                            currentState, nextState, hitSurfaceIndex, propagated, 6.0,
+                                                            10, itersDone, 0, zeroFirstStep, false);
+
+  EXPECT_DOUBLE_EQ(moved, 5.0);
+  EXPECT_TRUE(propagated);
+  EXPECT_EQ(ThrowingNavigator::stepCalls, 0);
+  ExpectVectorNear(position, vecgeom::Vector3D<double>{6.0, 2.0, 3.0}, 1.0e-14);
+  ExpectVectorNear(direction, vecgeom::Vector3D<double>{1.0, 0.0, 0.0}, 0.0);
+}
+
+// When the safety shortcut is not enough, the propagator must defer to the
+// navigator and stop at the boundary distance reported along the chord.
 TEST(FieldPropagatorRungeKutta, StopsAtNavigatorBoundaryAlongChord)
 {
   using Propagator = fieldPropagatorRungeKutta<DummyField, StraightLinePropagatorDriver, double, BoundaryNavigator>;


### PR DESCRIPTION
This PR improves the handling of the safety in the B field propagation.

- It makes the names intuitive (`safetyAtOrigin`, `safetyAtChordStart`), and removes a redundant variable (`newSafety`)
- Before, it was overly conservative, as the `currentSafety` (now `safetyAtChordStart`) was actually calculated with the `EndPosition`, which makes it significantly smaller than it should be, so a safety had to be `2* chordlen` to get away without geometry checks. To clear this up further, the calculation of the `safetyAtChordStart` is moved to the beginning of the loop.
- A unit test is added to prevent the case above
- all unit tests for the B field have a better description.
- The logic of recomputing the safety is simplified.