### PR TITLE
disentangle the returning of steps and the MC truth

### DIFF
--- a/docs/user/integration-g4.md
+++ b/docs/user/integration-g4.md
@@ -90,7 +90,8 @@ fAdePTConfiguration = new AdePTConfiguration();
 // Optional AdePT-side defaults. If these are set in ConstructProcess(), they override the usual /adept/* macro commands, since those are normally processed before /run/initialize. This might be useful to avoid having to call many UI commands for a fixed setup.
 fAdePTConfiguration->SetCUDAStackLimit(8192);
 fAdePTConfiguration->SetTrackInAllRegions(true);
-fAdePTConfiguration->SetCallUserTrackingAction(true);
+fAdePTConfiguration->SetCallUserActions(true);
+fAdePTConfiguration->SetReturnFirstAndLastStep(true);
 
 // Required: In ConstructProcess(), after registering the EM processes for the custom
 // EM constructor, create an AdePTTrackingManager:

--- a/include/AdePT/g4integration/AdePTConfiguration.hh
+++ b/include/AdePT/g4integration/AdePTConfiguration.hh
@@ -20,8 +20,11 @@ public:
   ~AdePTConfiguration();
   void SetNumThreads(int numThreads) { fNumThreads = numThreads; }
   void SetTrackInAllRegions(bool trackInAllRegions) { fTrackInAllRegions = trackInAllRegions; }
+  void SetCallUserActions(bool callUserActions) { fCallUserActions = callUserActions; }
   void SetCallUserSteppingAction(bool callUserSteppingAction) { fCallUserSteppingAction = callUserSteppingAction; }
   void SetCallUserTrackingAction(bool callUserTrackingAction) { fCallUserTrackingAction = callUserTrackingAction; }
+  void SetReturnAllSteps(bool returnAllSteps) { fReturnAllSteps = returnAllSteps; }
+  void SetReturnFirstAndLastStep(bool returnFirstAndLastStep) { fReturnFirstAndLastStep = returnFirstAndLastStep; }
   void AddGPURegionName(std::string name) { fGPURegionNames.push_back(name); }
   void RemoveGPURegionName(std::string name) { fCPURegionNames.push_back(name); }
   void AddWDTRegionName(std::string name) { fWDTRegionNames.push_back(name); }
@@ -61,8 +64,11 @@ public:
   void SetCovfieBfieldFile(std::string filename) { fCovfieBfieldFile = filename; }
 
   bool GetTrackInAllRegions() const { return fTrackInAllRegions; }
-  bool GetCallUserSteppingAction() const { return fCallUserSteppingAction; }
-  bool GetCallUserTrackingAction() const { return fCallUserTrackingAction; }
+  bool GetCallUserActions() const { return fCallUserActions; }
+  bool GetCallUserSteppingAction() const { return fCallUserActions || fCallUserSteppingAction; }
+  bool GetCallUserTrackingAction() const { return fCallUserActions || fCallUserTrackingAction; }
+  bool GetReturnAllSteps() const { return fReturnAllSteps; }
+  bool GetReturnFirstAndLastStep() const { return fReturnFirstAndLastStep; }
   bool GetSpeedOfLight() const { return fSpeedOfLight; }
   bool GetMultipleStepsInMSCWithTransportation() const { return fSetMultipleStepsInMSCWithTransportation; }
   bool GetEnergyLossFluctuation() const { return fSetEnergyLossFluctuation; }
@@ -92,8 +98,11 @@ public:
 
 private:
   bool fTrackInAllRegions{false};
+  bool fCallUserActions{false};
   bool fCallUserSteppingAction{false};
   bool fCallUserTrackingAction{false};
+  bool fReturnAllSteps{false};
+  bool fReturnFirstAndLastStep{false};
   bool fSpeedOfLight{false};
   bool fSetMultipleStepsInMSCWithTransportation{false};
   bool fSetEnergyLossFluctuation{false};

--- a/include/AdePT/g4integration/config/AdePTConfigurationMessenger.hh
+++ b/include/AdePT/g4integration/config/AdePTConfigurationMessenger.hh
@@ -42,8 +42,11 @@ private:
   std::unique_ptr<G4UIcmdWithAnInteger> fSetMaxChargedLooperCountCmd;
   std::unique_ptr<G4UIcmdWithADouble> fSetWDTKineticEnergyLimitCmd;
   std::unique_ptr<G4UIcmdWithABool> fSetTrackInAllRegionsCmd;
+  std::unique_ptr<G4UIcmdWithABool> fSetCallUserActionsCmd;
   std::unique_ptr<G4UIcmdWithABool> fSetCallUserSteppingActionCmd;
   std::unique_ptr<G4UIcmdWithABool> fSetCallUserTrackingActionCmd;
+  std::unique_ptr<G4UIcmdWithABool> fSetReturnAllStepsCmd;
+  std::unique_ptr<G4UIcmdWithABool> fSetReturnFirstAndLastStepCmd;
   std::unique_ptr<G4UIcmdWithABool> fSetSpeedOfLightCmd;
   std::unique_ptr<G4UIcmdWithABool> fSetMultipleStepsInMSCWithTransportationCmd;
   std::unique_ptr<G4UIcmdWithABool> fSetEnergyLossFluctuationCmd;

--- a/include/AdePT/g4integration/returned_steps/AdePTGeant4Integration.hh
+++ b/include/AdePT/g4integration/returned_steps/AdePTGeant4Integration.hh
@@ -58,7 +58,7 @@ public:
 
   /// @brief Reconstructs GPU steps on host and calls the user-defined sensitive detector code
   void ProcessGPUStep(std::span<const GPUStep> gpuSteps, bool const callUserSteppingAction = false,
-                      bool const callUserTrackingaction = false);
+                      bool const callUserTrackingAction = false, bool const useHostData = false);
 
   /// @brief Return a deferred parent track to Geant4 without rebuilding the visible G4 step.
   /// @details
@@ -66,7 +66,7 @@ public:
   /// no secondaries, and zero deposited energy. In that case there is no GPU
   /// step to process on the host, so only the parent G4Track is rebuilt from the
   /// post-step state and pushed back to the Geant4 stack.
