### PR TITLE
[mini] fix caching of safety

### DIFF
--- a/include/AdePT/transport/kernels/electrons.cuh
+++ b/include/AdePT/transport/kernels/electrons.cuh
@@ -300,14 +300,13 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     bool propagated    = true;
     long hitsurf_index = -1;
     double geometryStepLength;
-    SafetyCache geometrySafetyCache(currentTrack.safetyCache);
 
     if (gMagneticField) {
       int iterDone = -1;
       geometryStepLength =
           fieldPropagatorRungeKutta<Field_t, RkDriver_t, rk_integration_t, AdePTNavigator>::ComputeStepAndNextVolume(
               *gMagneticField, eKin, restMass, Charge, geometricalStepLengthFromPhysics, safeLength, pos, dir, navState,
-              nextState, hitsurf_index, propagated, geometrySafetyCache,
+              nextState, hitsurf_index, propagated, currentTrack.safetyCache,
               // activeSize < 100 ? max_iterations : max_iters_tail ), // Was
               max_iterations, iterDone, slot, verbose);
     } else {
@@ -349,10 +348,6 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     const bool hostBoundaryStep = currentTrack.hasHostData && nextState.IsOnBoundary();
     if (nextState.IsOnBoundary()) {
       currentTrack.SetSafety(pos, 0.);
-    } else {
-      // Store the safety cache back in the track after B field integration
-      // It already includes both safety and safety origin
-      currentTrack.safetyCache = geometrySafetyCache;
     }
 
     // Propagate information from geometrical step to MSC.

--- a/include/AdePT/transport/kernels/electrons.cuh
+++ b/include/AdePT/transport/kernels/electrons.cuh
@@ -218,12 +218,12 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
         // Recompute safety and update it in the track.
         // Use maximum accuracy only if safety is smaller than physicalStepLength
         safety = AdePTNavigator::ComputeSafety(pos, navState, physicalStepLength);
+        currentTrack.SetSafety(pos, safety);
 #if ADEPT_DEBUG_TRACK > 0
         if (verbose) printf("| new safety %g ", safety);
 #endif
       }
     }
-    currentTrack.SetSafety(pos, safety);
     theTrack->SetSafety(safety);
     bool restrictedPhysicalStepLength = false;
 
@@ -350,7 +350,9 @@ static __device__ __forceinline__ void TransportElectrons(ParticleManager &parti
     if (nextState.IsOnBoundary()) {
       currentTrack.SetSafety(pos, 0.);
     } else {
-      currentTrack.SetSafety(pos, geometrySafetyCache.SafetyAt(pos));
+      // Store the safety cache back in the track after B field integration
+      // It already includes both safety and safety origin
+      currentTrack.safetyCache = geometrySafetyCache;
     }
 
     // Propagate information from geometrical step to MSC.

--- a/include/AdePT/transport/kernels/electrons_split.cuh
+++ b/include/AdePT/transport/kernels/electrons_split.cuh
@@ -326,7 +326,6 @@ __global__ void ElectronPropagation(ChargedTrack *electronsOrPositrons, G4HepEmE
     currentTrack.propagated = true;
     currentTrack.hitsurfID  = -1;
     double geometryStepLength;
-    SafetyCache geometrySafetyCache(currentTrack.safetyCache);
 
     if (gMagneticField) {
       int iterDone = -1;
@@ -334,7 +333,7 @@ __global__ void ElectronPropagation(ChargedTrack *electronsOrPositrons, G4HepEmE
           fieldPropagatorRungeKutta<Field_t, RkDriver_t, rk_integration_t, AdePTNavigator>::ComputeStepAndNextVolume(
               *gMagneticField, currentTrack.eKin, restMass, Charge, theTrack->GetGStepLength(), currentTrack.safeLength,
               currentTrack.pos, currentTrack.dir, currentTrack.navState, currentTrack.nextState, currentTrack.hitsurfID,
-              currentTrack.propagated, geometrySafetyCache,
+              currentTrack.propagated, currentTrack.safetyCache,
               // activeSize < 100 ? max_iterations : max_iters_tail ), // Was
               max_iterations, iterDone, slot);
 
@@ -367,10 +366,6 @@ __global__ void ElectronPropagation(ChargedTrack *electronsOrPositrons, G4HepEmE
     currentTrack.navState.SetBoundaryState(currentTrack.nextState.IsOnBoundary());
     if (currentTrack.nextState.IsOnBoundary()) {
       currentTrack.SetSafety(currentTrack.pos, 0.);
-    } else {
-      // Store the safety cache back in the track after B field integration
-      // It already includes both safety and safety origin
-      currentTrack.safetyCache = geometrySafetyCache;
     }
 
     // Propagate information from geometrical step to MSC.

--- a/include/AdePT/transport/kernels/electrons_split.cuh
+++ b/include/AdePT/transport/kernels/electrons_split.cuh
@@ -245,9 +245,9 @@ __global__ void ElectronHowFar(ParticleManager particleManager, G4HepEmElectronT
         // Recompute safety and update it in the track.
         // Use maximum accuracy only if safety is smaller than physicalStepLength
         safety = AdePTNavigator::ComputeSafety(currentTrack.pos, currentTrack.navState, physicalStepLength);
+        currentTrack.SetSafety(currentTrack.pos, safety);
       }
     }
-    currentTrack.SetSafety(currentTrack.pos, safety);
     theTrack->SetSafety(safety);
     currentTrack.restrictedPhysicalStepLength = false;
 
@@ -368,7 +368,9 @@ __global__ void ElectronPropagation(ChargedTrack *electronsOrPositrons, G4HepEmE
     if (currentTrack.nextState.IsOnBoundary()) {
       currentTrack.SetSafety(currentTrack.pos, 0.);
     } else {
-      currentTrack.SetSafety(currentTrack.pos, geometrySafetyCache.SafetyAt(currentTrack.pos));
+      // Store the safety cache back in the track after B field integration
+      // It already includes both safety and safety origin
+      currentTrack.safetyCache = geometrySafetyCache;
     }
 
     // Propagate information from geometrical step to MSC.


### PR DESCRIPTION
This PR fixes the caching of the safety:

1. when the safety is needed for the `HowFarToMSC` it is recomputed if it is below the `physicalStepLength`. However, it was stored back in the track independently whether it actually had been recomputed or not. In case it had not been recomputed, this re-centered the safety at the current position, causing the cached safety to shrink—or, at best, remain unchanged.

2. Something similar applied to the safety that comes out of the B field integration: Before, it was also shortened by re-centering. When passing the safety cache of the track directly to the integrator, it will already update the safety and the safety center to the correct point.

A physics drift is expected, as this will change the safety, and consequently the step length and everything else