### PR TITLE
add looper count as UI command, move bools into small struct

### DIFF
--- a/include/AdePT/g4integration/AdePTConfiguration.hh
+++ b/include/AdePT/g4integration/AdePTConfiguration.hh
@@ -4,7 +4,9 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -36,6 +38,13 @@ public:
   void SetCUDAHeapLimit(int limit) { fCUDAHeapLimit = limit; }
   void SetLastNParticlesOnCPU(int Nparticles) { fLastNParticlesOnCPU = Nparticles; }
   void SetMaxWDTIter(int maxIter) { fMaxWDTIter = maxIter; }
+  void SetMaxChargedLooperCount(int maxCount)
+  {
+    if (maxCount < 0 || maxCount >= std::numeric_limits<unsigned short>::max()) {
+      throw std::out_of_range("MaxChargedLooperCount must be 0 or less than the unsigned short maximum");
+    }
+    fMaxChargedLooperCount = static_cast<unsigned short>(maxCount);
+  }
   void SetWDTKineticEnergyLimit(double ekin) { fWDTKineticEnergyLimit = ekin; }
   void SetSpeedOfLight(bool speedOfLight) { fSpeedOfLight = speedOfLight; }
   void SetMultipleStepsInMSCWithTransportation(bool setMultipleSteps)
@@ -64,6 +73,7 @@ public:
 
   unsigned short GetLastNParticlesOnCPU() const { return fLastNParticlesOnCPU; }
   unsigned short GetMaxWDTIter() const { return fMaxWDTIter; }
+  unsigned short GetMaxChargedLooperCount() const { return fMaxChargedLooperCount; }
   double GetWDTKineticEnergyLimit() const { return fWDTKineticEnergyLimit; }
   float GetHitBufferFlushThreshold() const { return fHitBufferFlushThreshold; }
   float GetCPUCapacityFactor() const { return fCPUCapacityFactor; }
@@ -98,6 +108,7 @@ private:
   double fMillionsOfHitSlots{1};
   unsigned short fLastNParticlesOnCPU{0};
   unsigned short fMaxWDTIter{5};
+  unsigned short fMaxChargedLooperCount{500};
   double fWDTKineticEnergyLimit{0.2}; // 200 keV
 
   std::vector<std::string> fGPURegionNames{};

--- a/include/AdePT/g4integration/AdePTConfiguration.hh
+++ b/include/AdePT/g4integration/AdePTConfiguration.hh
@@ -40,8 +40,9 @@ public:
   void SetMaxWDTIter(int maxIter) { fMaxWDTIter = maxIter; }
   void SetMaxChargedLooperCount(int maxCount)
   {
-    if (maxCount < 0 || maxCount >= std::numeric_limits<unsigned short>::max()) {
-      throw std::out_of_range("MaxChargedLooperCount must be 0 or less than the unsigned short maximum");
+    constexpr int maxActiveChargedLooperCount = std::numeric_limits<unsigned short>::max() - 1000;
+    if (maxCount < 0 || maxCount > maxActiveChargedLooperCount) {
+      throw std::out_of_range("MaxChargedLooperCount must be between 0 and 64535");
     }
     fMaxChargedLooperCount = static_cast<unsigned short>(maxCount);
   }

--- a/include/AdePT/g4integration/config/AdePTConfigurationMessenger.hh
+++ b/include/AdePT/g4integration/config/AdePTConfigurationMessenger.hh
@@ -39,6 +39,7 @@ private:
   std::unique_ptr<G4UIcmdWithAnInteger> fSetAdePTSeedCmd;
   std::unique_ptr<G4UIcmdWithAnInteger> fSetFinishOnCpuCmd;
   std::unique_ptr<G4UIcmdWithAnInteger> fSetMaxWDTIterCmd;
+  std::unique_ptr<G4UIcmdWithAnInteger> fSetMaxChargedLooperCountCmd;
   std::unique_ptr<G4UIcmdWithADouble> fSetWDTKineticEnergyLimitCmd;
   std::unique_ptr<G4UIcmdWithABool> fSetTrackInAllRegionsCmd;
   std::unique_ptr<G4UIcmdWithABool> fSetCallUserSteppingActionCmd;

--- a/include/AdePT/transport/AdePTTransport.cuh
+++ b/include/AdePT/transport/AdePTTransport.cuh
@@ -5,6 +5,8 @@
 
 #include <AdePT/transport/support/Portability.hh>
 
+#include <AdePT/transport/config/TransportKernelOptions.hh>
+
 #include <AdePT/transport/state/DeviceGlobals.cuh>
 #include <AdePT/transport/state/EventState.hh>
 #include <AdePT/transport/state/GPUState.cuh>
@@ -774,7 +776,7 @@ void StepProcessingLoop(StepProcessingContext *const context, GPUstate &gpuState
 
 void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuffer &trackBuffer, GPUstate &gpuState,
                    std::vector<std::atomic<EventState>> &eventStates, std::condition_variable &cvG4Workers,
-                   int adeptSeed, int debugLevel, bool returnAllSteps, bool returnLastStep,
+                   int adeptSeed, int debugLevel, TransportKernelOptions kernelOptions,
                    unsigned short lastNParticlesOnCPU, const double stepBufferSafetyFactor, bool hasWDTRegions)
 {
 
@@ -1027,30 +1029,29 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
 #ifdef ADEPT_USE_SPLIT_KERNELS
         ElectronHowFar<true, SelectedSteppingAction><<<blocks, threads, 0, electrons.stream>>>(
             particleManager, gpuState.hepEmBuffers_d.electronsHepEm, electrons.queues.propagation, gpuState.stats_dev,
-            steppingActionParams, allowFinishOffEvent, returnAllSteps, returnLastStep);
+            steppingActionParams, allowFinishOffEvent, kernelOptions);
         ElectronPropagation<true><<<blocks, threads, 0, electrons.stream>>>(
             electrons.tracks, gpuState.hepEmBuffers_d.electronsHepEm, electrons.queues.propagation);
         ElectronMSC<true><<<blocks, threads, 0, electrons.stream>>>(
             electrons.tracks, gpuState.hepEmBuffers_d.electronsHepEm, electrons.queues.propagation);
         ElectronSetupInteractions<true><<<blocks, threads, 0, electrons.stream>>>(
             gpuState.hepEmBuffers_d.electronsHepEm, electrons.queues.propagation, particleManager, electronSplitQueues,
-            returnAllSteps, returnLastStep);
+            kernelOptions);
         ADEPT_DEVICE_API_CALL(EventRecord(electrons.setupEvent, electrons.stream));
         ADEPT_DEVICE_API_CALL(StreamWaitEvent(electrons.auxiliaryStream, electrons.setupEvent, 0));
         ElectronRelocation<true><<<blocks, threads, 0, electrons.stream>>>(
             gpuState.hepEmBuffers_d.electronsHepEm, particleManager,
-            electrons.queues.splitQueues[ParticleQueues::relocation], returnAllSteps, returnLastStep);
+            electrons.queues.splitQueues[ParticleQueues::relocation], kernelOptions);
         ElectronIonization<true><<<blocks, threads, 0, electrons.auxiliaryStream>>>(
             gpuState.hepEmBuffers_d.electronsHepEm, particleManager,
-            electrons.queues.splitQueues[ParticleQueues::chargedIonization], returnAllSteps, returnLastStep);
+            electrons.queues.splitQueues[ParticleQueues::chargedIonization], kernelOptions);
         ElectronBremsstrahlung<true><<<blocks, threads, 0, electrons.auxiliaryStream>>>(
             gpuState.hepEmBuffers_d.electronsHepEm, particleManager,
-            electrons.queues.splitQueues[ParticleQueues::chargedBremsstrahlung], returnAllSteps, returnLastStep);
+            electrons.queues.splitQueues[ParticleQueues::chargedBremsstrahlung], kernelOptions);
         ADEPT_DEVICE_API_CALL(EventRecord(electrons.auxiliaryEvent, electrons.auxiliaryStream));
 #else
