### PR TITLE
guard tracking action and usage of HostTrackData in ATLAS MC truth

### DIFF
--- a/src/g4integration/tracking_managers/AdePTTrackingManager.cc
+++ b/src/g4integration/tracking_managers/AdePTTrackingManager.cc
@@ -556,7 +556,8 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
       // primaries by AthenaStackingAction, and secondaries during the SteppingAction of their parents,
       // in the step where the secondary was created. Thus, whether the hostTrackData is needed (to store the
       // G4VUserTrackInfo) is determined by whether the UserTrackInfo is already attached.
-      useHostData = useHostData || (aTrack->GetUserInformation() != nullptr);
+      // Tracks reconstructed without HostTrackData can carry the dummy G4 track id 0.
+      useHostData = useHostData || (aTrack->GetTrackID() > 0 && aTrack->GetUserInformation() != nullptr);
 #endif
       bool entryExists = trackMapper.getGPUId(aTrack->GetTrackID(), gpuTrackID);
       HostTrackData &hostTrackData =

--- a/test/regression/IntegrationTest/src/TrackingAction.cc
+++ b/test/regression/IntegrationTest/src/TrackingAction.cc
@@ -25,6 +25,10 @@ TrackingAction::TrackingAction() : G4UserTrackingAction() {}
 
 void TrackingAction::PreUserTrackingAction(const G4Track *track)
 {
+  // G4HepEm currently calls the PreUserTrackingAction for tracks resumed from the GPU,
+  // this guard prevents the call for non-initializing steps
+  if (track->GetCurrentStepNumber() > 0) return;
+
   auto *run               = CurrentRun();
   auto *truthHistogrammer = run != nullptr ? run->GetTruthHistogrammer() : nullptr;
   auto *mutableTrack      = const_cast<G4Track *>(track);


### PR DESCRIPTION
This PR fixes a bug introduced in #668:

1. A GPU track returned to CPU without HostTrackData (correct).
2. It was reconstructed with dummy G4 ids, as it had no HostTrackData (correct): trackID = 0, parentID = 0.
3. G4HepEm called PreUserTrackingAction on that resumed track (this should only be called on tracks with stepNumber == 0). There, the `TrackingAction` in the integrationTest saw `parentID == 0` and attached `TrackLineageInfo`, mistaking it for a primary.
4. When the track re-entered GPU, ATLAS logic saw UserInformation != nullptr and promoted it to useHostData (although it never had any).
Later a returned step had fHasHostData = true but fTrackID = 0, so host reconstruction tried to use mapper data that should never exist.

This is guarded by two things now: the `PreUserTrackingAction` in the `integrationTest` and also that the hostTrackData is not assumed to exist if the trackId is 0.

Note: This bug only occurs because the ATLAS SteppingAction and MC truth return policy is used not within ATLAS, but within our own example, which we do to avoid a rebuild when testing the ATLAS Russian Roulette. Therefore, it is a corner case that should generally not be exposed, but it shows problematic behavior. 