### PR TITLE
fix bug with replicated volumes in gdml path

### DIFF
--- a/include/AdePT/g4integration/geometry/AdePTGeometryBridge.hh
+++ b/include/AdePT/g4integration/geometry/AdePTGeometryBridge.hh
@@ -50,22 +50,22 @@ public:
   /// @return Packed, dense WDT data ready to be handed to the transport for device upload.
   static adeptint::WDTHostPacked PackWDT(adeptint::WDTHostRaw const &wdtRaw);
 
-  /// @brief Concrete Geant4 volume instance represented by a VecGeom placed volume.
-  struct G4PhysicalVolumeInstance {
-    G4VPhysicalVolume const *volume = nullptr;
-    EVolume type                    = kNormal;
-    int copyNo                      = -1;
+  /// @brief Geant4 placement information represented by a VecGeom placed volume.
+  struct MappedVolumeInstance {
+    G4VPhysicalVolume const *g4Volume = nullptr;
+    EVolume type                      = kNormal;
+    int copyNo                        = -1;
   };
 
   /// @brief Returns the Geant4 placed volume matching a VecGeom placed volume.
   /// @throws std::runtime_error if the VecGeom placed volume is not present in the global lookup table.
   static G4VPhysicalVolume const *GetG4PhysicalVolume(vecgeom::VPlacedVolume const *placedVolume);
 
-  /// @brief Returns the Geant4 physical-volume instance represented by a VecGeom placed volume.
+  /// @brief Returns the Geant4 placement information represented by a VecGeom placed volume.
   /// @details Replica and parameterised Geant4 physical volumes are shared by multiple concrete VecGeom placements.
   /// For those volumes, the VecGeom placement copy number identifies the concrete Geant4 instance.
   /// @throws std::runtime_error if the VecGeom placed volume is not present in the global lookup table.
-  static G4PhysicalVolumeInstance GetG4PhysicalVolumeInstance(vecgeom::VPlacedVolume const *placedVolume);
+  static MappedVolumeInstance GetMappedVolumeInstance(vecgeom::VPlacedVolume const *placedVolume);
 
 private:
   /// @brief Builds the lookup tables from VecGeom placed/logical volume ids to Geant4 volumes.

--- a/include/AdePT/g4integration/geometry/AdePTGeometryBridge.hh
+++ b/include/AdePT/g4integration/geometry/AdePTGeometryBridge.hh
@@ -9,11 +9,12 @@
 
 #include <VecGeom/base/Config.h>
 
+#include <G4VPhysicalVolume.hh>
+
 #include <string>
 #include <vector>
 
 class G4LogicalVolume;
-class G4VPhysicalVolume;
 struct G4HepEmData;
 
 /// @brief Global bridge between Geant4 host geometry and the VecGeom world used by AdePT.
@@ -49,9 +50,22 @@ public:
   /// @return Packed, dense WDT data ready to be handed to the transport for device upload.
   static adeptint::WDTHostPacked PackWDT(adeptint::WDTHostRaw const &wdtRaw);
 
+  /// @brief Concrete Geant4 volume instance represented by a VecGeom placed volume.
+  struct G4PhysicalVolumeInstance {
+    G4VPhysicalVolume const *volume = nullptr;
+    EVolume type                    = kNormal;
+    int copyNo                      = -1;
+  };
+
   /// @brief Returns the Geant4 placed volume matching a VecGeom placed volume.
   /// @throws std::runtime_error if the VecGeom placed volume is not present in the global lookup table.
   static G4VPhysicalVolume const *GetG4PhysicalVolume(vecgeom::VPlacedVolume const *placedVolume);
+
+  /// @brief Returns the Geant4 physical-volume instance represented by a VecGeom placed volume.
+  /// @details Replica and parameterised Geant4 physical volumes are shared by multiple concrete VecGeom placements.
+  /// For those volumes, the VecGeom placement copy number identifies the concrete Geant4 instance.
+  /// @throws std::runtime_error if the VecGeom placed volume is not present in the global lookup table.
+  static G4PhysicalVolumeInstance GetG4PhysicalVolumeInstance(vecgeom::VPlacedVolume const *placedVolume);
 
 private:
   /// @brief Builds the lookup tables from VecGeom placed/logical volume ids to Geant4 volumes.

--- a/src/g4integration/geometry/AdePTGeometryBridge.cpp
+++ b/src/g4integration/geometry/AdePTGeometryBridge.cpp
@@ -45,12 +45,23 @@ std::size_t GetMultiplicity(G4VPhysicalVolume const *daughter)
   return static_cast<std::size_t>(multiplicity);
 }
 
+// The visitor receives expandedPlacement=true when VecGeom has expanded a
+// Geant4 replica or parameterized daughter into concrete copy placements.
 template <typename Visitor>
-void VisitExpandedDaughters(G4LogicalVolume const *g4_lvol, vecgeom::LogicalVolume const *vg_lvol, Visitor visit)
+void VisitDaughters(G4LogicalVolume const *g4_lvol, vecgeom::LogicalVolume const *vg_lvol, Visitor visit)
 {
   auto const &vgDaughters = vg_lvol->GetDaughters();
-  std::size_t vgId        = 0;
 
+  if (vgDaughters.size() == g4_lvol->GetNoDaughters()) {
+    for (std::size_t id = 0; id < g4_lvol->GetNoDaughters(); ++id) {
+      auto const *g4Daughter = g4_lvol->GetDaughter(id);
+      (void)GetMultiplicity(g4Daughter);
+      visit(g4Daughter, vgDaughters[id], false);
+    }
+    return;
+  }
+
+  std::size_t vgId = 0;
   for (std::size_t g4Id = 0; g4Id < g4_lvol->GetNoDaughters(); ++g4Id) {
     auto const *g4Daughter      = g4_lvol->GetDaughter(g4Id);
     const auto multiplicity     = GetMultiplicity(g4Daughter);
@@ -63,43 +74,13 @@ void VisitExpandedDaughters(G4LogicalVolume const *g4_lvol, vecgeom::LogicalVolu
     }
 
     for (; vgId < nextVecGeomIndex; ++vgId) {
-      visit(g4Daughter, vgDaughters[vgId]);
+      visit(g4Daughter, vgDaughters[vgId], true);
     }
   }
 
   if (vgId != vgDaughters.size()) {
     throw std::runtime_error("Fatal: geometry traversal: VecGeom has unmatched daughters");
   }
-}
-
-template <typename Visitor>
-void VisitDaughtersMatchingVecGeomRepresentationWithMode(G4LogicalVolume const *g4_lvol,
-                                                         vecgeom::LogicalVolume const *vg_lvol, Visitor visit)
-{
-  auto const &vgDaughters = vg_lvol->GetDaughters();
-  if (vgDaughters.size() == g4_lvol->GetNoDaughters()) {
-    for (std::size_t id = 0; id < g4_lvol->GetNoDaughters(); ++id) {
-      auto const *g4Daughter = g4_lvol->GetDaughter(id);
-      (void)GetMultiplicity(g4Daughter);
-      visit(g4Daughter, vgDaughters[id], false);
-    }
-    return;
-  }
-
-  VisitExpandedDaughters(g4_lvol, vg_lvol,
-                         [&](G4VPhysicalVolume const *g4Daughter, vecgeom::VPlacedVolume const *vgDaughter) {
-                           visit(g4Daughter, vgDaughter, true);
-                         });
-}
-
-template <typename Visitor>
-void VisitDaughtersMatchingVecGeomRepresentation(G4LogicalVolume const *g4_lvol, vecgeom::LogicalVolume const *vg_lvol,
-                                                 Visitor visit)
-{
-  VisitDaughtersMatchingVecGeomRepresentationWithMode(
-      g4_lvol, vg_lvol, [&](G4VPhysicalVolume const *g4Daughter, vecgeom::VPlacedVolume const *vgDaughter, bool) {
-        visit(g4Daughter, vgDaughter);
-      });
 }
 
 } // namespace
@@ -128,7 +109,10 @@ void AdePTGeometryBridge::MapVecGeomToG4(std::vector<G4VPhysicalVolume const *> 
     // Now do the daughters. The GDML frontend can preserve replica nodes while
     // G4VG flattens them, so accept either representation when building this
     // fallback map from independently loaded Geant4 and VecGeom trees.
-    VisitDaughtersMatchingVecGeomRepresentation(g4_lvol, vg_lvol, visitGeometry);
+    VisitDaughters(g4_lvol, vg_lvol,
+                   [&](G4VPhysicalVolume const *g4Daughter, vecgeom::VPlacedVolume const *vgDaughter, bool) {
+                     visitGeometry(g4Daughter, vgDaughter);
+                   });
   };
 
   visitGeometry(g4world, vecgeomWorld);
@@ -256,10 +240,10 @@ void VisitGeometryForChecks(G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVo
   }
 
   // Now do the daughters.
-  VisitDaughtersMatchingVecGeomRepresentationWithMode(
+  VisitDaughters(
       g4_lvol, vg_lvol,
-      [&](G4VPhysicalVolume const *g4Daughter, vecgeom::VPlacedVolume const *vgDaughter, bool isExpandedPlacement) {
-        VisitGeometryForChecks(g4Daughter, vgDaughter, isExpandedPlacement, context);
+      [&](G4VPhysicalVolume const *g4Daughter, vecgeom::VPlacedVolume const *vgDaughter, bool expandedPlacement) {
+        VisitGeometryForChecks(g4Daughter, vgDaughter, expandedPlacement, context);
       });
 }
 } // namespace
@@ -395,10 +379,10 @@ void AdePTGeometryBridge::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4Hep
 #endif
 
     // Now do the daughters.
-    VisitDaughtersMatchingVecGeomRepresentation(
-        g4_lvol, vg_lvol, [&](G4VPhysicalVolume const *g4Daughter, vecgeom::VPlacedVolume const *vgDaughter) {
-          visitGeometry(g4Daughter, vgDaughter, currentNavState);
-        });
+    VisitDaughters(g4_lvol, vg_lvol,
+                   [&](G4VPhysicalVolume const *g4Daughter, vecgeom::VPlacedVolume const *vgDaughter, bool) {
+                     visitGeometry(g4Daughter, vgDaughter, currentNavState);
+                   });
 
     // Pop the navigation state before returning.
     currentNavState.Pop();

--- a/src/g4integration/geometry/AdePTGeometryBridge.cpp
+++ b/src/g4integration/geometry/AdePTGeometryBridge.cpp
@@ -8,6 +8,7 @@
 #include <VecGeom/gdml/Frontend.h>
 #endif
 #include <VecGeom/navigation/NavigationState.h>
+#include <VecGeom/volumes/LogicalVolume.h>
 
 #include <G4HepEmData.hh>
 #include <G4Exception.hh>
@@ -27,9 +28,71 @@
 #include <cmath>
 #include <functional>
 #include <stdexcept>
+#include <string>
 
 std::vector<G4VPhysicalVolume const *> AdePTGeometryBridge::fGlobalVecGeomPvToG4Map;
 std::vector<G4LogicalVolume const *> AdePTGeometryBridge::fGlobalVecGeomLvToG4Map;
+
+namespace {
+
+std::size_t GetExpandedDaughterCount(G4LogicalVolume const *g4_lvol)
+{
+  std::size_t result = 0;
+  for (std::size_t daughterId = 0; daughterId < g4_lvol->GetNoDaughters(); ++daughterId) {
+    auto const *daughter = g4_lvol->GetDaughter(daughterId);
+    if (daughter->GetMultiplicity() < 1) {
+      throw std::runtime_error("Fatal: geometry traversal: physical volume " + std::string(daughter->GetName()) +
+                               " has invalid multiplicity");
+    }
+    result += static_cast<std::size_t>(daughter->GetMultiplicity());
+  }
+  return result;
+}
+
+template <typename Visitor>
+void VisitExpandedDaughters(G4LogicalVolume const *g4_lvol, vecgeom::LogicalVolume const *vg_lvol, Visitor visit)
+{
+  auto const &vgDaughters = vg_lvol->GetDaughters();
+  std::size_t vgId        = 0;
+
+  for (std::size_t g4Id = 0; g4Id < g4_lvol->GetNoDaughters(); ++g4Id) {
+    auto const *g4Daughter      = g4_lvol->GetDaughter(g4Id);
+    const auto multiplicity     = static_cast<std::size_t>(g4Daughter->GetMultiplicity());
+    const auto nextVecGeomIndex = vgId + multiplicity;
+    if (nextVecGeomIndex > vgDaughters.size()) {
+      throw std::runtime_error("Fatal: geometry traversal: Geant4 daughter multiplicity exceeds VecGeom daughters");
+    }
+
+    for (; vgId < nextVecGeomIndex; ++vgId) {
+      visit(g4Daughter, vgDaughters[vgId]);
+    }
+  }
+
+  if (vgId != vgDaughters.size()) {
+    throw std::runtime_error("Fatal: geometry traversal: VecGeom has unmatched daughters");
+  }
+}
+
+template <typename Visitor>
+void VisitDaughtersMatchingVecGeomRepresentation(G4LogicalVolume const *g4_lvol, vecgeom::LogicalVolume const *vg_lvol,
+                                                 Visitor visit)
+{
+  auto const &vgDaughters = vg_lvol->GetDaughters();
+  if (vgDaughters.size() == GetExpandedDaughterCount(g4_lvol)) {
+    VisitExpandedDaughters(g4_lvol, vg_lvol, visit);
+    return;
+  }
+
+  if (vgDaughters.size() != g4_lvol->GetNoDaughters()) {
+    throw std::runtime_error("Fatal: geometry traversal: Geant4 and VecGeom daughter counts do not match");
+  }
+
+  for (std::size_t id = 0; id < g4_lvol->GetNoDaughters(); ++id) {
+    visit(g4_lvol->GetDaughter(id), vgDaughters[id]);
+  }
+}
+
+} // namespace
 
 void AdePTGeometryBridge::MapVecGeomToG4(std::vector<G4VPhysicalVolume const *> &vecgeomPvToG4Map,
                                          std::vector<G4LogicalVolume const *> &vecgeomLvToG4Map)