-        TransportElectrons<SelectedSteppingAction>
-            <<<blocks, threads, 0, electrons.stream>>>(particleManager, gpuState.stats_dev, steppingActionParams,
-                                                       allowFinishOffEvent, returnAllSteps, returnLastStep);
+        TransportElectrons<SelectedSteppingAction><<<blocks, threads, 0, electrons.stream>>>(
+            particleManager, gpuState.stats_dev, steppingActionParams, allowFinishOffEvent, kernelOptions);
 #endif
         ADEPT_DEVICE_API_CALL(EventRecord(electrons.event, electrons.stream));
         ADEPT_DEVICE_API_CALL(StreamWaitEvent(gpuState.stream, electrons.event, 0));
@@ -1070,36 +1071,35 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
 #ifdef ADEPT_USE_SPLIT_KERNELS
         ElectronHowFar<false, SelectedSteppingAction><<<blocks, threads, 0, positrons.stream>>>(
             particleManager, gpuState.hepEmBuffers_d.positronsHepEm, positrons.queues.propagation, gpuState.stats_dev,
-            steppingActionParams, allowFinishOffEvent, returnAllSteps, returnLastStep);
+            steppingActionParams, allowFinishOffEvent, kernelOptions);
         ElectronPropagation<false><<<blocks, threads, 0, positrons.stream>>>(
             positrons.tracks, gpuState.hepEmBuffers_d.positronsHepEm, positrons.queues.propagation);
         ElectronMSC<false><<<blocks, threads, 0, positrons.stream>>>(
             positrons.tracks, gpuState.hepEmBuffers_d.positronsHepEm, positrons.queues.propagation);
         ElectronSetupInteractions<false><<<blocks, threads, 0, positrons.stream>>>(
             gpuState.hepEmBuffers_d.positronsHepEm, positrons.queues.propagation, particleManager, positronSplitQueues,
-            returnAllSteps, returnLastStep);
+            kernelOptions);
         ADEPT_DEVICE_API_CALL(EventRecord(positrons.setupEvent, positrons.stream));
         ADEPT_DEVICE_API_CALL(StreamWaitEvent(positrons.auxiliaryStream, positrons.setupEvent, 0));
         ElectronRelocation<false><<<blocks, threads, 0, positrons.stream>>>(
             gpuState.hepEmBuffers_d.positronsHepEm, particleManager,
-            positrons.queues.splitQueues[ParticleQueues::relocation], returnAllSteps, returnLastStep);
+            positrons.queues.splitQueues[ParticleQueues::relocation], kernelOptions);
         ElectronIonization<false><<<blocks, threads, 0, positrons.auxiliaryStream>>>(
             gpuState.hepEmBuffers_d.positronsHepEm, particleManager,
-            positrons.queues.splitQueues[ParticleQueues::chargedIonization], returnAllSteps, returnLastStep);
+            positrons.queues.splitQueues[ParticleQueues::chargedIonization], kernelOptions);
         ElectronBremsstrahlung<false><<<blocks, threads, 0, positrons.auxiliaryStream>>>(
             gpuState.hepEmBuffers_d.positronsHepEm, particleManager,
-            positrons.queues.splitQueues[ParticleQueues::chargedBremsstrahlung], returnAllSteps, returnLastStep);
+            positrons.queues.splitQueues[ParticleQueues::chargedBremsstrahlung], kernelOptions);
         PositronAnnihilation<<<blocks, threads, 0, positrons.auxiliaryStream>>>(
             gpuState.hepEmBuffers_d.positronsHepEm, particleManager,
-            positrons.queues.splitQueues[ParticleQueues::positronAnnihilation], returnAllSteps, returnLastStep);
+            positrons.queues.splitQueues[ParticleQueues::positronAnnihilation], kernelOptions);
         PositronStoppedAnnihilation<<<blocks, threads, 0, positrons.auxiliaryStream>>>(
             gpuState.hepEmBuffers_d.positronsHepEm, particleManager,
-            positrons.queues.splitQueues[ParticleQueues::positronStoppedAnnihilation], returnAllSteps, returnLastStep);
+            positrons.queues.splitQueues[ParticleQueues::positronStoppedAnnihilation], kernelOptions);
         ADEPT_DEVICE_API_CALL(EventRecord(positrons.auxiliaryEvent, positrons.auxiliaryStream));
 #else
-        TransportPositrons<SelectedSteppingAction>
-            <<<blocks, threads, 0, positrons.stream>>>(particleManager, gpuState.stats_dev, steppingActionParams,
-                                                       allowFinishOffEvent, returnAllSteps, returnLastStep);
+        TransportPositrons<SelectedSteppingAction><<<blocks, threads, 0, positrons.stream>>>(
+            particleManager, gpuState.stats_dev, steppingActionParams, allowFinishOffEvent, kernelOptions);
 #endif
 
         ADEPT_DEVICE_API_CALL(EventRecord(positrons.event, positrons.stream));
@@ -1133,13 +1133,13 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
             particlesInFlight[GPUQueueIndex::Gamma] + particlesInFlight[GPUQueueIndex::GammaWDT]);
         GammaHowFar<SelectedSteppingAction><<<blocks, threads, 0, gammas.stream>>>(
             gpuState.hepEmBuffers_d.gammasHepEm, particleManager, gammas.queues.propagation, gpuState.stats_dev,
-            steppingActionParams, allowFinishOffEvent, returnAllSteps, returnLastStep);
+            steppingActionParams, allowFinishOffEvent, kernelOptions);
 #ifdef ADEPT_ENABLE_WDT
         if (hasWDTRegions) {
           GammaWoodcock<SelectedSteppingAction><<<wdtBlocks, wdtThreads, 0, gammas.auxiliaryStream>>>(
               gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
               gammaSplitQueues.queues[ParticleQueues::gammaWoodcock], gpuState.stats_dev, steppingActionParams,
-              allowFinishOffEvent, returnAllSteps, returnLastStep);
+              allowFinishOffEvent, kernelOptions);
           ADEPT_DEVICE_API_CALL(EventRecord(gammas.auxiliaryEvent, gammas.auxiliaryStream));
         }
 #endif
