### PR TITLE
Enable per track MC truth

### DIFF
--- a/include/AdePT/transport/AdePTTransport.cuh
+++ b/include/AdePT/transport/AdePTTransport.cuh
@@ -186,7 +186,7 @@ __device__ inline void InitTrackToQueue(SpeciesManagerT &speciesTM, const adepti
   speciesTM.InitTrack(slot, seed, trackInfo.eKin, trackInfo.globalTime, static_cast<float>(trackInfo.localTime),
                       static_cast<float>(trackInfo.properTime), trackInfo.weight, trackInfo.position,
                       trackInfo.direction, trackInfo.navState, trackInfo.eventId, trackInfo.trackId, trackInfo.parentId,
-                      trackInfo.threadId, trackInfo.stepCounter);
+                      trackInfo.threadId, trackInfo.stepCounter, trackInfo.hasHostData);
   toBeEnqueued->push_back(QueueIndexPair{slot, queueIndex});
 }
 

--- a/include/AdePT/transport/AdePTTransport.hh
+++ b/include/AdePT/transport/AdePTTransport.hh
@@ -78,7 +78,8 @@ public:
   /// @brief Adds a track to the buffer
   void AddTrack(int pdg, uint64_t trackId, uint64_t parentId, double energy, double x, double y, double z, double dirx,
                 double diry, double dirz, double globalTime, double localTime, double properTime, float weight,
-                unsigned short stepCounter, int threadId, unsigned int eventId, vecgeom::NavigationState &&state);
+                unsigned short stepCounter, int threadId, unsigned int eventId, vecgeom::NavigationState &&state,
+                bool hasHostData = false);
   int GetDebugLevel() const { return fDebugLevel; }
   /// @brief Handle the currently available returned GPU-step batches for one thread and event.
   /// @details

--- a/include/AdePT/transport/kernels/AdePTSteppingAction.cuh
+++ b/include/AdePT/transport/kernels/AdePTSteppingAction.cuh
@@ -5,6 +5,7 @@
 #include <AdePT/transport/geometry/GeometryAuxData.hh>
 #include <AdePT/transport/random/Ranluxpp.h>
 #include <AdePT/transport/support/SystemOfUnits.h>
+#include <AdePT/transport/tracks/Track.cuh>
 
 #include <G4HepEmData.hh>
 #include <G4HepEmMatCutData.hh>
@@ -281,8 +282,8 @@ struct ATLASAction {
 };
 #endif
 
-template <class ActionT, class ChildT, class ParentT>
-__device__ __forceinline__ void SetSecondaryHostData(ChildT &child, ParentT const &parent, double childMass,
+template <class ActionT>
+__device__ __forceinline__ void SetSecondaryHostData(TrackBase &child, TrackBase const &parent, double childMass,
                                                      bool returnLastStep)
 {
   child.hasHostData =

--- a/include/AdePT/transport/kernels/AdePTSteppingAction.cuh
+++ b/include/AdePT/transport/kernels/AdePTSteppingAction.cuh
@@ -59,6 +59,11 @@ struct NoAction {
   {
     return {true, parentWeight};
   }
+
+  __device__ __forceinline__ static bool NeedsHostTrackData(double, vecgeom::Vector3D<double> const &, double)
+  {
+    return false;
+  }
 };
 
 // ---------- CMS ----------
@@ -132,6 +137,11 @@ struct CMSAction {
   {
     return {true, parentWeight};
   }
+
+  __device__ __forceinline__ static bool NeedsHostTrackData(double, vecgeom::Vector3D<double> const &, double)
+  {
+    return false;
+  }
 };
 
 // ---------- LHCb ----------
@@ -178,6 +188,11 @@ struct LHCbAction {
   {
     return {true, parentWeight};
   }
+
+  __device__ __forceinline__ static bool NeedsHostTrackData(double, vecgeom::Vector3D<double> const &, double)
+  {
+    return false;
+  }
 };
 
 // ---------- ATLAS ----------
@@ -197,6 +212,15 @@ struct ATLASAction {
   static constexpr double kPhotonRussianRouletteThreshold = 0.5 * copcore::units::MeV;
   static constexpr float kPhotonRussianRouletteWeight     = 10.0f;
   static constexpr float kOneOverPhotonRouletteWeight     = 1.0f / kPhotonRussianRouletteWeight;
+  static constexpr double kTruthMinPt                     = 300. * copcore::units::MeV;
+
+  __device__ __forceinline__ static bool NeedsHostTrackData(double eKin, vecgeom::Vector3D<double> const &direction,
+                                                            double mass)
+  {
+    const double p2    = mass > 0. ? eKin * (eKin + 2. * mass) : eKin * eKin;
+    const double dirT2 = direction.x() * direction.x() + direction.y() * direction.y();
+    return p2 * dirT2 > kTruthMinPt * kTruthMinPt;
+  }
 
   __device__ __forceinline__ static void ElectronAction(bool &, double &, double &, vecgeom::Vector3D<double> const &,
                                                         double const &, adeptint::VolAuxData const &,
@@ -249,7 +273,20 @@ struct ATLASAction {
   {
     return {true, parentWeight};
   }
+
+  __device__ __forceinline__ static bool NeedsHostTrackData(double, vecgeom::Vector3D<double> const &, double)
+  {
+    return false;
+  }
 };
 #endif
+
+template <class ActionT, class ChildT, class ParentT>
+__device__ __forceinline__ void SetSecondaryHostData(ChildT &child, ParentT const &parent, double childMass,
+                                                     bool returnLastStep)
+{
+  child.hasHostData =
+      returnLastStep || (parent.hasHostData && ActionT::NeedsHostTrackData(child.eKin, child.dir, childMass));
+}
 
 } // namespace adept::SteppingAction

--- a/include/AdePT/transport/kernels/electrons.cuh
+++ b/include/AdePT/transport/kernels/electrons.cuh
@@ -38,7 +38,8 @@
 #include <G4HepEmElectronEnergyLossFluctuation.icc>
 
 using StepActionParam = adept::SteppingAction::Params;
-using VolAuxData      = adeptint::VolAuxData;
+using adept::SteppingAction::SetSecondaryHostData;
+using VolAuxData = adeptint::VolAuxData;
 
 // Compute velocity based on the kinetic energy of the particle
 __device__ double GetVelocity(double eKin)
@@ -155,9 +156,10 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
                                           preStepGlobalTime, // global time at preStepPoint
                                           currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                           false,                                       // parent continues on CPU
-                                          currentTrack.stepCounter,                    // stepcounter
-                                          nullptr,                                     // pointer to secondary init data
-                                          0);                                          // number of secondaries
+                                          currentTrack.hasHostData,
+                                          currentTrack.stepCounter, // stepcounter
+                                          nullptr,                  // pointer to secondary init data
+                                          0);                       // number of secondaries
       continue;
     }
 
@@ -572,10 +574,17 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
                 newRNG, deltaEkin, pos, vecgeom::Vector3D<double>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
                 navState, currentTrack, globalTime);
 
-            // if tracking or stepping action is called, return initial step
-            if (returnLastStep) {
-              secondaryData[nSecondaries++] = {secondary.trackId, secondary.dir, secondary.eKin,
-                                               /*creator process*/ short(winnerProcessIndex), ParticleType::Electron};
+            SetSecondaryHostData<SteppingActionT>(secondary, currentTrack, copcore::units::kElectronMassC2,
+                                                  returnLastStep);
+
+            // Return the initializing step when HostTrackData is needed for this secondary.
+            if (secondary.hasHostData) {
+              secondaryData[nSecondaries++] = {secondary.trackId,
+                                               secondary.dir,
+                                               secondary.eKin,
+                                               /*creator process*/ short(winnerProcessIndex),
+                                               ParticleType::Electron,
+                                               secondary.hasHostData};
             }
           }
 
@@ -636,10 +645,16 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
                   newRNG, deltaEkin, pos, vecgeom::Vector3D<double>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
                   navState, currentTrack, globalTime, gammaWeight);
 
-              // if tracking or stepping action is called, return initial step
-              if (returnLastStep) {
-                secondaryData[nSecondaries++] = {gamma.trackId, gamma.dir, gamma.eKin,
-                                                 /*creator process*/ short(winnerProcessIndex), ParticleType::Gamma};
+              SetSecondaryHostData<SteppingActionT>(gamma, currentTrack, 0., returnLastStep);
+
+              // Return the initializing step when HostTrackData is needed for this secondary.
+              if (gamma.hasHostData) {
+                secondaryData[nSecondaries++] = {gamma.trackId,
+                                                 gamma.dir,
+                                                 gamma.eKin,
+                                                 /*creator process*/ short(winnerProcessIndex),
+                                                 ParticleType::Gamma,
+                                                 gamma.hasHostData};
               }
 #if ADEPT_DEBUG_TRACK > 0
             } else {
@@ -701,10 +716,15 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
                   newRNG, theGamma1Ekin, pos,
                   vecgeom::Vector3D<double>{theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]}, navState, currentTrack,
                   globalTime, gamma1Weight);
-              // if tracking or stepping action is called, return initial step
-              if (returnLastStep) {
-                secondaryData[nSecondaries++] = {gamma1.trackId, gamma1.dir, gamma1.eKin,
-                                                 /*creator process*/ short(winnerProcessIndex), ParticleType::Gamma};
+              SetSecondaryHostData<SteppingActionT>(gamma1, currentTrack, 0., returnLastStep);
+              // Return the initializing step when HostTrackData is needed for this secondary.
+              if (gamma1.hasHostData) {
+                secondaryData[nSecondaries++] = {gamma1.trackId,
+                                                 gamma1.dir,
+                                                 gamma1.eKin,
+                                                 /*creator process*/ short(winnerProcessIndex),
+                                                 ParticleType::Gamma,
+                                                 gamma1.hasHostData};
               }
             }
           }
@@ -728,10 +748,15 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
                   currentTrack.rngState, theGamma2Ekin, pos,
                   vecgeom::Vector3D<double>{theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]}, navState, currentTrack,
                   globalTime, gamma2Weight);
-              // if tracking or stepping action is called, return initial step
-              if (returnLastStep) {
-                secondaryData[nSecondaries++] = {gamma2.trackId, gamma2.dir, gamma2.eKin,
-                                                 /*creator process*/ short(winnerProcessIndex), ParticleType::Gamma};
+              SetSecondaryHostData<SteppingActionT>(gamma2, currentTrack, 0., returnLastStep);
+              // Return the initializing step when HostTrackData is needed for this secondary.
+              if (gamma2.hasHostData) {
+                secondaryData[nSecondaries++] = {gamma2.trackId,
+                                                 gamma2.dir,
+                                                 gamma2.eKin,
+                                                 /*creator process*/ short(winnerProcessIndex),
+                                                 ParticleType::Gamma,
+                                                 gamma2.hasHostData};
               }
             }
           }
