### PR TITLE
use cached safety and update it in B field propagation

### DIFF
--- a/include/AdePT/transport/kernels/electrons.cuh
+++ b/include/AdePT/transport/kernels/electrons.cuh
@@ -215,12 +215,12 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
         // Recompute safety and update it in the track.
         // Use maximum accuracy only if safety is smaller than physicalStepLength
         safety = AdePTNavigator::ComputeSafety(pos, navState, physicalStepLength);
-        currentTrack.SetSafety(pos, safety);
 #if ADEPT_DEBUG_TRACK > 0
         if (verbose) printf("| new safety %g ", safety);
 #endif
       }
     }
+    currentTrack.SetSafety(pos, safety);
     theTrack->SetSafety(safety);
     bool restrictedPhysicalStepLength = false;
 
@@ -298,13 +298,14 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     long hitsurf_index = -1;
     double geometryStepLength;
     bool zero_first_step = false;
+    SafetyCache geometrySafetyCache(currentTrack.safetyCache);
 
     if (gMagneticField) {
       int iterDone = -1;
       geometryStepLength =
           fieldPropagatorRungeKutta<Field_t, RkDriver_t, rk_integration_t, AdePTNavigator>::ComputeStepAndNextVolume(
               magneticField, eKin, restMass, Charge, geometricalStepLengthFromPhysics, safeLength, pos, dir, navState,
-              nextState, hitsurf_index, propagated, /*lengthDone,*/ safety,
+              nextState, hitsurf_index, propagated, geometrySafetyCache,
               // activeSize < 100 ? max_iterations : max_iters_tail ), // Was
               max_iterations, iterDone, slot, zero_first_step, verbose);
       // In case of zero step detected by the field propagator this could be due to back scattering, or wrong relocation
@@ -347,7 +348,11 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     // correct information (navState = nextState only if relocated
     // in case of a boundary; see below)
     navState.SetBoundaryState(nextState.IsOnBoundary());
-    if (nextState.IsOnBoundary()) currentTrack.SetSafety(pos, 0.);
+    if (nextState.IsOnBoundary()) {
+      currentTrack.SetSafety(pos, 0.);
+    } else {
+      currentTrack.SetSafety(pos, geometrySafetyCache.SafetyAt(pos));
+    }
 
     // Propagate information from geometrical step to MSC.
     theTrack->SetDirection(dir.x(), dir.y(), dir.z());

--- a/include/AdePT/transport/kernels/electrons_split.cuh
+++ b/include/AdePT/transport/kernels/electrons_split.cuh
@@ -131,7 +131,7 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
                  "geoStepLength=%E "
                  "safety=%E\n",
                  currentTrack.eKin, currentTrack.eventId, currentTrack.trackId, currentTrack.looperCounter,
-                 energyDeposit, theTrack->GetGStepLength(), currentTrack.safety);
+                 energyDeposit, theTrack->GetGStepLength(), currentTrack.GetSafety(currentTrack.pos));
         trackSurvives = false;
         energyDeposit += IsElectron ? currentTrack.eKin : currentTrack.eKin + 2 * copcore::units::kElectronMassC2;
         currentTrack.eKin = 0.;