@@ -1150,37 +1150,35 @@ void TransportLoop(int trackCapacity, int stepCapacity, int numThreads, TrackBuf
         }
         GammaSetupInteractions<<<interactionBlocks, interactionThreads, 0, gammas.stream>>>(
             gpuState.hepEmBuffers_d.gammasHepEm, gammas.queues.propagation, particleManager, gammaSplitQueues,
-            returnAllSteps, returnLastStep);
+            kernelOptions);
         ADEPT_DEVICE_API_CALL(EventRecord(gammas.setupEvent, gammas.stream));
         ADEPT_DEVICE_API_CALL(StreamWaitEvent(gammas.auxiliaryStream, gammas.setupEvent, 0));
         GammaRelocation<<<blocks, threads, 0, gammas.stream>>>(gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
                                                                gammas.queues.splitQueues[ParticleQueues::relocation],
-                                                               returnAllSteps, returnLastStep);
+                                                               kernelOptions);
         // Copying the number of interacting tracks back to host and using this information to adjust
         // the launch parameters of the interactions kernel is complicated and expensive due to a
         // required additional kernel launch and copy. Instead, launch the kernels with the same
         // parameters, the unneeded threads immediately return and become free again.
         GammaConversion<<<interactionBlocks, interactionThreads, 0, gammas.auxiliaryStream>>>(
             gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
-            gammas.queues.splitQueues[ParticleQueues::gammaConversion], returnAllSteps, returnLastStep);
+            gammas.queues.splitQueues[ParticleQueues::gammaConversion], kernelOptions);
         GammaCompton<<<interactionBlocks, interactionThreads, 0, gammas.auxiliaryStream>>>(
             gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
-            gammas.queues.splitQueues[ParticleQueues::gammaCompton], returnAllSteps, returnLastStep);
+            gammas.queues.splitQueues[ParticleQueues::gammaCompton], kernelOptions);
         GammaPhotoelectric<<<interactionBlocks, interactionThreads, 0, gammas.auxiliaryStream>>>(
             gpuState.hepEmBuffers_d.gammasHepEm, particleManager,
-            gammas.queues.splitQueues[ParticleQueues::gammaPhotoelectric], returnAllSteps, returnLastStep);
+            gammas.queues.splitQueues[ParticleQueues::gammaPhotoelectric], kernelOptions);
         ADEPT_DEVICE_API_CALL(EventRecord(gammas.auxiliaryEvent, gammas.auxiliaryStream));
 #else
-        TransportGammas<SelectedSteppingAction>
-            <<<blocks, threads, 0, gammas.stream>>>(particleManager, gpuState.stats_dev, steppingActionParams,
-                                                    allowFinishOffEvent, returnAllSteps, returnLastStep);
+        TransportGammas<SelectedSteppingAction><<<blocks, threads, 0, gammas.stream>>>(
+            particleManager, gpuState.stats_dev, steppingActionParams, allowFinishOffEvent, kernelOptions);
 
 #ifdef ADEPT_ENABLE_WDT
         if (hasWDTRegions) {
           const auto [wdtThreads, wdtBlocks] = computeThreadsAndBlocks(particlesInFlight[GPUQueueIndex::GammaWDT]);
           TransportGammasWoodcock<SelectedSteppingAction><<<wdtBlocks, wdtThreads, 0, gammas.auxiliaryStream>>>(
-              particleManager, gpuState.stats_dev, steppingActionParams, allowFinishOffEvent, returnAllSteps,
-              returnLastStep);
+              particleManager, gpuState.stats_dev, steppingActionParams, allowFinishOffEvent, kernelOptions);
           ADEPT_DEVICE_API_CALL(EventRecord(gammas.auxiliaryEvent, gammas.auxiliaryStream));
         }
 #endif