@@ -782,12 +807,23 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
           auto &gamma2 = gammaPartManager.NextTrack(currentTrack.rngState, double{copcore::units::kElectronMassC2}, pos,
                                                     -gamma1.dir, navState, currentTrack, globalTime);
 
-          // if tracking or stepping action is called, return initial step
-          if (returnLastStep) {
-            secondaryData[nSecondaries++] = {gamma1.trackId, gamma1.dir, gamma1.eKin,
-                                             /*creator process: annihilation*/ short(2), ParticleType::Gamma};
-            secondaryData[nSecondaries++] = {gamma2.trackId, gamma2.dir, gamma2.eKin,
-                                             /*creator process: annihilation*/ short(2), ParticleType::Gamma};
+          SetSecondaryHostData<SteppingActionT>(gamma1, currentTrack, 0., returnLastStep);
+          SetSecondaryHostData<SteppingActionT>(gamma2, currentTrack, 0., returnLastStep);
+
+          // Return the initializing step when HostTrackData is needed for these secondaries.
+          if (gamma1.hasHostData) {
+            secondaryData[nSecondaries++] = {gamma1.trackId,
+                                             gamma1.dir,
+                                             gamma1.eKin,
+                                             /*creator process: annihilation*/ short(2),
+                                             ParticleType::Gamma,
+                                             gamma1.hasHostData};
+            secondaryData[nSecondaries++] = {gamma2.trackId,
+                                             gamma2.dir,
+                                             gamma2.eKin,
+                                             /*creator process: annihilation*/ short(2),
+                                             ParticleType::Gamma,
+                                             gamma2.hasHostData};
           }
         }
       }
@@ -839,7 +875,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
 
     // Record the step. Edep includes the continuous energy loss and edep from secondaries which were cut
     if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU ||
-        (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
+        ((returnLastStep || currentTrack.hasHostData) && (nSecondaries > 0 || !trackSurvives))) {
       adept_step_recording::RecordGPUStep(currentTrack.trackId, currentTrack.parentId, returnedProcessId,
                                           IsElectron ? ParticleType::Electron : ParticleType::Positron,
                                           elTrack.GetPStepLength(), // Step length
@@ -859,9 +895,10 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
                                           preStepGlobalTime,        // global time at preStepPoint
                                           currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                           !trackSurvives && !continuesOnCPU,           // whether this was the last step
-                                          currentTrack.stepCounter,                    // stepcounter
-                                          secondaryData,                               // pointer to secondary init data
-                                          nSecondaries);                               // number of secondaries
+                                          currentTrack.hasHostData,
+                                          currentTrack.stepCounter, // stepcounter
+                                          secondaryData,            // pointer to secondary init data
+                                          nSecondaries);            // number of secondaries
     }
   }
 }

--- a/include/AdePT/transport/kernels/electrons.cuh
+++ b/include/AdePT/transport/kernels/electrons.cuh
@@ -348,6 +348,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     // correct information (navState = nextState only if relocated
     // in case of a boundary; see below)
     navState.SetBoundaryState(nextState.IsOnBoundary());
+    const bool hostBoundaryStep = currentTrack.hasHostData && nextState.IsOnBoundary();
     if (nextState.IsOnBoundary()) {
       currentTrack.SetSafety(pos, 0.);
     } else {
@@ -874,7 +875,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     assert(nSecondaries <= 3);
 
     // Record the step. Edep includes the continuous energy loss and edep from secondaries which were cut
-    if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU ||
+    if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU || hostBoundaryStep ||
         ((returnLastStep || currentTrack.hasHostData) && (nSecondaries > 0 || !trackSurvives))) {
       adept_step_recording::RecordGPUStep(currentTrack.trackId, currentTrack.parentId, returnedProcessId,
                                           IsElectron ? ParticleType::Electron : ParticleType::Positron,

--- a/include/AdePT/transport/kernels/electrons_split.cuh
+++ b/include/AdePT/transport/kernels/electrons_split.cuh
@@ -36,8 +36,10 @@
 #include <G4HepEmPositronInteractionAnnihilation.icc>
 #include <G4HepEmElectronEnergyLossFluctuation.icc>
 
-using StepActionParam = adept::SteppingAction::Params;
-using VolAuxData      = adeptint::VolAuxData;
+using StepActionParam        = adept::SteppingAction::Params;
+using SelectedSteppingAction = adept::SteppingAction::Action;
+using adept::SteppingAction::SetSecondaryHostData;
+using VolAuxData = adeptint::VolAuxData;
 
 // Compute velocity based on the kinetic energy of the particle
 __device__ double GetVelocity(double eKin)
@@ -180,9 +182,10 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
                                               currentTrack.preStepGlobalTime,      // preStep global time
                                               currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                               false,                                       // parent continues on CPU
-                                              currentTrack.stepCounter,                    // stepcounter
-                                              nullptr, // pointer to secondary init data
-                                              0);      // number of secondaries
+                                              currentTrack.hasHostData,
+                                              currentTrack.stepCounter, // stepcounter
+                                              nullptr,                  // pointer to secondary init data
+                                              0);                       // number of secondaries
           continue;
         }
       } else {
@@ -190,7 +193,7 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
         slotManager.MarkSlotForFreeing(slot);
 
         // In case the last steps are recorded, record it now, as this track is killed
-        if (returnLastStep) {
+        if (returnLastStep || currentTrack.hasHostData) {
           adept_step_recording::RecordGPUStep(currentTrack.trackId,   // Track ID
                                               currentTrack.parentId,  // parent Track ID
                                               static_cast<short>(10), // step limiting process ID
@@ -213,9 +216,10 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
                                               currentTrack.eventId,           // eventID
                                               currentTrack.threadId,          // threadID
                                               true,                           // whether this was the last step
-                                              currentTrack.stepCounter,       // stepcounter
-                                              nullptr,                        // pointer to secondary init data
-                                              0);                             // number of secondaries
+                                              currentTrack.hasHostData,
+                                              currentTrack.stepCounter, // stepcounter
+                                              nullptr,                  // pointer to secondary init data
+                                              0);                       // number of secondaries
         }
         continue; // track is killed, can stop here
       }
@@ -574,7 +578,7 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
       // Only non-interacting, non-relocating tracks score here
       // Score the edep for particles that didn't reach the interaction
       if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU ||
-          (returnLastStep && (!trackSurvives || continuesOnCPU))) {
+          ((returnLastStep || currentTrack.hasHostData) && (!trackSurvives || continuesOnCPU))) {
         adept_step_recording::RecordGPUStep(currentTrack.trackId,                   // Track ID
                                             currentTrack.parentId,                  // parent Track ID
                                             static_cast<short>(winnerProcessIndex), // step defining process
@@ -597,9 +601,10 @@ __global__ void ElectronSetupInteractions(G4HepEmElectronTrack *hepEMTracks, con
                                             currentTrack.preStepGlobalTime,      // preStep global time
                                             currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                             !trackSurvives && !continuesOnCPU, // whether this was the last step
-                                            currentTrack.stepCounter,          // stepcounter
-                                            nullptr,                           // pointer to secondary init data
-                                            0);                                // number of secondaries
+                                            currentTrack.hasHostData,
+                                            currentTrack.stepCounter, // stepcounter
+                                            nullptr,                  // pointer to secondary init data
+                                            0);                       // number of secondaries
       }
     }
   }
@@ -674,7 +679,7 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
     }
 
     if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnsToCPU ||
-        (!trackSurvives && returnLastStep))
+        (!trackSurvives && (returnLastStep || currentTrack.hasHostData)))
       adept_step_recording::RecordGPUStep(currentTrack.trackId,  // Track ID
                                           currentTrack.parentId, // parent Track ID
                                           stepProcessId,         // step limiting process ID
@@ -696,9 +701,10 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
                                           currentTrack.preStepGlobalTime, // preStep global time
                                           currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                           isLastStep,                                  // whether this was the last step
-                                          currentTrack.stepCounter,                    // stepcounter
-                                          nullptr,                                     // pointer to secondary init data
-                                          0);                                          // number of secondaries
+                                          currentTrack.hasHostData,
+                                          currentTrack.stepCounter, // stepcounter
+                                          nullptr,                  // pointer to secondary init data
+                                          0);                       // number of secondaries
 
     if (cross_boundary) {
       // Check if the next volume belongs to the GPU region and push it to the appropriate queue
@@ -754,12 +760,17 @@ __device__ __forceinline__ void PerformStoppedAnnihilation(const int slot, Charg
         gammaPartManager.NextTrack(currentTrack.rngState, double{copcore::units::kElectronMassC2}, currentTrack.pos,
                                    -gamma1.dir, currentTrack.navState, currentTrack, currentTrack.globalTime);
 
-    // if tracking or stepping action is called, return initial step
-    if (returnLastStep) {
-      secondaryData[nSecondaries++] = {gamma1.trackId, gamma1.dir, gamma1.eKin, /*creator process*/ short(2),
-                                       ParticleType::Gamma};
-      secondaryData[nSecondaries++] = {gamma2.trackId, gamma2.dir, gamma2.eKin, /*creator process*/ short(2),
-                                       ParticleType::Gamma};
+    SetSecondaryHostData<SelectedSteppingAction>(gamma1, currentTrack, 0., returnLastStep);
+    SetSecondaryHostData<SelectedSteppingAction>(gamma2, currentTrack, 0., returnLastStep);
+
+    // Return the initializing step when HostTrackData is needed for these secondaries.
+    if (gamma1.hasHostData) {
+      secondaryData[nSecondaries++] = {gamma1.trackId,      gamma1.dir,
+                                       gamma1.eKin,         /*creator process*/ short(2),
+                                       ParticleType::Gamma, gamma1.hasHostData};
+      secondaryData[nSecondaries++] = {gamma2.trackId,      gamma2.dir,
+                                       gamma2.eKin,         /*creator process*/ short(2),
+                                       ParticleType::Gamma, gamma2.hasHostData};
     }
   }
 }
@@ -834,10 +845,14 @@ __global__ void ElectronIonization(G4HepEmElectronTrack *hepEMTracks, ParticleMa
           vecgeom::Vector3D<double>{dirSecondary[0], dirSecondary[1], dirSecondary[2]}, currentTrack.navState,
           currentTrack, currentTrack.globalTime);
 
-      // if tracking or stepping action is called, return initial step
-      if (returnLastStep) {
-        secondaryData[nSecondaries++] = {secondary.trackId, secondary.dir, secondary.eKin, /*creator process*/ short(0),
-                                         ParticleType::Electron};
+      SetSecondaryHostData<SelectedSteppingAction>(secondary, currentTrack, copcore::units::kElectronMassC2,
+                                                   returnLastStep);
+
+      // Return the initializing step when HostTrackData is needed for this secondary.
+      if (secondary.hasHostData) {
+        secondaryData[nSecondaries++] = {secondary.trackId,      secondary.dir,
+                                         secondary.eKin,         /*creator process*/ short(0),
+                                         ParticleType::Electron, secondary.hasHostData};
       }
     }
 
@@ -863,7 +878,7 @@ __global__ void ElectronIonization(G4HepEmElectronTrack *hepEMTracks, ParticleMa
     // Record the step. Edep includes the continuous energy loss and edep from secondaries which were cut
     // Note: step must be returned if track dies or secondaries have been generated
     if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps ||
-        (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
+        ((returnLastStep || currentTrack.hasHostData) && (nSecondaries > 0 || !trackSurvives))) {
       adept_step_recording::RecordGPUStep(currentTrack.trackId,  // Track ID
                                           currentTrack.parentId, // parent Track ID
                                           static_cast<short>(0), // step limiting process ID
@@ -885,9 +900,10 @@ __global__ void ElectronIonization(G4HepEmElectronTrack *hepEMTracks, ParticleMa
                                           currentTrack.preStepGlobalTime, // preStep global time
                                           currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                           !trackSurvives,                              // whether this was the last step
-                                          currentTrack.stepCounter,                    // stepcounter
-                                          secondaryData,                               // pointer to secondary init data
-                                          nSecondaries);                               // number of secondaries
+                                          currentTrack.hasHostData,
+                                          currentTrack.stepCounter, // stepcounter
+                                          secondaryData,            // pointer to secondary init data
+                                          nSecondaries);            // number of secondaries
     }
   }
 }