-  void ReturnDeferredTrack(std::span<const GPUStep> gpuSteps, bool const callUserActions = false);
+  void ReturnDeferredTrack(std::span<const GPUStep> gpuSteps, bool const useHostData = false);
 
   /// @brief Returns the Z value of the user-defined uniform magnetic field
   /// @details This function can only be called when the user-defined field is a G4UniformMagField

--- a/src/g4integration/config/AdePTConfigurationMessenger.cc
+++ b/src/g4integration/config/AdePTConfigurationMessenger.cc
@@ -84,6 +84,7 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
       "If true, both UserTrackingAction and UserSteppingAction are called for returned GPU steps. This does not "
       "change which GPU steps are returned; combine it with /adept/returnFirstAndLastStep and/or "
       "/adept/returnAllSteps to make the required steps available on the host.");
+  fSetCallUserActionsCmd->AvailableForStates(G4State_PreInit);
 
   fSetCallUserSteppingActionCmd = std::make_unique<G4UIcmdWithABool>("/adept/CallUserSteppingAction", this);
   fSetCallUserSteppingActionCmd->SetGuidance(
@@ -91,21 +92,25 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
       "that means it is not guaranteed that the UserSteppingAction is called in order, i.e., it could get called on "
       "the secondary before the primary has finished its track. This does not change which GPU steps are returned; "
       "use /adept/returnAllSteps to return every GPU step.");
+  fSetCallUserSteppingActionCmd->AvailableForStates(G4State_PreInit);
 
   fSetCallUserTrackingActionCmd = std::make_unique<G4UIcmdWithABool>("/adept/CallUserTrackingAction", this);
   fSetCallUserTrackingActionCmd->SetGuidance(
       "If true, the UserTrackingAction is called for returned GPU track starts and ends. This does not change which "
       "GPU steps are returned; use /adept/returnFirstAndLastStep to return the first and last GPU steps.");
+  fSetCallUserTrackingActionCmd->AvailableForStates(G4State_PreInit);
 
   fSetReturnFirstAndLastStepCmd = std::make_unique<G4UIcmdWithABool>("/adept/returnFirstAndLastStep", this);
   fSetReturnFirstAndLastStepCmd->SetGuidance(
       "If true, the first and last GPU steps of each track are returned to the host. This only controls GPU step "
       "returning; use /adept/CallUserActions or the individual action commands to invoke user actions on them.");
+  fSetReturnFirstAndLastStepCmd->AvailableForStates(G4State_PreInit);
 
   fSetReturnAllStepsCmd = std::make_unique<G4UIcmdWithABool>("/adept/returnAllSteps", this);
   fSetReturnAllStepsCmd->SetGuidance(
       "If true, every GPU step is returned to the host. This only controls GPU step returning; use "
       "/adept/CallUserActions or the individual action commands to invoke user actions on them.");
+  fSetReturnAllStepsCmd->AvailableForStates(G4State_PreInit);
 
   // ADEPT_DOCS_SECTION: Special Settings
   fSetSpeedOfLightCmd = std::make_unique<G4UIcmdWithABool>("/adept/SpeedOfLight", this);

--- a/src/g4integration/config/AdePTConfigurationMessenger.cc
+++ b/src/g4integration/config/AdePTConfigurationMessenger.cc
@@ -79,7 +79,7 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
       "Remove a region in which transport will be done on GPU (so it will be done on the CPU)");
 
   // ADEPT_DOCS_SECTION: User Actions
-  fSetCallUserActionsCmd = std::make_unique<G4UIcmdWithABool>("/adept/callUserActions", this);
+  fSetCallUserActionsCmd = std::make_unique<G4UIcmdWithABool>("/adept/CallUserActions", this);
   fSetCallUserActionsCmd->SetGuidance(
       "If true, both UserTrackingAction and UserSteppingAction are called for returned GPU steps. This does not "
       "change which GPU steps are returned; combine it with /adept/returnFirstAndLastStep and/or "
@@ -100,12 +100,12 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
   fSetReturnFirstAndLastStepCmd = std::make_unique<G4UIcmdWithABool>("/adept/returnFirstAndLastStep", this);
   fSetReturnFirstAndLastStepCmd->SetGuidance(
       "If true, the first and last GPU steps of each track are returned to the host. This only controls GPU step "
-      "returning; use /adept/callUserActions or the individual action commands to invoke user actions on them.");
+      "returning; use /adept/CallUserActions or the individual action commands to invoke user actions on them.");
 
   fSetReturnAllStepsCmd = std::make_unique<G4UIcmdWithABool>("/adept/returnAllSteps", this);
   fSetReturnAllStepsCmd->SetGuidance(
       "If true, every GPU step is returned to the host. This only controls GPU step returning; use "
-      "/adept/callUserActions or the individual action commands to invoke user actions on them.");
+      "/adept/CallUserActions or the individual action commands to invoke user actions on them.");
 
   // ADEPT_DOCS_SECTION: Special Settings
   fSetSpeedOfLightCmd = std::make_unique<G4UIcmdWithABool>("/adept/SpeedOfLight", this);

--- a/src/g4integration/config/AdePTConfigurationMessenger.cc
+++ b/src/g4integration/config/AdePTConfigurationMessenger.cc
@@ -79,17 +79,33 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
       "Remove a region in which transport will be done on GPU (so it will be done on the CPU)");
 
   // ADEPT_DOCS_SECTION: User Actions
