### PR TITLE
allow returnOfTrack UI commands to be callable from G4_Idle

### DIFF
--- a/include/AdePT/g4integration/AdePTConfiguration.hh
+++ b/include/AdePT/g4integration/AdePTConfiguration.hh
@@ -23,8 +23,22 @@ public:
   void SetCallUserActions(bool callUserActions) { fCallUserActions = callUserActions; }
   void SetCallUserSteppingAction(bool callUserSteppingAction) { fCallUserSteppingAction = callUserSteppingAction; }
   void SetCallUserTrackingAction(bool callUserTrackingAction) { fCallUserTrackingAction = callUserTrackingAction; }
-  void SetReturnAllSteps(bool returnAllSteps) { fReturnAllSteps = returnAllSteps; }
-  void SetReturnFirstAndLastStep(bool returnFirstAndLastStep) { fReturnFirstAndLastStep = returnFirstAndLastStep; }
+  bool SetReturnAllSteps(bool returnAllSteps)
+  {
+    if (fReturnStepOptionsLocked) return fReturnAllSteps == returnAllSteps;
+    fReturnAllSteps = returnAllSteps;
+    return true;
+  }
+  bool SetReturnFirstAndLastStep(bool returnFirstAndLastStep)
+  {
+    if (fReturnStepOptionsLocked) {
+      return fReturnFirstAndLastStep == returnFirstAndLastStep;
+    }
+    fReturnFirstAndLastStep = returnFirstAndLastStep;
+    return true;
+  }
+  void LockReturnStepOptions() { fReturnStepOptionsLocked = true; }
+  bool ReturnStepOptionsAreLocked() const { return fReturnStepOptionsLocked; }
   void AddGPURegionName(std::string name) { fGPURegionNames.push_back(name); }
   void RemoveGPURegionName(std::string name) { fCPURegionNames.push_back(name); }
   void AddWDTRegionName(std::string name) { fWDTRegionNames.push_back(name); }
@@ -103,6 +117,7 @@ private:
   bool fCallUserTrackingAction{false};
   bool fReturnAllSteps{false};
   bool fReturnFirstAndLastStep{false};
+  bool fReturnStepOptionsLocked{false};
   bool fSpeedOfLight{false};
   bool fSetMultipleStepsInMSCWithTransportation{false};
   bool fSetEnergyLossFluctuation{false};