@@ -974,10 +990,12 @@ __global__ void ElectronBremsstrahlung(G4HepEmElectronTrack *hepEMTracks, Partic
             gammaPartManager.NextTrack(newRNG, deltaEkin, currentTrack.pos,
                                        vecgeom::Vector3D<double>{dirSecondary[0], dirSecondary[1], dirSecondary[2]},
                                        currentTrack.navState, currentTrack, currentTrack.globalTime, gammaWeight);
-        // if tracking or stepping action is called, return initial step
-        if (returnLastStep) {
-          secondaryData[nSecondaries++] = {gamma.trackId, gamma.dir, gamma.eKin, /*creator process*/ short(1),
-                                           ParticleType::Gamma};
+        SetSecondaryHostData<SelectedSteppingAction>(gamma, currentTrack, 0., returnLastStep);
+        // Return the initializing step when HostTrackData is needed for this secondary.
+        if (gamma.hasHostData) {
+          secondaryData[nSecondaries++] = {gamma.trackId,       gamma.dir,
+                                           gamma.eKin,          /*creator process*/ short(1),
+                                           ParticleType::Gamma, gamma.hasHostData};
         }
       }
     }
@@ -1005,7 +1023,7 @@ __global__ void ElectronBremsstrahlung(G4HepEmElectronTrack *hepEMTracks, Partic
     // Record the step. Edep includes the continuous energy loss and edep from secondaries which were cut
     // Note: step must be returned if track dies or secondaries were generated
     if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps ||
-        (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
+        ((returnLastStep || currentTrack.hasHostData) && (nSecondaries > 0 || !trackSurvives))) {
       adept_step_recording::RecordGPUStep(currentTrack.trackId,  // Track ID
                                           currentTrack.parentId, // parent Track ID
                                           static_cast<short>(1), // step limiting process ID
@@ -1027,9 +1045,10 @@ __global__ void ElectronBremsstrahlung(G4HepEmElectronTrack *hepEMTracks, Partic
                                           currentTrack.preStepGlobalTime, // preStep global time
                                           currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                           !trackSurvives,                              // whether this was the last step
-                                          currentTrack.stepCounter,                    // stepcounter
-                                          secondaryData,                               // pointer to secondary init data
-                                          nSecondaries);                               // number of secondaries
+                                          currentTrack.hasHostData,
+                                          currentTrack.stepCounter, // stepcounter
+                                          secondaryData,            // pointer to secondary init data
+                                          nSecondaries);            // number of secondaries
     }
   }
 }
@@ -1103,10 +1122,12 @@ __global__ void PositronAnnihilation(G4HepEmElectronTrack *hepEMTracks, Particle
             gammaPartManager.NextTrack(newRNG, theGamma1Ekin, currentTrack.pos,
                                        vecgeom::Vector3D<double>{theGamma1Dir[0], theGamma1Dir[1], theGamma1Dir[2]},
                                        currentTrack.navState, currentTrack, currentTrack.globalTime, gamma1Weight);
-        // if tracking or stepping action is called, return initial step
-        if (returnLastStep) {
-          secondaryData[nSecondaries++] = {gamma1.trackId, gamma1.dir, gamma1.eKin, /*creator process*/ short(2),
-                                           ParticleType::Gamma};
+        SetSecondaryHostData<SelectedSteppingAction>(gamma1, currentTrack, 0., returnLastStep);
+        // Return the initializing step when HostTrackData is needed for this secondary.
+        if (gamma1.hasHostData) {
+          secondaryData[nSecondaries++] = {gamma1.trackId,      gamma1.dir,
+                                           gamma1.eKin,         /*creator process*/ short(2),
+                                           ParticleType::Gamma, gamma1.hasHostData};
         }
       }
     }
@@ -1130,10 +1151,12 @@ __global__ void PositronAnnihilation(G4HepEmElectronTrack *hepEMTracks, Particle
             gammaPartManager.NextTrack(currentTrack.rngState, theGamma2Ekin, currentTrack.pos,
                                        vecgeom::Vector3D<double>{theGamma2Dir[0], theGamma2Dir[1], theGamma2Dir[2]},
                                        currentTrack.navState, currentTrack, currentTrack.globalTime, gamma2Weight);
-        // if tracking or stepping action is called, return initial step
-        if (returnLastStep) {
-          secondaryData[nSecondaries++] = {gamma2.trackId, gamma2.dir, gamma2.eKin, /*creator process*/ short(2),
-                                           ParticleType::Gamma};
+        SetSecondaryHostData<SelectedSteppingAction>(gamma2, currentTrack, 0., returnLastStep);
+        // Return the initializing step when HostTrackData is needed for this secondary.
+        if (gamma2.hasHostData) {
+          secondaryData[nSecondaries++] = {gamma2.trackId,      gamma2.dir,
+                                           gamma2.eKin,         /*creator process*/ short(2),
+                                           ParticleType::Gamma, gamma2.hasHostData};
         }
       }
     }
@@ -1144,7 +1167,8 @@ __global__ void PositronAnnihilation(G4HepEmElectronTrack *hepEMTracks, Particle
     assert(nSecondaries <= 2);
 
     // Record the step. Edep includes the continuous energy loss and edep from secondaries which were cut
-    if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep) {
+    if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep ||
+        currentTrack.hasHostData) {
       adept_step_recording::RecordGPUStep(
           currentTrack.trackId,                        // Track ID
           currentTrack.parentId,                       // parent Track ID
@@ -1166,7 +1190,8 @@ __global__ void PositronAnnihilation(G4HepEmElectronTrack *hepEMTracks, Particle
           currentTrack.properTime,                     // proper time
           currentTrack.preStepGlobalTime,              // preStep global time
           currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-          true,                     // whether this was the last step: always true for annihilating positrons
+          true, // whether this was the last step: always true for annihilating positrons
+          currentTrack.hasHostData,
           currentTrack.stepCounter, // stepcounter
           secondaryData,            // pointer to secondary init data
           nSecondaries);            // number of secondaries
@@ -1218,7 +1243,8 @@ __global__ void PositronStoppedAnnihilation(G4HepEmElectronTrack *hepEMTracks, P
     assert(nSecondaries <= 2);
 
     // Record the step. Edep includes the continuous energy loss and edep from secondaries which were cut
-    if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep) {
+    if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep ||
+        currentTrack.hasHostData) {
       adept_step_recording::RecordGPUStep(
           currentTrack.trackId,                        // Track ID
           currentTrack.parentId,                       // parent Track ID
@@ -1240,7 +1266,8 @@ __global__ void PositronStoppedAnnihilation(G4HepEmElectronTrack *hepEMTracks, P
           currentTrack.properTime,                     // proper time
           currentTrack.preStepGlobalTime,              // preStep global time
           currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-          true,                     // whether this was the last step: always true for annihilating positrons
+          true, // whether this was the last step: always true for annihilating positrons
+          currentTrack.hasHostData,
           currentTrack.stepCounter, // stepcounter
           secondaryData,            // pointer to secondary init data
           nSecondaries);            // number of secondaries

--- a/include/AdePT/transport/kernels/electrons_split.cuh
+++ b/include/AdePT/transport/kernels/electrons_split.cuh
@@ -679,6 +679,7 @@ __global__ void ElectronRelocation(G4HepEmElectronTrack *hepEMTracks, ParticleMa
     }
 
     if ((energyDeposit > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnsToCPU ||
+        (cross_boundary && currentTrack.hasHostData) ||
         (!trackSurvives && (returnLastStep || currentTrack.hasHostData)))
       adept_step_recording::RecordGPUStep(currentTrack.trackId,  // Track ID
                                           currentTrack.parentId, // parent Track ID

--- a/include/AdePT/transport/kernels/gammas.cuh
+++ b/include/AdePT/transport/kernels/gammas.cuh
@@ -11,6 +11,7 @@
 #endif
 
 #include <AdePT/transport/support/PhysicalConstants.h>
+#include <AdePT/transport/kernels/AdePTSteppingActionSelector.cuh>
 #include <AdePT/transport/tracks/TrackDebug.cuh>
 #include <AdePT/transport/queues/ParticleManager.cuh>
 #include <AdePT/transport/state/DeviceGlobals.cuh>
@@ -33,6 +34,7 @@
 
 using VolAuxData      = adeptint::VolAuxData;
 using StepActionParam = adept::SteppingAction::Params;
+using adept::SteppingAction::SetSecondaryHostData;
 
 namespace adept::transport {
 // TransportGammas Interface
@@ -116,9 +118,10 @@ __global__ void __launch_bounds__(256, 1)
                                           preStepGlobalTime,        // global time at preStepPoint
                                           currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                           false,                                       // parent continues on CPU
-                                          currentTrack.stepCounter,                    // stepcounter
-                                          nullptr,                                     // pointer to secondary init data
-                                          0);                                          // number of secondaries
+                                          currentTrack.hasHostData,
+                                          currentTrack.stepCounter, // stepcounter
+                                          nullptr,                  // pointer to secondary init data
+                                          0);                       // number of secondaries
       continue;
     }
 
@@ -322,10 +325,17 @@ __global__ void __launch_bounds__(256, 1)
               vecgeom::Vector3D<double>{dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]}, navState,
               currentTrack, globalTime);
 
-          // if tracking or stepping action is called, return initial step
-          if (returnLastStep) {
-            secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin,
-                                             /*creator process*/ short(winnerProcessIndex), ParticleType::Electron};
+          SetSecondaryHostData<SteppingActionT>(electron, currentTrack, copcore::units::kElectronMassC2,
+                                                returnLastStep);
+
+          // Return the initializing step when HostTrackData is needed for this secondary.
+          if (electron.hasHostData) {
+            secondaryData[nSecondaries++] = {electron.trackId,
+                                             electron.dir,
+                                             electron.eKin,
+                                             /*creator process*/ short(winnerProcessIndex),
+                                             ParticleType::Electron,
+                                             electron.hasHostData};
           }
         }
 
@@ -338,10 +348,17 @@ __global__ void __launch_bounds__(256, 1)
               vecgeom::Vector3D<double>{dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]}, navState,
               currentTrack, globalTime);
 
