### PR TITLE
remove particle type from HostTrackData

### DIFF
--- a/include/AdePT/g4integration/returned_steps/AdePTGeant4Integration.hh
+++ b/include/AdePT/g4integration/returned_steps/AdePTGeant4Integration.hh
@@ -107,10 +107,9 @@ private:
   void FillG4Track(GPUStep const *aGPUStep, G4Track *aG4Track, const HostTrackData &hostTData,
                    G4TouchableHandle &aPreG4TouchableHandle, G4TouchableHandle &aPostG4TouchableHandle) const;
 
-  void FillG4Step(GPUStep const *aGPUStep, G4Step *aG4Step, const HostTrackData &hostTData,
-                  G4TouchableHandle &aPreG4TouchableHandle, G4TouchableHandle &aPostG4TouchableHandle,
-                  G4StepStatus aPreStepStatus, G4StepStatus aPostStepStatus, bool callUserTrackingAction,
-                  bool callUserSteppingAction) const;
+  void FillG4Step(GPUStep const *aGPUStep, G4Step *aG4Step, G4TouchableHandle &aPreG4TouchableHandle,
+                  G4TouchableHandle &aPostG4TouchableHandle, G4StepStatus aPreStepStatus, G4StepStatus aPostStepStatus,
+                  bool callUserTrackingAction, bool callUserSteppingAction) const;
 
   /// @brief Create a heap-owned track that can be pushed onto the Geant4 stack.
   /// @details

--- a/include/AdePT/g4integration/returned_steps/HostTrackDataMapper.hh
+++ b/include/AdePT/g4integration/returned_steps/HostTrackDataMapper.hh
@@ -6,7 +6,6 @@
 #include "G4VUserTrackInformation.hh"
 #include "G4VProcess.hh"
 
-#include <AdePT/transport/tracks/ParticleTypes.hh>
 #include <VecGeom/navigation/NavigationState.h>
 
 #include <unordered_map>
@@ -30,7 +29,6 @@ struct HostTrackData {
   G4ThreeVector vertexPosition;
   G4ThreeVector vertexMomentumDirection;
   G4double vertexKineticEnergy = 0.0;
-  ParticleType particleType{ParticleType::Electron};
 #ifdef ADEPT_USE_ORIGINNAVSTATE
   vecgeom::NavigationState originNavState;
 #endif

--- a/include/AdePT/transport/tracks/ParticleTypes.hh
+++ b/include/AdePT/transport/tracks/ParticleTypes.hh
@@ -5,8 +5,8 @@
 
 /// @brief Strongly-typed enum for the three EM particle species tracked by AdePT.
 ///
-/// Used in GPUStep, SecondaryInitData, HostTrackData, and anywhere a step or track
-/// needs to carry its particle species as data.
+/// Used in GPUStep, SecondaryInitData, and anywhere a step or track needs to
+/// carry its particle species as data.
 ///
 /// Note: The numeric values (0, 1, 2) intentionally match `GPUQueueIndex`
 /// (`transport/queues/ParticleQueues.cuh`), which is used as an array index for

--- a/src/g4integration/returned_steps/AdePTGeant4Integration.cpp
+++ b/src/g4integration/returned_steps/AdePTGeant4Integration.cpp
@@ -444,7 +444,7 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUStep> gpuSteps, b
     std::abort();
   }
 
-  FillG4Step(&parentStep, fStepReconstructionObjects->fG4Step, parentTData,
+  FillG4Step(&parentStep, fStepReconstructionObjects->fG4Step,
              *fStepReconstructionObjects->fPreG4TouchableHistoryHandle,
              *fStepReconstructionObjects->fPostG4TouchableHistoryHandle, preStepStatus, postStepStatus,
              callUserTrackingAction, callUserSteppingAction);
@@ -773,8 +773,7 @@ void AdePTGeant4Integration::InitSecondaryHostTrackDataFromParent(GPUStep const 
   }
 #endif
 
-  secTData.particleType = secStep->fParticleType;
-  secTData.g4parentid   = g4ParentID;
+  secTData.g4parentid = g4ParentID;
 
 #ifdef ADEPT_USE_ORIGINNAVSTATE
   secTData.originNavState = secStep->fPostStepPoint.fNavigationState;
@@ -790,7 +789,7 @@ void AdePTGeant4Integration::InitSecondaryHostTrackDataFromParent(GPUStep const 
   // For the initializing step, the step defining process ID is the creator process
   const int stepId = secStep->fStepLimProcessId;
   assert(stepId >= 0);
-  const ParticleType ptype = secTData.particleType;
+  const ParticleType ptype = secStep->fParticleType;
   if (ptype == ParticleType::Electron || ptype == ParticleType::Positron) {
     secTData.creatorProcess = fHepEmTrackingManager->GetElectronNoProcessVector()[stepId];
   } else if (ptype == ParticleType::Gamma) {
@@ -851,7 +850,7 @@ void AdePTGeant4Integration::FillG4Track(GPUStep const *aGPUStep, G4Track *aTrac
   // aTrack->SetAuxiliaryTrackInformation(0, nullptr);                                        // Missing data
 }
 
-void AdePTGeant4Integration::FillG4Step(GPUStep const *aGPUStep, G4Step *aG4Step, const HostTrackData &hostTData,
+void AdePTGeant4Integration::FillG4Step(GPUStep const *aGPUStep, G4Step *aG4Step,
                                         G4TouchableHandle &aPreG4TouchableHandle,
                                         G4TouchableHandle &aPostG4TouchableHandle, G4StepStatus aPreStepStatus,
                                         G4StepStatus aPostStepStatus, bool callUserTrackingAction,
@@ -881,7 +880,7 @@ void AdePTGeant4Integration::FillG4Step(GPUStep const *aGPUStep, G4Step *aG4Step
   if (aGPUStep->fStepCounter != 0) {
     // not an initial step, therefore setting the step defining process:
     const int stepId         = aGPUStep->fStepLimProcessId;
-    const ParticleType ptype = hostTData.particleType;
+    const ParticleType ptype = aGPUStep->fParticleType;
 
     if (ptype == ParticleType::Electron || ptype == ParticleType::Positron) {
       if (stepId == kAdePTTransportationProcess || stepId == kAdePTOutOfGPURegionProcess ||

--- a/src/g4integration/tracking_managers/AdePTTrackingManager.cc
+++ b/src/g4integration/tracking_managers/AdePTTrackingManager.cc
@@ -572,15 +572,6 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
           hostTrackData.logicalVolumeAtVertex   = const_cast<G4LogicalVolume *>(aTrack->GetLogicalVolumeAtVertex());
         }
 
-        // set the particle type
-        if (pdg == 11) {
-          hostTrackData.particleType = ParticleType::Electron;
-        } else if (pdg == -11) {
-          hostTrackData.particleType = ParticleType::Positron;
-        } else if (pdg == 22) {
-          hostTrackData.particleType = ParticleType::Gamma;
-        }
-
         // if there has been no step, call PreUserTrackingAction and try to attach UserInformation
         if (aTrack->GetCurrentStepNumber() == 0) {
           if (callUserActions) {


### PR DESCRIPTION
As the particle type is already returned for each step from the GPU, there is no need to store it in the HostTrackData.
Originally, it was the idea to return it only for the creation step, but as the size of the returned step does not change, it is better to keep it in the returned step, as otherwise it might not be available if the HostTrackData is not available. Since this is a very basic parameter, it should always be available.