--- a/include/AdePT/g4integration/AdePTConfiguration.hh
+++ b/include/AdePT/g4integration/AdePTConfiguration.hh
@@ -25,20 +25,20 @@ public:
   void SetCallUserTrackingAction(bool callUserTrackingAction) { fCallUserTrackingAction = callUserTrackingAction; }
   bool SetReturnAllSteps(bool returnAllSteps)
   {
-    if (fReturnStepOptionsLocked) return fReturnAllSteps == returnAllSteps;
+    if (sReturnStepOptionsLocked) return fReturnAllSteps == returnAllSteps;
     fReturnAllSteps = returnAllSteps;
     return true;
   }
   bool SetReturnFirstAndLastStep(bool returnFirstAndLastStep)
   {
-    if (fReturnStepOptionsLocked) {
+    if (sReturnStepOptionsLocked) {
       return fReturnFirstAndLastStep == returnFirstAndLastStep;
     }
     fReturnFirstAndLastStep = returnFirstAndLastStep;
     return true;
   }
-  void LockReturnStepOptions() { fReturnStepOptionsLocked = true; }
-  bool ReturnStepOptionsAreLocked() const { return fReturnStepOptionsLocked; }
+  void LockReturnStepOptions() { sReturnStepOptionsLocked = true; }
+  bool ReturnStepOptionsAreLocked() const { return sReturnStepOptionsLocked; }
   void AddGPURegionName(std::string name) { fGPURegionNames.push_back(name); }
   void RemoveGPURegionName(std::string name) { fCPURegionNames.push_back(name); }
   void AddWDTRegionName(std::string name) { fWDTRegionNames.push_back(name); }
@@ -117,7 +117,10 @@ private:
   bool fCallUserTrackingAction{false};
   bool fReturnAllSteps{false};
   bool fReturnFirstAndLastStep{false};
-  bool fReturnStepOptionsLocked{false};
+  // AdePTTransport is shared by all Geant4 workers, so the point at which its
+  // return-step options are captured is shared as well. Geant4 applies UI
+  // commands outside worker initialization/event processing.
+  inline static bool sReturnStepOptionsLocked{false};
   bool fSpeedOfLight{false};
   bool fSetMultipleStepsInMSCWithTransportation{false};
   bool fSetEnergyLossFluctuation{false};

--- a/src/g4integration/config/AdePTConfigurationMessenger.cc
+++ b/src/g4integration/config/AdePTConfigurationMessenger.cc
@@ -14,6 +14,18 @@
 #include "G4UIcmdWithABool.hh"
 #include "G4UIcmdWithADouble.hh"
 #include "G4Tokenizer.hh"
+#include "G4Exception.hh"
+
+namespace {
+void ReportLockedReturnStepOption(const G4String &commandPath)
+{
+  G4ExceptionDescription description;
+  description << commandPath
+              << " cannot be changed after AdePT transport initialization because the GPU worker has already "
+                 "captured this option. Configure it before the first run.";
+  G4Exception("AdePTConfigurationMessenger::SetNewValue", "AdePTConfig001", JustWarning, description);
+}
+} // namespace
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
@@ -101,12 +113,14 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
   fSetCallUserTrackingActionCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
   fSetReturnFirstAndLastStepCmd = std::make_unique<G4UIcmdWithABool>("/adept/returnFirstAndLastStep", this);
+  fSetReturnFirstAndLastStepCmd->SetToBeBroadcasted(false);
   fSetReturnFirstAndLastStepCmd->SetGuidance(
       "If true, the first and last GPU steps of each track are returned to the host. This only controls GPU step "
       "returning; use /adept/CallUserActions or the individual action commands to invoke user actions on them.");
   fSetReturnFirstAndLastStepCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
   fSetReturnAllStepsCmd = std::make_unique<G4UIcmdWithABool>("/adept/returnAllSteps", this);
+  fSetReturnAllStepsCmd->SetToBeBroadcasted(false);
   fSetReturnAllStepsCmd->SetGuidance(
       "If true, every GPU step is returned to the host. This only controls GPU step returning; use "
       "/adept/CallUserActions or the individual action commands to invoke user actions on them.");
@@ -182,9 +196,13 @@ void AdePTConfigurationMessenger::SetNewValue(G4UIcommand *command, G4String new
   } else if (command == fSetCallUserTrackingActionCmd.get()) {
     fAdePTConfiguration->SetCallUserTrackingAction(fSetCallUserTrackingActionCmd->GetNewBoolValue(newValue));
   } else if (command == fSetReturnFirstAndLastStepCmd.get()) {
-    fAdePTConfiguration->SetReturnFirstAndLastStep(fSetReturnFirstAndLastStepCmd->GetNewBoolValue(newValue));
+    if (!fAdePTConfiguration->SetReturnFirstAndLastStep(fSetReturnFirstAndLastStepCmd->GetNewBoolValue(newValue))) {
+      ReportLockedReturnStepOption(command->GetCommandPath());
+    }
   } else if (command == fSetReturnAllStepsCmd.get()) {
-    fAdePTConfiguration->SetReturnAllSteps(fSetReturnAllStepsCmd->GetNewBoolValue(newValue));
+    if (!fAdePTConfiguration->SetReturnAllSteps(fSetReturnAllStepsCmd->GetNewBoolValue(newValue))) {
+      ReportLockedReturnStepOption(command->GetCommandPath());
+    }
   } else if (command == fSetSpeedOfLightCmd.get()) {
     fAdePTConfiguration->SetSpeedOfLight(fSetSpeedOfLightCmd->GetNewBoolValue(newValue));
   } else if (command == fSetMultipleStepsInMSCWithTransportationCmd.get()) {

--- a/src/g4integration/config/AdePTConfigurationMessenger.cc
+++ b/src/g4integration/config/AdePTConfigurationMessenger.cc
@@ -17,13 +17,13 @@
 #include "G4Exception.hh"
 
 namespace {
-void ReportLockedReturnStepOption(const G4String &commandPath)
+void ReportLockedReturnStepOption(G4UIcommand *command)
 {
   G4ExceptionDescription description;
-  description << commandPath
+  description << command->GetCommandPath()
               << " cannot be changed after AdePT transport initialization because the GPU worker has already "
                  "captured this option. Configure it before the first run.";
-  G4Exception("AdePTConfigurationMessenger::SetNewValue", "AdePTConfig001", JustWarning, description);
+  command->CommandFailed(description);
 }
 } // namespace
 
@@ -113,18 +113,14 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
   fSetCallUserTrackingActionCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
   fSetReturnFirstAndLastStepCmd = std::make_unique<G4UIcmdWithABool>("/adept/returnFirstAndLastStep", this);
-  fSetReturnFirstAndLastStepCmd->SetToBeBroadcasted(false);
   fSetReturnFirstAndLastStepCmd->SetGuidance(
       "If true, the first and last GPU steps of each track are returned to the host. This only controls GPU step "
       "returning; use /adept/CallUserActions or the individual action commands to invoke user actions on them.");
-  fSetReturnFirstAndLastStepCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
   fSetReturnAllStepsCmd = std::make_unique<G4UIcmdWithABool>("/adept/returnAllSteps", this);
-  fSetReturnAllStepsCmd->SetToBeBroadcasted(false);
   fSetReturnAllStepsCmd->SetGuidance(
       "If true, every GPU step is returned to the host. This only controls GPU step returning; use "
       "/adept/CallUserActions or the individual action commands to invoke user actions on them.");
-  fSetReturnAllStepsCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
   // ADEPT_DOCS_SECTION: Special Settings
   fSetSpeedOfLightCmd = std::make_unique<G4UIcmdWithABool>("/adept/SpeedOfLight", this);
@@ -197,11 +193,11 @@ void AdePTConfigurationMessenger::SetNewValue(G4UIcommand *command, G4String new
     fAdePTConfiguration->SetCallUserTrackingAction(fSetCallUserTrackingActionCmd->GetNewBoolValue(newValue));
   } else if (command == fSetReturnFirstAndLastStepCmd.get()) {
     if (!fAdePTConfiguration->SetReturnFirstAndLastStep(fSetReturnFirstAndLastStepCmd->GetNewBoolValue(newValue))) {
-      ReportLockedReturnStepOption(command->GetCommandPath());
+      ReportLockedReturnStepOption(command);
     }
   } else if (command == fSetReturnAllStepsCmd.get()) {
     if (!fAdePTConfiguration->SetReturnAllSteps(fSetReturnAllStepsCmd->GetNewBoolValue(newValue))) {
-      ReportLockedReturnStepOption(command->GetCommandPath());
+      ReportLockedReturnStepOption(command);
     }
   } else if (command == fSetSpeedOfLightCmd.get()) {
     fAdePTConfiguration->SetSpeedOfLight(fSetSpeedOfLightCmd->GetNewBoolValue(newValue));

--- a/src/g4integration/config/AdePTConfigurationMessenger.cc
+++ b/src/g4integration/config/AdePTConfigurationMessenger.cc
@@ -84,7 +84,7 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
       "If true, both UserTrackingAction and UserSteppingAction are called for returned GPU steps. This does not "
       "change which GPU steps are returned; combine it with /adept/returnFirstAndLastStep and/or "
       "/adept/returnAllSteps to make the required steps available on the host.");
-  fSetCallUserActionsCmd->AvailableForStates(G4State_PreInit);
+  fSetCallUserActionsCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
   fSetCallUserSteppingActionCmd = std::make_unique<G4UIcmdWithABool>("/adept/CallUserSteppingAction", this);
   fSetCallUserSteppingActionCmd->SetGuidance(
@@ -92,25 +92,25 @@ AdePTConfigurationMessenger::AdePTConfigurationMessenger(AdePTConfiguration *ade
       "that means it is not guaranteed that the UserSteppingAction is called in order, i.e., it could get called on "
       "the secondary before the primary has finished its track. This does not change which GPU steps are returned; "
       "use /adept/returnAllSteps to return every GPU step.");
-  fSetCallUserSteppingActionCmd->AvailableForStates(G4State_PreInit);
+  fSetCallUserSteppingActionCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
   fSetCallUserTrackingActionCmd = std::make_unique<G4UIcmdWithABool>("/adept/CallUserTrackingAction", this);
   fSetCallUserTrackingActionCmd->SetGuidance(
       "If true, the UserTrackingAction is called for returned GPU track starts and ends. This does not change which "
       "GPU steps are returned; use /adept/returnFirstAndLastStep to return the first and last GPU steps.");
-  fSetCallUserTrackingActionCmd->AvailableForStates(G4State_PreInit);
+  fSetCallUserTrackingActionCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
   fSetReturnFirstAndLastStepCmd = std::make_unique<G4UIcmdWithABool>("/adept/returnFirstAndLastStep", this);
   fSetReturnFirstAndLastStepCmd->SetGuidance(
       "If true, the first and last GPU steps of each track are returned to the host. This only controls GPU step "
       "returning; use /adept/CallUserActions or the individual action commands to invoke user actions on them.");
-  fSetReturnFirstAndLastStepCmd->AvailableForStates(G4State_PreInit);
+  fSetReturnFirstAndLastStepCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
   fSetReturnAllStepsCmd = std::make_unique<G4UIcmdWithABool>("/adept/returnAllSteps", this);
   fSetReturnAllStepsCmd->SetGuidance(
       "If true, every GPU step is returned to the host. This only controls GPU step returning; use "
       "/adept/CallUserActions or the individual action commands to invoke user actions on them.");
-  fSetReturnAllStepsCmd->AvailableForStates(G4State_PreInit);
+  fSetReturnAllStepsCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
 
   // ADEPT_DOCS_SECTION: Special Settings
   fSetSpeedOfLightCmd = std::make_unique<G4UIcmdWithABool>("/adept/SpeedOfLight", this);

--- a/src/g4integration/tracking_managers/AdePTTrackingManager.cc
+++ b/src/g4integration/tracking_managers/AdePTTrackingManager.cc
@@ -192,7 +192,7 @@ void AdePTTrackingManager::InitializeSharedAdePTTransport()
       fAdePTConfiguration->GetGPURegionNames(), fAdePTConfiguration->GetDeadRegionNames(), wdtRaw);
   adeptint::WDTHostPacked wdtPacked = AdePTGeometryBridge::PackWDT(wdtRaw);
   // The GPU worker receives the return-step kernel options by value. Freeze the
-  // corresponding UI settings before taking that snapshot so later Idle-state
+  // corresponding UI settings before taking that snapshot so later UI
   // commands cannot make the host configuration disagree with the worker.
   fAdePTConfiguration->LockReturnStepOptions();
   auto transportConfig = MakeAdePTTransportConfig(*fAdePTConfiguration);

--- a/src/g4integration/tracking_managers/AdePTTrackingManager.cc
+++ b/src/g4integration/tracking_managers/AdePTTrackingManager.cc
@@ -191,7 +191,11 @@ void AdePTTrackingManager::InitializeSharedAdePTTransport()
       auxData, adeptG4HepEmState->GetData(), fHepEmTrackingManager.get(), fAdePTConfiguration->GetTrackInAllRegions(),
       fAdePTConfiguration->GetGPURegionNames(), fAdePTConfiguration->GetDeadRegionNames(), wdtRaw);
   adeptint::WDTHostPacked wdtPacked = AdePTGeometryBridge::PackWDT(wdtRaw);
-  auto transportConfig              = MakeAdePTTransportConfig(*fAdePTConfiguration);
+  // The GPU worker receives the return-step kernel options by value. Freeze the
+  // corresponding UI settings before taking that snapshot so later Idle-state
+  // commands cannot make the host configuration disagree with the worker.
+  fAdePTConfiguration->LockReturnStepOptions();
+  auto transportConfig = MakeAdePTTransportConfig(*fAdePTConfiguration);
 
   // Move the fully prepared host-side package into the shared transport. The
   // first worker creates the transport here; later workers only retrieve the

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -78,6 +78,7 @@ set(ADEPT_G4_INTEGRATION_UNIT_TESTS
 set(ADEPT_G4_INTEGRATION_GTESTS
   test_hostTrackDataMapper.cpp # Unit test for hostTrackDataMapper
   test_geometry_bridge.cpp     # Unit test for AdePTGeometryBridge replica traversal
+  test_return_step_options.cpp # Unit test for freezing GPU return-step options
 )
 if(Geant4_gdml_FOUND AND VECGEOM_GDML_SUPPORT)
   list(APPEND ADEPT_G4_INTEGRATION_GTESTS

--- a/test/unit/test_return_step_options.cpp
+++ b/test/unit/test_return_step_options.cpp
@@ -4,8 +4,12 @@
 #include <AdePT/g4integration/AdePTConfiguration.hh>
 
 #include <G4StateManager.hh>
+#include <G4UIcommand.hh>
+#include <G4UIcommandTree.hh>
 #include <G4UImanager.hh>
 #include <gtest/gtest.h>
+
+#include <algorithm>
 
 namespace {
 class G4StateGuard {
@@ -31,6 +35,23 @@ TEST(AdePTConfiguration, IdleReturnStepCommandsFreezeWithTransportSnapshot)
   ASSERT_TRUE(stateManager->SetNewState(G4State_Idle));
 
   auto *uiManager = G4UImanager::GetUIpointer();
+  ASSERT_NE(uiManager->GetTree()->FindPath("/adept/returnFirstAndLastStep"), nullptr);
+  ASSERT_NE(uiManager->GetTree()->FindPath("/adept/returnAllSteps"), nullptr);
+  auto *returnFirstAndLast = uiManager->GetTree()->FindPath("/adept/returnFirstAndLastStep");
+  auto *returnAll          = uiManager->GetTree()->FindPath("/adept/returnAllSteps");
+  EXPECT_TRUE(returnFirstAndLast->ToBeBroadcasted());
+  EXPECT_TRUE(returnAll->ToBeBroadcasted());
+
+  // With no AvailableForStates restriction, Geant4 leaves the commands
+  // available in every application state. The lifecycle guard below decides
+  // whether their values can still be changed.
+  for (const auto state :
+       {G4State_PreInit, G4State_Init, G4State_Idle, G4State_GeomClosed, G4State_EventProc, G4State_Abort}) {
+    EXPECT_NE(std::find(returnFirstAndLast->GetStateList()->begin(), returnFirstAndLast->GetStateList()->end(), state),
+              returnFirstAndLast->GetStateList()->end());
+    EXPECT_NE(std::find(returnAll->GetStateList()->begin(), returnAll->GetStateList()->end(), state),
+              returnAll->GetStateList()->end());
+  }
 
   // This models Gauss after master initialization but before the first worker
   // constructs AdePTTransport. The Idle commands must still configure the
@@ -46,8 +67,8 @@ TEST(AdePTConfiguration, IdleReturnStepCommandsFreezeWithTransportSnapshot)
   EXPECT_TRUE(configuration.ReturnStepOptionsAreLocked());
   EXPECT_EQ(uiManager->ApplyCommand("/adept/returnFirstAndLastStep true"), 0);
   EXPECT_EQ(uiManager->ApplyCommand("/adept/returnAllSteps true"), 0);
-  uiManager->ApplyCommand("/adept/returnFirstAndLastStep false");
-  uiManager->ApplyCommand("/adept/returnAllSteps false");
+  EXPECT_NE(uiManager->ApplyCommand("/adept/returnFirstAndLastStep false"), 0);
+  EXPECT_NE(uiManager->ApplyCommand("/adept/returnAllSteps false"), 0);
 
   EXPECT_TRUE(configuration.GetReturnFirstAndLastStep());
   EXPECT_TRUE(configuration.GetReturnAllSteps());

--- a/test/unit/test_return_step_options.cpp
+++ b/test/unit/test_return_step_options.cpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 CERN
+// SPDX-License-Identifier: Apache-2.0
+
+#include <AdePT/g4integration/AdePTConfiguration.hh>
+
+#include <G4StateManager.hh>
+#include <G4UImanager.hh>
+#include <gtest/gtest.h>
+
+namespace {
+class G4StateGuard {
+public:
+  explicit G4StateGuard(G4StateManager *stateManager)
+      : fStateManager(stateManager), fOriginalState(stateManager->GetCurrentState())
+  {
+  }
+
+  ~G4StateGuard() { fStateManager->SetNewState(fOriginalState); }
+
+private:
+  G4StateManager *fStateManager;
+  G4ApplicationState fOriginalState;
+};
+} // namespace
+
+TEST(AdePTConfiguration, IdleReturnStepCommandsFreezeWithTransportSnapshot)
+{
+  AdePTConfiguration configuration;
+  auto *stateManager = G4StateManager::GetStateManager();
+  G4StateGuard stateGuard(stateManager);
+  ASSERT_TRUE(stateManager->SetNewState(G4State_Idle));
+
+  auto *uiManager = G4UImanager::GetUIpointer();
+
+  // This models Gauss after master initialization but before the first worker
+  // constructs AdePTTransport. The Idle commands must still configure the
+  // values that will be copied into the GPU worker.
+  EXPECT_EQ(uiManager->ApplyCommand("/adept/returnFirstAndLastStep true"), 0);
+  EXPECT_EQ(uiManager->ApplyCommand("/adept/returnAllSteps true"), 0);
+  EXPECT_TRUE(configuration.GetReturnFirstAndLastStep());
+  EXPECT_TRUE(configuration.GetReturnAllSteps());
+
+  // This is the point at which AdePTTransport takes its by-value kernel-option
+  // snapshot. Later Idle commands may repeat, but must not change, the values.
+  configuration.LockReturnStepOptions();
+  EXPECT_TRUE(configuration.ReturnStepOptionsAreLocked());
+  EXPECT_EQ(uiManager->ApplyCommand("/adept/returnFirstAndLastStep true"), 0);
+  EXPECT_EQ(uiManager->ApplyCommand("/adept/returnAllSteps true"), 0);
+  uiManager->ApplyCommand("/adept/returnFirstAndLastStep false");
+  uiManager->ApplyCommand("/adept/returnAllSteps false");
+
+  EXPECT_TRUE(configuration.GetReturnFirstAndLastStep());
+  EXPECT_TRUE(configuration.GetReturnAllSteps());
+}


### PR DESCRIPTION
This fixes the UI commands to also be callable from G4 idle. As we do the late initialization, these commands did not run in Gauss anymore, where the UI commands are invoked only later.