@@ -326,6 +326,7 @@ __global__ void ElectronPropagation(ChargedTrack *electronsOrPositrons, G4HepEmE
     currentTrack.hitsurfID  = -1;
     double geometryStepLength;
     bool zero_first_step = false;
+    SafetyCache geometrySafetyCache(currentTrack.safetyCache);
 
     if (gMagneticField) {
       int iterDone = -1;
@@ -333,8 +334,7 @@ __global__ void ElectronPropagation(ChargedTrack *electronsOrPositrons, G4HepEmE
           fieldPropagatorRungeKutta<Field_t, RkDriver_t, rk_integration_t, AdePTNavigator>::ComputeStepAndNextVolume(
               magneticField, currentTrack.eKin, restMass, Charge, theTrack->GetGStepLength(), currentTrack.safeLength,
               currentTrack.pos, currentTrack.dir, currentTrack.navState, currentTrack.nextState, currentTrack.hitsurfID,
-              currentTrack.propagated,
-              /*lengthDone,*/ currentTrack.safety,
+              currentTrack.propagated, geometrySafetyCache,
               // activeSize < 100 ? max_iterations : max_iters_tail ), // Was
               max_iterations, iterDone, slot, zero_first_step);
       // In case of zero step detected by the field propagator this could be due to back scattering, or wrong relocation
@@ -358,8 +358,9 @@ __global__ void ElectronPropagation(ChargedTrack *electronsOrPositrons, G4HepEmE
     if (geometryStepLength < kPushStuck && geometryStepLength < theTrack->GetGStepLength()) {
       currentTrack.zeroStepCounter++;
       if (currentTrack.zeroStepCounter > kStepsStuckPush) currentTrack.pos += kPushStuck * currentTrack.dir;
-    } else
+    } else {
       currentTrack.zeroStepCounter = 0;
+    }
 
     // punish minuscule steps by increasing the looperCounter by 10
     if (geometryStepLength < 100 * vecgeom::kTolerance) currentTrack.looperCounter += 10;
@@ -368,7 +369,11 @@ __global__ void ElectronPropagation(ChargedTrack *electronsOrPositrons, G4HepEmE
     // correct information (navState = nextState only if relocated
     // in case of a boundary; see below)
     currentTrack.navState.SetBoundaryState(currentTrack.nextState.IsOnBoundary());
-    if (currentTrack.nextState.IsOnBoundary()) currentTrack.SetSafety(currentTrack.pos, 0.);
+    if (currentTrack.nextState.IsOnBoundary()) {
+      currentTrack.SetSafety(currentTrack.pos, 0.);
+    } else {
+      currentTrack.SetSafety(currentTrack.pos, geometrySafetyCache.SafetyAt(currentTrack.pos));
+    }
 
     // Propagate information from geometrical step to MSC.
     theTrack->SetDirection(currentTrack.dir.x(), currentTrack.dir.y(), currentTrack.dir.z());

--- a/include/AdePT/transport/magneticfield/fieldPropagatorConstBz.h
+++ b/include/AdePT/transport/magneticfield/fieldPropagatorConstBz.h
@@ -7,6 +7,7 @@
 
 #include <VecGeom/base/Vector3D.h>
 #include <AdePT/transport/support/PhysicalConstants.h>
+#include <AdePT/transport/tracks/SafetyCache.cuh>
 
 #include <AdePT/transport/navigation/AdePTNavigator.h>
 
@@ -30,7 +31,7 @@ public:
                                                       Vector3D &position, Vector3D &direction,
                                                       vecgeom::NavigationState const &current_state,
                                                       vecgeom::NavigationState &new_state, long &hitsurf_index,
-                                                      bool &propagated, const double safetyIn = 0.0,
+                                                      bool &propagated, SafetyCache &safetyCache,
                                                       const int max_iteration = 100);
 
 private:
@@ -60,7 +61,7 @@ template <class Navigator>
 __host__ __device__ double fieldPropagatorConstBz::ComputeStepAndNextVolume(
     double kinE, double mass, int charge, double physicsStep, vecgeom::Vector3D<double> &position,
     vecgeom::Vector3D<double> &direction, vecgeom::NavigationState const &current_state,
-    vecgeom::NavigationState &next_state, long &hitsurf_index, bool &propagated, const double safetyIn,
+    vecgeom::NavigationState &next_state, long &hitsurf_index, bool &propagated, SafetyCache &safetyCache,
     const int max_iterations)
 {
 
@@ -78,9 +79,6 @@ __host__ __device__ double fieldPropagatorConstBz::ComputeStepAndNextVolume(
 
   bool continueIteration = false;
 
-  // Cache the safety value together with the point where it was computed.
-  double safetyAtOrigin = safetyIn;
-  Vector3D safetyOrigin = position;
   // Prepare next_state in case we skip navigation inside the safety sphere.
   current_state.CopyTo(&next_state);
   next_state.SetBoundaryState(false);
@@ -96,7 +94,7 @@ __host__ __device__ double fieldPropagatorConstBz::ComputeStepAndNextVolume(
     double safeMove       = min(remains, maxNextSafeMove);
     // Reduce the cached safety to the current chord start before testing the
     // proposed chord. The position is updated only after the chord is accepted.
-    double safetyAtChordStart = safetyAtOrigin - (position - safetyOrigin).Length();
+    double safetyAtChordStart = safetyCache.SafetyAt(position);
 
     helixBz.DoStep<Vector3D, double, int>(position, direction, charge, momentumMag, safeMove, endPosition,
                                           endDirection);
@@ -108,9 +106,7 @@ __host__ __device__ double fieldPropagatorConstBz::ComputeStepAndNextVolume(
     if (safetyAtChordStart <= chordLen && stepDone > 0) {
       // The reduced cached safety is not enough for this chord, so refresh the
       // cache at the current chord start before falling back to navigation.
-      safetyOrigin       = position;
-      safetyAtOrigin     = Navigator::ComputeSafety(position, current_state, remains);
-      safetyAtChordStart = safetyAtOrigin;
+      safetyAtChordStart = safetyCache.Refresh(position, Navigator::ComputeSafety(position, current_state, remains));
     }
 
     double move;

--- a/include/AdePT/transport/magneticfield/fieldPropagatorRungeKutta.h
+++ b/include/AdePT/transport/magneticfield/fieldPropagatorRungeKutta.h
@@ -10,6 +10,7 @@
 #include "fieldConstants.h" // For kB2C factor with units
 
 #include <AdePT/transport/magneticfield/RkIntegrationDriver.h>
+#include <AdePT/transport/tracks/SafetyCache.cuh>
 
 #include <VecGeom/navigation/NavigationState.h>
 
@@ -34,7 +35,7 @@ public:
   /// @param[out] next_state Geometry state after propagation
   /// @param[out] hitsurf_index Index of the hit surface (surface model only)
   /// @param[out] propagated Checks if the step was fully propagated
-  /// @param safetyIn Geometric isotropic safety
+  /// @param safetyCache Cached geometric isotropic safety
   /// @param max_iterations Maximum allowed iterations
   /// @param[out] iterDone Number of iterations performed
   /// @param threadId Thread id
@@ -45,7 +46,7 @@ public:
       Field_t const &magneticField, double kinE, double mass, int charge, double physicsStep, double safeLength,
       vecgeom::Vector3D<double> &position, vecgeom::Vector3D<double> &direction,
       vecgeom::NavigationState const &current_state, vecgeom::NavigationState &next_state, long &hitsurf_index,
-      bool &propagated, const Real_t &safetyIn, const int max_iterations, int &iterDone, int threadId,
+      bool &propagated, SafetyCache &safetyCache, const int max_iterations, int &iterDone, int threadId,
       bool &zero_first_step, bool verbose = false);
   // Move the track,
   //   updating 'position', 'direction', the next state and returning the length moved.
@@ -92,8 +93,7 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
                              double safeLength, vecgeom::Vector3D<double> &position,
                              vecgeom::Vector3D<double> &direction, vecgeom::NavigationState const &current_state,
                              vecgeom::NavigationState &next_state, long &hitsurf_index, bool &propagated,
-                             const Real_t &safetyIn, //  eventually In/Out ?
-                             const int max_iterations,
+                             SafetyCache &safetyCache, const int max_iterations,
                              int &itersDone, //  useful for now - to monitor and report -- unclear if needed later
                              int index, bool &zero_first_step, bool verbose)
 {
@@ -121,21 +121,17 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
   const double momentumMag              = sqrt(kinE * (kinE + 2.0 * mass));
   vecgeom::Vector3D<double> momentumVec = momentumMag * direction;
 
-  // The allowed safe move is normally determined by the bending accuracy
-  // This is reduced if starting from a boundary and crossing a boundary in the first step
-  Real_t maxNextSafeMove =
-      vecCore::Max(Real_t(safeLength), safetyIn); // It can be reduced if, at the start, a boundary is encountered
-  int chordIters         = 0;                     ///< number of iterations for this integration
-  Real_t last_good_step  = 0.0;                   ///< to be reused for next cord iteration
+  // The allowed safe move is normally determined by the bending accuracy.
+  // It can be enlarged by the geometric safety at the current position.
+  Real_t maxNextSafeMove = vecCore::Max(Real_t(safeLength), Real_t(safetyCache.SafetyAt(position)));
+  int chordIters         = 0;   ///< number of iterations for this integration
+  Real_t last_good_step  = 0.0; ///< to be reused for next cord iteration
   bool found_end         = false;
   bool continueIteration = false;
   bool fullChord         = false;
   // bool lastWasZero             = false; // Debug only ?  JA 2022.09.05
   const Real_t inv_momentumMag = 1.0 / momentumMag;
 
-  // Cache the safety value together with the point where it was computed.
-  double safetyAtOrigin                  = safetyIn;
-  vecgeom::Vector3D<double> safetyOrigin = position;
   // Prepare next_state in case we skip navigation inside the safety sphere.
   current_state.CopyTo(&next_state);
   next_state.SetBoundaryState(false);
@@ -143,8 +139,8 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
   if (verbose) {
     printf("| fieldPropagatorRK start pos {%.19f, %.19f, %.19f} dir {%.19f, %.19f, %.19f} physicsStep %g safety %g "
            "safeLength %g",
-           position[0], position[1], position[2], direction[0], direction[1], direction[2], physicsStep, safetyAtOrigin,
-           safeLength);
+           position[0], position[1], position[2], direction[0], direction[1], direction[2], physicsStep,
+           safetyCache.SafetyAt(position), safeLength);
     current_state.Print();
   }
 #endif
@@ -161,7 +157,7 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
 
     // Reduce the cached safety to the current chord start before testing the
     // proposed chord. The position is updated only after the chord is accepted.
-    Real_t safetyAtChordStart = safetyAtOrigin - (position - safetyOrigin).Length();
+    Real_t safetyAtChordStart = safetyCache.SafetyAt(position);
 
     // Note: safeArc is not limited by geometry, so after pushing we need to validate that we have not crossed
     const Real_t safeArc = vecCore::Min(remains, maxNextSafeMove);
@@ -198,9 +194,7 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
     if (safetyAtChordStart <= chordLen && stepDone > 0) {
       // The reduced cached safety is not enough for this chord, so refresh the
       // cache at the current chord start before falling back to navigation.
-      safetyOrigin       = position;
-      safetyAtOrigin     = Navigator_t::ComputeSafety(position, current_state, remains);
-      safetyAtChordStart = safetyAtOrigin;
+      safetyAtChordStart = safetyCache.Refresh(position, Navigator_t::ComputeSafety(position, current_state, remains));
 #if ADEPT_DEBUG_TRACK > 0
       if (verbose) printf("| refreshedSafety %g  ", safetyAtChordStart);
 #endif
@@ -244,7 +238,7 @@ inline __host__ __device__ double fieldPropagatorRungeKutta<Field_t, RkDriver_t,
       if (verbose) printf("| full chord advance %g ", arcAdvanced);
 #endif
 
-      maxNextSafeMove   = vecCore::Max(arcAdvanced, Real_t(safetyAtOrigin)); // Reset it, once a step succeeds!!
+      maxNextSafeMove   = vecCore::Max(arcAdvanced, Real_t(safetyCache.SafetyAt(position))); // Reset after success.
       continueIteration = true;
     } else if (stepDone == 0 && move <= Navigator_t::kBoundaryPush) {
       // Cope with a track at a boundary that wants to bend back into the previous

--- a/include/AdePT/transport/tracks/SafetyCache.cuh
+++ b/include/AdePT/transport/tracks/SafetyCache.cuh
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2026 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <VecGeom/base/Vector3D.h>
+
+#include <VecCore/VecMath.h>
+
+/// Cached isotropic safety value together with the position where it was
+/// computed. SafetyAt() returns the conservative remaining safety at another
+/// point by subtracting the displacement from the cached origin.
+struct SafetyCache {
+  vecgeom::Vector3D<float> origin; ///< last position where the safety was computed
+  float value{0.f};                ///< safety value at origin
+
+  __host__ __device__ SafetyCache() = default;
+
+  /// @brief Get the conservative remaining safety at a given track position.
+  /// @param position Track position.
+  /// @param accurateLimit Only return non-zero if the remaining safety is larger than this limit.
+  /// @return Remaining safety at @p position.
+  __host__ __device__ VECGEOM_FORCE_INLINE float SafetyAt(vecgeom::Vector3D<double> const &position,
+                                                          float accurateLimit = 0.f) const
+  {
+    float remaining = value - accurateLimit;
+    if (remaining <= 0.f) return 0.f;
+    vecgeom::Vector3D<float> pos{static_cast<float>(position[0]), static_cast<float>(position[1]),
+                                 static_cast<float>(position[2])};
+    float distSq = (pos - origin).Mag2();
+    if (remaining * remaining < distSq) return 0.f;
+    return value - vecCore::math::Sqrt(distSq);
+  }
+
+  /// @brief Store a safety value computed at a new point.
+  /// @param position Position where the safety was computed.
+  /// @param safety Safety value.
+  /// @return Stored non-negative safety value.
+  __host__ __device__ VECGEOM_FORCE_INLINE float Refresh(vecgeom::Vector3D<double> const &position, double safety)
+  {
+    origin.Set(static_cast<float>(position[0]), static_cast<float>(position[1]), static_cast<float>(position[2]));
+    value = vecCore::math::Max(static_cast<float>(safety), 0.f);
+    return value;
+  }
+};

--- a/include/AdePT/transport/tracks/SafetyCache.cuh
+++ b/include/AdePT/transport/tracks/SafetyCache.cuh
@@ -11,8 +11,8 @@
 /// computed. SafetyAt() returns the conservative remaining safety at another
 /// point by subtracting the displacement from the cached origin.
 struct SafetyCache {
-  vecgeom::Vector3D<float> origin; ///< last position where the safety was computed
-  float value{0.f};                ///< safety value at origin
+  vecgeom::Vector3D<double> origin; ///< last position where the safety was computed
+  double value{0.};                 ///< safety value at origin
 
   __host__ __device__ SafetyCache() = default;
 
@@ -20,15 +20,13 @@ struct SafetyCache {
   /// @param position Track position.
   /// @param accurateLimit Only return non-zero if the remaining safety is larger than this limit.
   /// @return Remaining safety at @p position.
-  __host__ __device__ VECGEOM_FORCE_INLINE float SafetyAt(vecgeom::Vector3D<double> const &position,
-                                                          float accurateLimit = 0.f) const
+  __host__ __device__ VECGEOM_FORCE_INLINE double SafetyAt(vecgeom::Vector3D<double> const &position,
+                                                           double accurateLimit = 0.) const
   {
-    float remaining = value - accurateLimit;
-    if (remaining <= 0.f) return 0.f;
-    vecgeom::Vector3D<float> pos{static_cast<float>(position[0]), static_cast<float>(position[1]),
-                                 static_cast<float>(position[2])};
-    float distSq = (pos - origin).Mag2();
-    if (remaining * remaining < distSq) return 0.f;
+    double remaining = value - accurateLimit;
+    if (remaining <= 0.) return 0.;
+    double distSq = (position - origin).Mag2();
+    if (remaining * remaining < distSq) return 0.;
     return value - vecCore::math::Sqrt(distSq);
   }
 
@@ -36,10 +34,10 @@ struct SafetyCache {
   /// @param position Position where the safety was computed.
   /// @param safety Safety value.
   /// @return Stored non-negative safety value.
-  __host__ __device__ VECGEOM_FORCE_INLINE float Refresh(vecgeom::Vector3D<double> const &position, double safety)
+  __host__ __device__ VECGEOM_FORCE_INLINE double Refresh(vecgeom::Vector3D<double> const &position, double safety)
   {
-    origin.Set(static_cast<float>(position[0]), static_cast<float>(position[1]), static_cast<float>(position[2]));
-    value = vecCore::math::Max(static_cast<float>(safety), 0.f);
+    origin = position;
+    value  = vecCore::math::Max(safety, 0.);
     return value;
   }
 };

--- a/include/AdePT/transport/tracks/Track.cuh
+++ b/include/AdePT/transport/tracks/Track.cuh
@@ -152,8 +152,8 @@ struct ChargedTrack : TrackBase {
   /// @param new_pos Track position
   /// @param accurate_limit Only return non-zero if the recomputed safety if larger than the accurate_limit
   /// @return Recomputed safety.
-  __host__ __device__ VECGEOM_FORCE_INLINE float GetSafety(vecgeom::Vector3D<double> const &new_pos,
-                                                           float accurate_limit = 0.f) const
+  __host__ __device__ VECGEOM_FORCE_INLINE double GetSafety(vecgeom::Vector3D<double> const &new_pos,
+                                                            double accurate_limit = 0.) const
   {
     return safetyCache.SafetyAt(new_pos, accurate_limit);
   }
@@ -161,7 +161,7 @@ struct ChargedTrack : TrackBase {
   /// @brief Set Safety value computed in a new point
   /// @param new_pos Position where the safety is computed
   /// @param safe Safety value
-  __host__ __device__ VECGEOM_FORCE_INLINE void SetSafety(vecgeom::Vector3D<double> const &new_pos, float safe)
+  __host__ __device__ VECGEOM_FORCE_INLINE void SetSafety(vecgeom::Vector3D<double> const &new_pos, double safe)
   {
     safetyCache.Refresh(new_pos, safe);
   }

--- a/include/AdePT/transport/tracks/Track.cuh
+++ b/include/AdePT/transport/tracks/Track.cuh
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <AdePT/transport/tracks/TrackData.h>
+#include <AdePT/transport/tracks/SafetyCache.cuh>
 #include <AdePT/transport/support/SystemOfUnits.h>
 #include <AdePT/transport/random/Ranluxpp.h>
 
@@ -133,10 +134,7 @@ struct ChargedTrack : TrackBase {
 
   __host__ __device__ ChargedTrack() = default;
 
-  vecgeom::Vector3D<float> safetyPos; ///< last position where the safety was computed
-  // TODO: For better clarity in the split kernels, rename this to "stored safety" as opposed to the
-  // safety we get from GetSafety(), which is computed in the moment
-  float safety{0.f}; ///< last computed safety value
+  SafetyCache safetyCache; ///< cached geometric safety and its origin
 
 #ifndef ADEPT_USE_SPLIT_KERNELS
   float numIALeft[4]{-1.f, -1.f, -1.f, -1.f};
@@ -157,11 +155,7 @@ struct ChargedTrack : TrackBase {
   __host__ __device__ VECGEOM_FORCE_INLINE float GetSafety(vecgeom::Vector3D<double> const &new_pos,
                                                            float accurate_limit = 0.f) const
   {
-    float dsafe = safety - accurate_limit;
-    if (dsafe <= 0.f) return 0.f;
-    float distSq = (vecgeom::Vector3D<float>(new_pos) - safetyPos).Mag2();
-    if (dsafe * dsafe < distSq) return 0.f;
-    return (safety - vecCore::math::Sqrt(distSq));
+    return safetyCache.SafetyAt(new_pos, accurate_limit);
   }
 
   /// @brief Set Safety value computed in a new point
@@ -169,8 +163,7 @@ struct ChargedTrack : TrackBase {
   /// @param safe Safety value
   __host__ __device__ VECGEOM_FORCE_INLINE void SetSafety(vecgeom::Vector3D<double> const &new_pos, float safe)
   {
-    safetyPos.Set(static_cast<float>(new_pos[0]), static_cast<float>(new_pos[1]), static_cast<float>(new_pos[2]));
-    safety = vecCore::math::Max(safe, 0.f);
+    safetyCache.Refresh(new_pos, safe);
   }
 
   __host__ __device__ void Print(const char *label) const

--- a/test/unit/testField/electrons.cu
+++ b/test/unit/testField/electrons.cu
@@ -197,9 +197,11 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
       bool propagatedHx;
 
       fieldPropagatorConstBz fieldPropagatorBz(BzFieldValue);
+      SafetyCache helixSafetyCache;
+      helixSafetyCache.Refresh(positionHx, safety);
       double helixStepLength = fieldPropagatorBz.ComputeStepAndNextVolume<AdePTNavigator>(
           energy, Mass, Charge, geometricalStepLengthFromPhysics, positionHx, directionHx, navState, nextStateHx,
-          hitsurf_index, propagatedHx, safety, max_iterations);
+          hitsurf_index, propagatedHx, helixSafetyCache, max_iterations);
       // activeSize < 100 ? max_iterations : max_iters_tail );
       // End   Baseline reply
 #endif
@@ -215,10 +217,12 @@ static __device__ __forceinline__ void TransportElectrons(Track *electrons, cons
 
       int iterDone         = -1;
       bool zero_first_step = false;
+      SafetyCache fieldSafetyCache;
+      fieldSafetyCache.Refresh(pos, safety);
       geometryStepLength =
           fieldPropagatorRungeKutta<Field_t, RkDriver_t, double, AdePTNavigator>::ComputeStepAndNextVolume(
               magneticFieldB, energy, Mass, Charge, geometricalStepLengthFromPhysics, safeLength, pos, dir, navState,
-              nextState, hitsurf_index, propagated, /*lengthDone,*/ safety,
+              nextState, hitsurf_index, propagated, fieldSafetyCache,
               // activeSize < 100 ? max_iterations : max_iters_tail ), // Was
               max_iterations, iterDone, slot, zero_first_step);
 #ifdef CHECK_RESULTS

--- a/test/unit/test_bfield.cpp
+++ b/test/unit/test_bfield.cpp
@@ -581,10 +581,12 @@ TEST(FieldPropagatorRungeKutta, FailedAdvanceStopsBeforeZeroChordNormalization)
   bool propagated      = true;
   bool zeroFirstStep   = false;
   int itersDone        = 0;
+  SafetyCache safetyCache;
+  safetyCache.Refresh(position, 0.0);
 
   const double moved = Propagator::ComputeStepAndNextVolume(DummyField{}, 10.0, 1.0, 1, 5.0, 5.0, position, direction,
-                                                            currentState, nextState, hitSurfaceIndex, propagated, 0.0,
-                                                            10, itersDone, 0, zeroFirstStep, false);
+                                                            currentState, nextState, hitSurfaceIndex, propagated,
+                                                            safetyCache, 10, itersDone, 0, zeroFirstStep, false);
 
   EXPECT_DOUBLE_EQ(moved, 0.0);
   EXPECT_FALSE(propagated);
@@ -610,10 +612,12 @@ TEST(FieldPropagatorRungeKutta, UsesAcceptedArcLengthWhenDriverReportsIncomplete
   bool propagated      = false;
   bool zeroFirstStep   = false;
   int itersDone        = 0;
+  SafetyCache safetyCache;
+  safetyCache.Refresh(position, 100.0);
 
   const double moved = Propagator::ComputeStepAndNextVolume(DummyField{}, 10.0, 1.0, 1, 5.0, 5.0, position, direction,
-                                                            currentState, nextState, hitSurfaceIndex, propagated, 100.0,
-                                                            10, itersDone, 0, zeroFirstStep, false);
+                                                            currentState, nextState, hitSurfaceIndex, propagated,
+                                                            safetyCache, 10, itersDone, 0, zeroFirstStep, false);
 
   EXPECT_DOUBLE_EQ(moved, 5.0);
   EXPECT_TRUE(propagated);
@@ -638,10 +642,12 @@ TEST(FieldPropagatorRungeKutta, UsesSafetyToAcceptFullChordWithoutNavigation)
   bool propagated      = false;
   bool zeroFirstStep   = false;
   int itersDone        = 0;
+  SafetyCache safetyCache;
+  safetyCache.Refresh(position, 100.0);
 
   const double moved = Propagator::ComputeStepAndNextVolume(DummyField{}, 10.0, 1.0, 1, 5.0, 5.0, position, direction,
-                                                            currentState, nextState, hitSurfaceIndex, propagated, 100.0,
-                                                            10, itersDone, 0, zeroFirstStep, false);
+                                                            currentState, nextState, hitSurfaceIndex, propagated,
+                                                            safetyCache, 10, itersDone, 0, zeroFirstStep, false);
 
   EXPECT_DOUBLE_EQ(moved, 5.0);
   EXPECT_TRUE(propagated);
@@ -665,15 +671,47 @@ TEST(FieldPropagatorRungeKutta, UsesCurrentSafetyBeforeTestingCandidateChord)
   bool propagated      = false;
   bool zeroFirstStep   = false;
   int itersDone        = 0;
+  SafetyCache safetyCache;
+  safetyCache.Refresh(position, 6.0);
 
   const double moved = Propagator::ComputeStepAndNextVolume(DummyField{}, 10.0, 1.0, 1, 5.0, 5.0, position, direction,
-                                                            currentState, nextState, hitSurfaceIndex, propagated, 6.0,
-                                                            10, itersDone, 0, zeroFirstStep, false);
+                                                            currentState, nextState, hitSurfaceIndex, propagated,
+                                                            safetyCache, 10, itersDone, 0, zeroFirstStep, false);
 
   EXPECT_DOUBLE_EQ(moved, 5.0);
   EXPECT_TRUE(propagated);
   EXPECT_EQ(ThrowingNavigator::stepCalls, 0);
   ExpectVectorNear(position, vecgeom::Vector3D<double>{6.0, 2.0, 3.0}, 1.0e-14);
+  ExpectVectorNear(direction, vecgeom::Vector3D<double>{1.0, 0.0, 0.0}, 0.0);
+}
+
+// The stored cache value belongs to its origin, not necessarily to the current
+// position. A cache from an older point must be reduced before accepting a chord.
+TEST(FieldPropagatorRungeKutta, ReducesSafetyFromCacheOriginBeforeTestingChord)
+{
+  using Propagator = fieldPropagatorRungeKutta<DummyField, StraightLinePropagatorDriver, double, BoundaryNavigator>;
+
+  BoundaryNavigator::Reset();
+  vecgeom::Vector3D<double> position{1.0, 2.0, 3.0};
+  vecgeom::Vector3D<double> direction{1.0, 0.0, 0.0};
+  vecgeom::NavigationState currentState;
+  vecgeom::NavigationState nextState;
+  long hitSurfaceIndex = -1;
+  bool propagated      = false;
+  bool zeroFirstStep   = false;
+  int itersDone        = 0;
+  SafetyCache safetyCache;
+  safetyCache.Refresh(vecgeom::Vector3D<double>{0.0, 2.0, 3.0}, 5.5);
+
+  const double moved = Propagator::ComputeStepAndNextVolume(DummyField{}, 10.0, 1.0, 1, 5.0, 5.0, position, direction,
+                                                            currentState, nextState, hitSurfaceIndex, propagated,
+                                                            safetyCache, 10, itersDone, 0, zeroFirstStep, false);
+
+  EXPECT_DOUBLE_EQ(moved, 1.25);
+  EXPECT_TRUE(propagated);
+  EXPECT_TRUE(nextState.IsOnBoundary());
+  EXPECT_EQ(BoundaryNavigator::stepCalls, 1);
+  ExpectVectorNear(position, vecgeom::Vector3D<double>{2.25, 2.0, 3.0}, 0.0);
   ExpectVectorNear(direction, vecgeom::Vector3D<double>{1.0, 0.0, 0.0}, 0.0);
 }
 
@@ -692,10 +730,12 @@ TEST(FieldPropagatorRungeKutta, StopsAtNavigatorBoundaryAlongChord)
   bool propagated      = false;
   bool zeroFirstStep   = false;
   int itersDone        = 0;
+  SafetyCache safetyCache;
+  safetyCache.Refresh(position, 0.0);
 
   const double moved = Propagator::ComputeStepAndNextVolume(DummyField{}, 10.0, 1.0, 1, 8.0, 8.0, position, direction,
-                                                            currentState, nextState, hitSurfaceIndex, propagated, 0.0,
-                                                            10, itersDone, 0, zeroFirstStep, false);
+                                                            currentState, nextState, hitSurfaceIndex, propagated,
+                                                            safetyCache, 10, itersDone, 0, zeroFirstStep, false);
 
   EXPECT_DOUBLE_EQ(moved, 2.0);
   EXPECT_TRUE(propagated);

--- a/test/unit/test_bfield.cpp
+++ b/test/unit/test_bfield.cpp
@@ -562,6 +562,21 @@ TEST(RkIntegrationDriver, UniformFieldMatchesHelixInFloatPrecision)
   }
 }
 
+// Safety is allowed to be conservative, but it must never be overestimated by
+// losing a small displacement at large global coordinates. This catches the case
+// where the safety origin is stored in float and a sub-ULP move disappears.
+TEST(SafetyCache, PreservesSmallDisplacementsAtLargeGlobalCoordinates)
+{
+  SafetyCache safetyCache;
+  const vecgeom::Vector3D<double> origin{4601.5, 0.0, 0.0};
+  const vecgeom::Vector3D<double> position{4601.5002, 0.0, 0.0};
+
+  safetyCache.Refresh(origin, 3.0e-4);
+
+  const double expectedSafety = 3.0e-4 - (position - origin).Length();
+  EXPECT_NEAR(safetyCache.SafetyAt(position), expectedSafety, 1.0e-15);
+}
+
 // Full fieldPropagatorRungeKutta contract tests. These keep the RK driver fake
 // and focus on the surrounding propagation logic: failed RK advance, safety
 // shortcut, and navigator-limited chord acceptance.


### PR DESCRIPTION
This PR enhances the usage of safety in the B field propagation:

Previously, the track already cached the position where the safety was last calculated and the safety was updated.
In the B field, the position when the safety was recalculated was also cached. 
But those two caches were not in sync, i.e., when the safety was used in the B field propagation and updated, the main loop would still not know about it and recompute it.

This is fixed by adding a small `SafetyCache` struct that is shared between the B field propagation and the main tracking loop, so the main tracking loop sees the upgraded safety calculations. 


This PR changes the safety calculation. and hence fails the drift test.