@@ -1498,25 +1496,14 @@ void CloseGPUStepBatch(unsigned int threadId, GPUstate &gpuState, GPUStep *begin
 // separate init function that will compile here and be called from the .icc
 std::thread LaunchGPUWorker(int trackCapacity, int stepCapacity, int numThreads, TrackBuffer &trackBuffer,
                             GPUstate &gpuState, std::vector<std::atomic<EventState>> &eventStates,
-                            std::condition_variable &cvG4Workers, int adeptSeed, int debugLevel, bool returnAllSteps,
-                            bool returnLastStep, unsigned short lastNParticlesOnCPU,
+                            std::condition_variable &cvG4Workers, int adeptSeed, int debugLevel,
+                            TransportKernelOptions kernelOptions, unsigned short lastNParticlesOnCPU,
                             const double stepBufferSafetyFactor, bool hasWDTRegions)
 {
-  return std::thread{&TransportLoop,
-                     trackCapacity,
-                     stepCapacity,
-                     numThreads,
-                     std::ref(trackBuffer),
-                     std::ref(gpuState),
-                     std::ref(eventStates),
-                     std::ref(cvG4Workers),
-                     adeptSeed,
-                     debugLevel,
-                     returnAllSteps,
-                     returnLastStep,
-                     lastNParticlesOnCPU,
-                     stepBufferSafetyFactor,
-                     hasWDTRegions};
+  return std::thread{
+      &TransportLoop,     trackCapacity,         stepCapacity,           numThreads,   std::ref(trackBuffer),
+      std::ref(gpuState), std::ref(eventStates), std::ref(cvG4Workers),  adeptSeed,    debugLevel,
+      kernelOptions,      lastNParticlesOnCPU,   stepBufferSafetyFactor, hasWDTRegions};
 }
 
 void FreeGPU(std::unique_ptr<adept::transport::GPUstate, adept::transport::GPUstateDeleter> &gpuState,

--- a/include/AdePT/transport/AdePTTransport.hh
+++ b/include/AdePT/transport/AdePTTransport.hh
@@ -53,10 +53,8 @@ private:
   std::mutex fMutex_G4Workers;                       ///< Mutex associated to the condition variable
   std::vector<std::atomic<EventState>> fEventStates; ///< State machine for each G4 worker
   bool fHasWDTRegions = false;
-  // Flags for the kernels to return the last or all steps, needed for PostUserTrackingAction or UserSteppingAction
-  bool fReturnAllSteps         = false;
-  bool fReturnFirstAndLastStep = false;
-  std::string fBfieldFile{""}; ///< Path to magnetic field file (in the covfie format)
+  TransportKernelOptions fKernelOptions{}; // Runtime options copied into transport kernels.
+  std::string fBfieldFile{""};             ///< Path to magnetic field file (in the covfie format)
   double fCPUCapacityFactor{
       2.5}; ///< Factor by which the host step buffer is larger than the device step buffer. Must be at least 2
   ///< Filling fraction of the host step buffer when the steps are copied out and not taken directly by the G4 workers

--- a/include/AdePT/transport/config/AdePTTransportConfig.hh
+++ b/include/AdePT/transport/config/AdePTTransportConfig.hh
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <AdePT/transport/config/TransportKernelOptions.hh>
+
 #include <cstdint>
 #include <string>
 
@@ -17,8 +19,7 @@ struct AdePTTransportConfig {
   int cudaHeapLimit{0};
   unsigned short lastNParticlesOnCPU{0};
   unsigned short maxWDTIter{5};
-  bool returnAllSteps{false};
-  bool returnFirstAndLastStep{false};
+  adept::transport::TransportKernelOptions kernelOptions{};
   std::string bfieldFile{};
   double cpuCapacityFactor{2.5};
   double cpuCopyFraction{0.5};

--- a/include/AdePT/transport/config/TransportKernelOptions.hh
+++ b/include/AdePT/transport/config/TransportKernelOptions.hh
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace adept::transport {
+
+/// @brief Runtime options copied into transport kernels.
+struct TransportKernelOptions {
+  bool returnAllSteps{false};
+  bool returnLastStep{false};
+  /// Maximum charged-particle looper count before killing the track.
+  /// The transport service normalizes 0 to the maximum unsigned short value to disable this kill.
+  unsigned short maxChargedLooperCount{500};
+};
+
+} // namespace adept::transport

--- a/include/AdePT/transport/config/TransportKernelOptions.hh
+++ b/include/AdePT/transport/config/TransportKernelOptions.hh
@@ -10,7 +10,8 @@ struct TransportKernelOptions {
   bool returnAllSteps{false};
   bool returnLastStep{false};
   /// Maximum charged-particle looper count before killing the track.
-  /// The transport service normalizes 0 to the maximum unsigned short value to disable this kill.
+  /// The transport service normalizes 0 to the maximum unsigned short value to disable this kill;
+  /// active limits are capped below the overflow range.
   unsigned short maxChargedLooperCount{500};
 };
 

--- a/include/AdePT/transport/kernels/electrons.cuh
+++ b/include/AdePT/transport/kernels/electrons.cuh
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <AdePT/transport/navigation/AdePTNavigator.h>
+#include <AdePT/transport/config/TransportKernelOptions.hh>
 
 // Classes for Runge-Kutta integration
 #include <AdePT/transport/magneticfield/MagneticFieldEquation.h>
@@ -57,13 +58,15 @@ template <bool IsElectron, class SteppingActionT>
 static __device__ __forceinline__ void TransportElectrons(ParticleManager &particleManager, Stats *InFlightStats,
                                                           const StepActionParam params,
                                                           AllowFinishOffEventArray allowFinishOffEvent,
-                                                          const bool returnAllSteps, const bool returnLastStep)
+                                                          const TransportKernelOptions options)
 {
   constexpr unsigned short maxSteps = 10'000;
   constexpr int Charge              = IsElectron ? -1 : 1;
   constexpr double restMass         = copcore::units::kElectronMassC2;
   constexpr int Nvar                = 6;
   constexpr int max_iterations      = 10;
+  const bool returnAllSteps         = options.returnAllSteps;
+  const bool returnLastStep         = options.returnLastStep;
 
 #ifdef ADEPT_USE_EXT_BFIELD
   using Field_t = GeneralMagneticField;
@@ -791,7 +794,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     }
 
     if (trackSurvives) {
-      if (++currentTrack.looperCounter > 500) {
+      if (++currentTrack.looperCounter > options.maxChargedLooperCount) {
         // Kill loopers that are not advancing in free space or are scraping at a boundary
         if (printErrors)
           printf("Killing looper due to lack of advance or scraping at a boundary: E=%E event=%d track=%lu loop=%d "
@@ -866,19 +869,17 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
 // Instantiate kernels for electrons and positrons.
 template <class SteppingActionT>
 __global__ void TransportElectrons(ParticleManager particleManager, Stats *InFlightStats, const StepActionParam params,
-                                   AllowFinishOffEventArray allowFinishOffEvent, const bool returnAllSteps,
-                                   const bool returnLastStep)
+                                   AllowFinishOffEventArray allowFinishOffEvent, const TransportKernelOptions options)
 {
   TransportElectrons</*IsElectron*/ true, SteppingActionT>(particleManager, InFlightStats, params, allowFinishOffEvent,
-                                                           returnAllSteps, returnLastStep);
+                                                           options);
 }
 template <class SteppingActionT>
 __global__ void TransportPositrons(ParticleManager particleManager, Stats *InFlightStats, const StepActionParam params,
-                                   AllowFinishOffEventArray allowFinishOffEvent, const bool returnAllSteps,
-                                   const bool returnLastStep)
+                                   AllowFinishOffEventArray allowFinishOffEvent, const TransportKernelOptions options)
 {
   TransportElectrons</*IsElectron*/ false, SteppingActionT>(particleManager, InFlightStats, params, allowFinishOffEvent,
-                                                            returnAllSteps, returnLastStep);
+                                                            options);
 }
 
 } // namespace adept::transport

--- a/include/AdePT/transport/kernels/electrons_split.cuh
+++ b/include/AdePT/transport/kernels/electrons_split.cuh
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <AdePT/transport/navigation/AdePTNavigator.h>
+#include <AdePT/transport/config/TransportKernelOptions.hh>
 
 // Classes for Runge-Kutta integration
 #include <AdePT/transport/magneticfield/MagneticFieldEquation.h>
@@ -52,14 +53,14 @@ namespace adept::transport {
 template <bool IsElectron, class SteppingActionT>
 __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronTrack *hepEMTracks,
                                adept::MParray *propagationQueue, Stats *InFlightStats, const StepActionParam params,
-                               AllowFinishOffEventArray allowFinishOffEvent, const bool returnAllSteps,
-                               const bool returnLastStep)
+                               AllowFinishOffEventArray allowFinishOffEvent, const TransportKernelOptions options)
 {
   constexpr unsigned short maxSteps        = 10'000;
   constexpr int Charge                     = IsElectron ? -1 : 1;
   constexpr double restMass                = copcore::units::kElectronMassC2;
   constexpr int Nvar                       = 6;
   constexpr unsigned short kStepsStuckKill = 25;
+  const bool returnLastStep                = options.returnLastStep;
 
 #ifdef ADEPT_USE_EXT_BFIELD
   using Field_t = GeneralMagneticField;
@@ -123,7 +124,7 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
       double energyDeposit = 0.;
 
       // check for loopers
-      if (currentTrack.looperCounter > 500) {
+      if (currentTrack.looperCounter > options.maxChargedLooperCount) {
         // Kill loopers that are not advancing in free space or are scraping at a boundary
         if (printErrors)
           printf("Killing looper due to lack of advance or scraping at a boundary: E=%E event=%d track=%lu loop=%d "
@@ -459,10 +460,13 @@ __global__ void ElectronMSC(ChargedTrack *electrons, G4HepEmElectronTrack *hepEM
 template <bool IsElectron>
 __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, const adept::MParray *propagationQueue,
                                           ParticleManager particleManager, SplitQueues splitQueues,
-                                          const bool returnAllSteps, const bool returnLastStep)
+                                          const TransportKernelOptions options)
 {
   auto &electronsOrPositrons = (IsElectron ? particleManager.electrons : particleManager.positrons);
   SlotManager &slotManager   = *electronsOrPositrons.fSlotManager;
+
+  const bool returnAllSteps = options.returnAllSteps;
+  const bool returnLastStep = options.returnLastStep;
 
   int activeSize = propagationQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
@@ -603,13 +607,14 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
 
 template <bool IsElectron>
 __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleManager particleManager,
-                                   adept::MParray *relocatingQueue, const bool returnAllSteps,
-                                   const bool returnLastStep)
+                                   adept::MParray *relocatingQueue, const TransportKernelOptions options)
 {
   auto &electronsOrPositrons = (IsElectron ? particleManager.electrons : particleManager.positrons);
 
-  SlotManager &slotManager = *electronsOrPositrons.fSlotManager;
-  int activeSize           = relocatingQueue->size();
+  SlotManager &slotManager  = *electronsOrPositrons.fSlotManager;
+  const bool returnAllSteps = options.returnAllSteps;
+  const bool returnLastStep = options.returnLastStep;
+  int activeSize            = relocatingQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot             = (*relocatingQueue)[i];
     ChargedTrack &currentTrack = electronsOrPositrons.TrackAt(slot);
@@ -761,11 +766,12 @@ __device__ __forceinline__ void PerformStoppedAnnihilation(const int slot, Charg
 
 template <bool IsElectron>
 __global__ void ElectronIonization(G4HepEmElectronTrack *hepEMTracks, ParticleManager particleManager,
-                                   adept::MParray *interactingQueue, const bool returnAllSteps,
-                                   const bool returnLastStep)
+                                   adept::MParray *interactingQueue, const TransportKernelOptions options)
 {
   auto &electronsOrPositrons = (IsElectron ? particleManager.electrons : particleManager.positrons);
   SlotManager &slotManager   = *electronsOrPositrons.fSlotManager;
+  const bool returnAllSteps  = options.returnAllSteps;
+  const bool returnLastStep  = options.returnLastStep;
   int activeSize             = interactingQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     // const int slot           = (*active)[i];
@@ -888,11 +894,12 @@ __global__ void ElectronIonization(G4HepEmElectronTrack *hepEMTracks, ParticleMa
 
 template <bool IsElectron>
 __global__ void ElectronBremsstrahlung(G4HepEmElectronTrack *hepEMTracks, ParticleManager particleManager,
-                                       adept::MParray *interactingQueue, const bool returnAllSteps,
-                                       const bool returnLastStep)
+                                       adept::MParray *interactingQueue, const TransportKernelOptions options)
 {
   auto &electronsOrPositrons = (IsElectron ? particleManager.electrons : particleManager.positrons);
   SlotManager &slotManager   = *electronsOrPositrons.fSlotManager;
+  const bool returnAllSteps  = options.returnAllSteps;
+  const bool returnLastStep  = options.returnLastStep;
   int activeSize             = interactingQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     // const int slot           = (*active)[i];
@@ -1028,11 +1035,12 @@ __global__ void ElectronBremsstrahlung(G4HepEmElectronTrack *hepEMTracks, Partic
 }
 
 __global__ void PositronAnnihilation(G4HepEmElectronTrack *hepEMTracks, ParticleManager particleManager,
-                                     adept::MParray *interactingQueue, const bool returnAllSteps,
-                                     const bool returnLastStep)
+                                     adept::MParray *interactingQueue, const TransportKernelOptions options)
 {
-  SlotManager &slotManager = *particleManager.positrons.fSlotManager;
-  int activeSize           = interactingQueue->size();
+  SlotManager &slotManager  = *particleManager.positrons.fSlotManager;
+  const bool returnAllSteps = options.returnAllSteps;
+  const bool returnLastStep = options.returnLastStep;
+  int activeSize            = interactingQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot = (*interactingQueue)[i];
 
@@ -1167,11 +1175,12 @@ __global__ void PositronAnnihilation(G4HepEmElectronTrack *hepEMTracks, Particle
 }
 
 __global__ void PositronStoppedAnnihilation(G4HepEmElectronTrack *hepEMTracks, ParticleManager particleManager,
-                                            adept::MParray *interactingQueue, const bool returnAllSteps,
-                                            const bool returnLastStep)
+                                            adept::MParray *interactingQueue, const TransportKernelOptions options)
 {
-  SlotManager &slotManager = *particleManager.positrons.fSlotManager;
-  int activeSize           = interactingQueue->size();
+  SlotManager &slotManager  = *particleManager.positrons.fSlotManager;
+  const bool returnAllSteps = options.returnAllSteps;
+  const bool returnLastStep = options.returnLastStep;
+  int activeSize            = interactingQueue->size();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot = (*interactingQueue)[i];
 

--- a/include/AdePT/transport/kernels/gammas.cuh
+++ b/include/AdePT/transport/kernels/gammas.cuh
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <AdePT/transport/navigation/AdePTNavigator.h>
+#include <AdePT/transport/config/TransportKernelOptions.hh>
 #include <AdePT/transport/kernels/WoodcockHelper.cuh>
 #ifdef ADEPT_ENABLE_WDT
 #include <AdePT/transport/kernels/gammasWDT.cuh>
@@ -38,9 +39,11 @@ namespace adept::transport {
 template <class SteppingActionT>
 __global__ void __launch_bounds__(256, 1)
     TransportGammas(ParticleManager particleManager, Stats *InFlightStats, const StepActionParam params,
-                    AllowFinishOffEventArray allowFinishOffEvent, const bool returnAllSteps, const bool returnLastStep)
+                    AllowFinishOffEventArray allowFinishOffEvent, const TransportKernelOptions options)
 {
   constexpr unsigned short maxSteps = 10'000;
+  const bool returnAllSteps         = options.returnAllSteps;
+  const bool returnLastStep         = options.returnLastStep;
   auto &slotManager                 = *particleManager.gammas.fSlotManager;
   const int activeSize              = particleManager.gammas.ActiveSize();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {

--- a/include/AdePT/transport/kernels/gammasWDT.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT.cuh
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <AdePT/transport/navigation/AdePTNavigator.h>
+#include <AdePT/transport/config/TransportKernelOptions.hh>
 
 #include <AdePT/transport/support/PhysicalConstants.h>
 #include <AdePT/transport/tracks/TrackDebug.cuh>
@@ -35,8 +36,7 @@ namespace adept::transport {
 template <class SteppingActionT>
 __global__ void __launch_bounds__(256, 1)
     TransportGammasWoodcock(ParticleManager particleManager, Stats *InFlightStats, const StepActionParam params,
-                            AllowFinishOffEventArray allowFinishOffEvent, const bool returnAllSteps,
-                            const bool returnLastStep)
+                            AllowFinishOffEventArray allowFinishOffEvent, const TransportKernelOptions options)
 {
   // Implementation of the gamma transport using Woodcock tracking. The implementation is taken from
   // Mihaly Novak's G4HepEm (https://github.com/mnovak42/g4hepem), see G4HepEmWoodcockHelper.hh/cc and
@@ -44,6 +44,8 @@ __global__ void __launch_bounds__(256, 1)
   // instead of G4 navigation
 
   constexpr unsigned short maxSteps = 10'000;
+  const bool returnAllSteps         = options.returnAllSteps;
+  const bool returnLastStep         = options.returnLastStep;
   auto &slotManager                 = *particleManager.gammasWDT.fSlotManager;
   const int activeSize              = particleManager.gammasWDT.ActiveSize();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {

--- a/include/AdePT/transport/kernels/gammasWDT_split.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT_split.cuh
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <AdePT/transport/navigation/AdePTNavigator.h>
+#include <AdePT/transport/config/TransportKernelOptions.hh>
 
 #include <AdePT/transport/support/PhysicalConstants.h>
 #include <AdePT/transport/kernels/AdePTSteppingActionSelector.cuh>
@@ -37,7 +38,7 @@ template <class SteppingActionT>
 __global__ void __launch_bounds__(256, 1)
     GammaWoodcock(G4HepEmGammaTrack *hepEMTracks, ParticleManager particleManager,
                   adept::MParray *setupInteractionQueue, Stats *InFlightStats, const StepActionParam params,
-                  AllowFinishOffEventArray allowFinishOffEvent, const bool returnAllSteps, const bool returnLastStep)
+                  AllowFinishOffEventArray allowFinishOffEvent, const TransportKernelOptions options)
 {
   // Implementation of the gamma transport using Woodcock tracking. The implementation is taken from
   // Mihaly Novak's G4HepEm (https://github.com/mnovak42/g4hepem), see G4HepEmWoodcockHelper.hh/cc and
@@ -46,6 +47,7 @@ __global__ void __launch_bounds__(256, 1)
 
   constexpr unsigned short kStepsStuckKill = 25;
   constexpr unsigned short maxSteps        = 10'000;
+  const bool returnLastStep                = options.returnLastStep;
   auto &slotManager                        = *particleManager.gammasWDT.fSlotManager;
   const int activeSize                     = particleManager.gammasWDT.ActiveSize();
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {

--- a/include/AdePT/transport/kernels/gammas_split.cuh
+++ b/include/AdePT/transport/kernels/gammas_split.cuh
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <AdePT/transport/navigation/AdePTNavigator.h>
+#include <AdePT/transport/config/TransportKernelOptions.hh>
 #include <AdePT/transport/kernels/WoodcockHelper.cuh>
 
 #include <AdePT/transport/support/PhysicalConstants.h>
@@ -38,11 +39,11 @@ namespace adept::transport {
 template <class SteppingActionT>
 __global__ void GammaHowFar(G4HepEmGammaTrack *hepEMTracks, ParticleManager particleManager,
                             adept::MParray *propagationQueue, Stats *InFlightStats, const StepActionParam params,
-                            AllowFinishOffEventArray allowFinishOffEvent, const bool returnAllSteps,
-                            const bool returnLastStep)
+                            AllowFinishOffEventArray allowFinishOffEvent, const TransportKernelOptions options)
 {
   constexpr unsigned short maxSteps        = 10'000;
   constexpr unsigned short kStepsStuckKill = 25;
+  const bool returnLastStep                = options.returnLastStep;
   auto &slotManager                        = *particleManager.gammas.fSlotManager;
 
   const int activeSize = particleManager.gammas.ActiveSize();
@@ -239,8 +240,9 @@ __global__ void GammaPropagation(NeutralTrack *gammas, G4HepEmGammaTrack *hepEMT
 
 __global__ void GammaSetupInteractions(G4HepEmGammaTrack *hepEMTracks, const adept::MParray *propagationQueue,
                                        ParticleManager particleManager, SplitQueues splitQueues,
-                                       const bool returnAllSteps, const bool returnLastStep)
+                                       const TransportKernelOptions options)
 {
+  (void)options;
   auto &slotManager   = *particleManager.gammas.fSlotManager;
   auto *wdtSetupQueue = splitQueues.queues[ParticleQueues::gammaWoodcock];
   int normalSize      = propagationQueue->size();
@@ -304,10 +306,12 @@ __global__ void GammaSetupInteractions(G4HepEmGammaTrack *hepEMTracks, const ade
 }
 
 __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager particleManager,
-                                adept::MParray *relocatingQueue, const bool returnAllSteps, const bool returnLastStep)
+                                adept::MParray *relocatingQueue, const TransportKernelOptions options)
 {
-  auto &slotManager = *particleManager.gammas.fSlotManager;
-  int activeSize    = relocatingQueue->size();
+  auto &slotManager         = *particleManager.gammas.fSlotManager;
+  int activeSize            = relocatingQueue->size();
+  const bool returnAllSteps = options.returnAllSteps;
+  const bool returnLastStep = options.returnLastStep;
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot             = (*relocatingQueue)[i];
     NeutralTrack &currentTrack = particleManager.gammas.TrackAt(slot);
@@ -426,10 +430,12 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
 }
 
 __global__ void GammaConversion(G4HepEmGammaTrack *hepEMTracks, ParticleManager particleManager,
-                                adept::MParray *interactingQueue, const bool returnAllSteps, const bool returnLastStep)
+                                adept::MParray *interactingQueue, const TransportKernelOptions options)
 {
-  auto &slotManager = *particleManager.gammas.fSlotManager;
-  int activeSize    = interactingQueue->size();
+  auto &slotManager         = *particleManager.gammas.fSlotManager;
+  int activeSize            = interactingQueue->size();
+  const bool returnAllSteps = options.returnAllSteps;
+  const bool returnLastStep = options.returnLastStep;
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot             = (*interactingQueue)[i];
     NeutralTrack &currentTrack = particleManager.gammas.TrackAt(slot);
@@ -556,10 +562,12 @@ __global__ void GammaConversion(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
 }
 
 __global__ void GammaCompton(G4HepEmGammaTrack *hepEMTracks, ParticleManager particleManager,
-                             adept::MParray *interactingQueue, const bool returnAllSteps, const bool returnLastStep)
+                             adept::MParray *interactingQueue, const TransportKernelOptions options)
 {
-  auto &slotManager = *particleManager.gammas.fSlotManager;
-  int activeSize    = interactingQueue->size();
+  auto &slotManager         = *particleManager.gammas.fSlotManager;
+  int activeSize            = interactingQueue->size();
+  const bool returnAllSteps = options.returnAllSteps;
+  const bool returnLastStep = options.returnLastStep;
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot             = (*interactingQueue)[i];
     NeutralTrack &currentTrack = particleManager.gammas.TrackAt(slot);
@@ -684,11 +692,12 @@ __global__ void GammaCompton(G4HepEmGammaTrack *hepEMTracks, ParticleManager par
 }
 
 __global__ void GammaPhotoelectric(G4HepEmGammaTrack *hepEMTracks, ParticleManager particleManager,
-                                   adept::MParray *interactingQueue, const bool returnAllSteps,
-                                   const bool returnLastStep)
+                                   adept::MParray *interactingQueue, const TransportKernelOptions options)
 {
-  auto &slotManager = *particleManager.gammas.fSlotManager;
-  int activeSize    = interactingQueue->size();
+  auto &slotManager         = *particleManager.gammas.fSlotManager;
+  int activeSize            = interactingQueue->size();
+  const bool returnAllSteps = options.returnAllSteps;
+  const bool returnLastStep = options.returnLastStep;
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < activeSize; i += blockDim.x * gridDim.x) {
     const int slot             = (*interactingQueue)[i];
     NeutralTrack &currentTrack = particleManager.gammas.TrackAt(slot);

--- a/src/g4integration/config/AdePTConfigurationMessenger.cc
+++ b/src/g4integration/config/AdePTConfigurationMessenger.cc
@@ -107,6 +107,13 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
   fSetFinishOnCpuCmd->SetGuidance("Set N, the number of last N particles per event that are finished on CPU. Default: "
                                   "0. This is an important parameter for handling loopers in a magnetic field");
 
+  fSetMaxChargedLooperCountCmd = std::make_unique<G4UIcmdWithAnInteger>("/adept/MaxChargedLooperCount", this);
+  fSetMaxChargedLooperCountCmd->SetGuidance(
+      "Set N, the maximum charged-particle looper count before killing an electron or positron. Default: 500. "
+      "Set to 0 to disable this charged-looper kill.");
+  fSetMaxChargedLooperCountCmd->SetParameterName("MaxChargedLooperCount", false);
+  fSetMaxChargedLooperCountCmd->SetRange("MaxChargedLooperCount>=0&&MaxChargedLooperCount<65535");
+
   fSetMaxWDTIterCmd = std::make_unique<G4UIcmdWithAnInteger>("/adept/MaxWDTIterations", this);
   fSetMaxWDTIterCmd->SetGuidance("Set N, the number of maximum Woodcock tracking iterations per step before giving the "
                                  "gamma back to the normal gamma kernel. Default: "
@@ -193,6 +200,8 @@ void AdePTConfigurationMessenger::SetNewValue(G4UIcommand *command, G4String new
     fAdePTConfiguration->SetAdePTSeed(fSetAdePTSeedCmd->GetNewIntValue(newValue));
   } else if (command == fSetFinishOnCpuCmd.get()) {
     fAdePTConfiguration->SetLastNParticlesOnCPU(fSetFinishOnCpuCmd->GetNewIntValue(newValue));
+  } else if (command == fSetMaxChargedLooperCountCmd.get()) {
+    fAdePTConfiguration->SetMaxChargedLooperCount(fSetMaxChargedLooperCountCmd->GetNewIntValue(newValue));
   } else if (command == fSetMaxWDTIterCmd.get()) {
     fAdePTConfiguration->SetMaxWDTIter(fSetMaxWDTIterCmd->GetNewIntValue(newValue));
   } else if (command == fSetWDTKineticEnergyLimitCmd.get()) {

--- a/src/g4integration/config/AdePTConfigurationMessenger.cc
+++ b/src/g4integration/config/AdePTConfigurationMessenger.cc
@@ -112,7 +112,7 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
       "Set N, the maximum charged-particle looper count before killing an electron or positron. Default: 500. "
       "Set to 0 to disable this charged-looper kill.");
   fSetMaxChargedLooperCountCmd->SetParameterName("MaxChargedLooperCount", false);
-  fSetMaxChargedLooperCountCmd->SetRange("MaxChargedLooperCount>=0&&MaxChargedLooperCount<65535");
+  fSetMaxChargedLooperCountCmd->SetRange("MaxChargedLooperCount>=0&&MaxChargedLooperCount<=64535");
 
   fSetMaxWDTIterCmd = std::make_unique<G4UIcmdWithAnInteger>("/adept/MaxWDTIterations", this);
   fSetMaxWDTIterCmd->SetGuidance("Set N, the number of maximum Woodcock tracking iterations per step before giving the "

--- a/src/g4integration/tracking_managers/AdePTTrackingManager.cc
+++ b/src/g4integration/tracking_managers/AdePTTrackingManager.cc
@@ -51,15 +51,16 @@ AdePTTransportConfig MakeAdePTTransportConfig(const AdePTConfiguration &configur
   transportConfig.debugLevel     = configuration.GetVerbosity();
   transportConfig.cudaStackLimit = configuration.GetCUDAStackLimit();
   transportConfig.cudaHeapLimit  = configuration.GetCUDAHeapLimit();
-  transportConfig.lastNParticlesOnCPU = configuration.GetLastNParticlesOnCPU();
-  transportConfig.maxWDTIter          = configuration.GetMaxWDTIter();
-  transportConfig.returnAllSteps      = configuration.GetCallUserSteppingAction();
-  transportConfig.returnFirstAndLastStep =
+  transportConfig.lastNParticlesOnCPU          = configuration.GetLastNParticlesOnCPU();
+  transportConfig.maxWDTIter                   = configuration.GetMaxWDTIter();
+  transportConfig.kernelOptions.returnAllSteps = configuration.GetCallUserSteppingAction();
+  transportConfig.kernelOptions.returnLastStep =
       configuration.GetCallUserTrackingAction() || configuration.GetCallUserSteppingAction();
-  transportConfig.bfieldFile             = configuration.GetCovfieBfieldFile();
-  transportConfig.cpuCapacityFactor      = configuration.GetCPUCapacityFactor();
-  transportConfig.cpuCopyFraction        = configuration.GetHitBufferFlushThreshold();
-  transportConfig.stepBufferSafetyFactor = configuration.GetHitBufferSafetyFactor();
+  transportConfig.kernelOptions.maxChargedLooperCount = configuration.GetMaxChargedLooperCount();
+  transportConfig.bfieldFile                          = configuration.GetCovfieBfieldFile();
+  transportConfig.cpuCapacityFactor                   = configuration.GetCPUCapacityFactor();
+  transportConfig.cpuCopyFraction                     = configuration.GetHitBufferFlushThreshold();
+  transportConfig.stepBufferSafetyFactor              = configuration.GetHitBufferSafetyFactor();
   return transportConfig;
 }
 

--- a/src/transport/AdePTTransport.cc
+++ b/src/transport/AdePTTransport.cc
@@ -93,8 +93,13 @@ unsigned int ValidateNumThreads(unsigned int numThreads)
 
 TransportKernelOptions NormalizeKernelOptions(TransportKernelOptions options)
 {
+  constexpr unsigned short maxActiveChargedLooperCount = std::numeric_limits<unsigned short>::max() - 1000;
   if (options.maxChargedLooperCount == 0) {
     options.maxChargedLooperCount = std::numeric_limits<unsigned short>::max();
+    return options;
+  }
+  if (options.maxChargedLooperCount > maxActiveChargedLooperCount) {
+    throw std::invalid_argument("maxChargedLooperCount must be 0 or at most 64535");
   }
   return options;
 }

--- a/src/transport/AdePTTransport.cc
+++ b/src/transport/AdePTTransport.cc
@@ -20,6 +20,7 @@
 #include <cassert>
 #include <chrono>
 #include <iostream>
+#include <limits>
 #include <stdexcept>
 
 namespace adept::transport::detail {
@@ -29,7 +30,7 @@ void InitWDTOnDevice(const adeptint::WDTHostPacked &, adeptint::WDTDeviceBuffers
 void UploadG4HepEmToGPU(G4HepEmData *hepEmData, G4HepEmParameters *hepEmParameters);
 std::thread LaunchGPUWorker(int, int, int, adept::transport::TrackBuffer &, adept::transport::GPUstate &,
                             std::vector<std::atomic<adept::transport::EventState>> &, std::condition_variable &, int,
-                            int, bool, bool, unsigned short, const double, bool);
+                            int, TransportKernelOptions, unsigned short, const double, bool);
 std::unique_ptr<adept::transport::GPUstate, adept::transport::GPUstateDeleter> InitializeGPU(
     int trackCapacity, int stepCapacity, int numThreads, adept::transport::TrackBuffer &trackBuffer,
     double CPUCapacityFactor, double CPUCopyFraction, std::string &generalBfieldFile,
@@ -90,6 +91,14 @@ unsigned int ValidateNumThreads(unsigned int numThreads)
   return numThreads;
 }
 
+TransportKernelOptions NormalizeKernelOptions(TransportKernelOptions options)
+{
+  if (options.maxChargedLooperCount == 0) {
+    options.maxChargedLooperCount = std::numeric_limits<unsigned short>::max();
+  }
+  return options;
+}
+
 } // namespace
 
 AdePTTransport::AdePTTransport(const AdePTTransportConfig &configuration,
@@ -100,9 +109,9 @@ AdePTTransport::AdePTTransport(const AdePTTransportConfig &configuration,
       fDebugLevel{configuration.debugLevel}, fCUDAStackLimit{configuration.cudaStackLimit},
       fCUDAHeapLimit{configuration.cudaHeapLimit}, fLastNParticlesOnCPU{configuration.lastNParticlesOnCPU},
       fMaxWDTIter{configuration.maxWDTIter}, fAdePTG4HepEmState(std::move(adeptG4HepEmState)), fEventStates(fNThread),
-      fReturnAllSteps{configuration.returnAllSteps}, fReturnFirstAndLastStep{configuration.returnFirstAndLastStep},
-      fBfieldFile{configuration.bfieldFile}, fCPUCapacityFactor{configuration.cpuCapacityFactor},
-      fCPUCopyFraction{configuration.cpuCopyFraction}, fStepBufferSafetyFactor{configuration.stepBufferSafetyFactor}
+      fKernelOptions{NormalizeKernelOptions(configuration.kernelOptions)}, fBfieldFile{configuration.bfieldFile},
+      fCPUCapacityFactor{configuration.cpuCapacityFactor}, fCPUCopyFraction{configuration.cpuCopyFraction},
+      fStepBufferSafetyFactor{configuration.stepBufferSafetyFactor}
 {
   for (auto &eventState : fEventStates) {
     std::atomic_init(&eventState, EventState::DeviceFlushed);
@@ -231,10 +240,9 @@ void AdePTTransport::Initialize(adeptint::VolAuxData *auxData, const adeptint::W
   fGPUstate =
       adept::transport::detail::InitializeGPU(fTrackCapacity, fStepCapacity, fNThread, *fBuffer, fCPUCapacityFactor,
                                               fCPUCopyFraction, fBfieldFile, uniformFieldValues);
-  fGPUWorker = adept::transport::detail::LaunchGPUWorker(fTrackCapacity, fStepCapacity, fNThread, *fBuffer, *fGPUstate,
-                                                         fEventStates, fCV_G4Workers, fAdePTSeed, fDebugLevel,
-                                                         fReturnAllSteps, fReturnFirstAndLastStep, fLastNParticlesOnCPU,
-                                                         fStepBufferSafetyFactor, fHasWDTRegions);
+  fGPUWorker = adept::transport::detail::LaunchGPUWorker(
+      fTrackCapacity, fStepCapacity, fNThread, *fBuffer, *fGPUstate, fEventStates, fCV_G4Workers, fAdePTSeed,
+      fDebugLevel, fKernelOptions, fLastNParticlesOnCPU, fStepBufferSafetyFactor, fHasWDTRegions);
 }
 
 void AdePTTransport::InitBVH()

--- a/test/regression/scripts/test_ui_commands_template.mac
+++ b/test/regression/scripts/test_ui_commands_template.mac
@@ -106,7 +106,7 @@
 
 /adept/MaxChargedLooperCount 500
 # Set N, the maximum charged-particle looper count before killing an electron or positron.
-# Default: 500. Set to 0 to disable this charged-looper kill. Maximum active value: 65534.
+# Default: 500. Set to 0 to disable this charged-looper kill. Maximum active value: 64535.
 
 /adept/MaxWDTIterations 5
 # Set N, the number of maximum Woodcock tracking iterations per step before giving the gamma back to the normal gamma kernel.

--- a/test/regression/scripts/test_ui_commands_template.mac
+++ b/test/regression/scripts/test_ui_commands_template.mac
@@ -104,6 +104,10 @@
 # Set N, the number of last N particles per event that are finished on CPU. Default: 0.
 # This is an important parameter for handling loopers in a magnetic field, but breaks reproducibility!
 
+/adept/MaxChargedLooperCount 500
+# Set N, the maximum charged-particle looper count before killing an electron or positron.
+# Default: 500. Set to 0 to disable this charged-looper kill. Maximum active value: 65534.
+
 /adept/MaxWDTIterations 5
 # Set N, the number of maximum Woodcock tracking iterations per step before giving the gamma back to the normal gamma kernel.
 # Default: 5. This can be used to optimize the performance in highly granular geometries


### PR DESCRIPTION
Previously loopers in the B field were killed at a hardcoded count. This was obtained from using ATLAS simulations. However, this should be a UI command, as e.g., plenty of particles are killed in CMSSW (mostly low energy particles). 
Therefore it is important that this parameter is tunable, as in CMSSW a higher limit can be used, which has no performance penalty, but drastically reduces the amount of killed particles.

To clean the implementation a bit, the booleans are now passed as a small struct to the kernels, instead of invidivually.