### PR TITLE
clear SlotCounter and FreeCounter only in block 0

### DIFF
--- a/include/AdePT/transport/containers/SlotManager.cuh
+++ b/include/AdePT/transport/containers/SlotManager.cuh
@@ -89,7 +89,7 @@ __host__ __device__ void SlotManager::Clear()
   for (unsigned int i = threadIdx.x + blockIdx.x * blockDim.x; i < fSlotListSize; i += blockDim.x * gridDim.x) {
     fSlotList[i] = i;
   }
-  if (threadIdx.x == 0) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
     fSlotCounter = 0;
     fFreeCounter = 0;
   }


### PR DESCRIPTION
Technically speaking, there is a data race in the `SlotManager::Clear()` call, as in every block, the threadidx 0 clears the SlotCounter and the FreeCounter. The function is called with 80 blocks [here](https://github.com/apt-sim/AdePT/blob/master/include/AdePT/transport/AdePTTransport.cuh#L847).

Therefore, this PR fixes it, and only the first thread in the first block clears the counters.