+  fSetCallUserActionsCmd = std::make_unique<G4UIcmdWithABool>("/adept/callUserActions", this);
+  fSetCallUserActionsCmd->SetGuidance(
+      "If true, both UserTrackingAction and UserSteppingAction are called for returned GPU steps. This does not "
+      "change which GPU steps are returned; combine it with /adept/returnFirstAndLastStep and/or "
+      "/adept/returnAllSteps to make the required steps available on the host.");
+
   fSetCallUserSteppingActionCmd = std::make_unique<G4UIcmdWithABool>("/adept/CallUserSteppingAction", this);
   fSetCallUserSteppingActionCmd->SetGuidance(
-      "If true, the UserSteppingAction is called for on every step. WARNING: The steps are currently not sorted, that "
-      "means it is not guaranteed that the UserSteppingAction is called in order, i.e., it could get called on the "
-      "secondary before the primary has finished its track."
-      " NOTE: This means that every single step is recorded on GPU and send back to CPU, which can impact performance");
+      "If true, the UserSteppingAction is called for returned GPU steps. WARNING: The steps are currently not sorted, "
+      "that means it is not guaranteed that the UserSteppingAction is called in order, i.e., it could get called on "
+      "the secondary before the primary has finished its track. This does not change which GPU steps are returned; "
+      "use /adept/returnAllSteps to return every GPU step.");
 
   fSetCallUserTrackingActionCmd = std::make_unique<G4UIcmdWithABool>("/adept/CallUserTrackingAction", this);
   fSetCallUserTrackingActionCmd->SetGuidance(
-      "If true, the PostUserTrackingAction is called for on every track. NOTE: This "
-      "means that the last step of every track is recorded on GPU and send back to CPU");
+      "If true, the UserTrackingAction is called for returned GPU track starts and ends. This does not change which "
+      "GPU steps are returned; use /adept/returnFirstAndLastStep to return the first and last GPU steps.");
+
+  fSetReturnFirstAndLastStepCmd = std::make_unique<G4UIcmdWithABool>("/adept/returnFirstAndLastStep", this);
+  fSetReturnFirstAndLastStepCmd->SetGuidance(
+      "If true, the first and last GPU steps of each track are returned to the host. This only controls GPU step "
+      "returning; use /adept/callUserActions or the individual action commands to invoke user actions on them.");
+
+  fSetReturnAllStepsCmd = std::make_unique<G4UIcmdWithABool>("/adept/returnAllSteps", this);
+  fSetReturnAllStepsCmd->SetGuidance(
+      "If true, every GPU step is returned to the host. This only controls GPU step returning; use "
+      "/adept/callUserActions or the individual action commands to invoke user actions on them.");
 
   // ADEPT_DOCS_SECTION: Special Settings
   fSetSpeedOfLightCmd = std::make_unique<G4UIcmdWithABool>("/adept/SpeedOfLight", this);