@@ -38,7 +101,7 @@ void AdePTGeometryBridge::MapVecGeomToG4(std::vector<G4VPhysicalVolume const *> 
       G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
   const vecgeom::VPlacedVolume *vecgeomWorld = vecgeom::GeoManager::Instance().GetWorld();
 
-  // Recursive geometry visitor lambda matching one by one Geant4 and VecGeom logical volumes.
+  // Recursive geometry visitor lambda matching Geant4 volumes to VecGeom placements.
   using VisitFn         = std::function<void(G4VPhysicalVolume const *, vecgeom::VPlacedVolume const *)>;
   VisitFn visitGeometry = [&](G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVolume const *vg_pvol) {
     const auto g4_lvol = g4_pvol->GetLogicalVolume();
@@ -52,10 +115,10 @@ void AdePTGeometryBridge::MapVecGeomToG4(std::vector<G4VPhysicalVolume const *> 
     vecgeomLvToG4Map.resize(std::max<std::size_t>(vecgeomLvToG4Map.size(), vg_lvol->id() + 1), nullptr);
     vecgeomLvToG4Map[vg_lvol->id()] = g4_lvol;
 
-    // Now do the daughters.
-    for (size_t id = 0; id < g4_lvol->GetNoDaughters(); ++id) {
-      visitGeometry(g4_lvol->GetDaughter(id), vg_lvol->GetDaughters()[id]);
-    }
+    // Now do the daughters. The GDML frontend can preserve replica nodes while
+    // G4VG flattens them, so accept either representation when building this
+    // fallback map from independently loaded Geant4 and VecGeom trees.
+    VisitDaughtersMatchingVecGeomRepresentation(g4_lvol, vg_lvol, visitGeometry);
   };
 
   visitGeometry(g4world, vecgeomWorld);
@@ -125,11 +188,7 @@ void VisitGeometryForChecks(G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVo
 
   // Geant4 parameterised/replica volumes are represented with direct placements in VecGeom.
   // To accurately compare the number of daughters, sum multiplicity on the Geant4 side.
-  const size_t nd     = g4_lvol->GetNoDaughters();
-  size_t nd_converted = 0;
-  for (size_t daughter_id = 0; daughter_id < nd; ++daughter_id) {
-    nd_converted += g4_lvol->GetDaughter(daughter_id)->GetMultiplicity();
-  }
+  const auto nd_converted = GetExpandedDaughterCount(g4_lvol);
 
   const auto daughters = vg_lvol->GetDaughters();
   if (nd_converted != daughters.size()) {
@@ -195,9 +254,10 @@ void VisitGeometryForChecks(G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVo
   }
 
   // Now do the daughters.
-  for (size_t id = 0; id < g4_lvol->GetNoDaughters(); ++id) {
-    VisitGeometryForChecks(g4_lvol->GetDaughter(id), vg_lvol->GetDaughters()[id], context);
-  }
+  VisitExpandedDaughters(g4_lvol, vg_lvol,
+                         [&](G4VPhysicalVolume const *g4Daughter, vecgeom::VPlacedVolume const *vgDaughter) {
+                           VisitGeometryForChecks(g4Daughter, vgDaughter, context);
+                         });
 }
 } // namespace
 
@@ -258,7 +318,7 @@ void AdePTGeometryBridge::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4Hep
   std::vector<bool> atlasPhotonRRInitialized(vecgeom::GeoManager::Instance().GetRegisteredVolumesCount(), false);
 #endif
 
-  // Recursive geometry visitor lambda matching one by one Geant4 and VecGeom logical volumes.
+  // Recursive geometry visitor lambda matching Geant4 volumes to VecGeom placements.
   using VisitFn =
       std::function<void(G4VPhysicalVolume const *, vecgeom::VPlacedVolume const *, vecgeom::NavigationState)>;
   VisitFn visitGeometry = [&](G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVolume const *vg_pvol,
@@ -332,9 +392,10 @@ void AdePTGeometryBridge::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4Hep
 #endif
 
     // Now do the daughters.
-    for (size_t id = 0; id < g4_lvol->GetNoDaughters(); ++id) {
-      visitGeometry(g4_lvol->GetDaughter(id), vg_lvol->GetDaughters()[id], currentNavState);
-    }
+    VisitExpandedDaughters(g4_lvol, vg_lvol,
+                           [&](G4VPhysicalVolume const *g4Daughter, vecgeom::VPlacedVolume const *vgDaughter) {
+                             visitGeometry(g4Daughter, vgDaughter, currentNavState);
+                           });
 
     // Pop the navigation state before returning.
     currentNavState.Pop();

--- a/src/g4integration/geometry/AdePTGeometryBridge.cpp
+++ b/src/g4integration/geometry/AdePTGeometryBridge.cpp
@@ -35,18 +35,14 @@ std::vector<G4LogicalVolume const *> AdePTGeometryBridge::fGlobalVecGeomLvToG4Ma
 
 namespace {
 
-std::size_t GetExpandedDaughterCount(G4LogicalVolume const *g4_lvol)
+std::size_t GetMultiplicity(G4VPhysicalVolume const *daughter)
 {
-  std::size_t result = 0;
-  for (std::size_t daughterId = 0; daughterId < g4_lvol->GetNoDaughters(); ++daughterId) {
-    auto const *daughter = g4_lvol->GetDaughter(daughterId);
-    if (daughter->GetMultiplicity() < 1) {
-      throw std::runtime_error("Fatal: geometry traversal: physical volume " + std::string(daughter->GetName()) +
-                               " has invalid multiplicity");
-    }
-    result += static_cast<std::size_t>(daughter->GetMultiplicity());
+  const auto multiplicity = daughter->GetMultiplicity();
+  if (multiplicity < 1) {
+    throw std::runtime_error("Fatal: geometry traversal: physical volume " + std::string(daughter->GetName()) +
+                             " has invalid multiplicity");
   }
-  return result;
+  return static_cast<std::size_t>(multiplicity);
 }
 
 template <typename Visitor>
@@ -57,10 +53,13 @@ void VisitExpandedDaughters(G4LogicalVolume const *g4_lvol, vecgeom::LogicalVolu
 
   for (std::size_t g4Id = 0; g4Id < g4_lvol->GetNoDaughters(); ++g4Id) {
     auto const *g4Daughter      = g4_lvol->GetDaughter(g4Id);
-    const auto multiplicity     = static_cast<std::size_t>(g4Daughter->GetMultiplicity());
+    const auto multiplicity     = GetMultiplicity(g4Daughter);
     const auto nextVecGeomIndex = vgId + multiplicity;
     if (nextVecGeomIndex > vgDaughters.size()) {
-      throw std::runtime_error("Fatal: geometry traversal: Geant4 daughter multiplicity exceeds VecGeom daughters");
+      throw std::runtime_error("Fatal: geometry traversal: Geant4 daughter multiplicity exceeds VecGeom daughters in " +
+                               std::string(g4_lvol->GetName()) + " for daughter " + std::string(g4Daughter->GetName()) +
+                               " (multiplicity " + std::to_string(multiplicity) + ", VecGeom daughters " +
+                               std::to_string(vgDaughters.size()) + ")");
     }
 
     for (; vgId < nextVecGeomIndex; ++vgId) {
@@ -74,22 +73,33 @@ void VisitExpandedDaughters(G4LogicalVolume const *g4_lvol, vecgeom::LogicalVolu
 }
 
 template <typename Visitor>
-void VisitDaughtersMatchingVecGeomRepresentation(G4LogicalVolume const *g4_lvol, vecgeom::LogicalVolume const *vg_lvol,
-                                                 Visitor visit)
+void VisitDaughtersMatchingVecGeomRepresentationWithMode(G4LogicalVolume const *g4_lvol,
+                                                         vecgeom::LogicalVolume const *vg_lvol, Visitor visit)
 {
   auto const &vgDaughters = vg_lvol->GetDaughters();
-  if (vgDaughters.size() == GetExpandedDaughterCount(g4_lvol)) {
-    VisitExpandedDaughters(g4_lvol, vg_lvol, visit);
+  if (vgDaughters.size() == g4_lvol->GetNoDaughters()) {
+    for (std::size_t id = 0; id < g4_lvol->GetNoDaughters(); ++id) {
+      auto const *g4Daughter = g4_lvol->GetDaughter(id);
+      (void)GetMultiplicity(g4Daughter);
+      visit(g4Daughter, vgDaughters[id], false);
+    }
     return;
   }
 
-  if (vgDaughters.size() != g4_lvol->GetNoDaughters()) {
-    throw std::runtime_error("Fatal: geometry traversal: Geant4 and VecGeom daughter counts do not match");
-  }
+  VisitExpandedDaughters(g4_lvol, vg_lvol,
+                         [&](G4VPhysicalVolume const *g4Daughter, vecgeom::VPlacedVolume const *vgDaughter) {
+                           visit(g4Daughter, vgDaughter, true);
+                         });
+}
 
-  for (std::size_t id = 0; id < g4_lvol->GetNoDaughters(); ++id) {
-    visit(g4_lvol->GetDaughter(id), vgDaughters[id]);
-  }
+template <typename Visitor>
+void VisitDaughtersMatchingVecGeomRepresentation(G4LogicalVolume const *g4_lvol, vecgeom::LogicalVolume const *vg_lvol,
+                                                 Visitor visit)
+{
+  VisitDaughtersMatchingVecGeomRepresentationWithMode(
+      g4_lvol, vg_lvol, [&](G4VPhysicalVolume const *g4Daughter, vecgeom::VPlacedVolume const *vgDaughter, bool) {
+        visit(g4Daughter, vgDaughter);
+      });
 }
 
 } // namespace
@@ -181,33 +191,25 @@ struct VisitContext {
 
 /// @brief Recursively compare the Geant4 and VecGeom geometry trees.
 void VisitGeometryForChecks(G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVolume const *vg_pvol,
-                            const VisitContext &context)
+                            bool expandedPlacement, const VisitContext &context)
 {
   const auto g4_lvol = g4_pvol->GetLogicalVolume();
   const auto vg_lvol = vg_pvol->GetLogicalVolume();
 
-  // Geant4 parameterised/replica volumes are represented with direct placements in VecGeom.
-  // To accurately compare the number of daughters, sum multiplicity on the Geant4 side.
-  const auto nd_converted = GetExpandedDaughterCount(g4_lvol);
-
-  const auto daughters = vg_lvol->GetDaughters();
-  if (nd_converted != daughters.size()) {
-    throw std::runtime_error("Fatal: CheckGeometry: Mismatch in number of daughters");
-  }
-
   // Check whether transformations are matching.
-  // As above, with parameterized/replica volumes we need to compare the transforms between
-  // the VecGeom direct placement and that for the parameterised/replicated volume given the
-  // same copy number as that of the VecGeom physical volume.
+  // Parameterized/replica daughters can be flattened into direct VecGeom placements
+  // or preserved as replica nodes, depending on the geometry import path.
   // NOTE:
   // 1. This needs a const_cast because the current Geant4 API computes the transform by
   //    mutating the physical volume.
   // 2. This does modify the physical volume, but navigation will reset things afterwards.
-  if (G4VPVParameterisation *param = g4_pvol->GetParameterisation()) {
-    param->ComputeTransformation(vg_pvol->GetCopyNo(), const_cast<G4VPhysicalVolume *>(g4_pvol));
-  } else if (auto *replica = dynamic_cast<G4PVReplica *>(const_cast<G4VPhysicalVolume *>(g4_pvol))) {
-    G4ReplicaNavigation nav;
-    nav.ComputeTransformation(vg_pvol->GetCopyNo(), replica);
+  if (expandedPlacement) {
+    if (G4VPVParameterisation *param = g4_pvol->GetParameterisation()) {
+      param->ComputeTransformation(vg_pvol->GetCopyNo(), const_cast<G4VPhysicalVolume *>(g4_pvol));
+    } else if (auto *replica = dynamic_cast<G4PVReplica *>(const_cast<G4VPhysicalVolume *>(g4_pvol))) {
+      G4ReplicaNavigation nav;
+      nav.ComputeTransformation(vg_pvol->GetCopyNo(), replica);
+    }
   }
 
   const auto g4trans            = g4_pvol->GetTranslation();
@@ -254,10 +256,11 @@ void VisitGeometryForChecks(G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVo
   }
 
   // Now do the daughters.
-  VisitExpandedDaughters(g4_lvol, vg_lvol,
-                         [&](G4VPhysicalVolume const *g4Daughter, vecgeom::VPlacedVolume const *vgDaughter) {
-                           VisitGeometryForChecks(g4Daughter, vgDaughter, context);
-                         });
+  VisitDaughtersMatchingVecGeomRepresentationWithMode(
+      g4_lvol, vg_lvol,
+      [&](G4VPhysicalVolume const *g4Daughter, vecgeom::VPlacedVolume const *vgDaughter, bool isExpandedPlacement) {
+        VisitGeometryForChecks(g4Daughter, vgDaughter, isExpandedPlacement, context);
+      });
 }
 } // namespace
 
@@ -272,7 +275,7 @@ void AdePTGeometryBridge::CheckGeometry(G4HepEmData const *hepEmData)
 
   std::cout << "Visiting geometry ...\n";
   const VisitContext context{g4tohepmcindex, nvolumes, hepEmData};
-  VisitGeometryForChecks(g4world, vecgeomWorld, context);
+  VisitGeometryForChecks(g4world, vecgeomWorld, false, context);
   std::cout << "Visiting geometry done\n";
 }
 
@@ -392,10 +395,10 @@ void AdePTGeometryBridge::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4Hep
 #endif
 
     // Now do the daughters.
-    VisitExpandedDaughters(g4_lvol, vg_lvol,
-                           [&](G4VPhysicalVolume const *g4Daughter, vecgeom::VPlacedVolume const *vgDaughter) {
-                             visitGeometry(g4Daughter, vgDaughter, currentNavState);
-                           });
+    VisitDaughtersMatchingVecGeomRepresentation(
+        g4_lvol, vg_lvol, [&](G4VPhysicalVolume const *g4Daughter, vecgeom::VPlacedVolume const *vgDaughter) {
+          visitGeometry(g4Daughter, vgDaughter, currentNavState);
+        });
 
     // Pop the navigation state before returning.
     currentNavState.Pop();

--- a/src/g4integration/geometry/AdePTGeometryBridge.cpp
+++ b/src/g4integration/geometry/AdePTGeometryBridge.cpp
@@ -50,36 +50,44 @@ std::size_t GetMultiplicity(G4VPhysicalVolume const *daughter)
 template <typename Visitor>
 void VisitDaughters(G4LogicalVolume const *g4_lvol, vecgeom::LogicalVolume const *vg_lvol, Visitor visit)
 {
-  auto const &vgDaughters = vg_lvol->GetDaughters();
+  auto const &vgDaughters    = vg_lvol->GetDaughters();
+  const auto g4DaughterCount = static_cast<std::size_t>(g4_lvol->GetNoDaughters());
 
-  if (vgDaughters.size() == g4_lvol->GetNoDaughters()) {
-    for (std::size_t id = 0; id < g4_lvol->GetNoDaughters(); ++id) {
-      auto const *g4Daughter = g4_lvol->GetDaughter(id);
-      (void)GetMultiplicity(g4Daughter);
-      visit(g4Daughter, vgDaughters[id], false);
+  std::vector<std::size_t> multiplicities;
+  multiplicities.reserve(g4DaughterCount);
+
+  std::size_t expandedDaughterCount = 0;
+  bool hasExpandedDaughter          = false;
+  for (std::size_t id = 0; id < g4DaughterCount; ++id) {
+    const auto multiplicity = GetMultiplicity(g4_lvol->GetDaughter(id));
+    multiplicities.push_back(multiplicity);
+    expandedDaughterCount += multiplicity;
+    hasExpandedDaughter |= multiplicity > 1;
+  }
+
+  if (!hasExpandedDaughter && vgDaughters.size() == g4DaughterCount) {
+    for (std::size_t id = 0; id < g4DaughterCount; ++id) {
+      visit(g4_lvol->GetDaughter(id), vgDaughters[id], false);
     }
     return;
   }
 
-  std::size_t vgId = 0;
-  for (std::size_t g4Id = 0; g4Id < g4_lvol->GetNoDaughters(); ++g4Id) {
-    auto const *g4Daughter      = g4_lvol->GetDaughter(g4Id);
-    const auto multiplicity     = GetMultiplicity(g4Daughter);
-    const auto nextVecGeomIndex = vgId + multiplicity;
-    if (nextVecGeomIndex > vgDaughters.size()) {
-      throw std::runtime_error("Fatal: geometry traversal: Geant4 daughter multiplicity exceeds VecGeom daughters in " +
-                               std::string(g4_lvol->GetName()) + " for daughter " + std::string(g4Daughter->GetName()) +
-                               " (multiplicity " + std::to_string(multiplicity) + ", VecGeom daughters " +
-                               std::to_string(vgDaughters.size()) + ")");
-    }
-
-    for (; vgId < nextVecGeomIndex; ++vgId) {
-      visit(g4Daughter, vgDaughters[vgId], true);
-    }
+  if (vgDaughters.size() != expandedDaughterCount) {
+    throw std::runtime_error("Fatal: geometry traversal: VecGeom daughters do not match Geant4 multiplicities in " +
+                             std::string(g4_lvol->GetName()) + " (Geant4 daughters " + std::to_string(g4DaughterCount) +
+                             ", expanded multiplicity " + std::to_string(expandedDaughterCount) +
+                             ", VecGeom daughters " + std::to_string(vgDaughters.size()) + ")");
   }
 
-  if (vgId != vgDaughters.size()) {
-    throw std::runtime_error("Fatal: geometry traversal: VecGeom has unmatched daughters");
+  std::size_t vgId = 0;
+  for (std::size_t g4Id = 0; g4Id < g4DaughterCount; ++g4Id) {
+    auto const *g4Daughter      = g4_lvol->GetDaughter(g4Id);
+    const auto multiplicity     = multiplicities[g4Id];
+    const auto nextVecGeomIndex = vgId + multiplicity;
+
+    for (; vgId < nextVecGeomIndex; ++vgId) {
+      visit(g4Daughter, vgDaughters[vgId], multiplicity > 1);
+    }
   }
 }
 
@@ -181,8 +189,9 @@ void VisitGeometryForChecks(G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVo
   const auto vg_lvol = vg_pvol->GetLogicalVolume();
 
   // Check whether transformations are matching.
-  // Parameterized/replica daughters can be flattened into direct VecGeom placements
-  // or preserved as replica nodes, depending on the geometry import path.
+  // Parameterized/replica daughters are flattened into direct VecGeom placements
+  // by the supported import paths. Recompute the Geant4 transform for the
+  // concrete VecGeom copy before comparing placements.
   // NOTE:
   // 1. This needs a const_cast because the current Geant4 API computes the transform by
   //    mutating the physical volume.
@@ -469,12 +478,12 @@ G4VPhysicalVolume const *AdePTGeometryBridge::GetG4PhysicalVolume(vecgeom::VPlac
   return g4Volume;
 }
 
-AdePTGeometryBridge::G4PhysicalVolumeInstance AdePTGeometryBridge::GetG4PhysicalVolumeInstance(
+AdePTGeometryBridge::MappedVolumeInstance AdePTGeometryBridge::GetMappedVolumeInstance(
     vecgeom::VPlacedVolume const *placedVolume)
 {
   auto *g4Volume    = GetG4PhysicalVolume(placedVolume);
   const auto type   = g4Volume->VolumeType();
   const auto copyNo = type == kNormal ? g4Volume->GetCopyNo() : placedVolume->GetCopyNo();
 
-  return G4PhysicalVolumeInstance{g4Volume, type, copyNo};
+  return MappedVolumeInstance{g4Volume, type, copyNo};
 }

--- a/src/g4integration/geometry/AdePTGeometryBridge.cpp
+++ b/src/g4integration/geometry/AdePTGeometryBridge.cpp
@@ -45,31 +45,36 @@ std::size_t GetMultiplicity(G4VPhysicalVolume const *daughter)
   return static_cast<std::size_t>(multiplicity);
 }
 
-// The visitor receives expandedPlacement=true when VecGeom has expanded a
-// Geant4 replica or parameterized daughter into concrete copy placements.
+bool HasCopySpecificPlacement(G4VPhysicalVolume const *daughter)
+{
+  const auto type = daughter->VolumeType();
+  return type == kReplica || type == kParameterised;
+}
+
+struct DaughterInfo {
+  G4VPhysicalVolume const *volume = nullptr;
+  std::size_t multiplicity        = 0;
+  bool copySpecificPlacement      = false;
+};
+
+// The visitor receives copySpecificPlacement=true when the Geant4 daughter is a
+// replica or parameterised volume whose concrete copy transform/copy number is
+// represented by the matched VecGeom placement.
 template <typename Visitor>
 void VisitDaughters(G4LogicalVolume const *g4_lvol, vecgeom::LogicalVolume const *vg_lvol, Visitor visit)
 {
   auto const &vgDaughters    = vg_lvol->GetDaughters();
   const auto g4DaughterCount = static_cast<std::size_t>(g4_lvol->GetNoDaughters());
 
-  std::vector<std::size_t> multiplicities;
-  multiplicities.reserve(g4DaughterCount);
+  std::vector<DaughterInfo> daughters;
+  daughters.reserve(g4DaughterCount);
 
   std::size_t expandedDaughterCount = 0;
-  bool hasExpandedDaughter          = false;
   for (std::size_t id = 0; id < g4DaughterCount; ++id) {
-    const auto multiplicity = GetMultiplicity(g4_lvol->GetDaughter(id));
-    multiplicities.push_back(multiplicity);
+    auto const *g4Daughter  = g4_lvol->GetDaughter(id);
+    const auto multiplicity = GetMultiplicity(g4Daughter);
+    daughters.push_back(DaughterInfo{g4Daughter, multiplicity, HasCopySpecificPlacement(g4Daughter)});
     expandedDaughterCount += multiplicity;
-    hasExpandedDaughter |= multiplicity > 1;
-  }
-
-  if (!hasExpandedDaughter && vgDaughters.size() == g4DaughterCount) {
-    for (std::size_t id = 0; id < g4DaughterCount; ++id) {
-      visit(g4_lvol->GetDaughter(id), vgDaughters[id], false);
-    }
-    return;
   }
 
   if (vgDaughters.size() != expandedDaughterCount) {
@@ -80,13 +85,11 @@ void VisitDaughters(G4LogicalVolume const *g4_lvol, vecgeom::LogicalVolume const
   }
 
   std::size_t vgId = 0;
-  for (std::size_t g4Id = 0; g4Id < g4DaughterCount; ++g4Id) {
-    auto const *g4Daughter      = g4_lvol->GetDaughter(g4Id);
-    const auto multiplicity     = multiplicities[g4Id];
-    const auto nextVecGeomIndex = vgId + multiplicity;
+  for (auto const &daughter : daughters) {
+    const auto nextVecGeomIndex = vgId + daughter.multiplicity;
 
     for (; vgId < nextVecGeomIndex; ++vgId) {
-      visit(g4Daughter, vgDaughters[vgId], multiplicity > 1);
+      visit(daughter.volume, vgDaughters[vgId], daughter.copySpecificPlacement);
     }
   }
 }
@@ -114,9 +117,9 @@ void AdePTGeometryBridge::MapVecGeomToG4(std::vector<G4VPhysicalVolume const *> 
     vecgeomLvToG4Map.resize(std::max<std::size_t>(vecgeomLvToG4Map.size(), vg_lvol->id() + 1), nullptr);
     vecgeomLvToG4Map[vg_lvol->id()] = g4_lvol;
 
-    // Now do the daughters. The GDML frontend can preserve replica nodes while
-    // G4VG flattens them, so accept either representation when building this
-    // fallback map from independently loaded Geant4 and VecGeom trees.
+    // Now do the daughters. Supported VecGeom import paths represent
+    // replica/parameterised daughters as concrete copy placements, so traversal
+    // validates against the expanded Geant4 multiplicity count.
     VisitDaughters(g4_lvol, vg_lvol,
                    [&](G4VPhysicalVolume const *g4Daughter, vecgeom::VPlacedVolume const *vgDaughter, bool) {
                      visitGeometry(g4Daughter, vgDaughter);
@@ -183,7 +186,7 @@ struct VisitContext {
 
 /// @brief Recursively compare the Geant4 and VecGeom geometry trees.
 void VisitGeometryForChecks(G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVolume const *vg_pvol,
-                            bool expandedPlacement, const VisitContext &context)
+                            bool copySpecificPlacement, const VisitContext &context)
 {
   const auto g4_lvol = g4_pvol->GetLogicalVolume();
   const auto vg_lvol = vg_pvol->GetLogicalVolume();
@@ -196,7 +199,7 @@ void VisitGeometryForChecks(G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVo
   // 1. This needs a const_cast because the current Geant4 API computes the transform by
   //    mutating the physical volume.
   // 2. This does modify the physical volume, but navigation will reset things afterwards.
-  if (expandedPlacement) {
+  if (copySpecificPlacement) {
     if (G4VPVParameterisation *param = g4_pvol->GetParameterisation()) {
       param->ComputeTransformation(vg_pvol->GetCopyNo(), const_cast<G4VPhysicalVolume *>(g4_pvol));
     } else if (auto *replica = dynamic_cast<G4PVReplica *>(const_cast<G4VPhysicalVolume *>(g4_pvol))) {
@@ -251,8 +254,8 @@ void VisitGeometryForChecks(G4VPhysicalVolume const *g4_pvol, vecgeom::VPlacedVo
   // Now do the daughters.
   VisitDaughters(
       g4_lvol, vg_lvol,
-      [&](G4VPhysicalVolume const *g4Daughter, vecgeom::VPlacedVolume const *vgDaughter, bool expandedPlacement) {
-        VisitGeometryForChecks(g4Daughter, vgDaughter, expandedPlacement, context);
+      [&](G4VPhysicalVolume const *g4Daughter, vecgeom::VPlacedVolume const *vgDaughter, bool copySpecificPlacement) {
+        VisitGeometryForChecks(g4Daughter, vgDaughter, copySpecificPlacement, context);
       });
 }
 } // namespace

--- a/src/g4integration/geometry/AdePTGeometryBridge.cpp
+++ b/src/g4integration/geometry/AdePTGeometryBridge.cpp
@@ -468,3 +468,13 @@ G4VPhysicalVolume const *AdePTGeometryBridge::GetG4PhysicalVolume(vecgeom::VPlac
   }
   return g4Volume;
 }
+
+AdePTGeometryBridge::G4PhysicalVolumeInstance AdePTGeometryBridge::GetG4PhysicalVolumeInstance(
+    vecgeom::VPlacedVolume const *placedVolume)
+{
+  auto *g4Volume    = GetG4PhysicalVolume(placedVolume);
+  const auto type   = g4Volume->VolumeType();
+  const auto copyNo = type == kNormal ? g4Volume->GetCopyNo() : placedVolume->GetCopyNo();
+
+  return G4PhysicalVolumeInstance{g4Volume, type, copyNo};
+}

--- a/src/g4integration/returned_steps/AdePTGeant4Integration.cpp
+++ b/src/g4integration/returned_steps/AdePTGeant4Integration.cpp
@@ -165,12 +165,12 @@ namespace {
 
 constexpr double kG4HandoffPush = 100. * vecgeom::kTolerance;
 
-G4VPhysicalVolume *MutableG4Volume(AdePTGeometryBridge::G4PhysicalVolumeInstance const &instance)
+G4VPhysicalVolume *MutableG4Volume(AdePTGeometryBridge::MappedVolumeInstance const &instance)
 {
-  return const_cast<G4VPhysicalVolume *>(instance.volume);
+  return const_cast<G4VPhysicalVolume *>(instance.g4Volume);
 }
 
-void StampG4VolumeInstance(AdePTGeometryBridge::G4PhysicalVolumeInstance const &instance)
+void StampG4VolumeInstance(AdePTGeometryBridge::MappedVolumeInstance const &instance)
 {
   switch (instance.type) {
   case kReplica: {
@@ -196,9 +196,9 @@ void StampG4VolumeInstance(AdePTGeometryBridge::G4PhysicalVolumeInstance const &
 }
 
 bool MatchesHistoryLevel(G4NavigationHistory const &history, G4int level,
-                         AdePTGeometryBridge::G4PhysicalVolumeInstance const &instance)
+                         AdePTGeometryBridge::MappedVolumeInstance const &instance)
 {
-  if (history.GetVolume(level) != instance.volume) return false;
+  if (history.GetVolume(level) != instance.g4Volume) return false;
   if (level == 0) return true;
 
   return history.GetVolumeType(level) == instance.type && history.GetReplicaNo(level) == instance.copyNo;
@@ -736,8 +736,8 @@ void AdePTGeant4Integration::FillG4NavigationHistory(const vecgeom::NavigationSt
     // can share one Geant4 physical-volume pointer, so the volume type and copy number are
     // part of the instance identity.
     assert(aNavState.At(aLevel));
-    const auto newInstance = AdePTGeometryBridge::GetG4PhysicalVolumeInstance(aNavState.At(aLevel));
-    assert(newInstance.volume != nullptr);
+    const auto newInstance = AdePTGeometryBridge::GetMappedVolumeInstance(aNavState.At(aLevel));
+    assert(newInstance.g4Volume != nullptr);
 
     if (aG4HistoryDepth && (aLevel <= aG4HistoryDepth)) {
       // If they match we do not need to update the history at this level. Still stamp

--- a/src/g4integration/returned_steps/AdePTGeant4Integration.cpp
+++ b/src/g4integration/returned_steps/AdePTGeant4Integration.cpp
@@ -14,6 +14,8 @@
 #include <G4FieldManager.hh>
 #include <G4TouchableHandle.hh>
 #include <G4StepStatus.hh>
+#include <G4ReplicaNavigation.hh>
+#include <G4VPVParameterisation.hh>
 
 #include <G4HepEmNoProcess.hh>
 #include <G4HepEmConfig.hh>
@@ -162,6 +164,45 @@ void Deleter::operator()(StepReconstructionObjects *ptr)
 namespace {
 
 constexpr double kG4HandoffPush = 100. * vecgeom::kTolerance;
+
+G4VPhysicalVolume *MutableG4Volume(AdePTGeometryBridge::G4PhysicalVolumeInstance const &instance)
+{
+  return const_cast<G4VPhysicalVolume *>(instance.volume);
+}
+
+void StampG4VolumeInstance(AdePTGeometryBridge::G4PhysicalVolumeInstance const &instance)
+{
+  switch (instance.type) {
+  case kReplica: {
+    G4ReplicaNavigation nav;
+    auto *volume = MutableG4Volume(instance);
+    nav.ComputeTransformation(instance.copyNo, volume);
+    volume->SetCopyNo(instance.copyNo);
+    break;
+  }
+  case kParameterised: {
+    auto *volume           = MutableG4Volume(instance);
+    auto *parameterisation = volume->GetParameterisation();
+    if (parameterisation == nullptr) {
+      throw std::runtime_error("Parameterized Geant4 volume has no parameterisation");
+    }
+    parameterisation->ComputeTransformation(instance.copyNo, volume);
+    volume->SetCopyNo(instance.copyNo);
+    break;
+  }
+  default:
+    break;
+  }
+}
+
+bool MatchesHistoryLevel(G4NavigationHistory const &history, G4int level,
+                         AdePTGeometryBridge::G4PhysicalVolumeInstance const &instance)
+{
+  if (history.GetVolume(level) != instance.volume) return false;
+  if (level == 0) return true;
+
+  return history.GetVolumeType(level) == instance.type && history.GetReplicaNo(level) == instance.copyNo;
+}
 
 G4ParticleDefinition *GetParticleDefinition(ParticleType particleType)
 {
@@ -688,41 +729,45 @@ void AdePTGeant4Integration::FillG4NavigationHistory(const vecgeom::NavigationSt
   auto aVecGeomLevel = aNavState.GetLevel();
 
   unsigned int aLevel{0};
-  G4VPhysicalVolume const *pvol{nullptr};
-  G4VPhysicalVolume *pnewvol{nullptr};
 
   for (aLevel = 0; aLevel <= aVecGeomLevel; aLevel++) {
     // While we are in levels shallower than the history depth, it may be that we already
-    // have the correct volume in the history
+    // have the correct volume instance in the history. Replica and parameterised placements
+    // can share one Geant4 physical-volume pointer, so the volume type and copy number are
+    // part of the instance identity.
     assert(aNavState.At(aLevel));
-    pnewvol = const_cast<G4VPhysicalVolume *>(AdePTGeometryBridge::GetG4PhysicalVolume(aNavState.At(aLevel)));
-    assert(pnewvol != nullptr);
-    if (!pnewvol) throw std::runtime_error("VecGeom volume not found in G4 mapping!");
+    const auto newInstance = AdePTGeometryBridge::GetG4PhysicalVolumeInstance(aNavState.At(aLevel));
+    assert(newInstance.volume != nullptr);
 
     if (aG4HistoryDepth && (aLevel <= aG4HistoryDepth)) {
-      pvol = aG4NavigationHistory.GetVolume(aLevel);
-      // If they match we do not need to update the history at this level
-      if (pvol == pnewvol) continue;
-      // Once we find two non-matching volumes, we need to update the touchable history from this level on
+      // If they match we do not need to update the history at this level. Still stamp
+      // mutable Geant4 replica/parameterised volumes for code that queries the PV directly.
+      if (MatchesHistoryLevel(aG4NavigationHistory, aLevel, newInstance)) {
+        if (aLevel) StampG4VolumeInstance(newInstance);
+        continue;
+      }
+      // Once we find two non-matching volume instances, we need to update the touchable history from this level on
       if (aLevel) {
         // If we are not in the top level
         aG4NavigationHistory.BackLevel(aG4HistoryDepth - aLevel + 1);
         // Update the current level
-        aG4NavigationHistory.NewLevel(pnewvol, kNormal, pnewvol->GetCopyNo());
+        StampG4VolumeInstance(newInstance);
+        aG4NavigationHistory.NewLevel(MutableG4Volume(newInstance), newInstance.type, newInstance.copyNo);
       } else {
         // Update the top level
         aG4NavigationHistory.BackLevel(aG4HistoryDepth);
-        aG4NavigationHistory.SetFirstEntry(pnewvol);
+        aG4NavigationHistory.SetFirstEntry(MutableG4Volume(newInstance));
       }
       // Now we are overwriting the history, so set the depth to the current depth
       aG4HistoryDepth = aLevel;
     } else {
       // If the navigation state is deeper than the current history we need to add the new levels
       if (aLevel) {
-        aG4NavigationHistory.NewLevel(pnewvol, kNormal, pnewvol->GetCopyNo());
+        StampG4VolumeInstance(newInstance);
+        aG4NavigationHistory.NewLevel(MutableG4Volume(newInstance), newInstance.type, newInstance.copyNo);
         aG4HistoryDepth++;
       } else {
-        aG4NavigationHistory.SetFirstEntry(pnewvol);
+        aG4NavigationHistory.SetFirstEntry(MutableG4Volume(newInstance));
       }
     }
   }

--- a/src/g4integration/tracking_managers/AdePTTrackingManager.cc
+++ b/src/g4integration/tracking_managers/AdePTTrackingManager.cc
@@ -23,6 +23,8 @@
 
 #include <algorithm>
 #include <cassert>
+#include <stdexcept>
+#include <string>
 
 #ifdef ENABLE_POWER_METER
 #include <power_meter.hh>
@@ -78,6 +80,24 @@ bool CallUserTrackingAction(const AdePTConfiguration &configuration)
 bool CallUserActions(const AdePTConfiguration &configuration)
 {
   return CallUserSteppingAction(configuration) || CallUserTrackingAction(configuration);
+}
+
+bool IsCopySpecificVolume(EVolume type)
+{
+  return type == kReplica || type == kParameterised;
+}
+
+bool MatchesG4HistoryLevel(vecgeom::VPlacedVolume const *vecgeomDaughter, G4VPhysicalVolume const *g4Volume,
+                           EVolume g4VolumeType, G4int g4CopyNo)
+{
+  const auto instance = AdePTGeometryBridge::GetMappedVolumeInstance(vecgeomDaughter);
+  if (instance.g4Volume != g4Volume) return false;
+
+  if (IsCopySpecificVolume(instance.type) || IsCopySpecificVolume(g4VolumeType)) {
+    return instance.type == g4VolumeType && instance.copyNo == g4CopyNo;
+  }
+
+  return true;
 }
 
 std::shared_ptr<AdePTTransport> GetSharedAdePTTransport(
@@ -682,22 +702,17 @@ const vecgeom::NavigationState AdePTTrackingManager::GetVecGeomFromG4State(
   auto current_volume = vecgeom::GeoManager::Instance().GetWorld();
   aNavState.Push(current_volume);
 
-  bool found_volume;
   // we pushed already the world, so we can start at level 1
   for (unsigned int level = 1; level <= aG4HistoryDepth; ++level) {
 
-    found_volume = false;
+    // Get current G4 volume and its copy identity in the Geant4 navigation history.
+    const G4VPhysicalVolume *g4Volume = aG4NavigationHistory.GetVolume(level);
+    const auto g4VolumeType           = aG4NavigationHistory.GetVolumeType(level);
+    const auto g4CopyNo               = aG4NavigationHistory.GetReplicaNo(level);
 
-    // Get current G4 volume and parent volume.
-    const G4VPhysicalVolume *g4Volume_parent = aG4NavigationHistory.GetVolume(level - 1);
-    const G4VPhysicalVolume *g4Volume        = aG4NavigationHistory.GetVolume(level);
-
-    // The index of the VecGeom volume on this level (that we need to push the NavState to)
-    // is the same as the G4 volume. The index of the G4 volume is found by matching it against
-    // the daughters of the parent volume, since the G4 volume itself has no index.
-    for (size_t id = 0; id < g4Volume_parent->GetLogicalVolume()->GetNoDaughters(); ++id) {
-      if (g4Volume == g4Volume_parent->GetLogicalVolume()->GetDaughter(id)) {
-        auto daughter = current_volume->GetLogicalVolume()->GetDaughters()[id];
+    bool found_volume = false;
+    for (auto const *daughter : current_volume->GetLogicalVolume()->GetDaughters()) {
+      if (MatchesG4HistoryLevel(daughter, g4Volume, g4VolumeType, g4CopyNo)) {
         aNavState.Push(daughter);
         current_volume = daughter;
         found_volume   = true;
@@ -707,8 +722,8 @@ const vecgeom::NavigationState AdePTTrackingManager::GetVecGeomFromG4State(
 
     if (!found_volume) {
       throw std::runtime_error("Fatal: G4 To VecGeom Geometry matching failed: G4 Volume name " +
-                               std::string(g4Volume->GetLogicalVolume()->GetName()) +
-                               " was not found in VecGeom Parent volume " +
+                               std::string(g4Volume->GetLogicalVolume()->GetName()) + " with copy number " +
+                               std::to_string(g4CopyNo) + " was not found in VecGeom Parent volume " +
                                std::string(current_volume->GetLogicalVolume()->GetName()));
     }
   }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -79,6 +79,13 @@ set(ADEPT_G4_INTEGRATION_GTESTS
   test_hostTrackDataMapper.cpp # Unit test for hostTrackDataMapper
   test_geometry_bridge.cpp     # Unit test for AdePTGeometryBridge replica traversal
 )
+if(Geant4_gdml_FOUND AND VECGEOM_GDML_SUPPORT)
+  list(APPEND ADEPT_G4_INTEGRATION_GTESTS
+    test_geometry_bridge_cms.cpp # Unit test comparing CMS GDML VGDML and G4VG placement trees
+  )
+else()
+  message(STATUS "Disabling test_geometry_bridge_cms (needs Geant4 and VecGeom GDML support)")
+endif()
 
 if(ADEPT_USE_EXT_BFIELD)
   list(APPEND ADEPT_TRANSPORT_UNIT_TESTS
@@ -95,6 +102,12 @@ build_header_only_tests(${ADEPT_HEADER_ONLY_UNIT_TESTS})
 build_linked_tests(AdePT::Transport ${ADEPT_TRANSPORT_UNIT_TESTS} ${ADEPT_TRANSPORT_UTILITIES})
 build_gtest_tests(AdePT::Transport ${ADEPT_TRANSPORT_GTESTS})
 build_gtest_tests(AdePT::G4Integration ${ADEPT_G4_INTEGRATION_GTESTS})
+if(TARGET test_geometry_bridge_cms)
+  target_compile_definitions(test_geometry_bridge_cms
+    PRIVATE
+      ADEPT_CMS2018_GDML="${PROJECT_BINARY_DIR}/cms2018_sd.gdml"
+  )
+endif()
 build_linked_tests(AdePT::G4Integration ${ADEPT_G4_INTEGRATION_UNIT_TESTS})
 
 if(ADEPT_USE_EXT_BFIELD)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -77,6 +77,7 @@ set(ADEPT_G4_INTEGRATION_UNIT_TESTS
 
 set(ADEPT_G4_INTEGRATION_GTESTS
   test_hostTrackDataMapper.cpp # Unit test for hostTrackDataMapper
+  test_geometry_bridge.cpp     # Unit test for AdePTGeometryBridge replica traversal
 )
 
 if(ADEPT_USE_EXT_BFIELD)

--- a/test/unit/test_geometry_bridge.cpp
+++ b/test/unit/test_geometry_bridge.cpp
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include <G4EventManager.hh>
+#include <G4VTrackingManager.hh>
+#include <globals.hh>
+
+#include <string>
+#include <vector>
+
+#define private public
+#include <G4HepEmTrackingManager.hh>
+#undef private
+
+#include <AdePT/g4integration/geometry/AdePTGeometryBridge.hh>
+#include <AdePT/g4integration/tracking_managers/G4HepEmTrackingManagerSpecialized.hh>
+
+#include <VecGeom/management/GeoManager.h>
+#include <VecGeom/volumes/LogicalVolume.h>
+
+#include <G4HepEmData.hh>
+#include <G4HepEmMatCutData.hh>
+#include <G4HepEmWoodcockHelper.hh>
+
+#include <G4Box.hh>
+#include <G4GeometryManager.hh>
+#include <G4LogicalVolume.hh>
+#include <G4MaterialCutsCouple.hh>
+#include <G4NistManager.hh>
+#include <G4PVPlacement.hh>
+#include <G4PVReplica.hh>
+#include <G4ProductionCuts.hh>
+#include <G4Region.hh>
+#include <G4SystemOfUnits.hh>
+#include <G4TransportationManager.hh>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+struct GeometryCleanup {
+  ~GeometryCleanup()
+  {
+    G4GeometryManager::GetInstance()->OpenGeometry();
+    vecgeom::GeoManager::Instance().Clear();
+  }
+};
+
+} // namespace
+
+TEST(AdePTGeometryBridge, InitVolAuxDataIncludesAllReplicatedWdtRoots)
+{
+  GeometryCleanup cleanup;
+  G4GeometryManager::GetInstance()->OpenGeometry();
+  vecgeom::GeoManager::Instance().Clear();
+
+  auto *material = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+  ASSERT_NE(material, nullptr);
+
+  auto *worldSolid = new G4Box("replica_world_solid", 150.0 * mm, 10.0 * mm, 10.0 * mm);
+  auto *worldLV    = new G4LogicalVolume(worldSolid, material, "replica_world_lv");
+  auto *worldPV    = new G4PVPlacement(nullptr, G4ThreeVector(), worldLV, "replica_world", nullptr, false, 0, false);
+
+  auto *sliceSolid = new G4Box("slice_solid", 50.0 * mm, 10.0 * mm, 10.0 * mm);
+  auto *sliceLV    = new G4LogicalVolume(sliceSolid, material, "slice_lv");
+  new G4PVReplica("slice", sliceLV, worldLV, kXAxis, 3, 100.0 * mm);
+
+  auto *couple = new G4MaterialCutsCouple(material, new G4ProductionCuts);
+  couple->SetIndex(0);
+  couple->SetUseFlag(true);
+  worldLV->SetMaterialCutsCouple(couple);
+  sliceLV->SetMaterialCutsCouple(couple);
+
+  G4Region worldRegion("geometry_bridge_world_region");
+  worldRegion.AddRootLogicalVolume(worldLV);
+  worldRegion.RegisterMaterialCouplePair(material, couple);
+
+  G4Region wdtRegion("geometry_bridge_wdt_region");
+  wdtRegion.AddRootLogicalVolume(sliceLV);
+  wdtRegion.RegisterMaterialCouplePair(material, couple);
+  ASSERT_EQ(wdtRegion.FindCouple(material), couple);
+
+  auto *transport = G4TransportationManager::GetTransportationManager();
+  transport->SetWorldForTracking(worldPV);
+  G4GeometryManager::GetInstance()->CloseGeometry(true);
+
+  AdePTGeometryBridge::CreateVecGeomWorld(worldPV);
+  auto const *vgWorld = vecgeom::GeoManager::Instance().GetWorld();
+  ASSERT_NE(vgWorld, nullptr);
+
+  auto const &vgDaughters = vgWorld->GetLogicalVolume()->GetDaughters();
+  ASSERT_EQ(vgDaughters.size(), 3u);
+
+  int g4ToHepEm[]                   = {0};
+  G4HepEmMCCData hepEmMatCutData[]  = {G4HepEmMCCData{}};
+  hepEmMatCutData[0].fG4MatCutIndex = 0;
+  hepEmMatCutData[0].fG4RegionIndex = wdtRegion.GetInstanceID();
+
+  G4HepEmMatCutData matCutData;
+  matCutData.fNumG4MatCuts            = 1;
+  matCutData.fNumMatCutData           = 1;
+  matCutData.fG4MCIndexToHepEmMCIndex = g4ToHepEm;
+  matCutData.fMatCutData              = hepEmMatCutData;
+
+  G4HepEmData hepEmData;
+  hepEmData.fTheMatCutData = &matCutData;
+
+  G4HepEmTrackingManagerSpecialized hepEmTM;
+  hepEmTM.fWDTHelper = new G4HepEmWoodcockHelper;
+  std::vector<std::string> wdtRegionNames{wdtRegion.GetName()};
+  ASSERT_TRUE(hepEmTM.fWDTHelper->Initialize(wdtRegionNames, &matCutData, worldPV));
+
+  std::vector<adeptint::VolAuxData> volAuxData(vecgeom::GeoManager::Instance().GetRegisteredVolumesCount());
+  std::vector<std::string> gpuRegionNames;
+  std::vector<std::string> deadRegionNames;
+  adeptint::WDTHostRaw wdtRaw;
+
+  AdePTGeometryBridge::InitVolAuxData(volAuxData.data(), &hepEmData, &hepEmTM, true, &gpuRegionNames, deadRegionNames,
+                                      wdtRaw);
+
+  const auto regionRoots = wdtRaw.regionToRootIndices.find(wdtRegion.GetInstanceID());
+  ASSERT_NE(regionRoots, wdtRaw.regionToRootIndices.end());
+
+  // The G4VG conversion flattens the three Geant4 replica copies into three
+  // VecGeom placements. The previous one-for-one recursion visited only copy 0,
+  // so this collected one WDT root instead of all three.
+  EXPECT_EQ(regionRoots->second.size(), 3u);
+  EXPECT_EQ(wdtRaw.roots.size(), 3u);
+  for (auto const &root : wdtRaw.roots) {
+    EXPECT_EQ(root.hepemIMC, 0);
+  }
+}

--- a/test/unit/test_geometry_bridge.cpp
+++ b/test/unit/test_geometry_bridge.cpp
@@ -9,6 +9,9 @@
 #include <G4VTrackingManager.hh>
 #include <globals.hh>
 
+#include <array>
+#include <memory>
+#include <set>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -25,6 +28,10 @@
 
 #define private public
 #include <AdePT/g4integration/returned_steps/AdePTGeant4Integration.hh>
+#undef private
+
+#define private public
+#include <AdePT/g4integration/AdePTTrackingManager.hh>
 #undef private
 
 #include <VecGeom/base/Transformation3D.h>
@@ -100,6 +107,27 @@ vecgeom::Transformation3D MakeVecGeomRotation(G4RotationMatrix const &rotation)
 {
   return vecgeom::Transformation3D(0.0, 0.0, 0.0, rotation(0, 0), rotation(1, 0), rotation(2, 0), rotation(0, 1),
                                    rotation(1, 1), rotation(2, 1), rotation(0, 2), rotation(1, 2), rotation(2, 2));
+}
+
+void Require(bool condition, std::string const &message)
+{
+  if (!condition) throw std::runtime_error(message);
+}
+
+struct HandoffNavStateSummary {
+  int copyNo = -1;
+  std::array<double, 3> translation{};
+};
+
+HandoffNavStateSummary SummarizeTopPlacement(vecgeom::NavigationState const &state)
+{
+  Require(state.GetLevel() == 1, "converted handoff state does not have exactly one daughter level");
+  auto const *top = state.Top();
+  Require(top != nullptr, "converted handoff state has no top placement");
+
+  auto const *transform = top->GetTransformation();
+  return HandoffNavStateSummary{top->GetCopyNo(),
+                                {{transform->Translation(0), transform->Translation(1), transform->Translation(2)}}};
 }
 
 } // namespace
@@ -187,6 +215,100 @@ TEST(AdePTGeometryBridge, InitVolAuxDataIncludesAllReplicatedWdtRoots)
   EXPECT_EQ(wdtRaw.roots.size(), 3u);
   for (auto const &root : wdtRaw.roots) {
     EXPECT_EQ(root.hepemIMC, 0);
+  }
+}
+
+// G4-to-VecGeom handoff for flattened replicas: a Geant4 history in replica
+// copy 2 must choose the same VecGeom slice as an equivalent explicit-placement
+// geometry. Matching only by Geant4 daughter index incorrectly selected copy 0.
+TEST(AdePTGeometryBridge, G4HandoffReplicaCopyMatchesEquivalentExplicitPlacement)
+{
+  constexpr int selectedCopy = 2;
+
+  auto convertReplicaCopy = [](int copyNo) {
+    GeometryCleanup cleanup;
+    G4GeometryManager::GetInstance()->OpenGeometry();
+    vecgeom::GeoManager::Instance().Clear();
+
+    auto *material = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+    Require(material != nullptr, "G4_AIR material was not available");
+
+    auto *worldSolid = new G4Box("handoff_replica_world_solid", 150.0 * mm, 10.0 * mm, 10.0 * mm);
+    auto *worldLV    = new G4LogicalVolume(worldSolid, material, "handoff_replica_world_lv");
+    auto *worldPV =
+        new G4PVPlacement(nullptr, G4ThreeVector(), worldLV, "handoff_replica_world", nullptr, false, 0, false);
+
+    auto *sliceSolid = new G4Box("handoff_replica_slice_solid", 50.0 * mm, 10.0 * mm, 10.0 * mm);
+    auto *sliceLV    = new G4LogicalVolume(sliceSolid, material, "handoff_replica_slice_lv");
+    auto *replicaPV  = new G4PVReplica("handoff_replica_slice", sliceLV, worldLV, kXAxis, 3, 100.0 * mm);
+
+    auto *transport = G4TransportationManager::GetTransportationManager();
+    transport->SetWorldForTracking(worldPV);
+    G4GeometryManager::GetInstance()->CloseGeometry(true);
+
+    AdePTGeometryBridge::CreateVecGeomWorld(worldPV);
+    auto const *vgWorld = vecgeom::GeoManager::Instance().GetWorld();
+    Require(vgWorld != nullptr, "VecGeom replica world was not created");
+    Require(vgWorld->GetLogicalVolume()->GetDaughters().size() == 3, "replica conversion did not produce 3 copies");
+
+    G4ReplicaNavigation replicaNavigation;
+    replicaNavigation.ComputeTransformation(copyNo, replicaPV);
+    replicaPV->SetCopyNo(copyNo);
+
+    G4NavigationHistory history;
+    history.SetFirstEntry(worldPV);
+    history.NewLevel(replicaPV, kReplica, copyNo);
+
+    AdePTTrackingManager trackingManager(nullptr);
+    return SummarizeTopPlacement(trackingManager.GetVecGeomFromG4State(history));
+  };
+
+  auto convertExplicitCopy = [](int copyNo) {
+    GeometryCleanup cleanup;
+    G4GeometryManager::GetInstance()->OpenGeometry();
+    vecgeom::GeoManager::Instance().Clear();
+
+    auto *material = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+    Require(material != nullptr, "G4_AIR material was not available");
+
+    auto *worldSolid = new G4Box("handoff_explicit_world_solid", 150.0 * mm, 10.0 * mm, 10.0 * mm);
+    auto *worldLV    = new G4LogicalVolume(worldSolid, material, "handoff_explicit_world_lv");
+    auto *worldPV =
+        new G4PVPlacement(nullptr, G4ThreeVector(), worldLV, "handoff_explicit_world", nullptr, false, 0, false);
+
+    auto *sliceSolid = new G4Box("handoff_explicit_slice_solid", 50.0 * mm, 10.0 * mm, 10.0 * mm);
+    auto *sliceLV    = new G4LogicalVolume(sliceSolid, material, "handoff_explicit_slice_lv");
+    std::array<G4VPhysicalVolume *, 3> slicePVs{};
+    for (int id = 0; id < 3; ++id) {
+      const G4double x = -100.0 * mm + id * 100.0 * mm;
+      slicePVs[id] = new G4PVPlacement(nullptr, G4ThreeVector(x, 0.0, 0.0), sliceLV, "handoff_explicit_slice", worldLV,
+                                       false, id, false);
+    }
+
+    auto *transport = G4TransportationManager::GetTransportationManager();
+    transport->SetWorldForTracking(worldPV);
+    G4GeometryManager::GetInstance()->CloseGeometry(true);
+
+    AdePTGeometryBridge::CreateVecGeomWorld(worldPV);
+    auto const *vgWorld = vecgeom::GeoManager::Instance().GetWorld();
+    Require(vgWorld != nullptr, "VecGeom explicit world was not created");
+    Require(vgWorld->GetLogicalVolume()->GetDaughters().size() == 3,
+            "explicit placement conversion did not produce 3 copies");
+
+    G4NavigationHistory history;
+    history.SetFirstEntry(worldPV);
+    history.NewLevel(slicePVs[copyNo], kNormal, slicePVs[copyNo]->GetCopyNo());
+
+    AdePTTrackingManager trackingManager(nullptr);
+    return SummarizeTopPlacement(trackingManager.GetVecGeomFromG4State(history));
+  };
+
+  const auto replicaSummary  = convertReplicaCopy(selectedCopy);
+  const auto explicitSummary = convertExplicitCopy(selectedCopy);
+
+  EXPECT_EQ(replicaSummary.copyNo, explicitSummary.copyNo);
+  for (std::size_t i = 0; i < replicaSummary.translation.size(); ++i) {
+    EXPECT_NEAR(replicaSummary.translation[i], explicitSummary.translation[i], 1.e-9);
   }
 }
 

--- a/test/unit/test_geometry_bridge.cpp
+++ b/test/unit/test_geometry_bridge.cpp
@@ -10,6 +10,7 @@
 #include <globals.hh>
 
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -219,10 +220,10 @@ TEST(AdePTGeometryBridge, ReconstructedTouchableKeepsReplicaCopyNumber)
   EXPECT_NE(copy0, touchableCopy2.GetCopyNumber(0));
 }
 
-// Preserved replica traversal: VGDML can keep one VecGeom daughter for one
-// Geant4 replica node with multiplicity greater than one. CheckGeometry and
-// InitVolAuxData must accept this non-flattened representation as matching.
-TEST(AdePTGeometryBridge, PreservedReplicaRepresentationPassesCheckAndAuxInit)
+// Non-equivalent unexpanded replica guard: a single ordinary VecGeom
+// placement for a multi-copy G4PVReplica is not a valid preserved replica
+// representation. Traversal must reject it instead of visiting copy 0 only.
+TEST(AdePTGeometryBridge, RejectsUnexpandedReplicaWithoutVecGeomCopies)
 {
   GeometryCleanup cleanup;
   G4GeometryManager::GetInstance()->OpenGeometry();
@@ -231,14 +232,14 @@ TEST(AdePTGeometryBridge, PreservedReplicaRepresentationPassesCheckAndAuxInit)
   auto *material = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
   ASSERT_NE(material, nullptr);
 
-  auto *worldSolid = new G4Box("preserved_replica_world_solid", 150.0 * mm, 10.0 * mm, 10.0 * mm);
-  auto *worldLV    = new G4LogicalVolume(worldSolid, material, "preserved_replica_world_lv");
+  auto *worldSolid = new G4Box("unexpanded_replica_world_solid", 150.0 * mm, 10.0 * mm, 10.0 * mm);
+  auto *worldLV    = new G4LogicalVolume(worldSolid, material, "unexpanded_replica_world_lv");
   auto *worldPV =
-      new G4PVPlacement(nullptr, G4ThreeVector(), worldLV, "preserved_replica_world", nullptr, false, 0, false);
+      new G4PVPlacement(nullptr, G4ThreeVector(), worldLV, "unexpanded_replica_world", nullptr, false, 0, false);
 
-  auto *sliceSolid = new G4Box("preserved_slice_solid", 50.0 * mm, 10.0 * mm, 10.0 * mm);
-  auto *sliceLV    = new G4LogicalVolume(sliceSolid, material, "preserved_slice_lv");
-  new G4PVReplica("preserved_slice", sliceLV, worldLV, kXAxis, 3, 100.0 * mm);
+  auto *sliceSolid = new G4Box("unexpanded_slice_solid", 50.0 * mm, 10.0 * mm, 10.0 * mm);
+  auto *sliceLV    = new G4LogicalVolume(sliceSolid, material, "unexpanded_slice_lv");
+  new G4PVReplica("unexpanded_slice", sliceLV, worldLV, kXAxis, 3, 100.0 * mm);
 
   auto *couple = new G4MaterialCutsCouple(material, new G4ProductionCuts);
   couple->SetIndex(0);
@@ -246,11 +247,11 @@ TEST(AdePTGeometryBridge, PreservedReplicaRepresentationPassesCheckAndAuxInit)
   worldLV->SetMaterialCutsCouple(couple);
   sliceLV->SetMaterialCutsCouple(couple);
 
-  G4Region worldRegion("geometry_bridge_preserved_world_region");
+  G4Region worldRegion("geometry_bridge_unexpanded_world_region");
   worldRegion.AddRootLogicalVolume(worldLV);
   worldRegion.RegisterMaterialCouplePair(material, couple);
 
-  G4Region wdtRegion("geometry_bridge_preserved_wdt_region");
+  G4Region wdtRegion("geometry_bridge_unexpanded_wdt_region");
   wdtRegion.AddRootLogicalVolume(sliceLV);
   wdtRegion.RegisterMaterialCouplePair(material, couple);
   ASSERT_EQ(wdtRegion.FindCouple(material), couple);
@@ -260,13 +261,13 @@ TEST(AdePTGeometryBridge, PreservedReplicaRepresentationPassesCheckAndAuxInit)
   G4GeometryManager::GetInstance()->CloseGeometry(true);
 
   auto *vgWorldSolid = new vecgeom::UnplacedBox(150.0, 10.0, 10.0);
-  auto *vgWorldLV    = new vecgeom::LogicalVolume("preserved_replica_world_lv", vgWorldSolid);
+  auto *vgWorldLV    = new vecgeom::LogicalVolume("unexpanded_replica_world_lv", vgWorldSolid);
   auto *vgSliceSolid = new vecgeom::UnplacedBox(50.0, 10.0, 10.0);
-  auto *vgSliceLV    = new vecgeom::LogicalVolume("preserved_slice_lv", vgSliceSolid);
+  auto *vgSliceLV    = new vecgeom::LogicalVolume("unexpanded_slice_lv", vgSliceSolid);
 
   vecgeom::Transformation3D identity;
-  vgWorldLV->PlaceDaughter("preserved_slice", vgSliceLV, &identity);
-  auto *vgWorldPV = vgWorldLV->Place("preserved_replica_world", &identity);
+  vgWorldLV->PlaceDaughter("unexpanded_slice", vgSliceLV, &identity);
+  auto *vgWorldPV = vgWorldLV->Place("unexpanded_replica_world", &identity);
   vecgeom::GeoManager::Instance().SetWorldAndClose(vgWorldPV);
 
   auto const *vgWorld = vecgeom::GeoManager::Instance().GetWorld();
@@ -289,7 +290,7 @@ TEST(AdePTGeometryBridge, PreservedReplicaRepresentationPassesCheckAndAuxInit)
   G4HepEmData hepEmData;
   hepEmData.fTheMatCutData = &matCutData;
 
-  EXPECT_NO_THROW(AdePTGeometryBridge::CheckGeometry(&hepEmData));
+  EXPECT_THROW(AdePTGeometryBridge::CheckGeometry(&hepEmData), std::runtime_error);
 
   G4HepEmTrackingManagerSpecialized hepEmTM;
   hepEmTM.fWDTHelper = new G4HepEmWoodcockHelper;
@@ -301,16 +302,7 @@ TEST(AdePTGeometryBridge, PreservedReplicaRepresentationPassesCheckAndAuxInit)
   std::vector<std::string> deadRegionNames;
   adeptint::WDTHostRaw wdtRaw;
 
-  EXPECT_NO_THROW(AdePTGeometryBridge::InitVolAuxData(volAuxData.data(), &hepEmData, &hepEmTM, true, &gpuRegionNames,
-                                                      deadRegionNames, wdtRaw));
-
-  const auto regionRoots = wdtRaw.regionToRootIndices.find(wdtRegion.GetInstanceID());
-  ASSERT_NE(regionRoots, wdtRaw.regionToRootIndices.end());
-
-  // This mimics the preserved representation: one VecGeom daughter corresponds
-  // to the single Geant4 replica node, whose multiplicity is greater than one.
-  // CheckGeometry and InitVolAuxData must not require flattened copy placements.
-  EXPECT_EQ(regionRoots->second.size(), 1u);
-  EXPECT_EQ(wdtRaw.roots.size(), 1u);
-  EXPECT_EQ(wdtRaw.roots.front().hepemIMC, 0);
+  EXPECT_THROW(AdePTGeometryBridge::InitVolAuxData(volAuxData.data(), &hepEmData, &hepEmTM, true, &gpuRegionNames,
+                                                   deadRegionNames, wdtRaw),
+               std::runtime_error);
 }

--- a/test/unit/test_geometry_bridge.cpp
+++ b/test/unit/test_geometry_bridge.cpp
@@ -15,8 +15,10 @@
 #include <AdePT/g4integration/geometry/AdePTGeometryBridge.hh>
 #include <AdePT/g4integration/tracking_managers/G4HepEmTrackingManagerSpecialized.hh>
 
+#include <VecGeom/base/Transformation3D.h>
 #include <VecGeom/management/GeoManager.h>
 #include <VecGeom/volumes/LogicalVolume.h>
+#include <VecGeom/volumes/UnplacedBox.h>
 
 #include <G4HepEmData.hh>
 #include <G4HepEmMatCutData.hh>
@@ -129,4 +131,97 @@ TEST(AdePTGeometryBridge, InitVolAuxDataIncludesAllReplicatedWdtRoots)
   for (auto const &root : wdtRaw.roots) {
     EXPECT_EQ(root.hepemIMC, 0);
   }
+}
+
+TEST(AdePTGeometryBridge, PreservedReplicaRepresentationPassesCheckAndAuxInit)
+{
+  GeometryCleanup cleanup;
+  G4GeometryManager::GetInstance()->OpenGeometry();
+  vecgeom::GeoManager::Instance().Clear();
+
+  auto *material = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+  ASSERT_NE(material, nullptr);
+
+  auto *worldSolid = new G4Box("preserved_replica_world_solid", 150.0 * mm, 10.0 * mm, 10.0 * mm);
+  auto *worldLV    = new G4LogicalVolume(worldSolid, material, "preserved_replica_world_lv");
+  auto *worldPV =
+      new G4PVPlacement(nullptr, G4ThreeVector(), worldLV, "preserved_replica_world", nullptr, false, 0, false);
+
+  auto *sliceSolid = new G4Box("preserved_slice_solid", 50.0 * mm, 10.0 * mm, 10.0 * mm);
+  auto *sliceLV    = new G4LogicalVolume(sliceSolid, material, "preserved_slice_lv");
+  new G4PVReplica("preserved_slice", sliceLV, worldLV, kXAxis, 3, 100.0 * mm);
+
+  auto *couple = new G4MaterialCutsCouple(material, new G4ProductionCuts);
+  couple->SetIndex(0);
+  couple->SetUseFlag(true);
+  worldLV->SetMaterialCutsCouple(couple);
+  sliceLV->SetMaterialCutsCouple(couple);
+
+  G4Region worldRegion("geometry_bridge_preserved_world_region");
+  worldRegion.AddRootLogicalVolume(worldLV);
+  worldRegion.RegisterMaterialCouplePair(material, couple);
+
+  G4Region wdtRegion("geometry_bridge_preserved_wdt_region");
+  wdtRegion.AddRootLogicalVolume(sliceLV);
+  wdtRegion.RegisterMaterialCouplePair(material, couple);
+  ASSERT_EQ(wdtRegion.FindCouple(material), couple);
+
+  auto *transport = G4TransportationManager::GetTransportationManager();
+  transport->SetWorldForTracking(worldPV);
+  G4GeometryManager::GetInstance()->CloseGeometry(true);
+
+  auto *vgWorldSolid = new vecgeom::UnplacedBox(150.0, 10.0, 10.0);
+  auto *vgWorldLV    = new vecgeom::LogicalVolume("preserved_replica_world_lv", vgWorldSolid);
+  auto *vgSliceSolid = new vecgeom::UnplacedBox(50.0, 10.0, 10.0);
+  auto *vgSliceLV    = new vecgeom::LogicalVolume("preserved_slice_lv", vgSliceSolid);
+
+  vecgeom::Transformation3D identity;
+  vgWorldLV->PlaceDaughter("preserved_slice", vgSliceLV, &identity);
+  auto *vgWorldPV = vgWorldLV->Place("preserved_replica_world", &identity);
+  vecgeom::GeoManager::Instance().SetWorldAndClose(vgWorldPV);
+
+  auto const *vgWorld = vecgeom::GeoManager::Instance().GetWorld();
+  ASSERT_NE(vgWorld, nullptr);
+
+  auto const &vgDaughters = vgWorld->GetLogicalVolume()->GetDaughters();
+  ASSERT_EQ(vgDaughters.size(), 1u);
+
+  int g4ToHepEm[]                   = {0};
+  G4HepEmMCCData hepEmMatCutData[]  = {G4HepEmMCCData{}};
+  hepEmMatCutData[0].fG4MatCutIndex = 0;
+  hepEmMatCutData[0].fG4RegionIndex = wdtRegion.GetInstanceID();
+
+  G4HepEmMatCutData matCutData;
+  matCutData.fNumG4MatCuts            = 1;
+  matCutData.fNumMatCutData           = 1;
+  matCutData.fG4MCIndexToHepEmMCIndex = g4ToHepEm;
+  matCutData.fMatCutData              = hepEmMatCutData;
+
+  G4HepEmData hepEmData;
+  hepEmData.fTheMatCutData = &matCutData;
+
+  EXPECT_NO_THROW(AdePTGeometryBridge::CheckGeometry(&hepEmData));
+
+  G4HepEmTrackingManagerSpecialized hepEmTM;
+  hepEmTM.fWDTHelper = new G4HepEmWoodcockHelper;
+  std::vector<std::string> wdtRegionNames{wdtRegion.GetName()};
+  ASSERT_TRUE(hepEmTM.fWDTHelper->Initialize(wdtRegionNames, &matCutData, worldPV));
+
+  std::vector<adeptint::VolAuxData> volAuxData(vecgeom::GeoManager::Instance().GetRegisteredVolumesCount());
+  std::vector<std::string> gpuRegionNames;
+  std::vector<std::string> deadRegionNames;
+  adeptint::WDTHostRaw wdtRaw;
+
+  EXPECT_NO_THROW(AdePTGeometryBridge::InitVolAuxData(volAuxData.data(), &hepEmData, &hepEmTM, true, &gpuRegionNames,
+                                                      deadRegionNames, wdtRaw));
+
+  const auto regionRoots = wdtRaw.regionToRootIndices.find(wdtRegion.GetInstanceID());
+  ASSERT_NE(regionRoots, wdtRaw.regionToRootIndices.end());
+
+  // This mimics the preserved representation: one VecGeom daughter corresponds
+  // to the single Geant4 replica node, whose multiplicity is greater than one.
+  // CheckGeometry and InitVolAuxData must not require flattened copy placements.
+  EXPECT_EQ(regionRoots->second.size(), 1u);
+  EXPECT_EQ(wdtRaw.roots.size(), 1u);
+  EXPECT_EQ(wdtRaw.roots.front().hepemIMC, 0);
 }

--- a/test/unit/test_geometry_bridge.cpp
+++ b/test/unit/test_geometry_bridge.cpp
@@ -1,10 +1,15 @@
 // SPDX-FileCopyrightText: 2026 CERN
 // SPDX-License-Identifier: Apache-2.0
 
+#include <G4Event.hh>
 #include <G4EventManager.hh>
+#include <G4NavigationHistory.hh>
+#include <G4TouchableHistory.hh>
+#include <G4Track.hh>
 #include <G4VTrackingManager.hh>
 #include <globals.hh>
 
+#include <span>
 #include <string>
 #include <vector>
 
@@ -13,10 +18,17 @@
 #undef private
 
 #include <AdePT/g4integration/geometry/AdePTGeometryBridge.hh>
+#include <AdePT/g4integration/returned_steps/HostTrackDataMapper.hh>
 #include <AdePT/g4integration/tracking_managers/G4HepEmTrackingManagerSpecialized.hh>
+#include <AdePT/transport/steps/GPUStep.hh>
+
+#define private public
+#include <AdePT/g4integration/returned_steps/AdePTGeant4Integration.hh>
+#undef private
 
 #include <VecGeom/base/Transformation3D.h>
 #include <VecGeom/management/GeoManager.h>
+#include <VecGeom/navigation/NavigationState.h>
 #include <VecGeom/volumes/LogicalVolume.h>
 #include <VecGeom/volumes/UnplacedBox.h>
 
@@ -50,6 +62,9 @@ struct GeometryCleanup {
 
 } // namespace
 
+// Flattened replica traversal: G4VG expands one Geant4 replica daughter into
+// multiple concrete VecGeom placements. InitVolAuxData must visit each copy so
+// WDT root collection does not silently keep only replica copy 0.
 TEST(AdePTGeometryBridge, InitVolAuxDataIncludesAllReplicatedWdtRoots)
 {
   GeometryCleanup cleanup;
@@ -133,6 +148,80 @@ TEST(AdePTGeometryBridge, InitVolAuxDataIncludesAllReplicatedWdtRoots)
   }
 }
 
+// Returned-touchable reconstruction for flattened replicas: multiple VecGeom
+// placements map back to one mutable Geant4 replica physical volume. Reusing a
+// G4NavigationHistory level must compare and stamp the replica copy identity.
+TEST(AdePTGeometryBridge, ReconstructedTouchableKeepsReplicaCopyNumber)
+{
+  GeometryCleanup cleanup;
+  G4GeometryManager::GetInstance()->OpenGeometry();
+  vecgeom::GeoManager::Instance().Clear();
+
+  auto *material = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+  ASSERT_NE(material, nullptr);
+
+  auto *worldSolid = new G4Box("touchable_replica_world_solid", 150.0 * mm, 10.0 * mm, 10.0 * mm);
+  auto *worldLV    = new G4LogicalVolume(worldSolid, material, "touchable_replica_world_lv");
+  auto *worldPV =
+      new G4PVPlacement(nullptr, G4ThreeVector(), worldLV, "touchable_replica_world", nullptr, false, 0, false);
+
+  auto *sliceSolid = new G4Box("touchable_slice_solid", 50.0 * mm, 10.0 * mm, 10.0 * mm);
+  auto *sliceLV    = new G4LogicalVolume(sliceSolid, material, "touchable_slice_lv");
+  new G4PVReplica("touchable_slice", sliceLV, worldLV, kXAxis, 3, 100.0 * mm);
+
+  auto *transport = G4TransportationManager::GetTransportationManager();
+  transport->SetWorldForTracking(worldPV);
+  G4GeometryManager::GetInstance()->CloseGeometry(true);
+
+  AdePTGeometryBridge::CreateVecGeomWorld(worldPV);
+  auto const *vgWorld = vecgeom::GeoManager::Instance().GetWorld();
+  ASSERT_NE(vgWorld, nullptr);
+
+  auto const &vgDaughters = vgWorld->GetLogicalVolume()->GetDaughters();
+  ASSERT_EQ(vgDaughters.size(), 3u);
+  ASSERT_EQ(vgDaughters[0]->GetCopyNo(), 0);
+  ASSERT_EQ(vgDaughters[2]->GetCopyNo(), 2);
+  ASSERT_EQ(AdePTGeometryBridge::GetG4PhysicalVolume(vgDaughters[0]),
+            AdePTGeometryBridge::GetG4PhysicalVolume(vgDaughters[2]));
+
+  const auto makeNavState = [&](std::size_t replicaCopy) {
+    vecgeom::NavigationState state;
+    state.Push(vgWorld);
+    state.Push(vgDaughters[replicaCopy]);
+    state.SetBoundaryState(false);
+    return state;
+  };
+
+  AdePTGeant4Integration integration;
+  G4NavigationHistory history;
+
+  integration.FillG4NavigationHistory(makeNavState(0), history);
+  ASSERT_EQ(history.GetDepth(), 1u);
+  EXPECT_EQ(history.GetVolumeType(1), kReplica);
+  EXPECT_EQ(history.GetReplicaNo(1), 0);
+
+  G4TouchableHistory touchableCopy0(history);
+  auto *replicaVolume = touchableCopy0.GetVolume(0);
+  const auto copy0    = touchableCopy0.GetCopyNumber(0);
+  EXPECT_EQ(copy0, 0);
+  EXPECT_EQ(replicaVolume->GetCopyNo(), 0);
+
+  integration.FillG4NavigationHistory(makeNavState(2), history);
+  ASSERT_EQ(history.GetDepth(), 1u);
+  EXPECT_EQ(history.GetVolume(1), replicaVolume);
+  EXPECT_EQ(history.GetVolumeType(1), kReplica);
+  EXPECT_EQ(history.GetReplicaNo(1), 2);
+
+  G4TouchableHistory touchableCopy2(history);
+  EXPECT_EQ(touchableCopy2.GetVolume(0), replicaVolume);
+  EXPECT_EQ(touchableCopy2.GetCopyNumber(0), 2);
+  EXPECT_EQ(replicaVolume->GetCopyNo(), 2);
+  EXPECT_NE(copy0, touchableCopy2.GetCopyNumber(0));
+}
+
+// Preserved replica traversal: VGDML can keep one VecGeom daughter for one
+// Geant4 replica node with multiplicity greater than one. CheckGeometry and
+// InitVolAuxData must accept this non-flattened representation as matching.
 TEST(AdePTGeometryBridge, PreservedReplicaRepresentationPassesCheckAndAuxInit)
 {
   GeometryCleanup cleanup;

--- a/test/unit/test_geometry_bridge.cpp
+++ b/test/unit/test_geometry_bridge.cpp
@@ -42,10 +42,13 @@
 #include <G4LogicalVolume.hh>
 #include <G4MaterialCutsCouple.hh>
 #include <G4NistManager.hh>
+#include <G4PVParameterised.hh>
 #include <G4PVPlacement.hh>
 #include <G4PVReplica.hh>
+#include <G4VPVParameterisation.hh>
 #include <G4ProductionCuts.hh>
 #include <G4Region.hh>
+#include <G4ReplicaNavigation.hh>
 #include <G4SystemOfUnits.hh>
 #include <G4TransportationManager.hh>
 
@@ -60,6 +63,44 @@ struct GeometryCleanup {
     vecgeom::GeoManager::Instance().Clear();
   }
 };
+
+class SingleCopyOffsetParameterisation : public G4VPVParameterisation {
+public:
+  explicit SingleCopyOffsetParameterisation(G4ThreeVector translation) : fTranslation(translation) {}
+
+  void ComputeTransformation(const G4int copyNo, G4VPhysicalVolume *physicalVolume) const override
+  {
+    physicalVolume->SetTranslation(fTranslation);
+    physicalVolume->SetRotation(nullptr);
+    physicalVolume->SetCopyNo(copyNo);
+  }
+
+private:
+  G4ThreeVector fTranslation;
+};
+
+struct SingleMatCutHepEmData {
+  int g4ToHepEm[1]                  = {0};
+  G4HepEmMCCData hepEmMatCutData[1] = {G4HepEmMCCData{}};
+  G4HepEmMatCutData matCutData{};
+  G4HepEmData hepEmData{};
+
+  SingleMatCutHepEmData()
+  {
+    hepEmMatCutData[0].fG4MatCutIndex   = 0;
+    matCutData.fNumG4MatCuts            = 1;
+    matCutData.fNumMatCutData           = 1;
+    matCutData.fG4MCIndexToHepEmMCIndex = g4ToHepEm;
+    matCutData.fMatCutData              = hepEmMatCutData;
+    hepEmData.fTheMatCutData            = &matCutData;
+  }
+};
+
+vecgeom::Transformation3D MakeVecGeomRotation(G4RotationMatrix const &rotation)
+{
+  return vecgeom::Transformation3D(0.0, 0.0, 0.0, rotation(0, 0), rotation(1, 0), rotation(2, 0), rotation(0, 1),
+                                   rotation(1, 1), rotation(2, 1), rotation(0, 2), rotation(1, 2), rotation(2, 2));
+}
 
 } // namespace
 
@@ -147,6 +188,123 @@ TEST(AdePTGeometryBridge, InitVolAuxDataIncludesAllReplicatedWdtRoots)
   for (auto const &root : wdtRaw.roots) {
     EXPECT_EQ(root.hepemIMC, 0);
   }
+}
+
+// Single-copy parameterised traversal: GetMultiplicity() is one, but the
+// copy-0 transform still comes from the Geant4 parameterisation. CheckGeometry
+// must compute that transform instead of comparing the mutable prototype state.
+TEST(AdePTGeometryBridge, CheckGeometryUsesCopyTransformForSingleCopyParameterisation)
+{
+  GeometryCleanup cleanup;
+  G4GeometryManager::GetInstance()->OpenGeometry();
+  vecgeom::GeoManager::Instance().Clear();
+
+  auto *material = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+  ASSERT_NE(material, nullptr);
+
+  auto *worldSolid = new G4Box("single_param_world_solid", 100.0 * mm, 20.0 * mm, 20.0 * mm);
+  auto *worldLV    = new G4LogicalVolume(worldSolid, material, "single_param_world_lv");
+  auto *worldPV = new G4PVPlacement(nullptr, G4ThreeVector(), worldLV, "single_param_world", nullptr, false, 0, false);
+
+  auto *sliceSolid = new G4Box("single_param_slice_solid", 5.0 * mm, 5.0 * mm, 5.0 * mm);
+  auto *sliceLV    = new G4LogicalVolume(sliceSolid, material, "single_param_slice_lv");
+  const G4ThreeVector copyTranslation(35.0 * mm, 0.0, 0.0);
+  auto *parameterisation = new SingleCopyOffsetParameterisation(copyTranslation);
+  auto *parameterisedPV =
+      new G4PVParameterised("single_param_slice", sliceLV, worldLV, kXAxis, 1, parameterisation, false);
+
+  auto *couple = new G4MaterialCutsCouple(material, new G4ProductionCuts);
+  couple->SetIndex(0);
+  couple->SetUseFlag(true);
+  worldLV->SetMaterialCutsCouple(couple);
+  sliceLV->SetMaterialCutsCouple(couple);
+
+  auto *transport = G4TransportationManager::GetTransportationManager();
+  transport->SetWorldForTracking(worldPV);
+
+  auto *vgWorldSolid = new vecgeom::UnplacedBox(100.0, 20.0, 20.0);
+  auto *vgWorldLV    = new vecgeom::LogicalVolume("single_param_world_lv", vgWorldSolid);
+  auto *vgSliceSolid = new vecgeom::UnplacedBox(5.0, 5.0, 5.0);
+  auto *vgSliceLV    = new vecgeom::LogicalVolume("single_param_slice_lv", vgSliceSolid);
+
+  vecgeom::Transformation3D childTransform(35.0, 0.0, 0.0);
+  auto const *vgSlicePV = vgWorldLV->PlaceDaughter("single_param_slice", vgSliceLV, &childTransform);
+  const_cast<vecgeom::VPlacedVolume *>(vgSlicePV)->SetCopyNo(0);
+  vecgeom::Transformation3D identity;
+  auto *vgWorldPV = vgWorldLV->Place("single_param_world", &identity);
+  vecgeom::GeoManager::Instance().SetWorldAndClose(vgWorldPV);
+
+  auto const *vgWorld = vecgeom::GeoManager::Instance().GetWorld();
+  ASSERT_NE(vgWorld, nullptr);
+  ASSERT_EQ(vgWorld->GetLogicalVolume()->GetDaughters().size(), 1u);
+  EXPECT_EQ(parameterisedPV->VolumeType(), kParameterised);
+  EXPECT_EQ(parameterisedPV->GetMultiplicity(), 1);
+  EXPECT_NE(parameterisedPV->GetTranslation(), copyTranslation);
+
+  SingleMatCutHepEmData hepEm;
+  EXPECT_NO_THROW(AdePTGeometryBridge::CheckGeometry(&hepEm.hepEmData));
+  EXPECT_EQ(parameterisedPV->GetCopyNo(), 0);
+  EXPECT_EQ(parameterisedPV->GetTranslation(), copyTranslation);
+}
+
+// Single-copy replica traversal: a kPhi replica can have one copy and still
+// require G4ReplicaNavigation to stamp a non-identity copy-0 rotation. The
+// traversal flag must follow the Geant4 volume type, not only multiplicity > 1.
+TEST(AdePTGeometryBridge, CheckGeometryUsesCopyTransformForSingleCopyReplica)
+{
+  GeometryCleanup cleanup;
+  G4GeometryManager::GetInstance()->OpenGeometry();
+  vecgeom::GeoManager::Instance().Clear();
+
+  auto *material = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+  ASSERT_NE(material, nullptr);
+
+  auto *worldSolid = new G4Box("single_replica_world_solid", 100.0 * mm, 20.0 * mm, 20.0 * mm);
+  auto *worldLV    = new G4LogicalVolume(worldSolid, material, "single_replica_world_lv");
+  auto *worldPV =
+      new G4PVPlacement(nullptr, G4ThreeVector(), worldLV, "single_replica_world", nullptr, false, 0, false);
+
+  auto *sliceSolid = new G4Box("single_replica_slice_solid", 5.0 * mm, 5.0 * mm, 5.0 * mm);
+  auto *sliceLV    = new G4LogicalVolume(sliceSolid, material, "single_replica_slice_lv");
+  auto *replicaPV  = new G4PVReplica("single_replica_slice", sliceLV, worldLV, kPhi, 1, 0.5, 0.25);
+
+  auto *couple = new G4MaterialCutsCouple(material, new G4ProductionCuts);
+  couple->SetIndex(0);
+  couple->SetUseFlag(true);
+  worldLV->SetMaterialCutsCouple(couple);
+  sliceLV->SetMaterialCutsCouple(couple);
+
+  auto *transport = G4TransportationManager::GetTransportationManager();
+  transport->SetWorldForTracking(worldPV);
+
+  G4ReplicaNavigation replicaNavigation;
+  replicaNavigation.ComputeTransformation(0, replicaPV);
+  ASSERT_NE(replicaPV->GetRotation(), nullptr);
+  const G4RotationMatrix copyRotation = *replicaPV->GetRotation();
+  *replicaPV->GetRotation()           = G4RotationMatrix{};
+  ASSERT_GT(std::abs(copyRotation(0, 1) - (*replicaPV->GetRotation())(0, 1)), 1.e-12);
+
+  auto *vgWorldSolid = new vecgeom::UnplacedBox(100.0, 20.0, 20.0);
+  auto *vgWorldLV    = new vecgeom::LogicalVolume("single_replica_world_lv", vgWorldSolid);
+  auto *vgSliceSolid = new vecgeom::UnplacedBox(5.0, 5.0, 5.0);
+  auto *vgSliceLV    = new vecgeom::LogicalVolume("single_replica_slice_lv", vgSliceSolid);
+
+  auto childTransform   = MakeVecGeomRotation(copyRotation);
+  auto const *vgSlicePV = vgWorldLV->PlaceDaughter("single_replica_slice", vgSliceLV, &childTransform);
+  const_cast<vecgeom::VPlacedVolume *>(vgSlicePV)->SetCopyNo(0);
+  vecgeom::Transformation3D identity;
+  auto *vgWorldPV = vgWorldLV->Place("single_replica_world", &identity);
+  vecgeom::GeoManager::Instance().SetWorldAndClose(vgWorldPV);
+
+  auto const *vgWorld = vecgeom::GeoManager::Instance().GetWorld();
+  ASSERT_NE(vgWorld, nullptr);
+  ASSERT_EQ(vgWorld->GetLogicalVolume()->GetDaughters().size(), 1u);
+  EXPECT_EQ(replicaPV->VolumeType(), kReplica);
+  EXPECT_EQ(replicaPV->GetMultiplicity(), 1);
+
+  SingleMatCutHepEmData hepEm;
+  EXPECT_NO_THROW(AdePTGeometryBridge::CheckGeometry(&hepEm.hepEmData));
+  EXPECT_NEAR((*replicaPV->GetRotation())(0, 1), copyRotation(0, 1), 1.e-12);
 }
 
 // Returned-touchable reconstruction for flattened replicas: multiple VecGeom

--- a/test/unit/test_geometry_bridge_cms.cpp
+++ b/test/unit/test_geometry_bridge_cms.cpp
@@ -73,6 +73,9 @@ VecGeomTreeStats CollectVecGeomTreeStats()
 
 } // namespace
 
+// CMS GDML import parity: the G4VG and VGDML paths can use different
+// internal logical-volume registration, but they must produce the same placed
+// volume tree shape so traversal sees the same geometry hierarchy.
 TEST(AdePTGeometryBridge, CMS2018G4VGAndVGDMLHaveSamePlacementTree)
 {
   GeometryCleanup cleanup;

--- a/test/unit/test_geometry_bridge_cms.cpp
+++ b/test/unit/test_geometry_bridge_cms.cpp
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2026 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include <AdePT/g4integration/geometry/AdePTGeometryBridge.hh>
+
+#include <VecGeom/management/GeoManager.h>
+#include <VecGeom/volumes/PlacedVolume.h>
+
+#include <G4GDMLParser.hh>
+#include <G4GeometryManager.hh>
+#include <G4TransportationManager.hh>
+
+#include <algorithm>
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#ifndef ADEPT_CMS2018_GDML
+#define ADEPT_CMS2018_GDML "cms2018_sd.gdml"
+#endif
+
+namespace {
+
+struct GeometryCleanup {
+  ~GeometryCleanup()
+  {
+    G4GeometryManager::GetInstance()->OpenGeometry();
+    vecgeom::GeoManager::Instance().Clear();
+  }
+};
+
+struct VecGeomTreeStats {
+  std::size_t placements                = 0;
+  std::size_t edges                     = 0;
+  std::size_t leaves                    = 0;
+  std::size_t maxDepth                  = 0;
+  std::vector<std::size_t> daughterTree = {};
+};
+
+void AccumulateVecGeomTreeStats(vecgeom::VPlacedVolume const *placed, std::size_t depth, VecGeomTreeStats &stats)
+{
+  if (placed == nullptr) {
+    throw std::runtime_error("Cannot collect VecGeom tree stats from a null placed volume");
+  }
+
+  ++stats.placements;
+  stats.maxDepth = std::max(stats.maxDepth, depth);
+
+  auto const &daughters = placed->GetLogicalVolume()->GetDaughters();
+  stats.edges += daughters.size();
+  stats.daughterTree.push_back(daughters.size());
+  if (daughters.size() == 0) ++stats.leaves;
+
+  for (auto const *daughter : daughters) {
+    AccumulateVecGeomTreeStats(daughter, depth + 1, stats);
+  }
+}
+
+VecGeomTreeStats CollectVecGeomTreeStats()
+{
+  auto const *world = vecgeom::GeoManager::Instance().GetWorld();
+  if (world == nullptr) {
+    throw std::runtime_error("Cannot collect VecGeom tree stats before the world is initialized");
+  }
+
+  VecGeomTreeStats stats;
+  AccumulateVecGeomTreeStats(world, 0, stats);
+  return stats;
+}
+
+} // namespace
+
+TEST(AdePTGeometryBridge, CMS2018G4VGAndVGDMLHaveSamePlacementTree)
+{
+  GeometryCleanup cleanup;
+  G4GeometryManager::GetInstance()->OpenGeometry();
+  vecgeom::GeoManager::Instance().Clear();
+
+  G4GDMLParser parser;
+  parser.Read(ADEPT_CMS2018_GDML, false);
+  auto *world = parser.GetWorldVolume();
+  ASSERT_NE(world, nullptr);
+
+  auto *transport = G4TransportationManager::GetTransportationManager();
+  transport->SetWorldForTracking(world);
+  G4GeometryManager::GetInstance()->CloseGeometry(true);
+
+  AdePTGeometryBridge::CreateVecGeomWorld(world);
+  const auto g4vgStats = CollectVecGeomTreeStats();
+
+  vecgeom::GeoManager::Instance().Clear();
+
+#ifdef VECGEOM_GDML_SUPPORT
+  AdePTGeometryBridge::CreateVecGeomWorld(ADEPT_CMS2018_GDML);
+#else
+  GTEST_SKIP() << "VecGeom was built without GDML support";
+#endif
+  const auto vgdmlStats = CollectVecGeomTreeStats();
+
+  EXPECT_EQ(vgdmlStats.placements, g4vgStats.placements);
+  EXPECT_EQ(vgdmlStats.edges, g4vgStats.edges);
+  EXPECT_EQ(vgdmlStats.leaves, g4vgStats.leaves);
+  EXPECT_EQ(vgdmlStats.maxDepth, g4vgStats.maxDepth);
+  EXPECT_EQ(vgdmlStats.daughterTree, g4vgStats.daughterTree);
+}


### PR DESCRIPTION
In case of the gdml path (not via G4VG), replicated volumes were not visited correctly in AdePT.
This bug is fixed and a unit test is added.

Later, it was found that the inverse was also not set correctly, so that the VecGeom volumes were not pointing to the correct copy number of the replica.

More unit tests were added to also cover this case.
Most of the lines added in this PR are unit tests.

This was not causing issues so far, as none of the consumers use replica volumes and read from gdml.