### PR TITLE
make trackInAllRegions and removeGPURegion consistent

### DIFF
--- a/include/AdePT/g4integration/AdePTConfiguration.hh
+++ b/include/AdePT/g4integration/AdePTConfiguration.hh
@@ -3,11 +3,13 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 class AdePTConfigurationMessenger;
@@ -19,28 +21,50 @@ public:
   AdePTConfiguration();
   ~AdePTConfiguration();
   void SetNumThreads(int numThreads) { fNumThreads = numThreads; }
-  void SetTrackInAllRegions(bool trackInAllRegions) { fTrackInAllRegions = trackInAllRegions; }
+  bool SetTrackInAllRegions(bool trackInAllRegions)
+  {
+    if (sTransportInitializationOptionsLocked) return fTrackInAllRegions == trackInAllRegions;
+    fTrackInAllRegions = trackInAllRegions;
+    return true;
+  }
   void SetCallUserActions(bool callUserActions) { fCallUserActions = callUserActions; }
   void SetCallUserSteppingAction(bool callUserSteppingAction) { fCallUserSteppingAction = callUserSteppingAction; }
   void SetCallUserTrackingAction(bool callUserTrackingAction) { fCallUserTrackingAction = callUserTrackingAction; }
   bool SetReturnAllSteps(bool returnAllSteps)
   {
-    if (sReturnStepOptionsLocked) return fReturnAllSteps == returnAllSteps;
+    if (sTransportInitializationOptionsLocked) return fReturnAllSteps == returnAllSteps;
     fReturnAllSteps = returnAllSteps;
     return true;
   }
   bool SetReturnFirstAndLastStep(bool returnFirstAndLastStep)
   {
-    if (sReturnStepOptionsLocked) {
+    if (sTransportInitializationOptionsLocked) {
       return fReturnFirstAndLastStep == returnFirstAndLastStep;
     }
     fReturnFirstAndLastStep = returnFirstAndLastStep;
     return true;
   }
-  void LockReturnStepOptions() { sReturnStepOptionsLocked = true; }
-  bool ReturnStepOptionsAreLocked() const { return sReturnStepOptionsLocked; }
-  void AddGPURegionName(std::string name) { fGPURegionNames.push_back(name); }
-  void RemoveGPURegionName(std::string name) { fCPURegionNames.push_back(name); }
+  void LockTransportInitializationOptions() { sTransportInitializationOptionsLocked = true; }
+  bool TransportInitializationOptionsAreLocked() const { return sTransportInitializationOptionsLocked; }
+  // Keep the old names for source compatibility.
+  void LockReturnStepOptions() { LockTransportInitializationOptions(); }
+  bool ReturnStepOptionsAreLocked() const { return TransportInitializationOptionsAreLocked(); }
+  bool AddGPURegionName(std::string name)
+  {
+    if (sTransportInitializationOptionsLocked) {
+      return std::find(fGPURegionNames.begin(), fGPURegionNames.end(), name) != fGPURegionNames.end();
+    }
+    fGPURegionNames.push_back(std::move(name));
+    return true;
+  }
+  bool RemoveGPURegionName(std::string name)
+  {
+    if (sTransportInitializationOptionsLocked) {
+      return std::find(fCPURegionNames.begin(), fCPURegionNames.end(), name) != fCPURegionNames.end();
+    }
+    fCPURegionNames.push_back(std::move(name));
+    return true;
+  }
   void AddWDTRegionName(std::string name) { fWDTRegionNames.push_back(name); }
   void AddDeadRegionName(std::string name) { fDeadRegionNames.push_back(name); }
   void SetVerbosity(int verbosity) { fVerbosity = verbosity; };
@@ -117,10 +141,8 @@ private:
   bool fCallUserTrackingAction{false};
   bool fReturnAllSteps{false};
   bool fReturnFirstAndLastStep{false};
-  // AdePTTransport is shared by all Geant4 workers, so the point at which its
-  // return-step options are captured is shared as well. Geant4 applies UI
-  // commands outside worker initialization/event processing.
-  inline static bool sReturnStepOptionsLocked{false};
+  // These settings cannot change after the first worker initializes AdePT.
+  inline static bool sTransportInitializationOptionsLocked{false};
   bool fSpeedOfLight{false};
   bool fSetMultipleStepsInMSCWithTransportation{false};
   bool fSetEnergyLossFluctuation{false};

--- a/include/AdePT/g4integration/AdePTTrackingManager.hh
+++ b/include/AdePT/g4integration/AdePTTrackingManager.hh
@@ -74,6 +74,10 @@ private:
   /// corresponding one-time device initialization and upload.
   void InitializeSharedAdePTTransport();
 
+  /// @brief Set up the regions handled by AdePT.
+  /// In track-all mode, regions named with `removeGPURegion` are left out.
+  void InitializeGPURegions();
+
   /// @brief Drain returned GPU-step batches from transport and reconstruct the
   /// corresponding Geant4 steps on the CPU.
   /// @details
@@ -86,6 +90,7 @@ private:
   AdePTGeant4Integration fGeant4Integration;
   static inline int fNumThreads{0};
   std::set<G4Region const *> fGPURegions{};
+  bool fGPURegionsInitialized{false};
   std::shared_ptr<AdePTTransport> fAdeptTransport;
   AdePTConfiguration *const fAdePTConfiguration;
   int fVerbosity{0};

--- a/include/AdePT/g4integration/geometry/AdePTGeometryBridge.hh
+++ b/include/AdePT/g4integration/geometry/AdePTGeometryBridge.hh
@@ -11,10 +11,12 @@
 
 #include <G4VPhysicalVolume.hh>
 
+#include <set>
 #include <string>
 #include <vector>
 
 class G4LogicalVolume;
+class G4Region;
 struct G4HepEmData;
 
 /// @brief Global bridge between Geant4 host geometry and the VecGeom world used by AdePT.
@@ -40,9 +42,9 @@ public:
   static void CheckGeometry(G4HepEmData const *hepEmData);
 
   /// @brief Fills the auxiliary per-volume data needed by AdePT.
+  /// @param gpuRegions Regions handled by AdePT.
   static void InitVolAuxData(adeptint::VolAuxData *volAuxData, G4HepEmData const *hepEmData,
-                             G4HepEmTrackingManagerSpecialized *hepEmTM, bool trackInAllRegions,
-                             std::vector<std::string> const *gpuRegionNames,
+                             G4HepEmTrackingManagerSpecialized *hepEmTM, std::set<G4Region const *> const &gpuRegions,
                              std::vector<std::string> const &deadRegionNames, adeptint::WDTHostRaw &wdtRaw);
 
   /// @brief Pack the Woodcock tracking data from the sparse host-side map into arrays that can be copied to the GPU.

--- a/include/AdePT/g4integration/tracking_managers/G4HepEmTrackingManagerSpecialized.hh
+++ b/include/AdePT/g4integration/tracking_managers/G4HepEmTrackingManagerSpecialized.hh
@@ -19,9 +19,6 @@ public:
   ~G4HepEmTrackingManagerSpecialized();
 
   void SetGPURegions(const std::set<G4Region const *> &gpuRegions) { fGPURegions = gpuRegions; }
-  /// @brief Set whether AdePT should transport particles across the whole geometry
-  void SetTrackInAllRegions(bool trackInAllRegions) { fTrackInAllRegions = trackInAllRegions; }
-  bool GetTrackInAllRegions() const { return fTrackInAllRegions; }
 
   // Implement HandOverTrack that returns the track if it ends up in the GPU region
   void HandOverOneTrack(G4Track *aTrack) override;
@@ -39,7 +36,6 @@ public:
   int GetFinishEventOnCPU(int threadid) const { return fFinishEventOnCPU[threadid]; }
 
 private:
-  bool fTrackInAllRegions = false;          ///< Whether the whole geometry is a GPU region
   std::set<G4Region const *> fGPURegions{}; ///< List of GPU regions
   std::vector<int> fFinishEventOnCPU;       ///< Vector over worker threads for events finished on CPU
 

--- a/src/g4integration/config/AdePTConfigurationMessenger.cc
+++ b/src/g4integration/config/AdePTConfigurationMessenger.cc
@@ -17,12 +17,11 @@
 #include "G4Exception.hh"
 
 namespace {
-void ReportLockedReturnStepOption(G4UIcommand *command)
+void ReportLockedTransportInitializationOption(G4UIcommand *command)
 {
   G4ExceptionDescription description;
   description << command->GetCommandPath()
-              << " cannot be changed after AdePT transport initialization because the GPU worker has already "
-                 "captured this option. Configure it before the first run.";
+              << " cannot be changed after AdePT initialization has started. Set it before the first run.";
   command->CommandFailed(description);
 }
 } // namespace
@@ -184,7 +183,9 @@ void AdePTConfigurationMessenger::SetNewValue(G4UIcommand *command, G4String new
 {
 
   if (command == fSetTrackInAllRegionsCmd.get()) {
-    fAdePTConfiguration->SetTrackInAllRegions(fSetTrackInAllRegionsCmd->GetNewBoolValue(newValue));
+    if (!fAdePTConfiguration->SetTrackInAllRegions(fSetTrackInAllRegionsCmd->GetNewBoolValue(newValue))) {
+      ReportLockedTransportInitializationOption(command);
+    }
   } else if (command == fSetCallUserActionsCmd.get()) {
     fAdePTConfiguration->SetCallUserActions(fSetCallUserActionsCmd->GetNewBoolValue(newValue));
   } else if (command == fSetCallUserSteppingActionCmd.get()) {
@@ -193,11 +194,11 @@ void AdePTConfigurationMessenger::SetNewValue(G4UIcommand *command, G4String new
     fAdePTConfiguration->SetCallUserTrackingAction(fSetCallUserTrackingActionCmd->GetNewBoolValue(newValue));
   } else if (command == fSetReturnFirstAndLastStepCmd.get()) {
     if (!fAdePTConfiguration->SetReturnFirstAndLastStep(fSetReturnFirstAndLastStepCmd->GetNewBoolValue(newValue))) {
-      ReportLockedReturnStepOption(command);
+      ReportLockedTransportInitializationOption(command);
     }
   } else if (command == fSetReturnAllStepsCmd.get()) {
     if (!fAdePTConfiguration->SetReturnAllSteps(fSetReturnAllStepsCmd->GetNewBoolValue(newValue))) {
-      ReportLockedReturnStepOption(command);
+      ReportLockedTransportInitializationOption(command);
     }
   } else if (command == fSetSpeedOfLightCmd.get()) {
     fAdePTConfiguration->SetSpeedOfLight(fSetSpeedOfLightCmd->GetNewBoolValue(newValue));
@@ -207,11 +208,15 @@ void AdePTConfigurationMessenger::SetNewValue(G4UIcommand *command, G4String new
   } else if (command == fSetEnergyLossFluctuationCmd.get()) {
     fAdePTConfiguration->SetEnergyLossFluctuation(fSetEnergyLossFluctuationCmd->GetNewBoolValue(newValue));
   } else if (command == fAddRegionCmd.get()) {
-    fAdePTConfiguration->AddGPURegionName(newValue);
+    if (!fAdePTConfiguration->AddGPURegionName(newValue)) {
+      ReportLockedTransportInitializationOption(command);
+    }
   } else if (command == fAddWDTRegionCmd.get()) {
     fAdePTConfiguration->AddWDTRegionName(newValue);
   } else if (command == fRemoveRegionCmd.get()) {
-    fAdePTConfiguration->RemoveGPURegionName(newValue);
+    if (!fAdePTConfiguration->RemoveGPURegionName(newValue)) {
+      ReportLockedTransportInitializationOption(command);
+    }
   } else if (command == fSetVerbosityCmd.get()) {
     fAdePTConfiguration->SetVerbosity(fSetVerbosityCmd->GetNewIntValue(newValue));
   } else if (command == fSetMillionsOfTrackSlotsCmd.get()) {

--- a/src/g4integration/geometry/AdePTGeometryBridge.cpp
+++ b/src/g4integration/geometry/AdePTGeometryBridge.cpp
@@ -299,8 +299,8 @@ void AdePTGeometryBridge::CheckGeometry(G4HepEmData const *hepEmData)
 
 /// @brief Fill the auxiliary per-volume transport metadata used by AdePT.
 void AdePTGeometryBridge::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4HepEmData const *hepEmData,
-                                         G4HepEmTrackingManagerSpecialized *hepEmTM, bool trackInAllRegions,
-                                         std::vector<std::string> const *gpuRegionNames,
+                                         G4HepEmTrackingManagerSpecialized *hepEmTM,
+                                         std::set<G4Region const *> const &gpuRegions,
                                          std::vector<std::string> const &deadRegionNames, adeptint::WDTHostRaw &wdtRaw)
 {
   // Note: the hepEmTM must be passed explicitly here, since this is now a stateless
@@ -311,14 +311,6 @@ void AdePTGeometryBridge::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4Hep
       G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
   const vecgeom::VPlacedVolume *vecgeomWorld = vecgeom::GeoManager::Instance().GetWorld();
   const int *g4tohepmcindex                  = hepEmData->fTheMatCutData->fG4MCIndexToHepEmMCIndex;
-
-  // We need to go from region names to G4Region objects.
-  std::vector<G4Region *> gpuRegions{};
-  if (!trackInAllRegions) {
-    for (const std::string &regionName : *gpuRegionNames) {
-      gpuRegions.push_back(G4RegionStore::GetInstance()->GetRegion(regionName));
-    }
-  }
 
 #if defined(ADEPT_STEPACTION_TYPE) && (ADEPT_STEPACTION_TYPE == 1)
   // CMS stepping action: resolve configured dead-region names once on the host.
@@ -370,13 +362,7 @@ void AdePTGeometryBridge::InitVolAuxData(adeptint::VolAuxData *volAuxData, G4Hep
     }
 
     // Check if the volume belongs to a GPU region.
-    if (!trackInAllRegions) {
-      for (G4Region *gpuRegion : gpuRegions) {
-        if (g4_lvol->GetRegion() == gpuRegion) {
-          volAuxData[vg_lvol->id()].fGPUregionId = g4_lvol->GetRegion()->GetInstanceID();
-        }
-      }
-    } else {
+    if (gpuRegions.find(g4_lvol->GetRegion()) != gpuRegions.end()) {
       volAuxData[vg_lvol->id()].fGPUregionId = g4_lvol->GetRegion()->GetInstanceID();
     }
 

--- a/src/g4integration/tracking_managers/AdePTTrackingManager.cc
+++ b/src/g4integration/tracking_managers/AdePTTrackingManager.cc
@@ -175,9 +175,8 @@ void AdePTTrackingManager::InitializeSharedAdePTTransport()
   std::cout << "Reading in covfie file for magnetic field: " << fAdePTConfiguration->GetCovfieBfieldFile() << std::endl;
   if (fAdePTConfiguration->GetCovfieBfieldFile() == "") std::cout << "No magnetic field file provided!" << std::endl;
 #endif
-  // Prepare the complete host-side input package before constructing the
-  // shared transport. The transport constructor then performs the one-time
-  // device-side initialization from these prepared inputs.
+  fAdePTConfiguration->LockTransportInitializationOptions();
+
   const auto uniformFieldValues = fGeant4Integration.GetUniformField();
   auto adeptG4HepEmState = std::make_unique<adept::transport::AdePTG4HepEmState>(fHepEmTrackingManager->GetConfig());
 
@@ -188,21 +187,60 @@ void AdePTTrackingManager::InitializeSharedAdePTTransport()
   auto auxData = std::make_unique<adeptint::VolAuxData[]>(vecgeom::GeoManager::Instance().GetRegisteredVolumesCount());
   adeptint::WDTHostRaw wdtRaw;
   AdePTGeometryBridge::InitVolAuxData(auxData.get(), adeptG4HepEmState->GetData(), fHepEmTrackingManager.get(),
-                                      fAdePTConfiguration->GetTrackInAllRegions(),
-                                      fAdePTConfiguration->GetGPURegionNames(),
-                                      fAdePTConfiguration->GetDeadRegionNames(), wdtRaw);
+                                      fGPURegions, fAdePTConfiguration->GetDeadRegionNames(), wdtRaw);
   adeptint::WDTHostPacked wdtPacked = AdePTGeometryBridge::PackWDT(wdtRaw);
-  // The GPU worker receives the return-step kernel options by value. Freeze the
-  // corresponding UI settings before taking that snapshot so later UI
-  // commands cannot make the host configuration disagree with the worker.
-  fAdePTConfiguration->LockReturnStepOptions();
-  auto transportConfig = MakeAdePTTransportConfig(*fAdePTConfiguration);
+  auto transportConfig              = MakeAdePTTransportConfig(*fAdePTConfiguration);
 
-  // Move the fully prepared host-side package into the shared transport. The
-  // first worker creates the transport here; later workers only retrieve the
-  // already-created shared instance.
   fAdeptTransport = GetSharedAdePTTransport(transportConfig, std::move(adeptG4HepEmState), std::move(auxData),
                                             wdtPacked, uniformFieldValues);
+}
+
+void AdePTTrackingManager::InitializeGPURegions()
+{
+  if (fGPURegionsInitialized) return;
+
+  const auto &gpuRegionNames = *fAdePTConfiguration->GetGPURegionNames();
+  const auto &cpuRegionNames = *fAdePTConfiguration->GetCPURegionNames();
+  if (!fAdePTConfiguration->GetTrackInAllRegions()) {
+    // Only regions added with addGPURegion are handled by AdePT.
+    for (const std::string &regionName : gpuRegionNames) {
+      G4Region *region = G4RegionStore::GetInstance()->GetRegion(regionName);
+      if (!region) {
+        G4Exception("AdePTTrackingManager", "Invalid parameter", FatalErrorInArgument,
+                    ("Region given to /adept/addGPURegion: " + regionName + " not found\n").c_str());
+      }
+
+      for (const std::string &cpuRegionName : cpuRegionNames) {
+        if (regionName == cpuRegionName) {
+          G4Exception("AdePTTrackingManager", "Conflicting region assignment", FatalErrorInArgument,
+                      ("Region '" + regionName + "' is defined in both /adept/addGPURegion and /adept/removeGPURegion")
+                          .c_str());
+        }
+      }
+
+      G4cout << "AdePTTrackingManager: Marking " << regionName << " as a GPU Region" << G4endl;
+      fGPURegions.insert(region);
+    }
+  } else {
+    // Start with all regions, then remove the exclusions below.
+    for (G4Region *region : *G4RegionStore::GetInstance()) {
+      if (region) fGPURegions.insert(region);
+    }
+
+    for (const std::string &cpuRegionName : cpuRegionNames) {
+      G4Region *region = G4RegionStore::GetInstance()->GetRegion(cpuRegionName);
+      if (!region) {
+        G4Exception("AdePTTrackingManager", "Invalid parameter", FatalErrorInArgument,
+                    ("Region given to /adept/removeGPURegion: " + cpuRegionName + " not found\n").c_str());
+      }
+
+      G4cout << "AdePTTrackingManager: Removing " << cpuRegionName << " from GPU Regions" << G4endl;
+      fGPURegions.erase(region);
+    }
+  }
+
+  fHepEmTrackingManager->SetGPURegions(fGPURegions);
+  fGPURegionsInitialized = true;
 }
 
 void AdePTTrackingManager::InitializeAdePT()
@@ -246,6 +284,9 @@ void AdePTTrackingManager::InitializeAdePT()
     std::cout << " NUM OF THREADS ACCORDING TO G4: " << fNumThreads << std::endl;
     fAdePTConfiguration->SetNumThreads(fNumThreads);
 
+    // Build the GPU region set before creating the volume metadata.
+    InitializeGPURegions();
+
     // Load the VecGeom world using G4VG if we don't have a GDML file, VGDML otherwise
     if (fAdePTConfiguration->GetVecGeomGDML().empty()) {
       auto *tman  = G4TransportationManager::GetTransportationManager();
@@ -283,61 +324,8 @@ void AdePTTrackingManager::InitializeAdePT()
   // the first worker. The remaining workers only retrieve the shared pointer.
   fAdeptTransport = GetSharedAdePTTransport();
 
-  // Initialize the GPU region list
-  const auto &gpuRegionNames = *fAdePTConfiguration->GetGPURegionNames();
-  const auto &cpuRegionNames = *fAdePTConfiguration->GetCPURegionNames();
-  if (!fAdePTConfiguration->GetTrackInAllRegions()) {
-    // Case 1: GPU regions are explicitly listed, and CPU regions must not overlap
-    for (const std::string &regionName : gpuRegionNames) {
-      G4Region *region = G4RegionStore::GetInstance()->GetRegion(regionName);
-      if (!region) {
-        G4Exception("AdePTTrackingManager", "Invalid parameter", FatalErrorInArgument,
-                    ("Region given to /adept/addGPURegion: " + regionName + " not found\n").c_str());
-      }
-
-      // Check for conflict with CPURegionNames
-      for (const std::string &cpuRegionName : cpuRegionNames) {
-        if (regionName == cpuRegionName) {
-          G4Exception("AdePTTrackingManager", "Conflicting region assignment", FatalErrorInArgument,
-                      ("Region '" + regionName + "' is defined in both /adept/addGPURegion and /adept/removeGPURegion")
-                          .c_str());
-        }
-      }
-
-      G4cout << "AdePTTrackingManager: Marking " << regionName << " as a GPU Region" << G4endl;
-      fGPURegions.insert(region);
-    }
-
-    fHepEmTrackingManager->SetTrackInAllRegions(false);
-
-  } else if (!cpuRegionNames.empty()) {
-    // Case 2: Track everywhere except explicitly listed CPU regions
-    // First mark all regions as GPU regions
-    for (G4Region *region : *G4RegionStore::GetInstance()) {
-      if (region) {
-        fGPURegions.insert(region);
-      }
-    }
-
-    // Then remove explicitly listed CPU regions
-    for (const std::string &cpuRegionName : cpuRegionNames) {
-      G4Region *region = G4RegionStore::GetInstance()->GetRegion(cpuRegionName);
-      if (!region) {
-        G4Exception("AdePTTrackingManager", "Invalid parameter", FatalErrorInArgument,
-                    ("Region given to /adept/removeGPURegion: " + cpuRegionName + " not found\n").c_str());
-      }
-
-      G4cout << "AdePTTrackingManager: Removing " << cpuRegionName << " from GPU Regions" << G4endl;
-      fGPURegions.erase(region);
-    }
-
-    fHepEmTrackingManager->SetTrackInAllRegions(false);
-  } else {
-    // Case 3: Track everywhere, no CPU overrides
-    fHepEmTrackingManager->SetTrackInAllRegions(true);
-  }
-  // initialize special G4HepEmTrackingManager
-  fHepEmTrackingManager->SetGPURegions(fGPURegions);
+  // Populate this worker's set from the configured region names.
+  InitializeGPURegions();
   fHepEmTrackingManager->ResetFinishEventOnCPUSize(fNumThreads);
 
   fSpeedOfLight = fAdePTConfiguration->GetSpeedOfLight();
@@ -393,7 +381,7 @@ void AdePTTrackingManager::PreparePhysicsTable(const G4ParticleDefinition &part)
 
 void AdePTTrackingManager::HandOverOneTrack(G4Track *aTrack)
 {
-  if (fGPURegions.empty() && !fAdePTConfiguration->GetTrackInAllRegions()) {
+  if (fGPURegions.empty()) {
     // if no GPU regions, hand over directly to G4HepEmTrackingManager
     fHepEmTrackingManager->HandOverOneTrack(aTrack);
     if (aTrack->GetTrackStatus() != fStopAndKill) {
@@ -518,7 +506,6 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
   G4EventManager *eventManager       = G4EventManager::GetEventManager();
   G4TrackingManager *trackManager    = eventManager->GetTrackingManager();
   G4SteppingManager *steppingManager = trackManager->GetSteppingManager();
-  const bool trackInAllRegions       = fAdePTConfiguration->GetTrackInAllRegions();
   const bool callUserActions         = CallUserActions(*fAdePTConfiguration);
   const bool globalHostData =
       fAdePTConfiguration->GetReturnFirstAndLastStep() || fAdePTConfiguration->GetReturnAllSteps();
@@ -557,7 +544,7 @@ void AdePTTrackingManager::ProcessTrack(G4Track *aTrack)
     G4Region const *region = aTrack->GetNextVolume()->GetLogicalVolume()->GetRegion();
 
     // Check if the particle is in a GPU region
-    const bool isGPURegion = trackInAllRegions || fGPURegions.find(region) != fGPURegions.end();
+    const bool isGPURegion = fGPURegions.find(region) != fGPURegions.end();
 
     if (isGPURegion && (fHepEmTrackingManager->GetFinishEventOnCPU(threadId) < 0)) {
 

--- a/src/g4integration/tracking_managers/G4HepEmTrackingManagerSpecialized.cc
+++ b/src/g4integration/tracking_managers/G4HepEmTrackingManagerSpecialized.cc
@@ -35,8 +35,7 @@ bool G4HepEmTrackingManagerSpecialized::CheckEarlyTrackingExit(G4Track *track, G
   //       This can be checked from the pre- and post-steppoint
 
   // Not in the GPU region, continue normal tracking with G4HepEmTrackingManager
-  if ((!GetTrackInAllRegions() && fGPURegions.find(region) == fGPURegions.end()) ||
-      GetFinishEventOnCPU(threadId) >= 0) {
+  if (fGPURegions.find(region) == fGPURegions.end() || GetFinishEventOnCPU(threadId) >= 0) {
     return false; // Continue tracking with G4HepEmTrackingManager
   } else {
 

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -133,6 +133,26 @@ add_test(NAME test_UI_commands
 )
 set_tests_properties(test_UI_commands PROPERTIES LABELS "unit")
 
+# A track starting in a removed region must stay on the CPU. SpeedOfLight kills
+# tracks sent to AdePT, so the track must stay on the CPU to deposit any energy.
+add_test(NAME test_remove_gpu_region
+  COMMAND bash ${PROJECT_SOURCE_DIR}/test/regression/scripts/test_remove_gpu_region.sh
+  "$<TARGET_FILE:integrationTest>" "${PROJECT_SOURCE_DIR}" "${SCRIPTS_DIR}"
+  "${PROJECT_BINARY_DIR}/test_remove_gpu_region_tmp"
+  WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+)
+set_tests_properties(test_remove_gpu_region PROPERTIES LABELS "unit;region-routing")
+
+# testEm3.gdml has a calorimeter region and a world region. Adding only
+# caloregion must give the same result as tracking everywhere except the world.
+add_test(NAME test_gpu_region_configuration_equivalence
+  COMMAND bash ${PROJECT_SOURCE_DIR}/test/regression/scripts/test_gpu_region_configuration_equivalence.sh
+  "$<TARGET_FILE:integrationTest>" "${PROJECT_SOURCE_DIR}" "${SCRIPTS_DIR}"
+  "${PROJECT_BINARY_DIR}/test_gpu_region_configuration_equivalence_tmp"
+  WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+)
+set_tests_properties(test_gpu_region_configuration_equivalence PROPERTIES LABELS "unit;region-routing")
+
 set(PHYSICS_DRIFT_SCENARIOS
   default
   regions

--- a/test/regression/scripts/example_template.mac
+++ b/test/regression/scripts/example_template.mac
@@ -24,9 +24,10 @@
 /adept/setCUDAStackLimit 8192
 $finish_last_n_particles_on_cpu
 
-# If true, particles are transported on the GPU across the whole geometry, GPU regions are ignored
+# Track on the GPU everywhere except in removed regions
 /adept/setTrackInAllRegions $track_in_all_regions
 $regions
+$removed_regions
 
 # Woodcock tracking regions
 $wdt_regions

--- a/test/regression/scripts/python_scripts/macro_generator.py
+++ b/test/regression/scripts/python_scripts/macro_generator.py
@@ -88,6 +88,15 @@ def generate_macro(template_path, output_path, args):
     region_part = "\n".join(region_part)
     macro_content = macro_content.replace("$regions", region_part)
 
+    # Add removeGPURegion commands.
+    removed_region_part = []
+    for i in args.removed_regions.split(","):
+        region = i.strip()
+        if region:
+            removed_region_part.append(f"/adept/removeGPURegion {region}")
+    removed_region_part = "\n".join(removed_region_part)
+    macro_content = macro_content.replace("$removed_regions", removed_region_part)
+
     # Woodcock tracking regions should be a comma-separated list of region names.
     wdt_region_part = []
     for i in args.wdt_regions.split(","):
@@ -136,6 +145,8 @@ def main():
     parser.add_argument("--call_user_tracking_action", default="False", help="True or False")
     parser.add_argument("--regions", type=str, required=False, default="",
                         help="Comma-separated list of regions in which to do GPU transport, only if track_in_all_regions is False")
+    parser.add_argument("--removed_regions", type=str, required=False, default="",
+                        help="Comma-separated list of regions to exclude when track_in_all_regions is True")
     parser.add_argument("--wdt_regions", type=str, required=False, default="",
                         help="Comma-separated list of Woodcock tracking regions")
     args = parser.parse_args()

--- a/test/regression/scripts/test_gpu_region_configuration_equivalence.sh
+++ b/test/regression/scripts/test_gpu_region_configuration_equivalence.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 CERN
+# SPDX-License-Identifier: Apache-2.0
+
+# Compare two ways of selecting only the calorimeter for GPU tracking.
+# testEm3.gdml puts the calorimeter in `caloregion` and the surrounding volume
+# in `DefaultRegionForTheWorld`:
+#
+#     /adept/addGPURegion caloregion
+#
+#   and:
+#
+#     /adept/setTrackInAllRegions true
+#     /adept/removeGPURegion DefaultRegionForTheWorld
+#
+# Both runs use the same seed. Their per-volume energy deposits must match.
+
+set -eu -o pipefail
+
+ADEPT_EXECUTABLE=$1
+PROJECT_SOURCE_DIR=$2
+CI_TEST_DIR=$3
+CI_TMP_DIR=$4
+
+cleanup() {
+  rm -rf "${CI_TMP_DIR}"
+}
+trap cleanup EXIT
+cleanup
+
+EXPLICIT_DIR="${CI_TMP_DIR}/explicit"
+TRACK_ALL_DIR="${CI_TMP_DIR}/track_all"
+mkdir -p "${EXPLICIT_DIR}" "${TRACK_ALL_DIR}"
+
+generate_macro() {
+  local output=$1
+  local track_in_all_regions=$2
+  local added_regions=$3
+  local removed_regions=$4
+
+  "${CI_TEST_DIR}/python_scripts/macro_generator.py" \
+    --template "${CI_TEST_DIR}/example_template.mac" \
+    --output "${output}" \
+    --gdml_name "${PROJECT_SOURCE_DIR}/examples/data/testEm3.gdml" \
+    --num_threads 1 \
+    --num_events 1 \
+    --num_trackslots 1 \
+    --num_hitslots 1 \
+    --gun_number 1 \
+    --gun_type setDefault \
+    --track_in_all_regions "${track_in_all_regions}" \
+    --regions "${added_regions}" \
+    --removed_regions "${removed_regions}"
+}
+
+EXPLICIT_MACRO="${EXPLICIT_DIR}/explicit_add.mac"
+TRACK_ALL_MACRO="${TRACK_ALL_DIR}/track_all_remove.mac"
+
+generate_macro "${EXPLICIT_MACRO}" false caloregion ""
+generate_macro "${TRACK_ALL_MACRO}" true "" DefaultRegionForTheWorld
+
+grep -Fxq "/adept/addGPURegion caloregion" "${EXPLICIT_MACRO}"
+grep -Fxq "/adept/setTrackInAllRegions true" "${TRACK_ALL_MACRO}"
+grep -Fxq "/adept/removeGPURegion DefaultRegionForTheWorld" "${TRACK_ALL_MACRO}"
+
+run_configuration() {
+  local macro=$1
+  local output_dir=$2
+  local output_name=$3
+  local log=$4
+
+  if ! "${ADEPT_EXECUTABLE}" --allsensitive --accumulated_events \
+      -m "${macro}" --output_dir "${output_dir}" --output_file "${output_name}" \
+      >"${log}" 2>&1; then
+    cat "${log}"
+    exit 1
+  fi
+}
+
+run_configuration "${EXPLICIT_MACRO}" "${EXPLICIT_DIR}" explicit_add "${EXPLICIT_DIR}/explicit_add.log"
+run_configuration "${TRACK_ALL_MACRO}" "${TRACK_ALL_DIR}" track_all_remove "${TRACK_ALL_DIR}/track_all_remove.log"
+
+"${CI_TEST_DIR}/python_scripts/check_reproducibility.py" \
+  --file1 "${EXPLICIT_DIR}/explicit_add.csv" \
+  --file2 "${TRACK_ALL_DIR}/track_all_remove.csv" \
+  --tol 0.0
+
+echo "Explicit addGPURegion and track-all/removeGPURegion produced identical scored results."

--- a/test/regression/scripts/test_remove_gpu_region.sh
+++ b/test/regression/scripts/test_remove_gpu_region.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 CERN
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu -o pipefail
+
+# Check that a track starting in a removed region stays on the CPU. SpeedOfLight
+# kills tracks sent to AdePT, so this track only deposits energy if it stays on
+# the CPU.
+
+ADEPT_EXECUTABLE=$1
+PROJECT_SOURCE_DIR=$2
+CI_TEST_DIR=$3
+CI_TMP_DIR=$4
+
+cleanup() {
+  rm -rf "${CI_TMP_DIR}"
+}
+trap cleanup EXIT
+cleanup
+mkdir -p "${CI_TMP_DIR}"
+
+MACRO_FILE="${CI_TMP_DIR}/test_remove_gpu_region.mac"
+LOG_FILE="${CI_TMP_DIR}/test_remove_gpu_region.log"
+
+"${CI_TEST_DIR}/python_scripts/macro_generator.py" \
+  --template "${CI_TEST_DIR}/test_remove_gpu_region_template.mac" \
+  --output "${MACRO_FILE}" \
+  --gdml_name "${PROJECT_SOURCE_DIR}/examples/data/testEm3_regions.gdml"
+
+if ! "${ADEPT_EXECUTABLE}" --allsensitive -m "${MACRO_FILE}" >"${LOG_FILE}" 2>&1; then
+  cat "${LOG_FILE}"
+  exit 1
+fi
+
+DEPOSITED_ENERGY=$(awk '/Total energy deposited:/ {print $(NF - 1); exit}' "${LOG_FILE}")
+if ! awk -v energy="${DEPOSITED_ENERGY:-0}" 'BEGIN { exit !(energy > 0.0009) }'; then
+  echo "Expected the 1 keV primary in removed region Layer3 to remain on CPU and deposit its energy."
+  echo "Observed deposited energy: ${DEPOSITED_ENERGY:-missing} MeV"
+  cat "${LOG_FILE}"
+  exit 1
+fi
+
+echo "Initial track in removed region Layer3 remained on the CPU."

--- a/test/regression/scripts/test_remove_gpu_region_template.mac
+++ b/test/regression/scripts/test_remove_gpu_region_template.mac
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2026 CERN
+# SPDX-License-Identifier: Apache-2.0
+
+# The electron starts in Layer3, which is removed from GPU tracking. SpeedOfLight
+# kills tracks sent to AdePT, so the electron only deposits energy if it starts
+# on the CPU.
+
+/run/numberOfThreads 1
+/control/verbose 0
+/run/verbose 0
+/process/verbose 0
+/tracking/verbose 0
+/event/verbose 0
+
+/detector/filename $gdml_name
+/adept/setVerbosity 0
+/adept/setMillionsOfTrackSlots 1
+/adept/setMillionsOfHitSlots 1
+/adept/setCPUCapacityFactor 2.5
+/adept/setTrackInAllRegions true
+/adept/removeGPURegion Layer3
+/adept/SpeedOfLight true
+
+/run/setCut 0.7 mm
+/run/initialize
+/eventAction/verbose 1
+
+/gun/setDefault
+/gun/particle e-
+/gun/energy 1 keV
+# Layer3 is centred at x=-180 mm; its lead absorber is centred at -182.85 mm.
+/gun/position -182.85 0 0 mm
+/gun/direction 1 0 0
+/gun/print false
+
+/run/beamOn 1

--- a/test/unit/test_geometry_bridge.cpp
+++ b/test/unit/test_geometry_bridge.cpp
@@ -198,12 +198,11 @@ TEST(AdePTGeometryBridge, InitVolAuxDataIncludesAllReplicatedWdtRoots)
   ASSERT_TRUE(hepEmTM.fWDTHelper->Initialize(wdtRegionNames, &matCutData, worldPV));
 
   std::vector<adeptint::VolAuxData> volAuxData(vecgeom::GeoManager::Instance().GetRegisteredVolumesCount());
-  std::vector<std::string> gpuRegionNames;
+  std::set<G4Region const *> gpuRegions{&worldRegion, &wdtRegion};
   std::vector<std::string> deadRegionNames;
   adeptint::WDTHostRaw wdtRaw;
 
-  AdePTGeometryBridge::InitVolAuxData(volAuxData.data(), &hepEmData, &hepEmTM, true, &gpuRegionNames, deadRegionNames,
-                                      wdtRaw);
+  AdePTGeometryBridge::InitVolAuxData(volAuxData.data(), &hepEmData, &hepEmTM, gpuRegions, deadRegionNames, wdtRaw);
 
   const auto regionRoots = wdtRaw.regionToRootIndices.find(wdtRegion.GetInstanceID());
   ASSERT_NE(regionRoots, wdtRaw.regionToRootIndices.end());
@@ -216,6 +215,61 @@ TEST(AdePTGeometryBridge, InitVolAuxDataIncludesAllReplicatedWdtRoots)
   for (auto const &root : wdtRaw.roots) {
     EXPECT_EQ(root.hepemIMC, 0);
   }
+}
+
+TEST(AdePTGeometryBridge, UsesResolvedGPURegionSet)
+{
+  GeometryCleanup cleanup;
+  G4GeometryManager::GetInstance()->OpenGeometry();
+  vecgeom::GeoManager::Instance().Clear();
+
+  auto *material = G4NistManager::Instance()->FindOrBuildMaterial("G4_AIR");
+  ASSERT_NE(material, nullptr);
+
+  auto *worldSolid = new G4Box("cpu_override_world_solid", 10.0 * mm, 10.0 * mm, 10.0 * mm);
+  auto *worldLV    = new G4LogicalVolume(worldSolid, material, "cpu_override_world_lv");
+  auto *worldPV = new G4PVPlacement(nullptr, G4ThreeVector(), worldLV, "cpu_override_world", nullptr, false, 0, false);
+
+  auto *cpuSolid = new G4Box("cpu_override_solid", 1.0 * mm, 1.0 * mm, 1.0 * mm);
+  auto *cpuLV    = new G4LogicalVolume(cpuSolid, material, "cpu_override_lv");
+  new G4PVPlacement(nullptr, G4ThreeVector(), cpuLV, "cpu_override", worldLV, false, 0, false);
+
+  auto *couple = new G4MaterialCutsCouple(material, new G4ProductionCuts);
+  couple->SetIndex(0);
+  couple->SetUseFlag(true);
+  worldLV->SetMaterialCutsCouple(couple);
+  cpuLV->SetMaterialCutsCouple(couple);
+
+  G4Region worldRegion("cpu_override_world_region");
+  worldRegion.AddRootLogicalVolume(worldLV);
+  worldRegion.RegisterMaterialCouplePair(material, couple);
+
+  G4Region cpuRegion("cpu_override_region");
+  cpuRegion.AddRootLogicalVolume(cpuLV);
+  cpuRegion.RegisterMaterialCouplePair(material, couple);
+
+  auto *transport = G4TransportationManager::GetTransportationManager();
+  transport->SetWorldForTracking(worldPV);
+  G4GeometryManager::GetInstance()->CloseGeometry(true);
+
+  AdePTGeometryBridge::CreateVecGeomWorld(worldPV);
+  auto const *vgWorld = vecgeom::GeoManager::Instance().GetWorld();
+  ASSERT_NE(vgWorld, nullptr);
+  ASSERT_EQ(vgWorld->GetLogicalVolume()->GetDaughters().size(), 1u);
+  auto const *vgCPUVolume = vgWorld->GetLogicalVolume()->GetDaughters()[0];
+
+  SingleMatCutHepEmData hepEmData;
+  G4HepEmTrackingManagerSpecialized hepEmTM;
+  std::set<G4Region const *> gpuRegions{&worldRegion};
+  std::vector<std::string> deadRegionNames;
+  adeptint::WDTHostRaw wdtRaw;
+  std::vector<adeptint::VolAuxData> volAuxData(vecgeom::GeoManager::Instance().GetRegisteredVolumesCount());
+
+  AdePTGeometryBridge::InitVolAuxData(volAuxData.data(), &hepEmData.hepEmData, &hepEmTM, gpuRegions, deadRegionNames,
+                                      wdtRaw);
+
+  EXPECT_EQ(volAuxData[vgWorld->GetLogicalVolume()->id()].fGPUregionId, worldRegion.GetInstanceID());
+  EXPECT_EQ(volAuxData[vgCPUVolume->GetLogicalVolume()->id()].fGPUregionId, -1);
 }
 
 // G4-to-VecGeom handoff for flattened replicas: a Geant4 history in replica
@@ -621,11 +675,11 @@ TEST(AdePTGeometryBridge, RejectsUnexpandedReplicaWithoutVecGeomCopies)
   ASSERT_TRUE(hepEmTM.fWDTHelper->Initialize(wdtRegionNames, &matCutData, worldPV));
 
   std::vector<adeptint::VolAuxData> volAuxData(vecgeom::GeoManager::Instance().GetRegisteredVolumesCount());
-  std::vector<std::string> gpuRegionNames;
+  std::set<G4Region const *> gpuRegions;
   std::vector<std::string> deadRegionNames;
   adeptint::WDTHostRaw wdtRaw;
 
-  EXPECT_THROW(AdePTGeometryBridge::InitVolAuxData(volAuxData.data(), &hepEmData, &hepEmTM, true, &gpuRegionNames,
-                                                   deadRegionNames, wdtRaw),
-               std::runtime_error);
+  EXPECT_THROW(
+      AdePTGeometryBridge::InitVolAuxData(volAuxData.data(), &hepEmData, &hepEmTM, gpuRegions, deadRegionNames, wdtRaw),
+      std::runtime_error);
 }

--- a/test/unit/test_return_step_options.cpp
+++ b/test/unit/test_return_step_options.cpp
@@ -27,7 +27,7 @@ private:
 };
 } // namespace
 
-TEST(AdePTConfiguration, IdleReturnStepCommandsFreezeWithTransportSnapshot)
+TEST(AdePTConfiguration, RejectsChangesAfterInitializationStarts)
 {
   AdePTConfiguration configuration;
   auto *stateManager = G4StateManager::GetStateManager();
@@ -37,6 +37,9 @@ TEST(AdePTConfiguration, IdleReturnStepCommandsFreezeWithTransportSnapshot)
   auto *uiManager = G4UImanager::GetUIpointer();
   ASSERT_NE(uiManager->GetTree()->FindPath("/adept/returnFirstAndLastStep"), nullptr);
   ASSERT_NE(uiManager->GetTree()->FindPath("/adept/returnAllSteps"), nullptr);
+  ASSERT_NE(uiManager->GetTree()->FindPath("/adept/setTrackInAllRegions"), nullptr);
+  ASSERT_NE(uiManager->GetTree()->FindPath("/adept/addGPURegion"), nullptr);
+  ASSERT_NE(uiManager->GetTree()->FindPath("/adept/removeGPURegion"), nullptr);
   auto *returnFirstAndLast = uiManager->GetTree()->FindPath("/adept/returnFirstAndLastStep");
   auto *returnAll          = uiManager->GetTree()->FindPath("/adept/returnAllSteps");
   EXPECT_TRUE(returnFirstAndLast->ToBeBroadcasted());
@@ -60,16 +63,33 @@ TEST(AdePTConfiguration, IdleReturnStepCommandsFreezeWithTransportSnapshot)
   EXPECT_EQ(uiManager->ApplyCommand("/adept/returnAllSteps true"), 0);
   EXPECT_TRUE(configuration.GetReturnFirstAndLastStep());
   EXPECT_TRUE(configuration.GetReturnAllSteps());
+  EXPECT_EQ(uiManager->ApplyCommand("/adept/setTrackInAllRegions true"), 0);
+  EXPECT_EQ(uiManager->ApplyCommand("/adept/addGPURegion GPUBeforeInitialization"), 0);
+  EXPECT_EQ(uiManager->ApplyCommand("/adept/removeGPURegion CPUBeforeInitialization"), 0);
+  EXPECT_TRUE(configuration.GetTrackInAllRegions());
+  ASSERT_EQ(configuration.GetGPURegionNames()->size(), 1u);
+  ASSERT_EQ(configuration.GetCPURegionNames()->size(), 1u);
 
-  // This is the point at which AdePTTransport takes its by-value kernel-option
-  // snapshot. Later Idle commands may repeat, but must not change, the values.
-  configuration.LockReturnStepOptions();
-  EXPECT_TRUE(configuration.ReturnStepOptionsAreLocked());
+  // Lock the settings as the first worker does. Repeating a value is allowed,
+  // but changing it must fail.
+  configuration.LockTransportInitializationOptions();
+  EXPECT_TRUE(configuration.TransportInitializationOptionsAreLocked());
   EXPECT_EQ(uiManager->ApplyCommand("/adept/returnFirstAndLastStep true"), 0);
   EXPECT_EQ(uiManager->ApplyCommand("/adept/returnAllSteps true"), 0);
+  EXPECT_EQ(uiManager->ApplyCommand("/adept/setTrackInAllRegions true"), 0);
+  EXPECT_EQ(uiManager->ApplyCommand("/adept/addGPURegion GPUBeforeInitialization"), 0);
+  EXPECT_EQ(uiManager->ApplyCommand("/adept/removeGPURegion CPUBeforeInitialization"), 0);
   EXPECT_NE(uiManager->ApplyCommand("/adept/returnFirstAndLastStep false"), 0);
   EXPECT_NE(uiManager->ApplyCommand("/adept/returnAllSteps false"), 0);
+  EXPECT_NE(uiManager->ApplyCommand("/adept/setTrackInAllRegions false"), 0);
+  EXPECT_NE(uiManager->ApplyCommand("/adept/addGPURegion GPUAfterInitialization"), 0);
+  EXPECT_NE(uiManager->ApplyCommand("/adept/removeGPURegion CPUAfterInitialization"), 0);
 
   EXPECT_TRUE(configuration.GetReturnFirstAndLastStep());
   EXPECT_TRUE(configuration.GetReturnAllSteps());
+  EXPECT_TRUE(configuration.GetTrackInAllRegions());
+  EXPECT_EQ(configuration.GetGPURegionNames()->size(), 1u);
+  EXPECT_EQ(configuration.GetCPURegionNames()->size(), 1u);
+  EXPECT_EQ(configuration.GetGPURegionNames()->front(), "GPUBeforeInitialization");
+  EXPECT_EQ(configuration.GetCPURegionNames()->front(), "CPUBeforeInitialization");
 }


### PR DESCRIPTION
There was a bug with the removeGPURegion and trackInAllRegion flags: if trackInAllRegions was used, the removeGPURegion would not work correctly in the offloading of the TrackingManager.

This PR fixes that and makes the implementation more robust, by keeping only one list of GPU regions and no possibly conflicting flags. Furthermore, as soon as the GPU regions are initialized on GPU, the flags are locked and one cannot change them with subcommands anymore, to avoid any stale configurations.

Unit tests are added to cover the cases.