@@ -154,10 +170,16 @@ void AdePTConfigurationMessenger::SetNewValue(G4UIcommand *command, G4String new
 
   if (command == fSetTrackInAllRegionsCmd.get()) {
     fAdePTConfiguration->SetTrackInAllRegions(fSetTrackInAllRegionsCmd->GetNewBoolValue(newValue));
+  } else if (command == fSetCallUserActionsCmd.get()) {
+    fAdePTConfiguration->SetCallUserActions(fSetCallUserActionsCmd->GetNewBoolValue(newValue));
   } else if (command == fSetCallUserSteppingActionCmd.get()) {
     fAdePTConfiguration->SetCallUserSteppingAction(fSetCallUserSteppingActionCmd->GetNewBoolValue(newValue));
   } else if (command == fSetCallUserTrackingActionCmd.get()) {
     fAdePTConfiguration->SetCallUserTrackingAction(fSetCallUserTrackingActionCmd->GetNewBoolValue(newValue));
+  } else if (command == fSetReturnFirstAndLastStepCmd.get()) {
+    fAdePTConfiguration->SetReturnFirstAndLastStep(fSetReturnFirstAndLastStepCmd->GetNewBoolValue(newValue));
+  } else if (command == fSetReturnAllStepsCmd.get()) {
+    fAdePTConfiguration->SetReturnAllSteps(fSetReturnAllStepsCmd->GetNewBoolValue(newValue));
   } else if (command == fSetSpeedOfLightCmd.get()) {
     fAdePTConfiguration->SetSpeedOfLight(fSetSpeedOfLightCmd->GetNewBoolValue(newValue));
   } else if (command == fSetMultipleStepsInMSCWithTransportationCmd.get()) {

--- a/src/g4integration/returned_steps/AdePTGeant4Integration.cpp
+++ b/src/g4integration/returned_steps/AdePTGeant4Integration.cpp
@@ -234,7 +234,7 @@ AdePTGeant4Integration::DeferredStepStore AdePTGeant4Integration::TakeDeferredSt
   return deferred;
 }
 
-void AdePTGeant4Integration::ReturnDeferredTrack(std::span<const GPUStep> gpuSteps, bool const callUserActions)
+void AdePTGeant4Integration::ReturnDeferredTrack(std::span<const GPUStep> gpuSteps, bool const useHostData)
 {
   assert(gpuSteps.size() == 1);
 
@@ -244,7 +244,7 @@ void AdePTGeant4Integration::ReturnDeferredTrack(std::span<const GPUStep> gpuSte
          parentStep.fStepLimProcessId == kAdePTFinishOnCPUProcess);
   assert(parentStep.fTotalEnergyDeposit == 0.);
   HostTrackData dummy;
-  HostTrackData &parentTData = callUserActions ? fHostTrackDataMapper->get(parentStep.fTrackID) : dummy;
+  HostTrackData &parentTData = useHostData ? fHostTrackDataMapper->get(parentStep.fTrackID) : dummy;
 
   auto *returnedParentTrack = MakeReturnedTrackFromStep(
       parentStep, parentTData, /*setStopButAlive=*/parentStep.fStepLimProcessId == kAdePTFinishOnCPUProcess);
@@ -357,7 +357,7 @@ G4Track *AdePTGeant4Integration::ConstructSecondaryTrackInPlace(GPUStep const *s
 }
 
 void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUStep> gpuSteps, bool const callUserSteppingAction,
-                                            bool const callUserTrackingAction)
+                                            bool const callUserTrackingAction, bool const useHostData)
 {
 
   if (!fStepReconstructionObjects) {
@@ -405,9 +405,9 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUStep> gpuSteps, b
     postStepStatus = G4StepStatus::fWorldBoundary;
   }
 
-  // For all steps, the HostTrackData Mapper must already exist:
+  // When host data is used, the HostTrackData Mapper entry must already exist:
   // - for particles created on CPU, it was created in the AdePTTrackingManager when offloading to GPU,
-  // - for particles createdon GPU, it was created in InitSecondaryHostTrackDataFromParent below
+  // - for particles created on GPU, it was created in InitSecondaryHostTrackDataFromParent below
 
   const bool isGammaNuclearStep = parentStep.fParticleType == ParticleType::Gamma && parentStep.fStepLimProcessId == 3;
   const bool isLeptonNuclearStep =
@@ -423,11 +423,10 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUStep> gpuSteps, b
 
   HostTrackData dummy; // default constructed dummy if no advanced information is available
 
-  // if the userActions are used, advanced track information is available
-  const bool actions = (callUserTrackingAction || callUserSteppingAction);
+  const bool callUserActions = (callUserTrackingAction || callUserSteppingAction);
 
-  // Bind a reference *without* touching the mapper unless actions==true
-  HostTrackData &parentTData = actions ? fHostTrackDataMapper->get(parentStep.fTrackID) : dummy;
+  // The caller guarantees the mapper entry exists when useHostData is true.
+  HostTrackData &parentTData = useHostData ? fHostTrackDataMapper->get(parentStep.fTrackID) : dummy;
 
   // Fill the G4Step, fill the G4Track, and intertwine them
   switch (parentStep.fParticleType) {
@@ -500,7 +499,7 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUStep> gpuSteps, b
       throw std::runtime_error("Specialized HepEmTrackingManager no longer valid in integration!");
     }
 
-    HostTrackData &parentTDataAfterSecondaries = actions ? fHostTrackDataMapper->get(parentStep.fTrackID) : dummy;
+    HostTrackData &parentTDataAfterSecondaries = useHostData ? fHostTrackDataMapper->get(parentStep.fTrackID) : dummy;
 
     G4VProcess *nuclearProcess = nullptr;
     int particleID             = 2;
@@ -531,7 +530,7 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUStep> gpuSteps, b
       nuclearReactionTrack->SetProperTime(parentStep.fProperTime);
       nuclearReactionTrack->SetWeight(parentStep.fTrackWeight);
       G4TouchableHandle postTouchable;
-      if (actions) {
+      if (useHostData) {
         nuclearReactionTrack->SetTrackID(parentTDataAfterSecondaries.g4id);
         nuclearReactionTrack->SetParentID(parentTDataAfterSecondaries.g4parentid);
         nuclearReactionTrack->SetCreatorProcess(parentTDataAfterSecondaries.creatorProcess);
@@ -638,7 +637,7 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUStep> gpuSteps, b
   // step has been fully processed. Hadronic secondaries created by the host-side
   // nuclear process stay on the CPU and will receive their normal Geant4
   // tracking callbacks later.
-  if (callUserTrackingAction || callUserSteppingAction) {
+  if (callUserActions) {
     auto *evtMgr             = G4EventManager::GetEventManager();
     auto *userTrackingAction = evtMgr->GetUserTrackingAction();
     if (userTrackingAction) {

--- a/src/g4integration/tracking_managers/AdePTTrackingManager.cc
+++ b/src/g4integration/tracking_managers/AdePTTrackingManager.cc
@@ -112,10 +112,9 @@ std::shared_ptr<AdePTTransport> GetSharedAdePTTransport()
   return transport;
 }
 
-bool CanReturnTrackDirectly(const GPUStep &step, unsigned int blockSize, bool callUserSteppingAction,
-                            bool returnAllSteps)
+bool CanReturnTrackDirectly(const GPUStep &step, unsigned int blockSize, bool doUserSteppingAction, bool returnAllSteps)
 {
-  if (callUserSteppingAction || returnAllSteps) return false;
+  if (doUserSteppingAction || returnAllSteps) return false;
   if (step.fParticleType != ParticleType::Gamma) return false;
   if (step.fStepLimProcessId != kAdePTOutOfGPURegionProcess && step.fStepLimProcessId != kAdePTFinishOnCPUProcess) {
     return false;
@@ -408,6 +407,8 @@ void AdePTTrackingManager::FlushEvent()
   const bool callUserTrackingAction = CallUserTrackingAction(*fAdePTConfiguration);
   const bool returnAllSteps         = fAdePTConfiguration->GetReturnAllSteps();
   const bool useHostData            = fAdePTConfiguration->GetReturnFirstAndLastStep() || returnAllSteps;
+  const bool doUserSteppingAction   = callUserSteppingAction && useHostData;
+  const bool doUserTrackingAction   = callUserTrackingAction && useHostData;
 
   std::sort(deferredSteps.steps.begin(), deferredSteps.steps.end(),
             [&deferredSteps](const AdePTGeant4Integration::DeferredStep &lhs,
@@ -421,7 +422,7 @@ void AdePTTrackingManager::FlushEvent()
     if (deferredStep.type == AdePTGeant4Integration::DeferredStepType::ReturnTrack) {
       fGeant4Integration.ReturnDeferredTrack(gpuSteps, useHostData);
     } else {
-      fGeant4Integration.ProcessGPUStep(gpuSteps, callUserSteppingAction, callUserTrackingAction, useHostData);
+      fGeant4Integration.ProcessGPUStep(gpuSteps, doUserSteppingAction, doUserTrackingAction, useHostData);
     }
   }
   fAdeptTransport->MarkHostFlushed(threadId);
@@ -433,6 +434,8 @@ void AdePTTrackingManager::ProcessReturnedGPUSteps(int threadId, int eventId)
   const bool callUserTrackingAction = CallUserTrackingAction(*fAdePTConfiguration);
   const bool returnAllSteps         = fAdePTConfiguration->GetReturnAllSteps();
   const bool useHostData            = fAdePTConfiguration->GetReturnFirstAndLastStep() || returnAllSteps;
+  const bool doUserSteppingAction   = callUserSteppingAction && useHostData;
+  const bool doUserTrackingAction   = callUserTrackingAction && useHostData;
 
   // Transport owns the step-batch lifetime and calls this lambda once
   // for each currently available returned batch. This lambda provides the
@@ -469,14 +472,14 @@ void AdePTTrackingManager::ProcessReturnedGPUSteps(int threadId, int eventId)
            it->fStepLimProcessId == 3) ||
           it->fStepLimProcessId == kAdePTOutOfGPURegionProcess || it->fStepLimProcessId == kAdePTFinishOnCPUProcess;
       if (isDeferredStep) {
-        const bool returnTrackDirectly = CanReturnTrackDirectly(*it, blockSize, callUserSteppingAction, returnAllSteps);
+        const bool returnTrackDirectly = CanReturnTrackDirectly(*it, blockSize, doUserSteppingAction, returnAllSteps);
         fGeant4Integration.QueueDeferredStep(std::span<const GPUStep>(&*it, blockSize),
                                              returnTrackDirectly
                                                  ? AdePTGeant4Integration::DeferredStepType::ReturnTrack
                                                  : AdePTGeant4Integration::DeferredStepType::ReplayStep);
       } else {
-        fGeant4Integration.ProcessGPUStep(std::span<const GPUStep>(&*it, blockSize), callUserSteppingAction,
-                                          callUserTrackingAction, useHostData);
+        fGeant4Integration.ProcessGPUStep(std::span<const GPUStep>(&*it, blockSize), doUserSteppingAction,
+                                          doUserTrackingAction, useHostData);
       }
       it += blockSize;
     }

--- a/src/g4integration/tracking_managers/AdePTTrackingManager.cc
+++ b/src/g4integration/tracking_managers/AdePTTrackingManager.cc
@@ -53,9 +53,10 @@ AdePTTransportConfig MakeAdePTTransportConfig(const AdePTConfiguration &configur
   transportConfig.cudaHeapLimit  = configuration.GetCUDAHeapLimit();
   transportConfig.lastNParticlesOnCPU          = configuration.GetLastNParticlesOnCPU();
   transportConfig.maxWDTIter                   = configuration.GetMaxWDTIter();
-  transportConfig.kernelOptions.returnAllSteps = configuration.GetCallUserSteppingAction();
+  transportConfig.kernelOptions.returnAllSteps = configuration.GetReturnAllSteps();
+  // Returning every GPU step also requires the synthetic first-step records for GPU-born secondaries.
   transportConfig.kernelOptions.returnLastStep =
-      configuration.GetCallUserTrackingAction() || configuration.GetCallUserSteppingAction();
+      configuration.GetReturnFirstAndLastStep() || configuration.GetReturnAllSteps();
   transportConfig.kernelOptions.maxChargedLooperCount = configuration.GetMaxChargedLooperCount();
   transportConfig.bfieldFile                          = configuration.GetCovfieBfieldFile();
   transportConfig.cpuCapacityFactor                   = configuration.GetCPUCapacityFactor();
@@ -64,14 +65,19 @@ AdePTTransportConfig MakeAdePTTransportConfig(const AdePTConfiguration &configur
   return transportConfig;
 }
 
-bool ReturnAllSteps(const AdePTConfiguration &configuration)
+bool CallUserSteppingAction(const AdePTConfiguration &configuration)
 {
   return configuration.GetCallUserSteppingAction();
 }
 
-bool ReturnFirstAndLastStep(const AdePTConfiguration &configuration)
+bool CallUserTrackingAction(const AdePTConfiguration &configuration)
 {
-  return configuration.GetCallUserTrackingAction() || configuration.GetCallUserSteppingAction();
+  return configuration.GetCallUserTrackingAction();
+}
+
+bool CallUserActions(const AdePTConfiguration &configuration)
+{
+  return CallUserSteppingAction(configuration) || CallUserTrackingAction(configuration);
 }
 
 std::shared_ptr<AdePTTransport> GetSharedAdePTTransport(
@@ -397,8 +403,9 @@ void AdePTTrackingManager::FlushEvent()
   ProcessReturnedGPUSteps(threadId, eventId);
 
   auto deferredSteps                = fGeant4Integration.TakeDeferredSteps();
-  const bool returnAllSteps         = ReturnAllSteps(*fAdePTConfiguration);
-  const bool returnFirstAndLastStep = ReturnFirstAndLastStep(*fAdePTConfiguration);
+  const bool callUserSteppingAction = CallUserSteppingAction(*fAdePTConfiguration);
+  const bool callUserTrackingAction = CallUserTrackingAction(*fAdePTConfiguration);
+  const bool callUserActions        = CallUserActions(*fAdePTConfiguration);
 
   std::sort(deferredSteps.steps.begin(), deferredSteps.steps.end(),
             [&deferredSteps](const AdePTGeant4Integration::DeferredStep &lhs,
@@ -410,9 +417,9 @@ void AdePTTrackingManager::FlushEvent()
     std::span<const GPUStep> gpuSteps(deferredSteps.gpuSteps.data() + deferredStep.firstGPUStep,
                                       deferredStep.numGPUSteps);
     if (deferredStep.type == AdePTGeant4Integration::DeferredStepType::ReturnTrack) {
-      fGeant4Integration.ReturnDeferredTrack(gpuSteps, returnAllSteps || returnFirstAndLastStep);
+      fGeant4Integration.ReturnDeferredTrack(gpuSteps, callUserActions);
     } else {
-      fGeant4Integration.ProcessGPUStep(gpuSteps, returnAllSteps, returnFirstAndLastStep);
+      fGeant4Integration.ProcessGPUStep(gpuSteps, callUserSteppingAction, callUserTrackingAction);
     }
   }
   fAdeptTransport->MarkHostFlushed(threadId);
@@ -420,8 +427,8 @@ void AdePTTrackingManager::FlushEvent()
 
 void AdePTTrackingManager::ProcessReturnedGPUSteps(int threadId, int eventId)
 {
-  const bool returnAllSteps         = ReturnAllSteps(*fAdePTConfiguration);
-  const bool returnFirstAndLastStep = ReturnFirstAndLastStep(*fAdePTConfiguration);
+  const bool callUserSteppingAction = CallUserSteppingAction(*fAdePTConfiguration);
+  const bool callUserTrackingAction = CallUserTrackingAction(*fAdePTConfiguration);
 
   // Transport owns the step-batch lifetime and calls this lambda once
   // for each currently available returned batch. This lambda provides the
@@ -458,14 +465,14 @@ void AdePTTrackingManager::ProcessReturnedGPUSteps(int threadId, int eventId)
            it->fStepLimProcessId == 3) ||
           it->fStepLimProcessId == kAdePTOutOfGPURegionProcess || it->fStepLimProcessId == kAdePTFinishOnCPUProcess;
       if (isDeferredStep) {
-        const bool returnTrackDirectly = CanReturnTrackDirectly(*it, blockSize, returnAllSteps);
+        const bool returnTrackDirectly = CanReturnTrackDirectly(*it, blockSize, callUserSteppingAction);
         fGeant4Integration.QueueDeferredStep(std::span<const GPUStep>(&*it, blockSize),
                                              returnTrackDirectly
                                                  ? AdePTGeant4Integration::DeferredStepType::ReturnTrack
                                                  : AdePTGeant4Integration::DeferredStepType::ReplayStep);
       } else {
-        fGeant4Integration.ProcessGPUStep(std::span<const GPUStep>(&*it, blockSize), returnAllSteps,
-                                          returnFirstAndLastStep);
+        fGeant4Integration.ProcessGPUStep(std::span<const GPUStep>(&*it, blockSize), callUserSteppingAction,
+                                          callUserTrackingAction);
       }
       it += blockSize;
     }
@@ -478,7 +485,7 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
   G4TrackingManager *trackManager    = eventManager->GetTrackingManager();
   G4SteppingManager *steppingManager = trackManager->GetSteppingManager();
   const bool trackInAllRegions       = fAdePTConfiguration->GetTrackInAllRegions();
-  const bool callUserActions         = ReturnFirstAndLastStep(*fAdePTConfiguration);
+  const bool callUserActions         = CallUserActions(*fAdePTConfiguration);
 
   const auto eventID = eventManager->GetConstCurrentEvent()->GetEventID();
 

--- a/src/g4integration/tracking_managers/AdePTTrackingManager.cc
+++ b/src/g4integration/tracking_managers/AdePTTrackingManager.cc
@@ -405,7 +405,7 @@ void AdePTTrackingManager::FlushEvent()
   auto deferredSteps                = fGeant4Integration.TakeDeferredSteps();
   const bool callUserSteppingAction = CallUserSteppingAction(*fAdePTConfiguration);
   const bool callUserTrackingAction = CallUserTrackingAction(*fAdePTConfiguration);
-  const bool callUserActions        = CallUserActions(*fAdePTConfiguration);
+  const bool useHostData = fAdePTConfiguration->GetReturnFirstAndLastStep() || fAdePTConfiguration->GetReturnAllSteps();
 
   std::sort(deferredSteps.steps.begin(), deferredSteps.steps.end(),
             [&deferredSteps](const AdePTGeant4Integration::DeferredStep &lhs,
@@ -417,9 +417,9 @@ void AdePTTrackingManager::FlushEvent()
     std::span<const GPUStep> gpuSteps(deferredSteps.gpuSteps.data() + deferredStep.firstGPUStep,
                                       deferredStep.numGPUSteps);
     if (deferredStep.type == AdePTGeant4Integration::DeferredStepType::ReturnTrack) {
-      fGeant4Integration.ReturnDeferredTrack(gpuSteps, callUserActions);
+      fGeant4Integration.ReturnDeferredTrack(gpuSteps, useHostData);
     } else {
-      fGeant4Integration.ProcessGPUStep(gpuSteps, callUserSteppingAction, callUserTrackingAction);
+      fGeant4Integration.ProcessGPUStep(gpuSteps, callUserSteppingAction, callUserTrackingAction, useHostData);
     }
   }
   fAdeptTransport->MarkHostFlushed(threadId);
@@ -429,6 +429,7 @@ void AdePTTrackingManager::ProcessReturnedGPUSteps(int threadId, int eventId)
 {
   const bool callUserSteppingAction = CallUserSteppingAction(*fAdePTConfiguration);
   const bool callUserTrackingAction = CallUserTrackingAction(*fAdePTConfiguration);
+  const bool useHostData = fAdePTConfiguration->GetReturnFirstAndLastStep() || fAdePTConfiguration->GetReturnAllSteps();
 
   // Transport owns the step-batch lifetime and calls this lambda once
   // for each currently available returned batch. This lambda provides the
@@ -472,7 +473,7 @@ void AdePTTrackingManager::ProcessReturnedGPUSteps(int threadId, int eventId)
                                                  : AdePTGeant4Integration::DeferredStepType::ReplayStep);
       } else {
         fGeant4Integration.ProcessGPUStep(std::span<const GPUStep>(&*it, blockSize), callUserSteppingAction,
-                                          callUserTrackingAction);
+                                          callUserTrackingAction, useHostData);
       }
       it += blockSize;
     }
@@ -486,6 +487,7 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
   G4SteppingManager *steppingManager = trackManager->GetSteppingManager();
   const bool trackInAllRegions       = fAdePTConfiguration->GetTrackInAllRegions();
   const bool callUserActions         = CallUserActions(*fAdePTConfiguration);
+  const bool useHostData = fAdePTConfiguration->GetReturnFirstAndLastStep() || fAdePTConfiguration->GetReturnAllSteps();
 
   const auto eventID = eventManager->GetConstCurrentEvent()->GetEventID();
 
@@ -541,10 +543,10 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
       HostTrackData dummy; // default constructed dummy if no advanced information is available
       bool entryExists = trackMapper.getGPUId(aTrack->GetTrackID(), gpuTrackID);
       HostTrackData &hostTrackData =
-          callUserActions ? trackMapper.activateForGPU(gpuTrackID, aTrack->GetTrackID(), entryExists) : dummy;
+          useHostData ? trackMapper.activateForGPU(gpuTrackID, aTrack->GetTrackID(), entryExists) : dummy;
 
       // fill hostTracKData if being used:
-      if (callUserActions) {
+      if (useHostData) {
         // set pointers and G4 parent id
         hostTrackData.primary        = aTrack->GetDynamicParticle()->GetPrimaryParticle();
         hostTrackData.creatorProcess = const_cast<G4VProcess *>(aTrack->GetCreatorProcess());
@@ -575,13 +577,15 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
 
         // if there has been no step, call PreUserTrackingAction and try to attach UserInformation
         if (aTrack->GetCurrentStepNumber() == 0) {
-          auto *userTrackingAction = eventManager->GetUserTrackingAction();
-          if (userTrackingAction) {
+          if (callUserActions) {
+            auto *userTrackingAction = eventManager->GetUserTrackingAction();
+            if (userTrackingAction) {
 
-            // this assumes that the UserTrackInformation is attached to the track in the PreUserTrackingAction
-            userTrackingAction->PreUserTrackingAction(aTrack);
-            hostTrackData.userTrackInfo = aTrack->GetUserInformation();
+              // this assumes that the UserTrackInformation is attached to the track in the PreUserTrackingAction
+              userTrackingAction->PreUserTrackingAction(aTrack);
+            }
           }
+          hostTrackData.userTrackInfo = aTrack->GetUserInformation();
         } else {
           // not the initializing step, just attach user information in case it is there
           hostTrackData.userTrackInfo = aTrack->GetUserInformation();
@@ -614,7 +618,7 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
       // directly, but it has proven to be very expensive to create new G4TouchableHandle objects for each track in the
       // HostTrackData. Instead, it was much cheaper to just store the vecgeom::NavState and create the
       // G4TouchableHandle only when the track is returned from the GPU
-      if (callUserActions) {
+      if (useHostData) {
         if (aTrack->GetParentID() == 0 && aTrack->GetCurrentStepNumber() == 0) {
           // For the first step of primary tracks, the origin touchable handle is not set,
           // so we need to use the track's current position
@@ -640,11 +644,11 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
       aTrack->SetTrackStatus(fStopAndKill);
 
       // After the track has been offloaded to the GPU, it can be deleted on the CPU.
-      // However, the HostTrackData is now owning and therefore responsible for deleting the TrackUserInfo data
+      // If host data is used, HostTrackData now owns the TrackUserInfo data.
       // To avoid deletion of the TrackUserInfo data when the track is deleted, the pointer must be reset.
       // Then, the underlying data is either deleted via hostTrackData.removeTrack in case the track is finished on GPU,
-      // or the ownership is transferred back to G4, when the track is given back to the CPU
-      aTrack->SetUserInformation(nullptr);
+      // or the ownership is transferred back to G4, when the track is given back to the CPU.
+      if (useHostData) aTrack->SetUserInformation(nullptr);
 
     } else { // If the particle is not in a GPU region, track it on CPU
              // Track the particle step by step until it dies or enters a GPU region in the (specialized)

--- a/src/g4integration/tracking_managers/AdePTTrackingManager.cc
+++ b/src/g4integration/tracking_managers/AdePTTrackingManager.cc
@@ -112,9 +112,10 @@ std::shared_ptr<AdePTTransport> GetSharedAdePTTransport()
   return transport;
 }
 
-bool CanReturnTrackDirectly(const GPUStep &step, unsigned int blockSize, bool callUserSteppingAction)
+bool CanReturnTrackDirectly(const GPUStep &step, unsigned int blockSize, bool callUserSteppingAction,
+                            bool returnAllSteps)
 {
-  if (callUserSteppingAction) return false;
+  if (callUserSteppingAction || returnAllSteps) return false;
   if (step.fParticleType != ParticleType::Gamma) return false;
   if (step.fStepLimProcessId != kAdePTOutOfGPURegionProcess && step.fStepLimProcessId != kAdePTFinishOnCPUProcess) {
     return false;
@@ -405,7 +406,8 @@ void AdePTTrackingManager::FlushEvent()
   auto deferredSteps                = fGeant4Integration.TakeDeferredSteps();
   const bool callUserSteppingAction = CallUserSteppingAction(*fAdePTConfiguration);
   const bool callUserTrackingAction = CallUserTrackingAction(*fAdePTConfiguration);
-  const bool useHostData = fAdePTConfiguration->GetReturnFirstAndLastStep() || fAdePTConfiguration->GetReturnAllSteps();
+  const bool returnAllSteps         = fAdePTConfiguration->GetReturnAllSteps();
+  const bool useHostData            = fAdePTConfiguration->GetReturnFirstAndLastStep() || returnAllSteps;
 
   std::sort(deferredSteps.steps.begin(), deferredSteps.steps.end(),
             [&deferredSteps](const AdePTGeant4Integration::DeferredStep &lhs,
@@ -429,7 +431,8 @@ void AdePTTrackingManager::ProcessReturnedGPUSteps(int threadId, int eventId)
 {
   const bool callUserSteppingAction = CallUserSteppingAction(*fAdePTConfiguration);
   const bool callUserTrackingAction = CallUserTrackingAction(*fAdePTConfiguration);
-  const bool useHostData = fAdePTConfiguration->GetReturnFirstAndLastStep() || fAdePTConfiguration->GetReturnAllSteps();
+  const bool returnAllSteps         = fAdePTConfiguration->GetReturnAllSteps();
+  const bool useHostData            = fAdePTConfiguration->GetReturnFirstAndLastStep() || returnAllSteps;
 
   // Transport owns the step-batch lifetime and calls this lambda once
   // for each currently available returned batch. This lambda provides the
@@ -466,7 +469,7 @@ void AdePTTrackingManager::ProcessReturnedGPUSteps(int threadId, int eventId)
            it->fStepLimProcessId == 3) ||
           it->fStepLimProcessId == kAdePTOutOfGPURegionProcess || it->fStepLimProcessId == kAdePTFinishOnCPUProcess;
       if (isDeferredStep) {
-        const bool returnTrackDirectly = CanReturnTrackDirectly(*it, blockSize, callUserSteppingAction);
+        const bool returnTrackDirectly = CanReturnTrackDirectly(*it, blockSize, callUserSteppingAction, returnAllSteps);
         fGeant4Integration.QueueDeferredStep(std::span<const GPUStep>(&*it, blockSize),
                                              returnTrackDirectly
                                                  ? AdePTGeant4Integration::DeferredStepType::ReturnTrack

--- a/test/athena-performance/mono/run_adept.sh
+++ b/test/athena-performance/mono/run_adept.sh
@@ -17,6 +17,7 @@ flags.Sim.G4Commands+=[
   "/adept/MaxWDTIterations 10",
   "/adept/setSeed 2312452",
   "/adept/CallUserTrackingAction true",
+  "/adept/returnFirstAndLastStep true",
   "/adept/CallUserSteppingAction false",
   "/adept/setCovfieBfieldFile /cvmfs/atlas.cern.ch/repo/sw/database/GroupData/MagneticFieldMaps/bmagatlas_09_fullAsym20400_forGPU_v1.cvf",
   "/adept/setVerbosity 0",

--- a/test/athena-performance/split/run_adept.sh
+++ b/test/athena-performance/split/run_adept.sh
@@ -17,6 +17,7 @@ flags.Sim.G4Commands+=[
   "/adept/MaxWDTIterations 10",
   "/adept/setSeed 2312452",
   "/adept/CallUserTrackingAction true",
+  "/adept/returnFirstAndLastStep true",
   "/adept/CallUserSteppingAction false",
   "/adept/setCovfieBfieldFile /cvmfs/atlas.cern.ch/repo/sw/database/GroupData/MagneticFieldMaps/bmagatlas_09_fullAsym20400_forGPU_v1.cvf",
   "/adept/setVerbosity 0",

--- a/test/regression/scripts/example_template.mac
+++ b/test/regression/scripts/example_template.mac
@@ -42,9 +42,9 @@ $field_setup
 ## Set secondary production threshold, init. the run and set primary properties
 ## -----------------------------------------------------------------------------
 /run/setCut 0.7 mm
-/run/initialize
 $call_user_stepping_action
 $call_user_tracking_action
+/run/initialize
 
 ## User-defined Event verbosity: 1 = total edep, 2 = energy deposit per placed sensitive volume
 /eventAction/verbose 1

--- a/test/regression/scripts/python_scripts/macro_generator.py
+++ b/test/regression/scripts/python_scripts/macro_generator.py
@@ -62,11 +62,11 @@ def generate_macro(template_path, output_path, args):
         "$call_user_stepping_action",
         # Emit the command only when explicitly requested so templates can keep
         # the callback lines optional.
-        "/adept/CallUserSteppingAction true" if str(args.call_user_stepping_action) == "True" else "",
+        "/adept/CallUserSteppingAction true\n/adept/returnAllSteps true" if str(args.call_user_stepping_action) == "True" else "",
     )
     macro_content = macro_content.replace(
         "$call_user_tracking_action",
-        "/adept/CallUserTrackingAction true" if str(args.call_user_tracking_action) == "True" else "",
+        "/adept/CallUserTrackingAction true\n/adept/returnFirstAndLastStep true" if str(args.call_user_tracking_action) == "True" else "",
     )
 
     if str(args.gun_type) == "hepmc":

--- a/test/regression/scripts/test_ui_commands_template.mac
+++ b/test/regression/scripts/test_ui_commands_template.mac
@@ -70,15 +70,23 @@
 
 ### ------------
 ### UserActions:
+/adept/callUserActions true
+# If true, both UserTrackingAction and UserSteppingAction are called for returned GPU steps. This does not
+# change which GPU steps are returned; combine it with /adept/returnFirstAndLastStep and/or /adept/returnAllSteps
+# to make the required steps available on the host.
+
 /adept/CallUserSteppingAction true
-# If true, the UserSteppingAction is called for on every step. WARNING: The steps are currently not sorted, that
-# means it is not guaranteed that the UserSteppingAction is called in order, i.e., it could get called on the
-# secondary before the primary has finished its track.
-# NOTE: This means that every single step is recorded on GPU and send back to CPU, which can impact performance
+# If true, the UserSteppingAction is called for returned GPU steps. This does not change which GPU steps are returned.
 
 /adept/CallUserTrackingAction true
-# If true, the PostUserTrackingAction is called for on every track. NOTE: This
-# means that the last step of every track is recorded on GPU and send back to CPU
+# If true, the UserTrackingAction is called for returned GPU track starts and ends. This does not change which GPU steps
+# are returned.
+
+/adept/returnFirstAndLastStep true
+# If true, the first and last GPU steps of each track are returned to the host.
+
+/adept/returnAllSteps true
+# If true, every GPU step is returned to the host.
 
 
 

--- a/test/regression/scripts/test_ui_commands_template.mac
+++ b/test/regression/scripts/test_ui_commands_template.mac
@@ -70,7 +70,7 @@
 
 ### ------------
 ### UserActions:
-/adept/callUserActions true
+/adept/CallUserActions true
 # If true, both UserTrackingAction and UserSteppingAction are called for returned GPU steps. This does not
 # change which GPU steps are returned; combine it with /adept/returnFirstAndLastStep and/or /adept/returnAllSteps
 # to make the required steps available on the host.


### PR DESCRIPTION
Previously, the `/adept/callUserTrackingAction` and `/adept/callUserSteppingAction` UI commands would internally trigger the return of the first/last step and of all steps. 

This is not necessarily desirable, because we might want to call the UserSteppingAction but not return all steps.
Therefore, this PR disentangles the behavior of returning steps from calling user actions. This is in preparation to fix the MC truth for ATLAS.

Note that since this changes the behavior of the returning of steps and the new UI commands are not available on the master, this PR fails the drift tests.

Note that the UI commands are not clean: some start with a capital letter, some don't. This should be unified, although it will break all input scripts.