-          // if tracking or stepping action is called, return initial step
-          if (returnLastStep) {
-            secondaryData[nSecondaries++] = {positron.trackId, positron.dir, positron.eKin,
-                                             /*creator process*/ short(winnerProcessIndex), ParticleType::Positron};
+          SetSecondaryHostData<SteppingActionT>(positron, currentTrack, copcore::units::kElectronMassC2,
+                                                returnLastStep);
+
+          // Return the initializing step when HostTrackData is needed for this secondary.
+          if (positron.hasHostData) {
+            secondaryData[nSecondaries++] = {positron.trackId,
+                                             positron.dir,
+                                             positron.eKin,
+                                             /*creator process*/ short(winnerProcessIndex),
+                                             ParticleType::Positron,
+                                             positron.hasHostData};
           }
         }
         eKin = 0.;
@@ -375,10 +392,17 @@ __global__ void __launch_bounds__(256, 1)
 
           electron.dir.Normalize();
 
-          // if tracking or stepping action is called, return initial step
-          if (returnLastStep) {
-            secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin,
-                                             /*creator process*/ short(winnerProcessIndex), ParticleType::Electron};
+          SetSecondaryHostData<SteppingActionT>(electron, currentTrack, copcore::units::kElectronMassC2,
+                                                returnLastStep);
+
+          // Return the initializing step when HostTrackData is needed for this secondary.
+          if (electron.hasHostData) {
+            secondaryData[nSecondaries++] = {electron.trackId,
+                                             electron.dir,
+                                             electron.eKin,
+                                             /*creator process*/ short(winnerProcessIndex),
+                                             ParticleType::Electron,
+                                             electron.hasHostData};
           }
         } else {
           edep = energyEl;
@@ -421,10 +445,17 @@ __global__ void __launch_bounds__(256, 1)
               newRNG, photoElecE, pos, vecgeom::Vector3D<double>{dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]},
               navState, currentTrack, globalTime);
 
-          // if tracking or stepping action is called, return initial step
-          if (returnLastStep) {
-            secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin,
-                                             /*creator process*/ short(winnerProcessIndex), ParticleType::Electron};
+          SetSecondaryHostData<SteppingActionT>(electron, currentTrack, copcore::units::kElectronMassC2,
+                                                returnLastStep);
+
+          // Return the initializing step when HostTrackData is needed for this secondary.
+          if (electron.hasHostData) {
+            secondaryData[nSecondaries++] = {electron.trackId,
+                                             electron.dir,
+                                             electron.eKin,
+                                             /*creator process*/ short(winnerProcessIndex),
+                                             ParticleType::Electron,
+                                             electron.hasHostData};
           }
         } else {
           // If the secondary electron is cut, deposit all the energy of the gamma in this volume
@@ -479,7 +510,7 @@ __global__ void __launch_bounds__(256, 1)
 
     // If there is some edep from cutting particles, record the step
     if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU || winnerProcessIndex == 3 ||
-        (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
+        ((returnLastStep || currentTrack.hasHostData) && (nSecondaries > 0 || !trackSurvives))) {
       adept_step_recording::RecordGPUStep(currentTrack.trackId,  // Track ID
                                           currentTrack.parentId, // parent Track ID
                                           stepDefinedProcessId,  // step-defining process id
@@ -501,7 +532,8 @@ __global__ void __launch_bounds__(256, 1)
                                           preStepGlobalTime,     // global time at preStepPoint
                                           currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                           !trackSurvives &&
-                                              !continuesOnCPU,      // whether this is the last step of the track
+                                              !continuesOnCPU, // whether this is the last step of the track
+                                          currentTrack.hasHostData,
                                           currentTrack.stepCounter, // stepcounter
                                           secondaryData,            // pointer to secondary init data
                                           nSecondaries);            // number of secondaries

--- a/include/AdePT/transport/kernels/gammas.cuh
+++ b/include/AdePT/transport/kernels/gammas.cuh
@@ -212,7 +212,7 @@ __global__ void __launch_bounds__(256, 1)
     globalTime += deltaTime;
     localTime += deltaTime;
 
-    int winnerProcessIndex;
+    int winnerProcessIndex = -1;
     // data structure for possible secondaries that are generated
     SecondaryInitData secondaryData[3];
     unsigned int nSecondaries = 0;

--- a/include/AdePT/transport/kernels/gammas.cuh
+++ b/include/AdePT/transport/kernels/gammas.cuh
@@ -201,6 +201,7 @@ __global__ void __launch_bounds__(256, 1)
     // correct information (navState = nextState only if relocated
     // in case of a boundary; see below)
     navState.SetBoundaryState(nextState.IsOnBoundary());
+    const bool hostBoundaryStep = currentTrack.hasHostData && nextState.IsOnBoundary();
 
     // Propagate information from geometrical step to G4HepEm.
     theTrack->SetGStepLength(geometryStepLength);
@@ -510,7 +511,7 @@ __global__ void __launch_bounds__(256, 1)
 
     // If there is some edep from cutting particles, record the step
     if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU || winnerProcessIndex == 3 ||
-        ((returnLastStep || currentTrack.hasHostData) && (nSecondaries > 0 || !trackSurvives))) {
+        hostBoundaryStep || ((returnLastStep || currentTrack.hasHostData) && (nSecondaries > 0 || !trackSurvives))) {
       adept_step_recording::RecordGPUStep(currentTrack.trackId,  // Track ID
                                           currentTrack.parentId, // parent Track ID
                                           stepDefinedProcessId,  // step-defining process id

--- a/include/AdePT/transport/kernels/gammasWDT.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT.cuh
@@ -7,6 +7,7 @@
 #include <AdePT/transport/config/TransportKernelOptions.hh>
 
 #include <AdePT/transport/support/PhysicalConstants.h>
+#include <AdePT/transport/kernels/AdePTSteppingActionSelector.cuh>
 #include <AdePT/transport/tracks/TrackDebug.cuh>
 #include <AdePT/transport/queues/ParticleManager.cuh>
 #include <AdePT/transport/state/DeviceGlobals.cuh>
@@ -30,6 +31,7 @@
 
 using VolAuxData      = adeptint::VolAuxData;
 using StepActionParam = adept::SteppingAction::Params;
+using adept::SteppingAction::SetSecondaryHostData;
 
 namespace adept::transport {
 // TransportGammasWoodcock Interface
@@ -112,9 +114,10 @@ __global__ void __launch_bounds__(256, 1)
                                           preStepGlobalTime,        // global time at preStepPoint
                                           currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                           false,                                       // parent continues on CPU
-                                          currentTrack.stepCounter,                    // stepcounter
-                                          nullptr,                                     // pointer to secondary init data
-                                          0);                                          // number of secondaries
+                                          currentTrack.hasHostData,
+                                          currentTrack.stepCounter, // stepcounter
+                                          nullptr,                  // pointer to secondary init data
+                                          0);                       // number of secondaries
       continue;
     }
 
@@ -519,10 +522,17 @@ __global__ void __launch_bounds__(256, 1)
               vecgeom::Vector3D<double>{dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]}, navState,
               currentTrack, globalTime);
 
-          // if tracking or stepping action is called, return initial step
-          if (returnLastStep) {
-            secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin,
-                                             /*creator process*/ short(winnerProcessIndex), ParticleType::Electron};
+          SetSecondaryHostData<SteppingActionT>(electron, currentTrack, copcore::units::kElectronMassC2,
+                                                returnLastStep);
+
+          // Return the initializing step when HostTrackData is needed for this secondary.
+          if (electron.hasHostData) {
+            secondaryData[nSecondaries++] = {electron.trackId,
+                                             electron.dir,
+                                             electron.eKin,
+                                             /*creator process*/ short(winnerProcessIndex),
+                                             ParticleType::Electron,
+                                             electron.hasHostData};
           }
         }
 
@@ -535,10 +545,17 @@ __global__ void __launch_bounds__(256, 1)
               vecgeom::Vector3D<double>{dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]}, navState,
               currentTrack, globalTime);
 
-          // if tracking or stepping action is called, return initial step
-          if (returnLastStep) {
-            secondaryData[nSecondaries++] = {positron.trackId, positron.dir, positron.eKin,
-                                             /*creator process*/ short(winnerProcessIndex), ParticleType::Positron};
+          SetSecondaryHostData<SteppingActionT>(positron, currentTrack, copcore::units::kElectronMassC2,
+                                                returnLastStep);
+
+          // Return the initializing step when HostTrackData is needed for this secondary.
+          if (positron.hasHostData) {
+            secondaryData[nSecondaries++] = {positron.trackId,
+                                             positron.dir,
+                                             positron.eKin,
+                                             /*creator process*/ short(winnerProcessIndex),
+                                             ParticleType::Positron,
+                                             positron.hasHostData};
           }
         }
         eKin = 0.;
