### PR TITLE
use correct minimum length for displacement

### DIFF
--- a/include/AdePT/transport/kernels/electrons.cuh
+++ b/include/AdePT/transport/kernels/electrons.cuh
@@ -378,7 +378,7 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
       const double *mscDisplacement = mscData->GetDisplacement();
       vecgeom::Vector3D<double> displacement(mscDisplacement[0], mscDisplacement[1], mscDisplacement[2]);
       const double dLength2            = displacement.Length2();
-      constexpr double kGeomMinLength  = 5 * copcore::units::nm;          // 0.05 [nm]
+      constexpr double kGeomMinLength  = 0.05 * copcore::units::nm;       // 0.05 [nm]
       constexpr double kGeomMinLength2 = kGeomMinLength * kGeomMinLength; // (0.05 [nm])^2
       if (dLength2 > kGeomMinLength2) {
         const double dispR = std::sqrt(dLength2);

--- a/include/AdePT/transport/kernels/electrons_split.cuh
+++ b/include/AdePT/transport/kernels/electrons_split.cuh
@@ -412,7 +412,7 @@ __global__ void ElectronMSC(ChargedTrack *electrons, G4HepEmElectronTrack *hepEM
       const double *mscDisplacement = mscData->GetDisplacement();
       vecgeom::Vector3D<double> displacement(mscDisplacement[0], mscDisplacement[1], mscDisplacement[2]);
       const double dLength2            = displacement.Length2();
-      constexpr double kGeomMinLength  = 5 * copcore::units::nm;          // 0.05 [nm]
+      constexpr double kGeomMinLength  = 0.05 * copcore::units::nm;       // 0.05 [nm]
       constexpr double kGeomMinLength2 = kGeomMinLength * kGeomMinLength; // (0.05 [nm])^2
       if (dLength2 > kGeomMinLength2) {
         const double dispR = std::sqrt(dLength2);


### PR DESCRIPTION
Despite the comment saying 0.05nm and the [original implementation](https://github.com/mnovak42/g4hepem/blob/master/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc#L560) using 0.05nm, AdePT used 5nm for the minimal displacement distance under which no displacement was applied.

That is fixed in this PR.

Drift test is expected to fail, as physics output changes with this PR.