### PR TITLE
fix safety in split kernels

### DIFF
--- a/include/AdePT/transport/kernels/electrons_split.cuh
+++ b/include/AdePT/transport/kernels/electrons_split.cuh
@@ -242,9 +242,9 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
         // Recompute safety and update it in the track.
         // Use maximum accuracy only if safety is smaller than physicalStepLength
         safety = AdePTNavigator::ComputeSafety(currentTrack.pos, currentTrack.navState, physicalStepLength);
-        currentTrack.SetSafety(currentTrack.pos, safety);
       }
     }
+    currentTrack.SetSafety(currentTrack.pos, safety);
     theTrack->SetSafety(safety);
     currentTrack.restrictedPhysicalStepLength = false;
 


### PR DESCRIPTION
This fixes a bug regarding the safety in the split kernels.

In the split kernels, the field propagator gets directly the `currentTrack.safety` value as an input. However, in the setup of `ElectronHowFar` the safety value is not always refreshed based on the current position (it is only refreshed in the track if it is recomputed). The fix is straightforward to always write back the safety to the `currentTrack` in the split kernels, such that the field propagator always gets a safety / position that is in sync.