### PR TITLE
Reduce reserve HostTrackDataMapper, move unit test to GTest

### DIFF
--- a/include/AdePT/g4integration/returned_steps/HostTrackDataMapper.hh
+++ b/include/AdePT/g4integration/returned_steps/HostTrackDataMapper.hh
@@ -49,6 +49,9 @@ struct HostTrackData {
 // such as the pointer to the creator process, the G4 primary particle, and the G4VUserTrackInformation
 class HostTrackDataMapper {
 public:
+  static constexpr size_t kDefaultExpectedTracks           = 30'000;
+  static constexpr size_t kDefaultMaxRetainedTrackCapacity = 4 * kDefaultExpectedTracks;
+
   ~HostTrackDataMapper()
   {
     // Clear all memory upon destruction
@@ -60,8 +63,9 @@ public:
   }
 
   // Using a hash map to find the correct index for a given GPU id and then a vector for all the CPU-only data
-  /// Call once at the start of each event, so we can clear and reserve
-  void beginEvent(int eventID, size_t expectedTracks = 1'000'000)
+  /// Call once at the start of each event, so we can clear and reserve.
+  /// Keeps normal-event storage around, but releases rare large-event allocations.
+  void beginEvent(int eventID, size_t expectedTracks = kDefaultExpectedTracks)
   {
     if (eventID != currentEventID) {
       currentEventID = eventID;
@@ -72,19 +76,24 @@ public:
       // std::cout << " CLEARING HostTrackDataMapper size of gpuToIndex " << gpuToIndex.size() << " size of g4idToGPUid
       // " << g4idToGpuId.size() << " size of hostDataVec " << hostDataVec.size() << std::endl;
 
-      gpuToIndex.clear();
       gpuToIndex.max_load_factor(0.5f);
-      gpuToIndex.reserve(expectedTracks);
+      clearAndReserve(gpuToIndex, expectedTracks);
 
-      g4idToGpuId.clear();
       g4idToGpuId.max_load_factor(0.25f);
-      g4idToGpuId.reserve(expectedTracks);
+      clearAndReserve(g4idToGpuId, expectedTracks);
 
       hostDataVec.clear();
+      if (hostDataVec.capacity() > maxRetainedCapacity(expectedTracks)) {
+        std::vector<HostTrackData>().swap(hostDataVec);
+      }
       hostDataVec.reserve(expectedTracks);
       currentGpuReturnG4ID = std::numeric_limits<int>::max();
     }
   }
+
+  size_t hostDataCapacity() const noexcept { return hostDataVec.capacity(); }
+  size_t gpuToIndexRetainedCapacity() const noexcept { return retainedCapacity(gpuToIndex); }
+  size_t g4idToGpuIdRetainedCapacity() const noexcept { return retainedCapacity(g4idToGpuId); }
 
   /// HOT PATH: 1 hash + bucket probe, returns a reference into the table
 
@@ -124,7 +133,7 @@ public:
     auto [it, inserted] = gpuToIndex.try_emplace(gpuId, static_cast<int>(hostDataVec.size()));
     if (!inserted) return hostDataVec[it->second];
 
-    // We reserved in beginEvent(), so emplace_back() should not reallocate.
+    // beginEvent() pre-reserves the normal event size; rare large events may grow here.
     hostDataVec.emplace_back();
     HostTrackData &d = hostDataVec.back();
     d.gpuId          = gpuId;
@@ -187,6 +196,27 @@ public:
 
 private:
   using GpuToIndexMap = std::unordered_map<uint64_t, int>;
+
+  static size_t maxRetainedCapacity(size_t expectedTracks) noexcept
+  {
+    return std::max(expectedTracks, kDefaultExpectedTracks) * 4;
+  }
+
+  template <typename Map>
+  static size_t retainedCapacity(Map const &map) noexcept
+  {
+    return static_cast<size_t>(map.bucket_count() * map.max_load_factor());
+  }
+
+  template <typename Map>
+  static void clearAndReserve(Map &map, size_t expectedTracks)
+  {
+    map.clear();
+    if (retainedCapacity(map) > maxRetainedCapacity(expectedTracks)) {
+      map.rehash(0);
+    }
+    map.reserve(expectedTracks);
+  }
 
   void eraseHostTrackData(GpuToIndexMap::iterator it, bool keepReverseMap, bool deleteUserTrackInfo)
   {

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -73,6 +73,9 @@ set(ADEPT_TRANSPORT_UTILITIES
 )
 
 set(ADEPT_G4_INTEGRATION_UNIT_TESTS
+)
+
+set(ADEPT_G4_INTEGRATION_GTESTS
   test_hostTrackDataMapper.cpp # Unit test for hostTrackDataMapper
 )
 
@@ -90,6 +93,7 @@ add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda;>")
 build_header_only_tests(${ADEPT_HEADER_ONLY_UNIT_TESTS})
 build_linked_tests(AdePT::Transport ${ADEPT_TRANSPORT_UNIT_TESTS} ${ADEPT_TRANSPORT_UTILITIES})
 build_gtest_tests(AdePT::Transport ${ADEPT_TRANSPORT_GTESTS})
+build_gtest_tests(AdePT::G4Integration ${ADEPT_G4_INTEGRATION_GTESTS})
 build_linked_tests(AdePT::G4Integration ${ADEPT_G4_INTEGRATION_UNIT_TESTS})
 
 if(ADEPT_USE_EXT_BFIELD)
@@ -117,7 +121,6 @@ set(ADEPT_UNIT_TEST_NAMES
   test_queue
   test_track_block
   test_hostCircularBuffer
-  test_hostTrackDataMapper
 )
 if(ADEPT_USE_EXT_BFIELD)
   list(APPEND ADEPT_UNIT_TEST_NAMES

--- a/test/unit/test_hostTrackDataMapper.cpp
+++ b/test/unit/test_hostTrackDataMapper.cpp
@@ -1,237 +1,228 @@
 // SPDX-FileCopyrightText: 2025 CERN
 // SPDX-License-Identifier: Apache-2.0
 
-#include <iostream>
-#include <limits>
-#include <vector>
-
 #include "AdePT/g4integration/returned_steps/HostTrackDataMapper.hh"
 
-#define CHECK(expr)                                                                         \
-  do {                                                                                      \
-    if (!(expr)) {                                                                          \
-      std::cerr << "CHECK failed: " #expr << " at " << __FILE__ << ":" << __LINE__ << "\n"; \
-      return 1;                                                                             \
-    }                                                                                       \
-  } while (0)
+#include <gtest/gtest.h>
 
-static int test_beginEvent_clear_and_reserve()
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+TEST(HostTrackDataMapper, BeginEventClearsOnlyWhenEventChanges)
 {
-  HostTrackDataMapper m;
-  // Event 1: create something
-  m.beginEvent(/*eventID*/ 1, /*expectedTracks*/ 8);
-  auto &d1 = m.create(/*gpuId*/ 100u, /*useNewId=*/false); // g4id = 100
-  CHECK(d1.gpuId == 100u);
-  CHECK(d1.g4id == 100);
-  CHECK(&d1 == &m.get(100u)); // alias check
-  CHECK(m.contains(100u));
+  HostTrackDataMapper mapper;
+
+  // A new event clears old state and prepares storage. Entries created in the
+  // event must remain addressable through both GPU-id and G4-id lookups.
+  mapper.beginEvent(/*eventID*/ 1, /*expectedTracks*/ 8);
+  auto &first = mapper.create(/*gpuId*/ 100u, /*useNewId=*/false);
+  EXPECT_EQ(first.gpuId, 100u);
+  EXPECT_EQ(first.g4id, 100);
+  EXPECT_EQ(&first, &mapper.get(100u));
+  EXPECT_TRUE(mapper.contains(100u));
+
   uint64_t gotGpu{};
-  CHECK(m.getGPUId(/*g4id*/ 100, gotGpu) == true);
-  CHECK(gotGpu == 100u);
+  EXPECT_TRUE(mapper.getGPUId(/*g4id*/ 100, gotGpu));
+  EXPECT_EQ(gotGpu, 100u);
 
-  // Calling beginEvent with same ID must NOT clear
-  m.beginEvent(1);
-  CHECK(m.contains(100u));
-  CHECK(m.getGPUId(100, gotGpu) == true && gotGpu == 100u);
+  // Re-entering beginEvent() with the same event ID is intentionally a no-op:
+  // ProcessTrack can call it repeatedly inside one event without losing mapper state.
+  mapper.beginEvent(1);
+  EXPECT_TRUE(mapper.contains(100u));
+  EXPECT_TRUE(mapper.getGPUId(100, gotGpu));
+  EXPECT_EQ(gotGpu, 100u);
 
-  // New event ID must clear everything and reset counters
-  m.beginEvent(2);
-  CHECK(!m.contains(100u));
-  CHECK(m.getGPUId(100, gotGpu) == false); // returns gpuId=100 by convention
-  CHECK(gotGpu == 100u);
+  // A different event ID starts a fresh event. Old live entries and reverse-map
+  // entries must disappear, and missing G4 IDs fall back to gpuId == g4id.
+  mapper.beginEvent(2);
+  EXPECT_FALSE(mapper.contains(100u));
+  EXPECT_FALSE(mapper.getGPUId(100, gotGpu));
+  EXPECT_EQ(gotGpu, 100u);
 
-  // Verify currentGpuReturnG4ID reset behavior by creating two with useNewId=true
-  auto &a = m.create(/*gpuId*/ 1u, /*useNewId=*/true);
-  auto &b = m.create(/*gpuId*/ 2u, /*useNewId=*/true);
-  CHECK(a.g4id == std::numeric_limits<int>::max());
-  CHECK(b.g4id == std::numeric_limits<int>::max() - 1);
-
-  return 0;
+  // GPU-born tracks use descending synthetic G4 IDs. The counter must reset at
+  // event boundaries so runs remain reproducible event by event.
+  auto &a = mapper.create(/*gpuId*/ 1u, /*useNewId=*/true);
+  auto &b = mapper.create(/*gpuId*/ 2u, /*useNewId=*/true);
+  EXPECT_EQ(a.g4id, std::numeric_limits<int>::max());
+  EXPECT_EQ(b.g4id, std::numeric_limits<int>::max() - 1);
 }
 
-static int test_default_beginEvent_uses_small_capacity()
+TEST(HostTrackDataMapper, DefaultBeginEventUsesSmallRetainedCapacity)
 {
-  HostTrackDataMapper m;
-  m.beginEvent(1);
+  HostTrackDataMapper mapper;
 
-  CHECK(m.hostDataCapacity() >= HostTrackDataMapper::kDefaultExpectedTracks);
-  CHECK(m.hostDataCapacity() <= HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity);
-  CHECK(m.gpuToIndexRetainedCapacity() >= HostTrackDataMapper::kDefaultExpectedTracks);
-  CHECK(m.gpuToIndexRetainedCapacity() <= HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity);
-  CHECK(m.g4idToGpuIdRetainedCapacity() >= HostTrackDataMapper::kDefaultExpectedTracks);
-  CHECK(m.g4idToGpuIdRetainedCapacity() <= HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity);
+  // The default reserve should cover ordinary events without keeping the old
+  // million-track buffer alive in every worker thread.
+  mapper.beginEvent(1);
 
-  return 0;
+  EXPECT_GE(mapper.hostDataCapacity(), HostTrackDataMapper::kDefaultExpectedTracks);
+  EXPECT_LE(mapper.hostDataCapacity(), HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity);
+  EXPECT_GE(mapper.gpuToIndexRetainedCapacity(), HostTrackDataMapper::kDefaultExpectedTracks);
+  EXPECT_LE(mapper.gpuToIndexRetainedCapacity(), HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity);
+  EXPECT_GE(mapper.g4idToGpuIdRetainedCapacity(), HostTrackDataMapper::kDefaultExpectedTracks);
+  EXPECT_LE(mapper.g4idToGpuIdRetainedCapacity(), HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity);
 }
 
-static int test_large_event_capacity_is_released()
+TEST(HostTrackDataMapper, LargeEventCapacityIsReleasedBeforeNextDefaultEvent)
 {
-  HostTrackDataMapper m;
+  HostTrackDataMapper mapper;
   constexpr size_t largeEventTracks = HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity + 1;
 
-  m.beginEvent(1, largeEventTracks);
-  CHECK(m.hostDataCapacity() >= largeEventTracks);
-  CHECK(m.gpuToIndexRetainedCapacity() >= largeEventTracks);
-  CHECK(m.g4idToGpuIdRetainedCapacity() >= largeEventTracks);
+  // Rare large events are allowed to grow beyond the default retained capacity.
+  // This keeps correctness for pathological showers; the reserve is not a hard cap.
+  mapper.beginEvent(1, largeEventTracks);
+  EXPECT_GE(mapper.hostDataCapacity(), largeEventTracks);
+  EXPECT_GE(mapper.gpuToIndexRetainedCapacity(), largeEventTracks);
+  EXPECT_GE(mapper.g4idToGpuIdRetainedCapacity(), largeEventTracks);
 
-  m.beginEvent(2);
-  CHECK(m.hostDataCapacity() <= HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity);
-  CHECK(m.gpuToIndexRetainedCapacity() <= HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity);
-  CHECK(m.g4idToGpuIdRetainedCapacity() <= HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity);
+  // The next default-sized event should release that oversized storage before
+  // reserving the normal capacity again, reducing long-lived worker RSS.
+  mapper.beginEvent(2);
+  EXPECT_LE(mapper.hostDataCapacity(), HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity);
+  EXPECT_LE(mapper.gpuToIndexRetainedCapacity(), HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity);
+  EXPECT_LE(mapper.g4idToGpuIdRetainedCapacity(), HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity);
 
-  auto &d = m.create(/*gpuId*/ 7u, /*useNewId=*/false);
-  CHECK(d.gpuId == 7u);
-  CHECK(d.g4id == 7);
-  CHECK(m.contains(7u));
-
-  return 0;
+  // After shrinking, the mapper must still be fully usable for new entries.
+  auto &data = mapper.create(/*gpuId*/ 7u, /*useNewId=*/false);
+  EXPECT_EQ(data.gpuId, 7u);
+  EXPECT_EQ(data.g4id, 7);
+  EXPECT_TRUE(mapper.contains(7u));
 }
 
-static int test_create_and_lookup()
+TEST(HostTrackDataMapper, CreateAndLookupReturnStableSlot)
 {
-  HostTrackDataMapper m;
-  m.beginEvent(1, 8);
+  HostTrackDataMapper mapper;
+  mapper.beginEvent(1, 8);
 
-  auto &d = m.create(/*gpuId*/ 42u, /*useNewId=*/false); // g4id = 42
-  CHECK(d.gpuId == 42u);
-  CHECK(d.g4id == 42);
-  CHECK(m.contains(42u));
+  // create(..., false) represents a CPU-born track entering the GPU: its GPU ID
+  // is the original G4 track ID, and both maps should point back to one slot.
+  auto &data = mapper.create(/*gpuId*/ 42u, /*useNewId=*/false);
+  EXPECT_EQ(data.gpuId, 42u);
+  EXPECT_EQ(data.g4id, 42);
+  EXPECT_TRUE(mapper.contains(42u));
 
   uint64_t gotGpu{};
-  CHECK(m.getGPUId(42, gotGpu) == true);
-  CHECK(gotGpu == 42u);
+  EXPECT_TRUE(mapper.getGPUId(42, gotGpu));
+  EXPECT_EQ(gotGpu, 42u);
 
-  // get() must return same slot
-  auto &d2 = m.get(42u);
-  CHECK(&d == &d2);
-
-  return 0;
+  // No extra insertion happened, so get() must return the exact same vector slot.
+  auto &same = mapper.get(42u);
+  EXPECT_EQ(&data, &same);
 }
 
-static int test_removeTrack_swap_erase()
+TEST(HostTrackDataMapper, RemoveTrackSwapErasesLiveSlotAndReverseMap)
 {
-  HostTrackDataMapper m;
-  m.beginEvent(1, 8);
+  HostTrackDataMapper mapper;
+  mapper.beginEvent(1, 8);
 
-  auto &d1 = m.create(1u, false); // g4id=1
-  auto &d2 = m.create(2u, false); // g4id=2
-  CHECK(m.contains(1u) && m.contains(2u));
-  CHECK(d1.g4id == 1 && d2.g4id == 2);
+  auto &first  = mapper.create(1u, false);
+  auto &second = mapper.create(2u, false);
+  EXPECT_TRUE(mapper.contains(1u));
+  EXPECT_TRUE(mapper.contains(2u));
+  EXPECT_EQ(first.g4id, 1);
+  EXPECT_EQ(second.g4id, 2);
 
-  // Remove front (1u), should swap-erase with last (2u)
-  m.removeTrack(1u);
-  CHECK(!m.contains(1u));
-  CHECK(m.contains(2u));
+  // Removing a non-last vector element uses swap-erase. The moved survivor must
+  // keep a correct gpuId -> vector-slot entry after its index changes.
+  mapper.removeTrack(1u);
+  EXPECT_FALSE(mapper.contains(1u));
+  EXPECT_TRUE(mapper.contains(2u));
 
-  // Reverse map should have erased g4id=1; getting it should return false
+  // removeTrack() means the track is done, so both the live slot and reverse map
+  // are erased. A later query falls back to gpuId == g4id.
   uint64_t got{};
-  CHECK(m.getGPUId(1, got) == false);
-  CHECK(got == 1u);
+  EXPECT_FALSE(mapper.getGPUId(1, got));
+  EXPECT_EQ(got, 1u);
 
-  // Still consistent for the survivor
-  CHECK(m.getGPUId(2, got) == true && got == 2u);
-  auto &d2_again = m.get(2u);
-  CHECK(d2_again.g4id == 2 && d2_again.gpuId == 2u);
+  EXPECT_TRUE(mapper.getGPUId(2, got));
+  EXPECT_EQ(got, 2u);
+  auto &survivor = mapper.get(2u);
+  EXPECT_EQ(survivor.g4id, 2);
+  EXPECT_EQ(survivor.gpuId, 2u);
 
-  // Removing non-existent should be safe (no crash)
-  m.removeTrack(123456u);
-
-  return 0;
+  // Removing an already-absent track is part of the cleanup contract and must be harmless.
+  EXPECT_NO_THROW(mapper.removeTrack(123456u));
 }
 
-static int test_retire_reactivate_preserve_reverse()
+TEST(HostTrackDataMapper, RetireToCPUCanReactivateWithPreservedReverseMap)
 {
-  HostTrackDataMapper m;
-  m.beginEvent(1, 8);
+  HostTrackDataMapper mapper;
+  mapper.beginEvent(1, 8);
 
-  // Case A: CPU-born track (useNewId=false => g4id == gpuId)
-  auto &d = m.create(/*gpuId*/ 10u, /*useNewId=*/false);
-  CHECK(d.g4id == 10);
-  CHECK(m.contains(10u));
+  // A CPU-born track that leaves the GPU temporarily loses its live HostTrackData
+  // slot, but it keeps the reverse map so a future GPU handoff reuses the same ID.
+  auto &data = mapper.create(/*gpuId*/ 10u, /*useNewId=*/false);
+  EXPECT_EQ(data.g4id, 10);
+  EXPECT_TRUE(mapper.contains(10u));
 
-  // Retire: removes slot, keeps reverse map
-  m.retireToCPU(10u);
-  CHECK(!m.contains(10u));
+  mapper.retireToCPU(10u);
+  EXPECT_FALSE(mapper.contains(10u));
 
   uint64_t gotGpu{};
-  CHECK(m.getGPUId(/*g4id*/ 10, gotGpu) == true);
-  CHECK(gotGpu == 10u);
+  EXPECT_TRUE(mapper.getGPUId(/*g4id*/ 10, gotGpu));
+  EXPECT_EQ(gotGpu, 10u);
 
-  // Reactivate with haveReverse=true; must not change mapping; must re-create slot
-  auto &revived = m.activateForGPU(/*gpuId*/ 10u, /*g4id*/ 10, /*haveReverse*/ true);
-  CHECK(m.contains(10u));
-  CHECK(revived.gpuId == 10u && revived.g4id == 10);
+  // Reactivation with an existing reverse-map entry must recreate the live slot
+  // without changing the preserved ID relationship.
+  auto &revived = mapper.activateForGPU(/*gpuId*/ 10u, /*g4id*/ 10, /*haveReverse*/ true);
+  EXPECT_TRUE(mapper.contains(10u));
+  EXPECT_EQ(revived.gpuId, 10u);
+  EXPECT_EQ(revived.g4id, 10);
 
-  // Double-activate should be a no-op (same address, no growth)
-  auto &same = m.activateForGPU(10u, 10, true);
-  CHECK(&same == &revived);
+  // A second activation for an already-live track is a no-op and returns the same slot.
+  auto &same = mapper.activateForGPU(10u, 10, true);
+  EXPECT_EQ(&same, &revived);
 
-  // Case B: First activation via activateForGPU with haveReverse=false
-  m.beginEvent(2, 8);
-  auto &x = m.activateForGPU(/*gpuId*/ 77u, /*g4id*/ 77, /*haveReverse*/ false);
-  CHECK(x.gpuId == 77u && x.g4id == 77);
-  CHECK(m.contains(77u));
-  CHECK(m.getGPUId(77, gotGpu) == true && gotGpu == 77u);
-
-  return 0;
+  // A first activation with no reverse-map entry should create both the live slot
+  // and the reverse mapping in one pass.
+  mapper.beginEvent(2, 8);
+  auto &created = mapper.activateForGPU(/*gpuId*/ 77u, /*g4id*/ 77, /*haveReverse*/ false);
+  EXPECT_EQ(created.gpuId, 77u);
+  EXPECT_EQ(created.g4id, 77);
+  EXPECT_TRUE(mapper.contains(77u));
+  EXPECT_TRUE(mapper.getGPUId(77, gotGpu));
+  EXPECT_EQ(gotGpu, 77u);
 }
 
-static int test_gpu_born_reactivate_preserve_g4id()
+TEST(HostTrackDataMapper, GPUBornTrackReactivationPreservesSyntheticG4Id)
 {
-  HostTrackDataMapper m;
-  m.beginEvent(1, 8);
+  HostTrackDataMapper mapper;
+  mapper.beginEvent(1, 8);
 
-  // GPU-born: useNewId=true assigns a special decreasing g4id (not equal to gpuId)
-  auto &born           = m.create(/*gpuId*/ 555u, /*useNewId=*/true);
+  // GPU-born secondaries get synthetic decreasing G4 IDs. If they later return to
+  // CPU and are handed back to the GPU, reproducibility requires preserving that ID.
+  auto &born           = mapper.create(/*gpuId*/ 555u, /*useNewId=*/true);
   const int originalG4 = born.g4id;
-  CHECK(originalG4 == std::numeric_limits<int>::max());
+  EXPECT_EQ(originalG4, std::numeric_limits<int>::max());
 
-  // Retire slot (keep reverse map)
-  m.retireToCPU(555u);
-  CHECK(!m.contains(555u));
+  mapper.retireToCPU(555u);
+  EXPECT_FALSE(mapper.contains(555u));
 
-  // Reactivate with the SAME g4id (this is how CPU would call it)
-  auto &rev = m.activateForGPU(/*gpuId*/ 555u, /*g4id*/ originalG4, /*haveReverse*/ true);
-  CHECK(rev.g4id == originalG4);
-  CHECK(rev.gpuId == 555u);
-  CHECK(m.contains(555u));
+  auto &revived = mapper.activateForGPU(/*gpuId*/ 555u, /*g4id*/ originalG4, /*haveReverse*/ true);
+  EXPECT_EQ(revived.g4id, originalG4);
+  EXPECT_EQ(revived.gpuId, 555u);
+  EXPECT_TRUE(mapper.contains(555u));
 
-  // Reverse map still points from originalG4 -> 555
   uint64_t gotGpu{};
-  CHECK(m.getGPUId(originalG4, gotGpu) == true && gotGpu == 555u);
-
-  return 0;
+  EXPECT_TRUE(mapper.getGPUId(originalG4, gotGpu));
+  EXPECT_EQ(gotGpu, 555u);
 }
 
-static int test_contains_and_getGPUId_contract()
+TEST(HostTrackDataMapper, GetGPUIdFallsBackToG4IdForUnknownTracks)
 {
-  HostTrackDataMapper m;
-  m.beginEvent(1, 8);
+  HostTrackDataMapper mapper;
+  mapper.beginEvent(1, 8);
 
-  // Non-existent query
-  uint64_t gp{};
-  CHECK(m.getGPUId(42, gp) == false);
-  CHECK(gp == 42u); // contract: default gpuId returned equals g4id
+  // Unknown G4 IDs are CPU-born by convention, so getGPUId() returns false while
+  // still giving the caller gpuId == g4id as the handoff ID to use.
+  uint64_t gpuId{};
+  EXPECT_FALSE(mapper.getGPUId(42, gpuId));
+  EXPECT_EQ(gpuId, 42u);
 
-  // After create
-  m.create(42u, false);
-  CHECK(m.contains(42u));
-  CHECK(m.getGPUId(42, gp) == true && gp == 42u);
-
-  return 0;
-}
-
-int main()
-{
-  if (int r = test_beginEvent_clear_and_reserve()) return r;
-  if (int r = test_default_beginEvent_uses_small_capacity()) return r;
-  if (int r = test_large_event_capacity_is_released()) return r;
-  if (int r = test_create_and_lookup()) return r;
-  if (int r = test_removeTrack_swap_erase()) return r;
-  if (int r = test_retire_reactivate_preserve_reverse()) return r;
-  if (int r = test_gpu_born_reactivate_preserve_g4id()) return r;
-  if (int r = test_contains_and_getGPUId_contract()) return r;
-
-  std::cout << "All HostTrackDataMapper tests passed.\n";
-  return 0;
+  // Once the track is created, the same lookup becomes an existing reverse-map hit.
+  mapper.create(42u, false);
+  EXPECT_TRUE(mapper.contains(42u));
+  EXPECT_TRUE(mapper.getGPUId(42, gpuId));
+  EXPECT_EQ(gpuId, 42u);
 }

--- a/test/unit/test_hostTrackDataMapper.cpp
+++ b/test/unit/test_hostTrackDataMapper.cpp
@@ -49,6 +49,44 @@ static int test_beginEvent_clear_and_reserve()
   return 0;
 }
 
+static int test_default_beginEvent_uses_small_capacity()
+{
+  HostTrackDataMapper m;
+  m.beginEvent(1);
+
+  CHECK(m.hostDataCapacity() >= HostTrackDataMapper::kDefaultExpectedTracks);
+  CHECK(m.hostDataCapacity() <= HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity);
+  CHECK(m.gpuToIndexRetainedCapacity() >= HostTrackDataMapper::kDefaultExpectedTracks);
+  CHECK(m.gpuToIndexRetainedCapacity() <= HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity);
+  CHECK(m.g4idToGpuIdRetainedCapacity() >= HostTrackDataMapper::kDefaultExpectedTracks);
+  CHECK(m.g4idToGpuIdRetainedCapacity() <= HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity);
+
+  return 0;
+}
+
+static int test_large_event_capacity_is_released()
+{
+  HostTrackDataMapper m;
+  constexpr size_t largeEventTracks = HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity + 1;
+
+  m.beginEvent(1, largeEventTracks);
+  CHECK(m.hostDataCapacity() >= largeEventTracks);
+  CHECK(m.gpuToIndexRetainedCapacity() >= largeEventTracks);
+  CHECK(m.g4idToGpuIdRetainedCapacity() >= largeEventTracks);
+
+  m.beginEvent(2);
+  CHECK(m.hostDataCapacity() <= HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity);
+  CHECK(m.gpuToIndexRetainedCapacity() <= HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity);
+  CHECK(m.g4idToGpuIdRetainedCapacity() <= HostTrackDataMapper::kDefaultMaxRetainedTrackCapacity);
+
+  auto &d = m.create(/*gpuId*/ 7u, /*useNewId=*/false);
+  CHECK(d.gpuId == 7u);
+  CHECK(d.g4id == 7);
+  CHECK(m.contains(7u));
+
+  return 0;
+}
+
 static int test_create_and_lookup()
 {
   HostTrackDataMapper m;
@@ -186,6 +224,8 @@ static int test_contains_and_getGPUId_contract()
 int main()
 {
   if (int r = test_beginEvent_clear_and_reserve()) return r;
+  if (int r = test_default_beginEvent_uses_small_capacity()) return r;
+  if (int r = test_large_event_capacity_is_released()) return r;
   if (int r = test_create_and_lookup()) return r;
   if (int r = test_removeTrack_swap_erase()) return r;
   if (int r = test_retire_reactivate_preserve_reverse()) return r;


### PR DESCRIPTION
Previously, the HostTrackDataMapper was reserving for 1'000'000 expected tracks, which was humongous. In fact, for 64 threads, that would lead to reserving ~10 GB of RAM (as this is done per thread).

Recent profiling has shown that in most production setups in LHCb, ATLAS, CMS, most events stay below 30k tracks in flight and rarely exceed that (but then sometimes they do so heavily). 
Therefore, this PR reduces the expected size to 30k. In case a large event came through, the reserved size is reduced to currently 4 times the initial 30k. This drastically reduces the memory footprint where it usually was not needed. 

Note that this high number of tracks can easily occur when benchmarking testEm3 or other setups, therefore this is a relevant use case, it should just not reserve so much memory per default.

Two more unit tests are added and the HostTrackData mapper unit test is moved to google test.