### PR TITLE
remove backward compatiblity to previous file tree layout

### DIFF
--- a/include/AdePT/core/AdePTConfiguration.hh
+++ b/include/AdePT/core/AdePTConfiguration.hh
@@ -1,6 +1,0 @@
-// SPDX-FileCopyrightText: 2026 CERN
-// SPDX-License-Identifier: Apache-2.0
-
-#pragma once
-
-#include <AdePT/g4integration/AdePTConfiguration.hh>

--- a/include/AdePT/integration/AdePTTrackingManager.hh
+++ b/include/AdePT/integration/AdePTTrackingManager.hh
@@ -1,6 +1,0 @@
-// SPDX-FileCopyrightText: 2026 CERN
-// SPDX-License-Identifier: Apache-2.0
-
-#pragma once
-
-#include <AdePT/g4integration/AdePTTrackingManager.hh>

--- a/include/AdePT/integration/G4EmStandardPhysics_AdePT.hh
+++ b/include/AdePT/integration/G4EmStandardPhysics_AdePT.hh
@@ -1,6 +1,0 @@
-// SPDX-FileCopyrightText: 2026 CERN
-// SPDX-License-Identifier: Apache-2.0
-
-#pragma once
-
-#include <AdePT/g4integration/G4EmStandardPhysics_AdePT.hh>

--- a/include/AdePT/integration/G4EmStandardPhysics_HepEm.hh
+++ b/include/AdePT/integration/G4EmStandardPhysics_HepEm.hh
@@ -1,6 +1,0 @@
-// SPDX-FileCopyrightText: 2026 CERN
-// SPDX-License-Identifier: Apache-2.0
-
-#pragma once
-
-#include <AdePT/g4integration/G4EmStandardPhysics_HepEm.hh>


### PR DESCRIPTION
This PR closes #613. 

Since all known customers were AdePT was previously integrated have adopted the new file layout, the old backward compatibility files can be deleted.