@@ -572,10 +589,17 @@ __global__ void __launch_bounds__(256, 1)
 
           electron.dir.Normalize();
 
-          // if tracking or stepping action is called, return initial step
-          if (returnLastStep) {
-            secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin,
-                                             /*creator process*/ short(winnerProcessIndex), ParticleType::Electron};
+          SetSecondaryHostData<SteppingActionT>(electron, currentTrack, copcore::units::kElectronMassC2,
+                                                returnLastStep);
+
+          // Return the initializing step when HostTrackData is needed for this secondary.
+          if (electron.hasHostData) {
+            secondaryData[nSecondaries++] = {electron.trackId,
+                                             electron.dir,
+                                             electron.eKin,
+                                             /*creator process*/ short(winnerProcessIndex),
+                                             ParticleType::Electron,
+                                             electron.hasHostData};
           }
         } else {
           edep = energyEl;
@@ -618,10 +642,17 @@ __global__ void __launch_bounds__(256, 1)
               newRNG, photoElecE, pos, vecgeom::Vector3D<double>{dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]},
               navState, currentTrack, globalTime);
 
-          // if tracking or stepping action is called, return initial step
-          if (returnLastStep) {
-            secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin,
-                                             /*creator process*/ short(winnerProcessIndex), ParticleType::Electron};
+          SetSecondaryHostData<SteppingActionT>(electron, currentTrack, copcore::units::kElectronMassC2,
+                                                returnLastStep);
+
+          // Return the initializing step when HostTrackData is needed for this secondary.
+          if (electron.hasHostData) {
+            secondaryData[nSecondaries++] = {electron.trackId,
+                                             electron.dir,
+                                             electron.eKin,
+                                             /*creator process*/ short(winnerProcessIndex),
+                                             ParticleType::Electron,
+                                             electron.hasHostData};
           }
         } else {
           // If the secondary electron is cut, deposit all the energy of the gamma in this volume
@@ -678,7 +709,7 @@ __global__ void __launch_bounds__(256, 1)
 
     // If there is some edep from cutting particles or if it is the last step, record the step
     if ((edep > 0 && nextauxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU || winnerProcessIndex == 3 ||
-        (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
+        ((returnLastStep || currentTrack.hasHostData) && (nSecondaries > 0 || !trackSurvives))) {
       adept_step_recording::RecordGPUStep(currentTrack.trackId,  // Track ID
                                           currentTrack.parentId, // parent Track ID
                                           stepDefinedProcessId,  // step-defining process id
@@ -700,7 +731,8 @@ __global__ void __launch_bounds__(256, 1)
                                           preStepGlobalTime,     // global time at preStepPoint
                                           currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                           !trackSurvives &&
-                                              !continuesOnCPU,      // whether this is the last step of the track
+                                              !continuesOnCPU, // whether this is the last step of the track
+                                          currentTrack.hasHostData,
                                           currentTrack.stepCounter, // stepcounter
                                           secondaryData,            // pointer to secondary init data
                                           nSecondaries);            // number of secondaries

--- a/include/AdePT/transport/kernels/gammasWDT.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT.cuh
@@ -407,7 +407,7 @@ __global__ void __launch_bounds__(256, 1)
     const int nextlvolID          = nextState.GetLogicalId();
     VolAuxData const &nextauxData = gVolAuxData[nextlvolID];
 
-    int winnerProcessIndex;
+    int winnerProcessIndex = -1;
     // data structure for possible secondaries that are generated
     SecondaryInitData secondaryData[3];
     unsigned int nSecondaries = 0;

--- a/include/AdePT/transport/kernels/gammasWDT.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT.cuh
@@ -709,6 +709,7 @@ __global__ void __launch_bounds__(256, 1)
 
     // If there is some edep from cutting particles or if it is the last step, record the step
     if ((edep > 0 && nextauxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU || winnerProcessIndex == 3 ||
+        (currentTrack.hasHostData && isWDTReachedBoundary) ||
         ((returnLastStep || currentTrack.hasHostData) && (nSecondaries > 0 || !trackSurvives))) {
       adept_step_recording::RecordGPUStep(currentTrack.trackId,  // Track ID
                                           currentTrack.parentId, // parent Track ID

--- a/include/AdePT/transport/kernels/gammasWDT.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT.cuh
@@ -707,9 +707,10 @@ __global__ void __launch_bounds__(256, 1)
 
     assert(nSecondaries <= 3);
 
-    // If there is some edep from cutting particles or if it is the last step, record the step
+    // If there is some edep from cutting particles or if it is the last step, record the step.
+    // Do not record boundary crossing steps in Woodcock tracking: WDT intentionally collapses
+    // pre-step state to the post-step point, and the ATLAS MCTruth recording envelopes are not these WDT root volumes.
     if ((edep > 0 && nextauxData.fSensIndex >= 0) || returnAllSteps || continuesOnCPU || winnerProcessIndex == 3 ||
-        (currentTrack.hasHostData && isWDTReachedBoundary) ||
         ((returnLastStep || currentTrack.hasHostData) && (nSecondaries > 0 || !trackSurvives))) {
       adept_step_recording::RecordGPUStep(currentTrack.trackId,  // Track ID
                                           currentTrack.parentId, // parent Track ID

--- a/include/AdePT/transport/kernels/gammasWDT_split.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT_split.cuh
@@ -497,9 +497,9 @@ __global__ void __launch_bounds__(256, 1)
           }
 #endif
 
-          // Note: in the ATLAS MC truth setup, all volume-crossing steps are returned for particles that are stored in
-          // the MC truth. While it is done in the other kernels, it is deliberately skipped for the crossings between
-          // WDT root volumes, as those crossings are irrelevant for the ATLAS MC truth.
+          // Do not record boundary crossing steps in Woodcock tracking: WDT intentionally collapses
+          // pre-step state to the post-step point, and the ATLAS MCTruth recording envelopes are not these WDT root
+          // volumes. CPU handoff is recorded below.
 
         } else {
 

--- a/include/AdePT/transport/kernels/gammasWDT_split.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT_split.cuh
@@ -496,6 +496,11 @@ __global__ void __launch_bounds__(256, 1)
             printf("| After WDT check: leftWDTRegion %d \n", leftWDTRegion);
           }
 #endif
+
+          // Note: in the ATLAS MC truth setup, all volume-crossing steps are returned for particles that are stored in
+          // the MC truth. While it is done in the other kernels, it is deliberately skipped for the crossings between
+          // WDT root volumes, as those crossings are irrelevant for the ATLAS MC truth.
+
         } else {
 
 #if ADEPT_DEBUG_TRACK > 0

--- a/include/AdePT/transport/kernels/gammasWDT_split.cuh
+++ b/include/AdePT/transport/kernels/gammasWDT_split.cuh
@@ -156,9 +156,10 @@ __global__ void __launch_bounds__(256, 1)
                                               currentTrack.preStepGlobalTime, // preStep global time
                                               currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                               false,                                       // parent continues on CPU
-                                              currentTrack.stepCounter,                    // stepcounter
-                                              nullptr, // pointer to secondary init data
-                                              0);      // number of secondaries
+                                              currentTrack.hasHostData,
+                                              currentTrack.stepCounter, // stepcounter
+                                              nullptr,                  // pointer to secondary init data
+                                              0);                       // number of secondaries
           continue;
         }
       } else {
@@ -166,7 +167,7 @@ __global__ void __launch_bounds__(256, 1)
         slotManager.MarkSlotForFreeing(slot);
 
         // In case the last steps are recorded, record it now, as this track is killed
-        if (returnLastStep) {
+        if (returnLastStep || currentTrack.hasHostData) {
           adept_step_recording::RecordGPUStep(currentTrack.trackId,              // Track ID
                                               currentTrack.parentId,             // parent Track ID
                                               static_cast<short>(10),            // step limiting process ID
@@ -187,7 +188,8 @@ __global__ void __launch_bounds__(256, 1)
                                               currentTrack.properTime,           // proper time
                                               currentTrack.preStepGlobalTime,    // preStep global time
                                               currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                                              true,                     // whether this was the last step
+                                              true, // whether this was the last step
+                                              currentTrack.hasHostData,
                                               currentTrack.stepCounter, // stepcounter
                                               nullptr,                  // pointer to secondary init data
                                               0);                       // number of secondaries
@@ -522,9 +524,10 @@ __global__ void __launch_bounds__(256, 1)
                                               currentTrack.preStepGlobalTime,    // preStep global time
                                               currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                               false,                                       // parent continues on CPU
-                                              currentTrack.stepCounter,                    // stepcounter
-                                              nullptr, // pointer to secondary init data
-                                              0);      // number of secondaries
+                                              currentTrack.hasHostData,
+                                              currentTrack.stepCounter, // stepcounter
+                                              nullptr,                  // pointer to secondary init data
+                                              0);                       // number of secondaries
           continue;
         }
       } // else particle has left the world

--- a/include/AdePT/transport/kernels/gammas_split.cuh
+++ b/include/AdePT/transport/kernels/gammas_split.cuh
@@ -31,8 +31,10 @@
 #include <G4HepEmGammaInteractionPhotoelectric.icc>
 #endif
 
-using StepActionParam = adept::SteppingAction::Params;
-using VolAuxData      = adeptint::VolAuxData;
+using StepActionParam        = adept::SteppingAction::Params;
+using SelectedSteppingAction = adept::SteppingAction::Action;
+using adept::SteppingAction::SetSecondaryHostData;
+using VolAuxData = adeptint::VolAuxData;
 
 namespace adept::transport {
 
@@ -135,9 +137,10 @@ __global__ void GammaHowFar(G4HepEmGammaTrack *hepEMTracks, ParticleManager part
                                               currentTrack.preStepGlobalTime, // preStep global time
                                               currentTrack.eventId, currentTrack.threadId, // eventID and threadID
                                               false,                                       // parent continues on CPU
-                                              currentTrack.stepCounter,                    // stepcounter
-                                              nullptr, // pointer to secondary init data
-                                              0);      // number of secondaries
+                                              currentTrack.hasHostData,
+                                              currentTrack.stepCounter, // stepcounter
+                                              nullptr,                  // pointer to secondary init data
+                                              0);                       // number of secondaries
           continue;
         }
       } else {
@@ -145,7 +148,7 @@ __global__ void GammaHowFar(G4HepEmGammaTrack *hepEMTracks, ParticleManager part
         slotManager.MarkSlotForFreeing(slot);
 
         // In case the last steps are recorded, record it now, as this track is killed
-        if (returnLastStep) {
+        if (returnLastStep || currentTrack.hasHostData) {
           adept_step_recording::RecordGPUStep(currentTrack.trackId,           // Track ID
                                               currentTrack.parentId,          // parent Track ID
                                               static_cast<short>(10),         // step limiting process ID
@@ -166,7 +169,8 @@ __global__ void GammaHowFar(G4HepEmGammaTrack *hepEMTracks, ParticleManager part
                                               currentTrack.properTime,        // proper time
                                               currentTrack.preStepGlobalTime, // preStep global time
                                               currentTrack.eventId, currentTrack.threadId, // eventID and threadID
-                                              true,                     // whether this was the last step
+                                              true, // whether this was the last step
+                                              currentTrack.hasHostData,
                                               currentTrack.stepCounter, // stepcounter
                                               nullptr,                  // pointer to secondary init data
                                               0);                       // number of secondaries
@@ -296,7 +300,8 @@ __global__ void GammaSetupInteractions(G4HepEmGammaTrack *hepEMTracks, const ade
                                             currentTrack.properTime,        // proper time
                                             currentTrack.preStepGlobalTime, // preStep global time
                                             currentTrack.eventId, currentTrack.threadId, // event and thread ID
-                                            true,                     // gamma nuclear kills the parent
+                                            true, // gamma nuclear kills the parent
+                                            currentTrack.hasHostData,
                                             currentTrack.stepCounter, // stepcounter
                                             nullptr,                  // pointer to secondary init data
                                             0);                       // number of secondaries
@@ -376,7 +381,8 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
                                             currentTrack.properTime,        // proper time
                                             currentTrack.preStepGlobalTime, // preStep global time
                                             currentTrack.eventId, currentTrack.threadId, // event and thread ID
-                                            false,                    // whether this is the last step of the track
+                                            false, // whether this is the last step of the track
+                                            currentTrack.hasHostData,
                                             currentTrack.stepCounter, // stepcounter
                                             nullptr,                  // pointer to secondary init data
                                             0);                       // number of secondaries
@@ -398,7 +404,7 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
       slotManager.MarkSlotForFreeing(slot);
 
       // particle has left the world, record hit if last or all steps are returned
-      if (returnAllSteps || returnLastStep)
+      if (returnAllSteps || returnLastStep || currentTrack.hasHostData)
         adept_step_recording::RecordGPUStep(
             currentTrack.trackId,                        // Track ID
             currentTrack.parentId,                       // parent Track ID
@@ -421,6 +427,7 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
             currentTrack.preStepGlobalTime,              // preStep global time
             currentTrack.eventId, currentTrack.threadId, // event and thread ID
             true, // whether this is the last step of the track: true, as particle has left the world
+            currentTrack.hasHostData,
             currentTrack.stepCounter, // stepcounter
             nullptr,                  // pointer to secondary init data
             0);                       // number of secondaries
@@ -502,10 +509,14 @@ __global__ void GammaConversion(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
           vecgeom::Vector3D<double>{dirSecondaryEl[0], dirSecondaryEl[1], dirSecondaryEl[2]}, currentTrack.navState,
           currentTrack, currentTrack.globalTime);
 
-      // if tracking or stepping action is called, return initial step
-      if (returnLastStep) {
-        secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin, /*creator process*/ short(0),
-                                         ParticleType::Electron};
+      SetSecondaryHostData<SelectedSteppingAction>(electron, currentTrack, copcore::units::kElectronMassC2,
+                                                   returnLastStep);
+
+      // Return the initializing step when HostTrackData is needed for this secondary.
+      if (electron.hasHostData) {
+        secondaryData[nSecondaries++] = {electron.trackId,       electron.dir,
+                                         electron.eKin,          /*creator process*/ short(0),
+                                         ParticleType::Electron, electron.hasHostData};
       }
     }
 
@@ -518,10 +529,14 @@ __global__ void GammaConversion(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
           vecgeom::Vector3D<double>{dirSecondaryPos[0], dirSecondaryPos[1], dirSecondaryPos[2]}, currentTrack.navState,
           currentTrack, currentTrack.globalTime);
 
-      // if tracking or stepping action is called, return initial step
-      if (returnLastStep) {
-        secondaryData[nSecondaries++] = {positron.trackId, positron.dir, positron.eKin, /*creator process*/ short(0),
-                                         ParticleType::Positron};
+      SetSecondaryHostData<SelectedSteppingAction>(positron, currentTrack, copcore::units::kElectronMassC2,
+                                                   returnLastStep);
+
+      // Return the initializing step when HostTrackData is needed for this secondary.
+      if (positron.hasHostData) {
+        secondaryData[nSecondaries++] = {positron.trackId,       positron.dir,
+                                         positron.eKin,          /*creator process*/ short(0),
+                                         ParticleType::Positron, positron.hasHostData};
       }
     }
 
@@ -531,7 +546,7 @@ __global__ void GammaConversion(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
     assert(nSecondaries <= 2);
 
     // If there is some edep from cutting particles, record the step
-    if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep) {
+    if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep || currentTrack.hasHostData) {
       adept_step_recording::RecordGPUStep(
           currentTrack.trackId,                        // Track ID
           currentTrack.parentId,                       // parent Track ID
@@ -554,6 +569,7 @@ __global__ void GammaConversion(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
           currentTrack.preStepGlobalTime,              // preStep global time
           currentTrack.eventId, currentTrack.threadId, // event and thread ID
           true, // whether this is the last step of the track: always true as gammas undergoing conversion are killed
+          currentTrack.hasHostData,
           currentTrack.stepCounter, // stepcounter
           secondaryData,            // pointer to secondary init data
           nSecondaries);            // number of secondaries
@@ -631,10 +647,14 @@ __global__ void GammaCompton(G4HepEmGammaTrack *hepEMTracks, ParticleManager par
           currentTrack.navState, currentTrack, currentTrack.globalTime);
       electron.dir.Normalize();
 
-      // if tracking or stepping action is called, return initial step
-      if (returnLastStep) {
-        secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin, /*creator process*/ short(1),
-                                         ParticleType::Electron};
+      SetSecondaryHostData<SelectedSteppingAction>(electron, currentTrack, copcore::units::kElectronMassC2,
+                                                   returnLastStep);
+
+      // Return the initializing step when HostTrackData is needed for this secondary.
+      if (electron.hasHostData) {
+        secondaryData[nSecondaries++] = {electron.trackId,       electron.dir,
+                                         electron.eKin,          /*creator process*/ short(1),
+                                         ParticleType::Electron, electron.hasHostData};
       }
 
     } else {
@@ -662,7 +682,7 @@ __global__ void GammaCompton(G4HepEmGammaTrack *hepEMTracks, ParticleManager par
     // If there is some edep from cutting particles, record the step
     // Note: step must be returned even if track dies or secondaries are generated
     if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps ||
-        (returnLastStep && (nSecondaries > 0 || !trackSurvives))) {
+        ((returnLastStep || currentTrack.hasHostData) && (nSecondaries > 0 || !trackSurvives))) {
       adept_step_recording::RecordGPUStep(currentTrack.trackId,           // Track ID
                                           currentTrack.parentId,          // parent Track ID
                                           static_cast<short>(1),          // step defining process ID
@@ -683,7 +703,8 @@ __global__ void GammaCompton(G4HepEmGammaTrack *hepEMTracks, ParticleManager par
                                           currentTrack.properTime,        // proper time
                                           currentTrack.preStepGlobalTime, // preStep global time
                                           currentTrack.eventId, currentTrack.threadId, // event and thread ID
-                                          !trackSurvives,           // whether this is the last step of the track
+                                          !trackSurvives, // whether this is the last step of the track
+                                          currentTrack.hasHostData,
                                           currentTrack.stepCounter, // stepcounter
                                           secondaryData,            // pointer to secondary init data
                                           nSecondaries);            // number of secondaries
@@ -747,10 +768,14 @@ __global__ void GammaPhotoelectric(G4HepEmGammaTrack *hepEMTracks, ParticleManag
           vecgeom::Vector3D<double>{dirPhotoElec[0], dirPhotoElec[1], dirPhotoElec[2]}, currentTrack.navState,
           currentTrack, currentTrack.globalTime);
 
-      // if tracking or stepping action is called, return initial step
-      if (returnLastStep) {
-        secondaryData[nSecondaries++] = {electron.trackId, electron.dir, electron.eKin, /*creator process*/ short(2),
-                                         ParticleType::Electron};
+      SetSecondaryHostData<SelectedSteppingAction>(electron, currentTrack, copcore::units::kElectronMassC2,
+                                                   returnLastStep);
+
+      // Return the initializing step when HostTrackData is needed for this secondary.
+      if (electron.hasHostData) {
+        secondaryData[nSecondaries++] = {electron.trackId,       electron.dir,
+                                         electron.eKin,          /*creator process*/ short(2),
+                                         ParticleType::Electron, electron.hasHostData};
       }
 
     } else {
@@ -765,7 +790,7 @@ __global__ void GammaPhotoelectric(G4HepEmGammaTrack *hepEMTracks, ParticleManag
     assert(nSecondaries <= 1);
 
     // If there is some edep from cutting particles, record the step
-    if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep) {
+    if ((edep > 0 && auxData.fSensIndex >= 0) || returnAllSteps || returnLastStep || currentTrack.hasHostData) {
       adept_step_recording::RecordGPUStep(currentTrack.trackId,       // Track ID
                                           currentTrack.parentId,      // parent Track ID
                                           static_cast<short>(2),      // step defining process ID
@@ -788,6 +813,7 @@ __global__ void GammaPhotoelectric(G4HepEmGammaTrack *hepEMTracks, ParticleManag
                                           currentTrack.eventId, currentTrack.threadId, // event and thread ID
                                           true, // whether this is the last step of the track: always true as gammas
                                                 // undergoing the PhotoElectric effect are killed
+                                          currentTrack.hasHostData,
                                           currentTrack.stepCounter, // stepcounter
                                           secondaryData,            // pointer to secondary init data
                                           nSecondaries);            // number of secondaries

--- a/include/AdePT/transport/kernels/gammas_split.cuh
+++ b/include/AdePT/transport/kernels/gammas_split.cuh
@@ -360,7 +360,7 @@ __global__ void GammaRelocation(G4HepEmGammaTrack *hepEMTracks, ParticleManager 
         stepProcessId = kAdePTOutOfGPURegionProcess;
       }
 
-      if (returnAllSteps || returnsToCPU)
+      if (returnAllSteps || returnsToCPU || currentTrack.hasHostData)
         adept_step_recording::RecordGPUStep(currentTrack.trackId,           // Track ID
                                             currentTrack.parentId,          // parent Track ID
                                             stepProcessId,                  // step defining process ID

--- a/include/AdePT/transport/steps/GPUStep.hh
+++ b/include/AdePT/transport/steps/GPUStep.hh
@@ -36,6 +36,7 @@ struct GPUStep {
   short threadId{-1};
   unsigned short fStepCounter{0};
   bool fLastStepOfTrack{false};
+  bool fHasHostData{false};
   ParticleType fParticleType{ParticleType::Electron};
   unsigned char fNumSecondaries{0};
 
@@ -95,6 +96,7 @@ struct SecondaryInitData {
   double eKin;
   short creatorProcessId{-1};
   ParticleType particleType{ParticleType::Electron};
+  bool hasHostData{false};
 };
 
 /// @brief Utility function to copy a 3D vector, used for filling the Step Points
@@ -113,7 +115,7 @@ __device__ __forceinline__ void FillGPUStep(
     vecgeom::Vector3D<double> const &aPrePosition, vecgeom::Vector3D<double> const &aPreMomentumDirection,
     double aPreEKin, vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<double> const &aPostPosition,
     vecgeom::Vector3D<double> const &aPostMomentumDirection, double aPostEKin, double aGlobalTime, float aLocalTime,
-    float aProperTime, double aPreGlobalTime, unsigned int eventID, short threadID, bool isLastStep,
+    float aProperTime, double aPreGlobalTime, unsigned int eventID, short threadID, bool isLastStep, bool hasHostData,
     unsigned short stepCounter, unsigned char aNumSecondaries)
 {
   aGPUStep.fEventId = eventID;
@@ -121,6 +123,7 @@ __device__ __forceinline__ void FillGPUStep(
 
   aGPUStep.fStepCounter     = stepCounter;
   aGPUStep.fLastStepOfTrack = isLastStep;
+  aGPUStep.fHasHostData     = hasHostData;
   // Fill the required data
   aGPUStep.fTrackID            = aTrackID;
   aGPUStep.fParentID           = aParentID;

--- a/include/AdePT/transport/steps/GPUStepRecording.cuh
+++ b/include/AdePT/transport/steps/GPUStepRecording.cuh
@@ -12,16 +12,14 @@
 namespace adept_step_recording {
 
 /// @brief Record a GPU step
-__device__ void RecordGPUStep(uint64_t aTrackID, uint64_t aParentID, short stepLimProcessId, ParticleType aParticleType,
-                              double aStepLength, double aTotalEnergyDeposit, float aTrackWeight,
-                              vecgeom::NavigationState const &aPreState, vecgeom::Vector3D<double> const &aPrePosition,
-                              vecgeom::Vector3D<double> const &aPreMomentumDirection, double aPreEKin,
-                              vecgeom::NavigationState const &aPostState,
-                              vecgeom::Vector3D<double> const &aPostPosition,
-                              vecgeom::Vector3D<double> const &aPostMomentumDirection, double aPostEKin,
-                              double aGlobalTime, float aLocalTime, float aProperTime, double aPreGlobalTime,
-                              unsigned int eventID, short threadID, bool isLastStep, unsigned short stepCounter,
-                              SecondaryInitData const *secondaryData, unsigned int nSecondaries)
+__device__ void RecordGPUStep(
+    uint64_t aTrackID, uint64_t aParentID, short stepLimProcessId, ParticleType aParticleType, double aStepLength,
+    double aTotalEnergyDeposit, float aTrackWeight, vecgeom::NavigationState const &aPreState,
+    vecgeom::Vector3D<double> const &aPrePosition, vecgeom::Vector3D<double> const &aPreMomentumDirection,
+    double aPreEKin, vecgeom::NavigationState const &aPostState, vecgeom::Vector3D<double> const &aPostPosition,
+    vecgeom::Vector3D<double> const &aPostMomentumDirection, double aPostEKin, double aGlobalTime, float aLocalTime,
+    float aProperTime, double aPreGlobalTime, unsigned int eventID, short threadID, bool isLastStep, bool hasHostData,
+    unsigned short stepCounter, SecondaryInitData const *secondaryData, unsigned int nSecondaries)
 {
 
   // defensive check
@@ -39,7 +37,7 @@ __device__ void RecordGPUStep(uint64_t aTrackID, uint64_t aParentID, short stepL
   FillGPUStep(parentStep, aTrackID, aParentID, stepLimProcessId, aParticleType, aStepLength, aTotalEnergyDeposit,
               aTrackWeight, aPreState, aPrePosition, aPreMomentumDirection, aPreEKin, aPostState, aPostPosition,
               aPostMomentumDirection, aPostEKin, aGlobalTime, aLocalTime, aProperTime, aPreGlobalTime, eventID,
-              threadID, isLastStep, stepCounter, nSecondaries);
+              threadID, isLastStep, hasHostData, stepCounter, nSecondaries);
 
   // Fill the steps for the secondaries
   for (unsigned int i = 0; i < nSecondaries; ++i) {
@@ -51,7 +49,7 @@ __device__ void RecordGPUStep(uint64_t aTrackID, uint64_t aParentID, short stepL
                 secondaryData[i].eKin, aPostState, aPostPosition, secondaryData[i].dir, secondaryData[i].eKin,
                 aGlobalTime,
                 /*localTime*/ 0.f, /*properTime*/ 0.f, aGlobalTime, eventID, threadID, /*isLastStep*/ false,
-                /*stepCounter*/ 0, /*nSecondaries*/ 0);
+                secondaryData[i].hasHostData, /*stepCounter*/ 0, /*nSecondaries*/ 0);
   }
 }
 

--- a/include/AdePT/transport/tracks/Track.cuh
+++ b/include/AdePT/transport/tracks/Track.cuh
@@ -48,6 +48,8 @@ struct TrackBase {
   unsigned short stepCounter{0};
   unsigned short looperCounter{0};
   unsigned short zeroStepCounter{0};
+  bool hasHostData{false};
+
 #ifdef ADEPT_USE_SPLIT_KERNELS
   bool hepEmTrackExists{false};
   // These flags are only used by charged split kernels, but storing them here
@@ -65,10 +67,10 @@ struct TrackBase {
   __device__ TrackBase(uint64_t rngSeed, double eKin, double globalTime, float localTime, float properTime,
                        float weight, double const position[3], double const direction[3],
                        const vecgeom::NavigationState &newNavState, unsigned int eventId, uint64_t trackId,
-                       uint64_t parentId, short threadId, unsigned short stepCounter)
+                       uint64_t parentId, short threadId, unsigned short stepCounter, bool hasHostData = false)
       : rngState{rngSeed}, eKin{eKin}, globalTime{globalTime}, trackId{trackId}, parentId{parentId},
         navState{newNavState}, weight{weight}, localTime{localTime}, properTime{properTime}, eventId{eventId},
-        threadId{threadId}, stepCounter{stepCounter}, looperCounter{0}, zeroStepCounter{0}
+        threadId{threadId}, stepCounter{stepCounter}, looperCounter{0}, zeroStepCounter{0}, hasHostData{hasHostData}
   {
     pos = {position[0], position[1], position[2]};
     dir = {direction[0], direction[1], direction[2]};
@@ -91,7 +93,7 @@ struct TrackBase {
       : rngState{rng_state}, eKin{eKin}, globalTime{globalTime}, pos{parentPos}, dir{newDirection},
         trackId{rngState.IntRndm64()}, parentId{parentTrack.trackId}, navState{newNavState}, weight{childWeight},
         eventId{parentTrack.eventId}, threadId{parentTrack.threadId}, stepCounter{0}, looperCounter{0},
-        zeroStepCounter{0}
+        zeroStepCounter{0}, hasHostData{parentTrack.hasHostData}
   {
   }
 

--- a/include/AdePT/transport/tracks/TrackData.h
+++ b/include/AdePT/transport/tracks/TrackData.h
@@ -28,14 +28,16 @@ struct TrackData {
   unsigned short stepCounter{0};
   unsigned int eventId{0};
   short threadId{-1};
+  bool hasHostData{false};
 
   TrackData() = default;
   TrackData(int pdg_id, uint64_t trackId, uint64_t parentId, double ene, double x, double y, double z, double dirx,
             double diry, double dirz, double gTime, double lTime, double pTime, float weight,
-            unsigned short stepCounter, vecgeom::NavigationState &&state, unsigned int eventId = 0, short threadId = -1)
+            unsigned short stepCounter, vecgeom::NavigationState &&state, unsigned int eventId = 0, short threadId = -1,
+            bool hasHostData = false)
       : navState{std::move(state)}, position{x, y, z}, direction{dirx, diry, dirz}, eKin{ene}, globalTime{gTime},
         localTime{lTime}, properTime{pTime}, weight{weight}, pdg{pdg_id}, trackId{trackId}, parentId{parentId},
-        stepCounter{stepCounter}, eventId{eventId}, threadId{threadId}
+        stepCounter{stepCounter}, eventId{eventId}, threadId{threadId}, hasHostData{hasHostData}
   {
   }
 };

--- a/src/g4integration/returned_steps/AdePTGeant4Integration.cpp
+++ b/src/g4integration/returned_steps/AdePTGeant4Integration.cpp
@@ -638,19 +638,17 @@ void AdePTGeant4Integration::ProcessGPUStep(std::span<const GPUStep> gpuSteps, b
   // nuclear process stay on the CPU and will receive their normal Geant4
   // tracking callbacks later.
   if (callUserActions) {
-    auto *evtMgr             = G4EventManager::GetEventManager();
-    auto *userTrackingAction = evtMgr->GetUserTrackingAction();
-    if (userTrackingAction) {
-      std::span<const GPUStep> secondaries = gpuSteps.subspan(1);
-      for (size_t i = 0; i < secondaries.size(); ++i) {
-        auto *secondary = (*fStepReconstructionObjects->fSecondaryVector)[i];
-        if (secondary == nullptr) continue;
+    auto *evtMgr                         = G4EventManager::GetEventManager();
+    auto *userTrackingAction             = callUserTrackingAction ? evtMgr->GetUserTrackingAction() : nullptr;
+    std::span<const GPUStep> secondaries = gpuSteps.subspan(1);
+    for (size_t i = 0; i < secondaries.size(); ++i) {
+      auto *secondary = (*fStepReconstructionObjects->fSecondaryVector)[i];
+      if (secondary == nullptr) continue;
 
-        userTrackingAction->PreUserTrackingAction(secondary);
-        auto &secTData = fHostTrackDataMapper->get(secondaries[i].fTrackID);
-        if (secTData.userTrackInfo == nullptr && secondary->GetUserInformation() != nullptr) {
-          secTData.userTrackInfo = secondary->GetUserInformation();
-        }
+      if (userTrackingAction) userTrackingAction->PreUserTrackingAction(secondary);
+      auto &secTData = fHostTrackDataMapper->get(secondaries[i].fTrackID);
+      if (secTData.userTrackInfo == nullptr && secondary->GetUserInformation() != nullptr) {
+        secTData.userTrackInfo = secondary->GetUserInformation();
       }
     }
   }

--- a/src/g4integration/tracking_managers/AdePTTrackingManager.cc
+++ b/src/g4integration/tracking_managers/AdePTTrackingManager.cc
@@ -552,13 +552,17 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
       HostTrackData dummy; // default constructed dummy if no advanced information is available
       bool useHostData = globalHostData;
 #if defined(ADEPT_STEPACTION_TYPE) && (ADEPT_STEPACTION_TYPE == 3)
+      // In ATLAS, the G4VUserTrackInfo is already attached when tracks are given to AdePT:
+      // primaries by AthenaStackingAction, and secondaries during the SteppingAction of their parents,
+      // in the step where the secondary was created. Thus, whether the hostTrackData is needed (to store the
+      // G4VUserTrackInfo) is determined by whether the UserTrackInfo is already attached.
       useHostData = useHostData || (aTrack->GetUserInformation() != nullptr);
 #endif
       bool entryExists = trackMapper.getGPUId(aTrack->GetTrackID(), gpuTrackID);
       HostTrackData &hostTrackData =
           useHostData ? trackMapper.activateForGPU(gpuTrackID, aTrack->GetTrackID(), entryExists) : dummy;
 
-      // fill hostTracKData if being used:
+      // Fill HostTrackData if being used.
       if (useHostData) {
         // set pointers and G4 parent id
         hostTrackData.primary        = aTrack->GetDynamicParticle()->GetPrimaryParticle();
@@ -579,19 +583,20 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
           hostTrackData.logicalVolumeAtVertex   = const_cast<G4LogicalVolume *>(aTrack->GetLogicalVolumeAtVertex());
         }
 
-        // if there has been no step, call PreUserTrackingAction and try to attach UserInformation
+        // For an initializing step, call PreUserTrackingAction
         if (aTrack->GetCurrentStepNumber() == 0) {
           if (callUserActions) {
             auto *userTrackingAction = eventManager->GetUserTrackingAction();
             if (userTrackingAction) {
 
-              // this assumes that the UserTrackInformation is attached to the track in the PreUserTrackingAction
+              // PreUserTrackingAction may attach or replace the user information; store the final pointer below.
+              // Already-attached information is preserved if the action leaves it unchanged.
               userTrackingAction->PreUserTrackingAction(aTrack);
             }
           }
           hostTrackData.userTrackInfo = aTrack->GetUserInformation();
         } else {
-          // not the initializing step, just attach user information in case it is there
+          // For non-initializing steps, just preserve user information if it is present.
           hostTrackData.userTrackInfo = aTrack->GetUserInformation();
         }
       }

--- a/src/g4integration/tracking_managers/AdePTTrackingManager.cc
+++ b/src/g4integration/tracking_managers/AdePTTrackingManager.cc
@@ -406,9 +406,7 @@ void AdePTTrackingManager::FlushEvent()
   const bool callUserSteppingAction = CallUserSteppingAction(*fAdePTConfiguration);
   const bool callUserTrackingAction = CallUserTrackingAction(*fAdePTConfiguration);
   const bool returnAllSteps         = fAdePTConfiguration->GetReturnAllSteps();
-  const bool useHostData            = fAdePTConfiguration->GetReturnFirstAndLastStep() || returnAllSteps;
-  const bool doUserSteppingAction   = callUserSteppingAction && useHostData;
-  const bool doUserTrackingAction   = callUserTrackingAction && useHostData;
+  const bool globalHostData         = fAdePTConfiguration->GetReturnFirstAndLastStep() || returnAllSteps;
 
   std::sort(deferredSteps.steps.begin(), deferredSteps.steps.end(),
             [&deferredSteps](const AdePTGeant4Integration::DeferredStep &lhs,
@@ -419,6 +417,9 @@ void AdePTTrackingManager::FlushEvent()
   for (const auto &deferredStep : deferredSteps.steps) {
     std::span<const GPUStep> gpuSteps(deferredSteps.gpuSteps.data() + deferredStep.firstGPUStep,
                                       deferredStep.numGPUSteps);
+    const bool useHostData          = globalHostData || gpuSteps.front().fHasHostData;
+    const bool doUserSteppingAction = callUserSteppingAction && useHostData;
+    const bool doUserTrackingAction = callUserTrackingAction && useHostData;
     if (deferredStep.type == AdePTGeant4Integration::DeferredStepType::ReturnTrack) {
       fGeant4Integration.ReturnDeferredTrack(gpuSteps, useHostData);
     } else {
@@ -433,9 +434,7 @@ void AdePTTrackingManager::ProcessReturnedGPUSteps(int threadId, int eventId)
   const bool callUserSteppingAction = CallUserSteppingAction(*fAdePTConfiguration);
   const bool callUserTrackingAction = CallUserTrackingAction(*fAdePTConfiguration);
   const bool returnAllSteps         = fAdePTConfiguration->GetReturnAllSteps();
-  const bool useHostData            = fAdePTConfiguration->GetReturnFirstAndLastStep() || returnAllSteps;
-  const bool doUserSteppingAction   = callUserSteppingAction && useHostData;
-  const bool doUserTrackingAction   = callUserTrackingAction && useHostData;
+  const bool globalHostData         = fAdePTConfiguration->GetReturnFirstAndLastStep() || returnAllSteps;
 
   // Transport owns the step-batch lifetime and calls this lambda once
   // for each currently available returned batch. This lambda provides the
@@ -465,7 +464,10 @@ void AdePTTrackingManager::ProcessReturnedGPUSteps(int threadId, int eventId)
                   << static_cast<short>(it->fParticleType) << " stepLimit / creator process " << it->fStepLimProcessId
                   << "\033[0m" << std::endl;
       }
-      auto blockSize = 1 + it->fNumSecondaries;
+      auto blockSize                  = 1 + it->fNumSecondaries;
+      const bool useHostData          = globalHostData || it->fHasHostData;
+      const bool doUserSteppingAction = callUserSteppingAction && useHostData;
+      const bool doUserTrackingAction = callUserTrackingAction && useHostData;
       const bool isDeferredStep =
           ((it->fParticleType == ParticleType::Gamma || it->fParticleType == ParticleType::Electron ||
             it->fParticleType == ParticleType::Positron) &&
@@ -493,7 +495,8 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
   G4SteppingManager *steppingManager = trackManager->GetSteppingManager();
   const bool trackInAllRegions       = fAdePTConfiguration->GetTrackInAllRegions();
   const bool callUserActions         = CallUserActions(*fAdePTConfiguration);
-  const bool useHostData = fAdePTConfiguration->GetReturnFirstAndLastStep() || fAdePTConfiguration->GetReturnAllSteps();
+  const bool globalHostData =
+      fAdePTConfiguration->GetReturnFirstAndLastStep() || fAdePTConfiguration->GetReturnAllSteps();
 
   const auto eventID = eventManager->GetConstCurrentEvent()->GetEventID();
 
@@ -547,6 +550,10 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
       // new one is created in case it either never existed or was retired after the track left the GPU region
       uint64_t gpuTrackID;
       HostTrackData dummy; // default constructed dummy if no advanced information is available
+      bool useHostData = globalHostData;
+#if defined(ADEPT_STEPACTION_TYPE) && (ADEPT_STEPACTION_TYPE == 3)
+      useHostData = useHostData || (aTrack->GetUserInformation() != nullptr);
+#endif
       bool entryExists = trackMapper.getGPUId(aTrack->GetTrackID(), gpuTrackID);
       HostTrackData &hostTrackData =
           useHostData ? trackMapper.activateForGPU(gpuTrackID, aTrack->GetTrackID(), entryExists) : dummy;
@@ -633,7 +640,7 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
       fAdeptTransport->AddTrack(pdg, gpuTrackID, gpuParentID, energy, particlePosition[0], particlePosition[1],
                                 particlePosition[2], particleDirection[0], particleDirection[1], particleDirection[2],
                                 globalTime, localTime, properTime, weight, stepNumber, threadId, eventID,
-                                std::move(converted));
+                                std::move(converted), useHostData);
 
       fTrackCounter++; // increment the track counter for AdePT
 

--- a/src/transport/AdePTTransport.cc
+++ b/src/transport/AdePTTransport.cc
@@ -133,7 +133,7 @@ AdePTTransport::~AdePTTransport()
 void AdePTTransport::AddTrack(int pdg, uint64_t trackId, uint64_t parentId, double energy, double x, double y, double z,
                               double dirx, double diry, double dirz, double globalTime, double localTime,
                               double properTime, float weight, unsigned short stepCounter, int threadId,
-                              unsigned int eventId, vecgeom::NavigationState &&state)
+                              unsigned int eventId, vecgeom::NavigationState &&state, bool hasHostData)
 {
   if (pdg != 11 && pdg != -11 && pdg != 22) {
     std::cerr << __FILE__ << ":" << __LINE__ << ": Only supporting EM tracks. Got pdgID=" << pdg << "\n";
@@ -148,7 +148,8 @@ void AdePTTransport::AddTrack(int pdg, uint64_t trackId, uint64_t parentId, doub
                             globalTime,  localTime,
                             properTime,  weight,
                             stepCounter, std::move(state),
-                            eventId,     static_cast<short>(threadId)};
+                            eventId,     static_cast<short>(threadId),
+                            hasHostData};
 
   {
     auto trackHandle  = fBuffer->createToDeviceSlot();


### PR DESCRIPTION
Previously, there were only global flags to return all steps or the first and the last step. 

This PR makes enables a return policy of advanced MC truth information (which requires the HostTrackData), based on the ADEPT_STEPPINGACTION. Here, it is implemented for ATLAS.

That means, the first and the last step (plus all boundary crossings) are only returned for those particles that are marked for full MC truth information.

This PR accelerates the full ATLAS simulation by 10% as less steps have to be returned from the GPU and processed on CPU.